### PR TITLE
fdisk: fix to build for IA32

### DIFF
--- a/fdisk/fdiskbsdlabel.h
+++ b/fdisk/fdiskbsdlabel.h
@@ -46,7 +46,7 @@
 
 #define BSD_LINUX_BOOTDIR "/usr/ucb/mdec"
 
-#if defined (i386) || defined (__sparc__) || defined (__arm__) || \
+#if defined (__i386__) || defined (__sparc__) || defined (__arm__) || \
     defined (__mips__) || defined (__s390__) || defined (__sh__) || \
     defined(__x86_64__) || defined (__avr32__) || defined(__cris__)
 #define BSD_LABELSECTOR   1


### PR DESCRIPTION
Tested architectures:
- i486 using gcc -march=i486
- i586 using gcc -march=pentium-mmx
- i686 using gcc -march={pentiumpro,pentium2,pentium3,pentium-m,pentium4}

Without this fix building fdisk fails for for all tested arch/cpu types
## emiting following error:

In file included from fdiskbsdlabel.c:62:0:
fdiskbsdlabel.h:61:2: error: #error unknown architecture
fdiskbsdlabel.c: In function 'bselect':
fdiskbsdlabel.c:180:44: error: 'BSD_LABELSECTOR' undeclared (first use in this function)
fdiskbsdlabel.c:180:44: note: each undeclared identifier is reported only once for each function it appears in
fdiskbsdlabel.c: In function 'xbsd_write_bootstrap':
fdiskbsdlabel.c:539:24: error: 'BSD_LABELSECTOR' undeclared (first use in this function)
fdiskbsdlabel.c: In function 'xbsd_readlabel':
fdiskbsdlabel.c:744:28: error: 'BSD_LABELSECTOR' undeclared (first use in this function)
fdiskbsdlabel.c:744:60: error: 'BSD_LABELOFFSET' undeclared (first use in this function)
fdiskbsdlabel.c: In function 'xbsd_writelabel':
fdiskbsdlabel.c:769:32: error: 'BSD_LABELSECTOR' undeclared (first use in this function)
fdiskbsdlabel.c:780:61: error: 'BSD_LABELOFFSET' undeclared (first use in this function)
## make[2]: **\* [fdisk-fdiskbsdlabel.o] Error 1

This fix was tested with following major toolchain components:

binutils 2.21.53.0.2
gcc 4.6.2
glibc 2.14.1
