### PR TITLE
cal: Fix building under uClibc.

### DIFF
--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -299,7 +299,7 @@ main(int argc, char **argv) {
  * the locale database, which can be overridden with the
  * -s (Sunday) or -m (Monday) options.
  */
-#ifdef HAVE_DECL__NL_TIME_WEEK_1STDAY
+#if HAVE_DECL__NL_TIME_WEEK_1STDAY
 	/*
 	 * You need to use 2 locale variables to get the first day of the week.
 	 * This is needed to support first_weekday=2 and first_workday=1 for


### PR DESCRIPTION
Commit fbc333fec09394bf4e47707de08a65e8c0e9c288 broke building under uClibc because HAVE_DECL macros are set to 0, not undefined.

Signed-off-by: James Le Cuirot chewi@aura-online.co.uk
