### PR TITLE
regexec only returns 0 or REG_NOMATCH so remove a meaningless test

### DIFF
--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -1634,8 +1634,6 @@ void search(char buf[], FILE *file, register int n)
 		    }
 		    break;
 		}
-	} else if (rv != REG_NOMATCH)
-	    more_error (_("Regular expression botch"));
     }
     if (feof (file)) {
 	if (!no_intty) {


### PR DESCRIPTION
Signed-off-by: Jeremy Huntwork jhuntwork@lightcubesolutions.com
