### PR TITLE
Ensure mkfs is linked with gettext.

### DIFF
--- a/disk-utils/Makefile.am
+++ b/disk-utils/Makefile.am
@@ -41,6 +41,8 @@ mkfs_bfs_SOURCES = \
 	$(top_srcdir)/lib/strutils.c \
 	$(utils_common)
 
+mkfs_LDADD = $(LDADD) $(LTLIBINTL)
+
 swaplabel_SOURCES = swaplabel.c $(utils_common)
 swaplabel_LDADD = $(uuid_ldadd)
 swaplabel_CFLAGS = $(AM_CFLAGS) $(uuid_cflags)


### PR DESCRIPTION
NOTE: I'm not sure this is the best solution, but it does work for me.  I'm happy to rework it any required direction to make it more inline with project style or requirements.

The gettext library libdir and includedir location are correctly
detected by autoconf but mkfs was not configured to use the detected
flags.  This patch ensures that when mkfs is linked, libtool will use
the appropriate -L, -R and -l options.

This problem was noted while building mkfs on Solaris 10.

Signed-off-by: Ben Walton bwalton@artsci.utoronto.ca
