### PR TITLE
Add missing rpmatch.h everywhere it needs to be.

### DIFF
--- a/disk-utils/fsck.minix.c
+++ b/disk-utils/fsck.minix.c
@@ -111,6 +111,7 @@
 #include "ismounted.h"
 #include "all-io.h"
 #include "closestream.h"
+#include "rpmatch.h"
 
 #define ROOT_INO 1
 #define YESNO_LENGTH 64

--- a/login-utils/vipw.c
+++ b/login-utils/vipw.c
@@ -78,6 +78,7 @@
 #include "setpwnam.h"
 #include "strutils.h"
 #include "xalloc.h"
+#include "rpmatch.h"
 
 #ifdef HAVE_LIBSELINUX
 # include <selinux/selinux.h>

--- a/term-utils/mesg.c
+++ b/term-utils/mesg.c
@@ -58,6 +58,7 @@
 #include "closestream.h"
 #include "nls.h"
 #include "c.h"
+#include "rpmatch.h"
 
 /* exit codes */
 


### PR DESCRIPTION
Some files were missing rpmatch() compatibility macro header, which broke compilation on uClibc, which does not provide rpmatch().

Signed-off-by: William Pitcock nenolod@dereferenced.org
