### PR TITLE
libblkid: fix block size for UDF probe

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -385,5 +385,6 @@ CONTRIBUTORS:
       Yoshihiro Takahashi <ytakahashi@miraclelinux.com>
       Yuri Chornoivan <yurchor@ukr.net>
       Yu Zhiguo <yuzg@cn.fujitsu.com>
+      Zachary Catlin <z@zc.is>
       Zdenek Behan <rain@matfyz.cz>
       Zhi Li <lizhi1215@gmail.com>

--- a/libblkid/src/superblocks/udf.c
+++ b/libblkid/src/superblocks/udf.c
@@ -64,17 +64,25 @@ static int probe_udf(blkid_probe pr,
 	struct volume_descriptor *vd;
 	struct volume_structure_descriptor *vsd;
 	unsigned int bs;
+	unsigned int pbs[2];
 	unsigned int b;
 	unsigned int type;
 	unsigned int count;
 	unsigned int loc;
+	unsigned int i;
 
-	/* search Volume Sequence Descriptor (VSD) to get the logical
-	 * block size of the volume */
-	for (bs = 0x800; bs < 0x8000; bs += 0x800) {
+	/* The block size of a UDF filesystem is that of the underlying
+	 * storage; we check later on for the special case of image files,
+	 * which may have the 2048-byte block size of optical media. */
+	pbs[0] = blkid_probe_get_sectorsize(pr);
+	pbs[1] = 0x800;
+
+	/* check for a Volume Structure Descriptor (VSD); each is
+	 * 2048 bytes long */
+	for (b = 0; b < 0x8000; b += 0x800) {
 		vsd = (struct volume_structure_descriptor *)
 			blkid_probe_get_buffer(pr,
-					UDF_VSD_OFFSET + bs,
+					UDF_VSD_OFFSET + b,
 					sizeof(*vsd));
 		if (!vsd)
 			return 1;
@@ -88,7 +96,7 @@ nsr:
 	for (b = 0; b < 64; b++) {
 		vsd = (struct volume_structure_descriptor *)
 			blkid_probe_get_buffer(pr,
-					UDF_VSD_OFFSET + ((blkid_loff_t) b * bs),
+					UDF_VSD_OFFSET + ((blkid_loff_t) b * 0x800),
 					sizeof(*vsd));
 		if (!vsd)
 			return -1;
@@ -102,17 +110,24 @@ nsr:
 	return -1;
 
 anchor:
-	/* read Anchor Volume Descriptor (AVDP) */
-	vd = (struct volume_descriptor *)
-		blkid_probe_get_buffer(pr, 256 * bs, sizeof(*vd));
-	if (!vd)
-		return -1;
+	/* read Anchor Volume Descriptor (AVDP), checking block size */
+	for (i = 0; i < 2; i++) {
+		vd = (struct volume_descriptor *)
+			blkid_probe_get_buffer(pr, 256 * pbs[i], sizeof(*vd));
+		if (!vd)
+			return -1;
 
-	type = le16_to_cpu(vd->tag.id);
-	if (type != 2) /* TAG_ID_AVDP */
-		return 0;
+		type = le16_to_cpu(vd->tag.id);
+		if (type == 2) /* TAG_ID_AVDP */
+			goto real_blksz;
+	}
+	return 0;
 
-	/* get desriptor list address and block count */
+real_blksz:
+	/* Use the actual block size from here on out */
+	bs = pbs[i];
+
+	/* get descriptor list address and block count */
 	count = le32_to_cpu(vd->type.anchor.length) / bs;
 	loc = le32_to_cpu(vd->type.anchor.location);
 


### PR DESCRIPTION
Quoting my commit message:

> In UDF, Volume Structure Descriptors are always 2048 bytes long (ECMA-167, 3rd ed., §2/9.1), while filesystem sectors are the same size as the sectors of the underlying media (e.g., UDF 2.01 §1.3.2). Before this commit, the block size was estimated from VSD offsets, which gives incorrect answers for non-optical media.

To give an example, I have a UDF partition `/dev/sdb2` on a flash drive, with a block size of 512 bytes; it has a label of **Flashback**. Before this commit, running `blkid` doesn't find the label:

<pre>
$ ./blkid.static /dev/sdb2
/dev/sdb2: TYPE="udf"
</pre>


After this commit, I get the following:

<pre>
$ ./blkid.static /dev/sdb2
/dev/sdb2: LABEL="Flashback" TYPE="udf"
</pre>


As for DVD images (for which the 'device' block size is 512 bytes but we really want 2048-byte blocks):

<pre>
$ genisoimage -V Test-GENISOIMG -graft-points -udf -o x.iso config=config lib=lib libblkid=libblkid libuuid=libuuid
$ mkudffs -b 2048 --vid=Test-mkudffs --media-type=dvd --utf8 y.iso 8192
$ ./blkid.static x.iso
x.iso: UUID="2013-03-01-21-21-42-00" LABEL="Test-GENISOIMG" TYPE="udf" 
$ ./blkid.static y.iso
y.iso: LABEL="Test-mkudffs" TYPE="udf"
</pre>


I believe this covers most use-cases.
