### PR TITLE
"getty: unrecognized option '--loginpause'"

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -1691,7 +1691,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE *out)
 	fputs(_(" -m, --extract-baud         extract baud rate during connect\n"), out);
 	fputs(_(" -n, --skip-login           do not prompt for login\n"), out);
 	fputs(_(" -o, --login-options <opts> options that are passed to login\n"), out);
-	fputs(_(" -p, --loginpause           wait for any key before the login\n"), out);
+	fputs(_(" -p, --login-pause          wait for any key before the login\n"), out);
 	fputs(_(" -r, --chroot <dir>         change root to the directory\n"), out);
 	fputs(_(" -R, --hangup               do virtually hangup on the tty\n"), out);
 	fputs(_(" -s, --keep-baud            try to keep baud rate after break\n"), out);
@@ -1701,7 +1701,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE *out)
 	fputs(_("     --noclear              do not clear the screen before prompt\n"), out);
 	fputs(_("     --nohints              do not print hints\n"), out);
 	fputs(_("     --nonewline            do not print a newline before issue\n"), out);
-	fputs(_("     --no-hostname          no hostname at all will be shown\n"), out);
+	fputs(_("     --nohostname           no hostname at all will be shown\n"), out);
 	fputs(_("     --long-hostname        show full qualified hostname\n"), out);
 	fputs(_("     --erase-chars <string> additional backspace chars\n"), out);
 	fputs(_("     --kill-chars <string>  additional kill chars\n"), out);


### PR DESCRIPTION
Usage incorrectly stated --loginpause is a valid option, where instead --login-pause is.

Also --no-hostname --> --nohostname, as per the manual.

 I can imagine how these came to be. :D
