### PR TITLE
tests: fix fdisk GPT test

### DIFF
--- a/tests/expected/fdisk/gpt
+++ b/tests/expected/fdisk/gpt
@@ -143,3 +143,4 @@ Device             Start          End Size Type
 <removed>8        16384        18431   1M Linux filesystem
 
 -------------------
+


### PR DESCRIPTION
There was a missing newline since cd05de50.

Signed-off-by: Ruediger Meier ruediger.meier@ga-group.nl
