### PR TITLE
tests, skip fallocate for unsupported filesystems

### DIFF
--- a/tests/ts/misc/fallocate
+++ b/tests/ts/misc/fallocate
@@ -23,8 +23,16 @@ ts_check_test_command "$TS_CMD_FALLOCATE"
 IMAGE=${TS_OUTDIR}/${TS_TESTNAME}.file
 rm -f $IMAGE
 
-$TS_CMD_FALLOCATE -o 128 -l 256 $IMAGE > $TS_OUTPUT 2>&1
-stat -c "%s" $IMAGE > $TS_OUTPUT 2>&1
+# fs type of $TS_OUTDIR, could be used to skip this test early
+fs_type=$(${TS_CMD_FINDMNT} -n -o FSTYPE -T ${TS_OUTDIR})
+
+if $TS_CMD_FALLOCATE -o 128 -l 256 $IMAGE > $TS_OUTPUT 2>&1; then
+	stat -c "%s" $IMAGE >> $TS_OUTPUT 2>&1
+else
+	test "$(<$TS_OUTPUT)" \
+	     = "fallocate: fallocate failed: Operation not supported" \
+	&& ts_skip "filesystem '${fs_type}' not supported"
+fi
 
 rm -f $IMAGE
 


### PR DESCRIPTION
This test always failed on usual file systems like nfs or ext3.
