### PR TITLE
unshare: include libmount.h to provide missing MS_* defines

### DIFF
--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -296,6 +296,7 @@ usrbin_exec_PROGRAMS += unshare
 dist_man_MANS += sys-utils/unshare.1
 unshare_SOURCES = sys-utils/unshare.c
 unshare_LDADD = $(LDADD) libcommon.la
+unshare_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 endif
 
 if BUILD_NSENTER

--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -27,6 +27,9 @@
 #include <sys/wait.h>
 #include <sys/mount.h>
 
+/* we only need some defines missing in sys/mount.h, no libmount linkage */
+#include <libmount.h>
+
 #include "nls.h"
 #include "c.h"
 #include "closestream.h"


### PR DESCRIPTION
Since 6728ca10 we are using MS_PRIVATE and MS_REC which are not defined
in some systems's sys/mount.h.

Signed-off-by: Ruediger Meier ruediger.meier@ga-group.nl
