### PR TITLE
build-sys: libcommon needs -lrt

### DIFF
--- a/lib/Makemodule.am
+++ b/lib/Makemodule.am
@@ -1,6 +1,7 @@
 
 noinst_LTLIBRARIES += libcommon.la
 libcommon_la_CFLAGS = $(AM_CFLAGS)
+libcommon_la_LIBADD = -lrt
 libcommon_la_SOURCES = \
 	lib/at.c \
 	lib/blkdev.c \

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -71,7 +71,7 @@ if LINUX
 bin_PROGRAMS += dmesg
 dist_man_MANS += sys-utils/dmesg.1
 dmesg_SOURCES = sys-utils/dmesg.c
-dmesg_LDADD = $(LDADD) libcommon.la -lrt
+dmesg_LDADD = $(LDADD) libcommon.la
 
 sbin_PROGRAMS += ctrlaltdel
 dist_man_MANS += sys-utils/ctrlaltdel.8


### PR DESCRIPTION
We need this since clock_gettime() call was moved from dmesg
in 929f939e.
