### PR TITLE
lsblk: fix, set default sort_id = -1

### DIFF
--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -1560,7 +1560,6 @@ int main(int argc, char *argv[])
 	atexit(close_stdout);
 
 	lsblk = &_ls;
-	memset(lsblk, 0, sizeof(*lsblk));
 
 	while((c = getopt_long(argc, argv,
 			       "abdDe:fhlnmo:OpPiI:rstVSx:", longopts, NULL)) != -1) {


### PR DESCRIPTION
Introduced in 642048e4:
 $ lsblk -o SIZE /dev/loop1
lsblk: the sort column has to be between output columns.

Signed-off-by: Ruediger Meier ruediger.meier@ga-group.nl
