### PR TITLE
build: fix some compiler warnings

### DIFF
--- a/disk-utils/fsck.cramfs.c
+++ b/disk-utils/fsck.cramfs.c
@@ -618,11 +618,11 @@ static void test_fs(int start)
 	if (start_data != ~0UL) {
 		if (start_data < (sizeof(struct cramfs_super) + start))
 			errx(FSCK_EX_UNCORRECTED,
-			     _("directory data start (%ld) < sizeof(struct cramfs_super) + start (%ld)"),
+			     _("directory data start (%lu) < sizeof(struct cramfs_super) + start (%zu)"),
 			     start_data, sizeof(struct cramfs_super) + start);
 		if (end_dir != start_data)
 			errx(FSCK_EX_UNCORRECTED,
-			     _("directory data end (%ld) != file data start (%ld)"),
+			     _("directory data end (%lu) != file data start (%lu)"),
 			     end_dir, start_data);
 	}
 	if (super.flags & CRAMFS_FLAG_FSID_VERSION_2)

--- a/lib/boottime.c
+++ b/lib/boottime.c
@@ -9,8 +9,11 @@
 
 int get_boot_time(struct timeval *boot_time)
 {
+#ifdef CLOCK_BOOTTIME
 	struct timespec hires_uptime;
-	struct timeval lores_uptime, now;
+	struct timeval lores_uptime;
+#endif
+	struct timeval now;
 	struct sysinfo info;
 
 	if (gettimeofday(&now, NULL) != 0) {

--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -137,7 +137,6 @@ static void my_putstring(char *s)
 
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBNCURSESW) || defined(HAVE_LIBTERMCAP)
 static const char	*term="";
-static int		Slen;		/* strlen of Senter+Sexit */
 #endif
 
 static const char	*Senter="", *Sexit="";/* enter and exit standout mode */
@@ -304,7 +303,6 @@ int main(int argc, char **argv)
 		if (ret > 0) {
 			Senter = my_tgetstr("so","smso");
 			Sexit = my_tgetstr("se","rmso");
-			Slen = strlen(Senter) + strlen(Sexit);
 		}
 	}
 #endif

--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -77,7 +77,6 @@ static struct colinfo infos[] = {
 
 static int columns[NCOLS] = {-1};
 static int ncolumns;
-static int verbose;
 
 static int get_column_id(int num)
 {
@@ -543,7 +542,6 @@ int main(int argc, char **argv)
 			showdev = 1;
 			break;
 		case 'v':
-			verbose = 1;
 			break;
 		case 'V':
 			printf(UTIL_LINUX_VERSION);

--- a/sys-utils/lscpu-dmi.c
+++ b/sys-utils/lscpu-dmi.c
@@ -168,6 +168,7 @@ done:
 	return rc;
 }
 
+#if defined(__x86_64__) || defined(__i386__)
 static int hypervisor_decode_legacy(uint8_t *buf, const char *devmem)
 {
 	if (!checksum(buf, 0x0F))
@@ -177,6 +178,7 @@ static int hypervisor_decode_legacy(uint8_t *buf, const char *devmem)
 			 WORD(buf + 0x0C),
 		devmem);
 }
+#endif
 
 static int hypervisor_decode_smbios(uint8_t *buf, const char *devmem)
 {

--- a/sys-utils/switch_root.c
+++ b/sys-utils/switch_root.c
@@ -181,7 +181,8 @@ static int switchroot(const char *newroot)
 		if (pid <= 0) {
 			struct statfs stfs;
 			if (fstatfs(cfd, &stfs) == 0 &&
-			    (stfs.f_type == STATFS_RAMFS_MAGIC || stfs.f_type == STATFS_TMPFS_MAGIC))
+			    (stfs.f_type == (__SWORD_TYPE)STATFS_RAMFS_MAGIC ||
+			     stfs.f_type == (__SWORD_TYPE)STATFS_TMPFS_MAGIC))
 				recursiveRemove(cfd);
 			else
 				warn(_("old root filesystem is not an initramfs"));

--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -27,7 +27,7 @@ typedef struct {
 
 static int hlp_wordsize(void)
 {
-	printf("%lu\n", CHAR_BIT * sizeof(void*));
+	printf("%zu\n", CHAR_BIT * sizeof(void*));
 	return 0;
 }
 


### PR DESCRIPTION
Don't know whether you would fix all of them like this.

Some additional notes:
- sys-utils/losetup.c: "set but never used"
  ... maybe a good motivation to give some love to "losetup --verbose"
- sys-utils/switch_root.c:  "comparison between signed and unsigned"
  ... could be generally fixed in include/statfs_magic.h for a better future
- there is a one more serious warning on big endian systems but I don't see how this could happen:
  
  <pre>
  libblkid/src/superblocks/zfs.c: In function 'probe_zfs':
  libblkid/src/superblocks/zfs.c:214:27: warning: 'ub_offset' may be used uninitialized in this function [-Wmaybe-uninitialized]
  if (blkid_probe_set_magic(pr, ub_offset,
                           ^
  </pre>
