### PR TITLE
umount: Make sure exit code does not overflow

### DIFF
--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -646,6 +646,6 @@ int main(int argc, char **argv)
 	}
 
 	mnt_free_context(cxt);
-	return rc;
+	return (rc < 256) ? rc : 255;
 }
 


### PR DESCRIPTION
POSIX exit code is only 8-bit, and since umount sums up error codes, it can sometimes report success (exit code 0) even though a number of operations failed.

For example, running, in an empty directory:

```
 umount `seq 1 7`
```

returns 224 (7*32), since none of the 7 mount point exists but

```
 umount `seq 1 8`
```

returns 0 (8*32=256)

This patch clips the return value to 255.
