### PR TITLE
lib/loopdev.c: reset errno before strtol() call

### DIFF
--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -458,6 +458,7 @@ static int loop_scandir(const char *dirname, int **ary, int hasprefix)
 			/* /dev/loop/<N> */
 			char *end = NULL;
 
+			errno = 0;
 			n = strtol(d->d_name, &end, 10);
 			if (d->d_name == end || (end && *end) || errno)
 				continue;


### PR DESCRIPTION
Fixed unsuccessful attempt to find unused loop devices if 0-7 devices already used and /dev/loop directory exists.
It's my solution for Issue #99.
