### PR TITLE
fdisk: fdisk -l exits if it cannot open some of the devices

### DIFF
--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -672,8 +672,11 @@ static int is_ide_cdrom_or_tape(char *device)
 
 static void print_device_pt(struct fdisk_context *cxt, char *device)
 {
-	if (fdisk_context_assign_device(cxt, device, 1) != 0)	/* read-only */
-		err(EXIT_FAILURE, _("cannot open %s"), device);
+	if (fdisk_context_assign_device(cxt, device, 1) != 0) { /* read-only */
+		/* skip devices that cannot be opened for some reason */
+		warn(_("cannot open %s"), device);
+		return;
+	}
 
 	list_disk_geometry(cxt);
 


### PR DESCRIPTION
Now fdisk will print a warning, including the reason and contunue.

Singed-off-by: Boian Bonev bbonev@ipacct.com
