### PR TITLE
build-sys: fix double prefix with explict --libdir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ usrsbin_execdir='${exec_prefix}/sbin'
 AC_SUBST([usrsbin_execdir])
 
 AS_CASE([$libdir],
- ['${exec_prefix}/'* | '${prefix}/'* | /usr/*],
+ ['${exec_prefix}/'* | '${prefix}/'* | /usr/* | "${prefix}"/* ],
    [usrlib_execdir=$libdir],
  [usrlib_execdir='${exec_prefix}'$libdir]
 )


### PR DESCRIPTION
- with configure --prefix=$HOME --libdir=$HOME usrlib_execdir
  ends up being ${exec_prefix}/${libbir}, which is double-prefixed
- fix: use explict given ${libbir} if is matches ${prefix}/*

Signed-off-by: Christoph Junghans ottxor@gentoo.org
