### PR TITLE
cal: add landscape layout for yearly views

### DIFF
--- a/misc-utils/cal.1
+++ b/misc-utils/cal.1
@@ -65,6 +65,11 @@ Display Julian dates (days one-based, numbered from January 1).
 \fB\-y\fR, \fB\-\-year\fR
 Display a calendar for the whole year.
 .TP
+\fB\-l\fR, \fB\-\-landscape\fR
+Stretch the yearly calendar calendar into landscape layout
+(3x4 and 4x3 for Julian, 4x3 and 6x2 for regular). Can be used
+up to two times.
+.TP
 \fB\-w\fR, \fB\-\-week\fR[\fI=number\fR]
 Display week numbers in the calendar (US or ISO-8601).
 .TP


### PR DESCRIPTION
With the high availability of wide screens and high-resolution emulated
terminals and terminal window managers it's sometimes useful to change
the output of cal(1) yearly views to more stretched out ones
horizontally.

This patch adds a new -l/--landscape flag that stretches out the yearly
view to 3x4 and 4x3 months in Julian mode and 4x3 and 6x2 in regular
mode. The flag can be used up to two times.
