### PR TITLE
cal: `color` option documentation should match actual behaviour

### DIFF
--- a/misc-utils/cal.1
+++ b/misc-utils/cal.1
@@ -68,7 +68,7 @@ Display a calendar for the whole year.
 \fB\-w\fR, \fB\-\-week\fR[\fI=number\fR]
 Display week numbers in the calendar (US or ISO-8601).
 .TP
-\fB\-\-color\fR [\fIwhen\fR]
+\fB\-\-color\fR[\fI=when\fR]
 Colorize output.  The
 .I when
 can be


### PR DESCRIPTION
long-format `color` option uses conventional `=value` syntax, but this is incorrectly documented as `--color [value]`. the diff amends documentation to match reality. i don't believe there's any implication with regard to SUS standards.
