### PR TITLE
libfdisk: fix partition names on GNU Hurd.

### DIFF
--- a/libfdisk/src/utils.c
+++ b/libfdisk/src/utils.c
@@ -90,7 +90,11 @@ char *fdisk_partname(const char *dev, size_t partno)
 
 	w = strlen(dev);
 	if (isdigit(dev[w - 1]))
+#ifdef __GNU__
+		p = "s";
+#else
 		p = "p";
+#endif
 
 	/* devfs kludge - note: fdisk partition names are not supposed
 	   to equal kernel names, so there is no reason to do this */


### PR DESCRIPTION
Hi,
forwarding Debian bug https://bugs.debian.org/769897
On Hurd, e.g. on first ide disk hd0, first partition is hd0s1, currently called hd0p1 by *fdisk tools.

Thanks for considering.
