### PR TITLE
agetty: use getttynam() if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -586,7 +586,9 @@ AC_CHECK_FUNCS([openat fstatat unlinkat], [have_openat=yes], [have_openat=no])
 AC_CHECK_FUNCS([open_memstream], [have_open_memstream=yes],[have_open_memstream=no])
 AC_CHECK_FUNCS([reboot], [have_reboot=yes],[have_reboot=no])
 AC_CHECK_FUNCS([updwtmpx updwtmpx], [have_gnu_utmpx=yes], [have_gnu_utmpx=no])
+AC_CHECK_FUNCS([getttynam], [have_getttynam=yes], [have_getttynam=no])
 
+AM_CONDITIONAL([HAVE_GETTTYNAM], [test "x$have_getttynam" = xyes])
 AM_CONDITIONAL([HAVE_OPENAT], [test "x$have_openat" = xyes])
 
 have_setns_syscall="yes"

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -56,6 +56,10 @@
 # include <sys/param.h>
 #endif
 
+#ifdef HAVE_GETTTYNAM
+# include <ttyent.h>
+#endif
+
 #if defined(__FreeBSD_kernel__)
 # include <pty.h>
 # ifdef HAVE_UTMP_H
@@ -1159,6 +1163,15 @@ static void open_tty(char *tty, struct termios *tp, struct options *op)
 	memset(tp, 0, sizeof(struct termios));
 	if (tcgetattr(STDIN_FILENO, tp) < 0)
 		log_err(_("%s: failed to get terminal attributes: %m"), tty);
+
+#ifdef HAVE_GETTTYNAM
+	if (!op->term) {
+		struct ttyent *ent = getttynam(tty);
+		/* a bit nasty as it's never freed */
+		if (ent && ent->ty_type)
+			op->term = strdup(ent->ty_type);
+	}
+#endif
 
 #if defined (__s390__) || defined (__s390x__)
 	if (!op->term) {


### PR DESCRIPTION
/etc/ttys seems to be a rather archaic concept that is not meant to
exist on Linux. Nevertheless it does. glibc has getttynam() which
correctly parses /etc/ttys. So let's give it a try before falling back
to the built in defaults. One can set the terminal type for a
specific tty using e.g.:

echo 'ttyS0 "" xterm' > /etc/ttys