### PR TITLE
vipw: flush stdout before getting answer.

### DIFF
--- a/login-utils/vipw.c
+++ b/login-utils/vipw.c
@@ -353,6 +353,7 @@ int main(int argc, char *argv[])
 		 * which means they can be translated. */
 		printf(_("Would you like to edit %s now [y/n]? "), orig_file);
 
+		fflush(stdout);
 		if (fgets(response, sizeof(response), stdin) &&
 		    rpmatch(response) == RPMATCH_YES)
 			edit_file(1);


### PR DESCRIPTION
Otherwise the question is displayed only after the user presses Return,
and the program looks like it's hanging.

This happens at least on musl libc.

Reported by @loreb.

Signed-off-by: Érico Nogueira <erico.erc@gmail.com>