### PR TITLE
lsfd.1.adoc: Add missing underscores

### DIFF
--- a/misc-utils/lsfd.1.adoc
+++ b/misc-utils/lsfd.1.adoc
@@ -135,7 +135,7 @@ Name of the file.
 NLINK <__number__>::
 Link count.
 
-OWNER <_string_>::
+OWNER <__string__>::
 Owner of the file.
 
 PARTITION <__string__>::


### PR DESCRIPTION
The OWNER option in lsfd.1.adoc has single underscores (_string_) which appear literally in the rendered man page. Changed to double underscores.