### PR TITLE
ci: add a GHAction sending data to Coverity

### DIFF
--- a/.github/workflows/cibuild-setup-ubuntu.sh
+++ b/.github/workflows/cibuild-setup-ubuntu.sh
@@ -30,12 +30,15 @@ PACKAGES_OPTIONAL=(
 PACKAGES+=(linux-modules-extra-$(uname -r))
 
 COMPILER="${COMPILER:?}"
-COMPILER_VERSION="${COMPILER_VERSION:?}"
 RELEASE="$(lsb_release -cs)"
 
 bash -c "echo 'deb-src http://archive.ubuntu.com/ubuntu/ $RELEASE main restricted universe multiverse' >>/etc/apt/sources.list"
 
-if [[ "$COMPILER" == clang ]]; then
+# cov-build fails to compile util-linux when CC is set to gcc-*
+# so let's just install and use the default compiler
+if [[ "$COMPILER_VERSION" == "" ]]; then
+    PACKAGES+=("$COMPILER")
+elif [[ "$COMPILER" == clang ]]; then
     # Latest LLVM stack deb packages provided by https://apt.llvm.org/
     # Following snippet was borrowed from https://apt.llvm.org/llvm.sh
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -

--- a/.github/workflows/cibuild.sh
+++ b/.github/workflows/cibuild.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
  
+set -ex
+
 PHASES=(${@:-CONFIGURE MAKE INSTALL CHECK DISTCHECK})
 COMPILER="${COMPILER:?}"
 COMPILER_VERSION="${COMPILER_VERSION}"
 CFLAGS=(-O1 -g)
 CXXFLAGS=(-O1 -g)
 LDFLAGS=()
+COVERITY_SCAN_TOOL_BASE="/tmp/coverity-scan-analysis"
+
+# The project is still called "karelzak/util-linux" on Coverity
+# so it shouldn't be changed to "util-linux/util-linux"
+COVERITY_SCAN_PROJECT_NAME="karelzak/util-linux"
 
 if [[ "$COMPILER" == clang ]]; then
     CC="clang${COMPILER_VERSION:+-$COMPILER_VERSION}"
@@ -15,7 +22,59 @@ elif [[ "$COMPILER" == gcc ]]; then
     CXX="g++${COMPILER_VERSION:+-$COMPILER_VERSION}"
 fi
 
-set -ex
+function coverity_install_script {
+    set +x # This is supposed to hide COVERITY_SCAN_TOKEN
+    local platform=$(uname)
+    local tool_url="https://scan.coverity.com/download/${platform}"
+    local tool_archive="/tmp/cov-analysis-${platform}.tgz"
+
+    echo -e "\033[33;1mDownloading Coverity Scan Analysis Tool...\033[0m"
+    wget -nv -O $tool_archive $tool_url --post-data "project=$COVERITY_SCAN_PROJECT_NAME&token=$COVERITY_SCAN_TOKEN" || return
+
+    echo -e "\033[33;1mExtracting Coverity Scan Analysis Tool...\033[0m"
+    mkdir -p $COVERITY_SCAN_TOOL_BASE
+    pushd $COVERITY_SCAN_TOOL_BASE
+    tar xzf $tool_archive || return
+    popd
+    set -x
+}
+
+function run_coverity {
+    set +x # This is supposed to hide COVERITY_SCAN_TOKEN
+    local results_dir="cov-int"
+    local tool_dir=$(find $COVERITY_SCAN_TOOL_BASE -type d -name 'cov-analysis*')
+    local results_archive="analysis-results.tgz"
+    local sha=$(git rev-parse --short HEAD)
+    local author_email=$(git log -1 --pretty="%aE")
+    local response status_code
+
+    echo -e "\033[33;1mRunning Coverity Scan Analysis Tool...\033[0m"
+    COVERITY_UNSUPPORTED=1 $tool_dir/bin/cov-build --dir $results_dir sh -c "make -j && make -j check-programs" || return
+    $tool_dir/bin/cov-import-scm --dir $results_dir --scm git --log $results_dir/scm_log.txt || return
+
+    echo -e "\033[33;1mTarring Coverity Scan Analysis results...\033[0m"
+    tar czf $results_archive $results_dir || return
+
+    echo -e "\033[33;1mUploading Coverity Scan Analysis results...\033[0m"
+    response=$(curl \
+               --silent --write-out "\n%{http_code}\n" \
+               --form project=$COVERITY_SCAN_PROJECT_NAME \
+               --form token=$COVERITY_SCAN_TOKEN \
+               --form email=$author_email \
+               --form file=@$results_archive \
+               --form version=$sha \
+               --form description="Daily build" \
+               https://scan.coverity.com/builds)
+    printf "\033[33;1mThe response is\033[0m\n%s\n" "$response"
+    status_code=$(echo "$response" | sed -n '$p')
+    if [ "$status_code" != "200" ]; then
+        echo -e "\033[33;1mCoverity Scan upload failed: $(echo "$response" | sed '$d').\033[0m"
+        return 1
+    fi
+
+    echo -e "\n\033[33;1mCoverity Scan Analysis completed successfully.\033[0m"
+    set -x
+}
 
 for phase in "${PHASES[@]}"; do
     case $phase in
@@ -106,6 +165,10 @@ for phase in "${PHASES[@]}"; do
         ;;
     DISTCHECK)
         make distcheck
+        ;;
+    COVERITY)
+        coverity_install_script
+        run_coverity
         ;;
 
     *)

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,24 @@
+---
+name: Coverity
+
+on:
+  schedule:
+    # send data to Coverity daily at midnight
+    - cron:  '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository == 'util-linux/util-linux'
+    env:
+      COMPILER: gcc
+      COVERITY_SCAN_TOKEN: "${{ secrets.COVERITY_SCAN_TOKEN }}"
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v1
+      - name: Ubuntu setup
+        run: sudo -E .github/workflows/cibuild-setup-ubuntu.sh
+      - name: Configure
+        run: .github/workflows/cibuild.sh CONFIGURE
+      - name: Coverity
+        run: .github/workflows/cibuild.sh COVERITY

--- a/Documentation/howto-tests.txt
+++ b/Documentation/howto-tests.txt
@@ -139,7 +139,7 @@ lgtm CI - automatically executed security code analysis
 
 Coverity Scan
 
-    URL: https://scan.coverity.com/projects/util-linux-util-linux
+    URL: https://scan.coverity.com/projects/karelzak-util-linux
 
 Fossies codespell report
 


### PR DESCRIPTION
To get it to work a secret named COVERITY_SCAN_TOKEN should
be added to the util-linux repository:
https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository

It has to match the util-linux project token, which
can be found at
https://scan.coverity.com/projects/karelzak-util-linux?tab=project_settings

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>