### PR TITLE
sysfs: fallback for partitions not including parent name

### DIFF
--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -210,9 +210,10 @@ int sysfs_blkdev_is_partition_dirent(DIR *dir, struct dirent *d, const char *par
 	    d->d_type != DT_UNKNOWN)
 		return 0;
 #endif
+	size_t len = 0;
+
 	if (parent_name) {
 		const char *p = parent_name;
-		size_t len;
 
 		/* /dev/sda --> "sda" */
 		if (*parent_name == '/') {
@@ -223,14 +224,15 @@ int sysfs_blkdev_is_partition_dirent(DIR *dir, struct dirent *d, const char *par
 		}
 
 		len = strlen(p);
-		if (strlen(d->d_name) <= len)
-			return 0;
+		if ((strlen(d->d_name) <= len) || (strncmp(p, d->d_name, len) != 0))
+			len = 0;
+	}
 
+	if (len > 0) {
 		/* partitions subdir name is
 		 *	"<parent>[:digit:]" or "<parent>p[:digit:]"
 		 */
-		return strncmp(p, d->d_name, len) == 0 &&
-		       ((*(d->d_name + len) == 'p' && isdigit(*(d->d_name + len + 1)))
+		return ((*(d->d_name + len) == 'p' && isdigit(*(d->d_name + len + 1)))
 			|| isdigit(*(d->d_name + len)));
 	}
 


### PR DESCRIPTION
Because of the commit [libblkid: use /sys to read all block devices](https://github.com/util-linux/util-linux/commit/8d3f9430c59416e4c1eddc899578158a7a1ed414#diff-2376ac4742ecca128eea0f972266b72b02d8730bf7169dc67988f6444f357fc4R511-R512) tools like `fsck` are broken on systems not including the parent name in partition name. This happen on embedded devices what are using eMMC.
Like the parent name is `mmcblk0` and the partition is named in Android style like `system` or `data`.

This PR will check if the parent name is included in partition name at all, if not it fall back to the "old" method and the tools using function `sysfs_blkdev_is_partition_dirent` are working again.