### PR TITLE
Do not include sys/syscall.h if not available

### DIFF
--- a/include/fileutils.h
+++ b/include/fileutils.h
@@ -77,7 +77,7 @@ static inline struct dirent *xreaddir(DIR *dp)
 	return d;
 }
 
-#if defined(__linux__)
+#ifdef HAVE_SYS_SYSCALL_H
 # include <sys/syscall.h>
 # if defined(SYS_close_range)
 #  include <sys/types.h>
@@ -89,7 +89,7 @@ static inline int close_range(unsigned int first, unsigned int last, int flags)
 #  endif
 #  define HAVE_CLOSE_RANGE 1
 # endif	/* SYS_close_range */
-#endif	/* __linux__ */
+#endif	/* HAVE_SYS_SYSCALL_H */
 
 extern void ul_close_all_fds(unsigned int first, unsigned int last);
 

--- a/include/pidfd-utils.h
+++ b/include/pidfd-utils.h
@@ -1,7 +1,7 @@
 #ifndef UTIL_LINUX_PIDFD_UTILS
 #define UTIL_LINUX_PIDFD_UTILS
 
-#if defined(__linux__)
+#ifdef HAVE_SYS_SYSCALL_H
 # include <sys/syscall.h>
 # if defined(SYS_pidfd_send_signal) && defined(SYS_pidfd_open)
 #  include <sys/types.h>
@@ -24,5 +24,5 @@ static inline int pidfd_open(pid_t pid, unsigned int flags)
 #  define UL_HAVE_PIDFD 1
 
 # endif	/* SYS_pidfd_send_signal */
-#endif /* __linux__ */
+#endif /* HAVE_SYS_SYSCALL_H */
 #endif /* UTIL_LINUX_PIDFD_UTILS */

--- a/lib/cpuset.c
+++ b/lib/cpuset.c
@@ -20,7 +20,9 @@
 #include <errno.h>
 #include <string.h>
 #include <ctype.h>
+#ifdef HAVE_SYS_SYSCALL_H
 #include <sys/syscall.h>
+#endif
 
 #include "cpuset.h"
 #include "c.h"

--- a/lib/randutils.c
+++ b/lib/randutils.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
-#ifdef __linux__
+#ifdef HAVE_SYS_SYSCALL_H
 #include <sys/syscall.h>
 #endif
 #include "c.h"

--- a/schedutils/ionice.c
+++ b/schedutils/ionice.c
@@ -11,7 +11,9 @@
 #include <errno.h>
 #include <getopt.h>
 #include <unistd.h>
+#ifdef HAVE_SYS_SYSCALL_H
 #include <sys/syscall.h>
+#endif
 #include <ctype.h>
 
 #include "nls.h"

--- a/schedutils/sched_attr.h
+++ b/schedutils/sched_attr.h
@@ -68,7 +68,7 @@
 # define SCHED_FLAG_UTIL_CLAMP_MAX 0x40
 #endif
 
-#if defined (__linux__)
+#ifdef HAVE_SYS_SYSCALL_H
 # include <sys/syscall.h>
 #endif
 

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -71,7 +71,9 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#ifdef HAVE_SYS_SYSCALL_H
 #include <sys/syscall.h>
+#endif
 #include <time.h>
 #include <unistd.h>
 #include <inttypes.h>


### PR DESCRIPTION
Some platforms do not provide sys/syscall.h. The configure script already
checks for the existance of the file. Include sys/syscall.h only in case
HAVE_SYS_SYSCALL_H has been set.