### PR TITLE
loopdev: accept ENOSYS for LOOP_CONFIGURE

### DIFF
--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -1364,7 +1364,7 @@ int loopcxt_setup_device(struct loopdev_cxt *lc)
 	if (ioctl(dev_fd, LOOP_CONFIGURE, &lc->config) < 0) {
 		rc = -errno;
 		errsv = errno;
-		if (errno != EINVAL && errno != ENOTTY) {
+		if (errno != EINVAL && errno != ENOTTY && errno != ENOSYS) {
 			DBG(SETUP, ul_debugobj(lc, "LOOP_CONFIGURE failed: %m"));
 			goto err;
 		}


### PR DESCRIPTION
qemu returns this if it doesn't understand the ioctl. according to ioctl(2) it should actually return EINVAL, but considering that it's been doing this for at least 20 years already, I doubt there's much appetite for change, considering that it has a slightly better error message if propagated back to the user and changing it to EINVAL may break other programs.