### PR TITLE
wipefs, sfdisk man: Escape ((…)) in AsciiDoc

### DIFF
--- a/disk-utils/sfdisk.8.adoc
+++ b/disk-utils/sfdisk.8.adoc
@@ -366,7 +366,7 @@ The GPT header can later be restored by:
 
 ____
 dd  if=~/sfdisk-sda-0x00000200.bak  of=/dev/sda  \
-  seek=$((0x00000200))  bs=1  conv=notrunc
+  seek=$\((0x00000200))  bs=1  conv=notrunc
 ____
 
 Note that *sfdisk* since version 2.26 no longer provides the *-I* option to restore sectors. *dd*(1) provides all necessary functionality.

--- a/misc-utils/wipefs.8.adoc
+++ b/misc-utils/wipefs.8.adoc
@@ -97,7 +97,7 @@ Prints information about sda and all partitions on sda.
 *wipefs --all --backup /dev/sdb*::
 Erases all signatures from the device _/dev/sdb_ and creates a signature backup file _~/wipefs-sdb-<offset>.bak_ for each signature.
 
-*dd if=~/wipefs-sdb-0x00000438.bak of=/dev/sdb seek=$((0x00000438)) bs=1 conv=notrunc*::
+*dd if=~/wipefs-sdb-0x00000438.bak of=/dev/sdb seek=$\((0x00000438)) bs=1 conv=notrunc*::
 Restores an ext2 signature from the backup file _~/wipefs-sdb-0x00000438.bak_.
 
 == AUTHORS


### PR DESCRIPTION
In AsciiDoc, double parentheses are used to mark flow index terms, but in this document, their use is intended to be interpreted by the shell's arithmetic expansion.  By escaping them with a backslash in the AsciiDoc, they pass through as-is to the manpage and other targets.

So, instead of a rendered result of `dd if=~/wipefs-sdb-0x00000438.bak of=/dev/sdb seek=$0x00000438 bs=1 conv=notrunc`, we get `dd if=~/wipefs-sdb-0x00000438.bak of=/dev/sdb seek=$((0x00000438)) bs=1 conv=notrunc`.  

Seperately, when interpreted by a shell's arithmetic expansion, the $((0x00000438)) hex is converted to decimal 1080 `dd if=~/wipefs-sdb-0x00000438.bak of=/dev/sdb seek=1080 bs=1 conv=notrunc`