### PR TITLE
tests: (lsfd) make DGRAM socketpair to mitigate the change of protoname

### DIFF
--- a/tests/ts/lsfd/mkfds-socketpair
+++ b/tests/ts/lsfd/mkfds-socketpair
@@ -32,7 +32,7 @@ FD1=4
 EXPR=
 
 {
-    coproc MKFDS { "$TS_HELPER_MKFDS" socketpair $FD0 $FD1 socktype=STREAM; }
+    coproc MKFDS { "$TS_HELPER_MKFDS" socketpair $FD0 $FD1 socktype=DGRAM; }
     if read -u ${MKFDS[0]} PID; then
 	EXPR='(PID == '"${PID}"') and ((FD == '"$FD0"') or (FD == '"$FD1"'))'
 	${TS_CMD_LSFD} -n -o ASSOC,MODE,TYPE,SOURCE,PROTONAME -Q "${EXPR}"


### PR DESCRIPTION
    The protoname for a socket can be get from its xattr slot of
    /proc/$PID/fd/$FD.
    
    The protoname for (AF_UNIX, SOCK_STREAM) sockets was changed
    from "UNIX" to "UNIX-STREAM" in
    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=94531cfcbe79c3598acf96806627b2137ca32eb9
    
    As the result, the test case, mkfds-socketpair doesn't work well on a
    newer kernel.
    
    To mitigate the impact of the change in the kernel, use (AF_UNIX, SOCK_DGRAM)
    for making a socket pair.
    
    In the commit, the protoname of (AF_UNIX, SOCK_DGRAM) sockets was also changed
    to "UNIX-DGRAM". However, it was renamed back to "UNIX" in
    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0edf0824e0dc359ed76bf96af986e6570ca2c0b9
    
    Partially close #1511.
    
    Signed-off-by: Masatake YAMATO <yamato@redhat.com>
