### PR TITLE
Complete Linux-PAM compliance for forked child in su and login.

### DIFF
--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1533,6 +1533,9 @@ int main(int argc, char **argv)
 
 	child_argv[child_argc++] = NULL;
 
+	/* http://www.linux-pam.org/Linux-PAM-html/adg-interface-by-app-expected.html#adg-pam_end */
+	(void) pam_end(cxt.pamh, PAM_SUCCESS|PAM_DATA_SILENT);
+
 	execvp(child_argv[0], child_argv + 1);
 
 	if (!strcmp(child_argv[0], "/bin/sh"))

--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -1263,6 +1263,9 @@ int su_main(int argc, char **argv, int mode)
 	if (su->simulate_login && chdir(su->pwd->pw_dir) != 0)
 		warn(_("warning: cannot change directory to %s"), su->pwd->pw_dir);
 
+	/* http://www.linux-pam.org/Linux-PAM-html/adg-interface-by-app-expected.html#adg-pam_end */
+	(void) pam_end(su->pamh, PAM_SUCCESS|PAM_DATA_SILENT);
+
 	if (shell)
 		run_shell(su, shell, command, argv + optind, max(0, argc - optind));
 


### PR DESCRIPTION
As documented here:

http://www.linux-pam.org/Linux-PAM-html/adg-interface-by-app-expected.html#adg-pam_end

The child that is about to exec*() the user shell is supposed to pam_end()
with PAM_DATA_SILENT. This gives the modules a last chance to do a minor
cleanup of the module state before the user's shell is launched.

Signed-off-by: Andrew G. Morgan <morgan@kernel.org>