### PR TITLE
tests: (lsfd) normalize protoname before comparing

### DIFF
--- a/tests/ts/lsfd/mkfds-socketpair
+++ b/tests/ts/lsfd/mkfds-socketpair
@@ -24,6 +24,8 @@ ts_check_test_command "$TS_CMD_LSFD"
 
 ts_check_test_command "$TS_HELPER_MKFDS"
 
+ts_check_prog "sed"
+
 ts_cd "$TS_OUTDIR"
 
 PID=
@@ -35,7 +37,7 @@ EXPR=
     coproc MKFDS { "$TS_HELPER_MKFDS" socketpair $FD0 $FD1 socktype=DGRAM; }
     if read -u ${MKFDS[0]} PID; then
 	EXPR='(PID == '"${PID}"') and ((FD == '"$FD0"') or (FD == '"$FD1"'))'
-	${TS_CMD_LSFD} -n -o ASSOC,MODE,TYPE,SOURCE,PROTONAME -Q "${EXPR}"
+	${TS_CMD_LSFD} -n -o ASSOC,MODE,TYPE,SOURCE,PROTONAME -Q "${EXPR}" | sed -e 's/UNIX-DGRAM/UNIX/'
 	echo 'ASSOC,MODE,TYPE,SOURCE,PROTONAME': $?
 
 	kill -CONT ${PID}


### PR DESCRIPTION
This is a follow-up commit to a60ac11fe0087584f37329b4733edfade3452c64.

>    In the commit, the protoname of (AF_UNIX, SOCK_DGRAM) sockets was also
>    changed to "UNIX-DGRAM". However, it was renamed back to "UNIX" in
>    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0edf0824e0dc359ed76bf96af986e6570ca2c0b9

To make this test case more portable, this change makes the test case
accept "UINX-DGRAM" in addition to "UINX", too.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>