### PR TITLE
make lsns build to depend on kernel header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -457,6 +457,7 @@ have_linux_blkzoned_h=$ac_cv_header_linux_blkzoned_h
 have_linux_btrfs_h=$ac_cv_header_linux_btrfs_h
 have_linux_capability_h=$ac_cv_header_linux_capability_h
 have_linux_kcmp_h=$ac_cv_header_linux_kcmp_h
+have_linux_nsfs_h=$ac_cv_header_linux_nsfs_h
 have_linux_raw_h=$ac_cv_header_linux_raw_h
 have_linux_securebits_h=$ac_cv_header_linux_securebits_h
 have_linux_version_h=$ac_cv_header_linux_version_h
@@ -1871,10 +1872,15 @@ UL_REQUIRES_LINUX([lsipc])
 UL_REQUIRES_BUILD([lsipc], [libsmartcols])
 AM_CONDITIONAL([BUILD_LSIPC], [test "x$build_lsipc" = xyes])
 
-UL_BUILD_INIT([lsns], [check])
+AC_ARG_ENABLE([lsns],
+  AS_HELP_STRING([--disable-lsns], [do not build lsns]),
+  [], [UL_DEFAULT_ENABLE([lsns], [check])]
+)
+UL_BUILD_INIT([lsns])
 UL_REQUIRES_LINUX([lsns])
 UL_REQUIRES_BUILD([lsns], [libsmartcols])
 UL_REQUIRES_BUILD([lsns], [libmount])
+UL_REQUIRES_HAVE([lsns], [linux_nsfs_h], [linux/nsfs.h header file])
 AM_CONDITIONAL([BUILD_LSNS], [test "x$build_lsns" = xyes])
 
 UL_BUILD_INIT([renice], [yes])


### PR DESCRIPTION
Don't build `lsns` on missing kernel header.

Like 5d19f1dc9db0406597b928be2e7459c86e3881ff , but for `lsns`, which depends on `nsfs.h` kernel header (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/nsfs.h)

Without `nsfs.h` :
```
$ make
...
  CC       sys-utils/lsns-lsns.o
sys-utils/lsns.c: In function ‘add_namespace_for_nsfd’:
sys-utils/lsns.c:717:25: error: ‘NS_GET_NSTYPE’ undeclared (first use in this function)
  clone_type = ioctl(fd, NS_GET_NSTYPE);
                         ^
sys-utils/lsns.c:717:25: note: each undeclared identifier is reported only once for each function it appears in
sys-utils/lsns.c:724:23: error: ‘NS_GET_USERNS’ undeclared (first use in this function)
  fd_owner = ioctl(fd, NS_GET_USERNS);
                       ^
sys-utils/lsns.c:732:24: error: ‘NS_GET_PARENT’ undeclared (first use in this function)
  fd_parent = ioctl(fd, NS_GET_PARENT);
                        ^
sys-utils/lsns.c:741:12: error: ‘NS_GET_OWNER_UID’ undeclared (first use in this function)
  ioctl(fd, NS_GET_OWNER_UID, &ns->uid_fallback);
            ^
sys-utils/lsns.c: In function ‘interpolate_missing_namespaces’:
sys-utils/lsns.c:771:19: error: ‘NS_GET_PARENT’ undeclared (first use in this function)
   [RELA_PARENT] = NS_GET_PARENT,
                   ^
sys-utils/lsns.c:772:18: error: ‘NS_GET_USERNS’ undeclared (first use in this function)
   [RELA_OWNER] = NS_GET_USERNS
                  ^
```

PS: can we have centos-7 vm added to CI tests? 