### PR TITLE
Login with write permissions + read capabilities

### DIFF
--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -530,7 +530,7 @@ static void init_tty(struct login_context *cxt)
 	if (!cxt->tty_path || !*cxt->tty_path ||
 	    lstat(cxt->tty_path, &st) != 0 || !S_ISCHR(st.st_mode) ||
 	    (st.st_nlink > 1 && strncmp(cxt->tty_path, "/dev/", 5) != 0) ||
-	    access(cxt->tty_path, R_OK | W_OK) != 0) {
+	    access(cxt->tty_path, W_OK) != 0) {
 
 		syslog(LOG_ERR, _("FATAL: bad tty"));
 		sleepexit(EXIT_FAILURE);


### PR DESCRIPTION
On my RHEL 8.4 system, TTY devices have the following permissions:
````bash
$ sudo ls -al /dev/tty3
crw--w----. 1 root tty 4, 3 Nov 29 20:10 /dev/tty3
````

My application can read from and write to the TTY device because it belongs to the "tty" group (so can write) and has the CAP_DAC_READ_SEARCH capability (so can read). However, it does not run as the "root" user, and access(cxt->tty_path, R_OK | W_OK) always fails. The man page explains:

access() checks whether the calling process can access the file pathname. If pathname is a symbolic link, it is dereferenced.

The mode specifies the accessibility check(s) to be performed, and is either the value F_OK, or a mask consisting of the bitwise OR of one or more of R_OK, W_OK, and X_OK. F_OK tests for the existence of the file.  R_OK, W_OK, and X_OK test whether the file exists and grants read, write, and execute permissions, respectively.

The check is done using the calling process's real UID and GID, rather than the effective IDs as is done when actually attempting an operation (e.g., open(2)) on the file. Similarly, for the root user, the check uses the set of permitted capabilities rather than the set of effective capabilities; and **for non-root users, the check uses an empty set of capabilities**.

This means that login always fails with the "bad tty" error. I would like it if login could change to allow this use case, but I realize it's very unusual and not something you may want to support.

I kept the code change as minimal as possible, but some other options might be:

1) Change "R_OK | W_OK" to "F_OK" (just check existence of TTY instead of permissions)
2) Remove the call to access() completely
3) Add "&& !user_has_capabilities()" after the call to access (check the user's capabilities, only if the call to access() fails)

I am a little nervous about this change since the comment mentions a security issue here. But I think it's not an issue since login is no longer suid? Your review is appreciated.