### PR TITLE
Fix integer overflow for alpha like linux

### DIFF
--- a/sys-utils/swapon.c
+++ b/sys-utils/swapon.c
@@ -543,7 +543,7 @@ static int swapon_checks(const struct swapon_ctl *ctl, struct swap_device *dev)
 
 	/* test for holes by LBT */
 	if (S_ISREG(st.st_mode)) {
-		if (st.st_blocks * 512 < st.st_size) {
+		if (st.st_blocks * 512L < st.st_size) {
 			warnx(_("%s: skipping - it appears to have holes."),
 				dev->path);
 			goto err;


### PR DESCRIPTION
For alpha linux, the `struct stat` is a little different with other 64 bits architecture.

https://github.com/bminor/glibc/blob/bada2e312a8b94c5fc2f5571b249c71cb466a640/sysdeps/unix/sysv/linux/alpha/bits/struct_stat.h#L36-L42

https://github.com/bminor/glibc/blob/bada2e312a8b94c5fc2f5571b249c71cb466a640/sysdeps/unix/sysv/linux/alpha/bits/typesizes.h#L41-L42

The `st_blocks` is a `__U32_TYPE` member, which causes a integer overflow for swapon's file holes checking.

https://github.com/util-linux/util-linux/blob/2401078c9cf9ddec105e44af074cf2fcbd4ef153/sys-utils/swapon.c#L546

This PR should fix it.