### PR TITLE
uuidgen.1.adoc: mention uuidparse in SEE ALSO

### DIFF
--- a/misc-utils/uuidgen.1.adoc
+++ b/misc-utils/uuidgen.1.adoc
@@ -69,6 +69,7 @@ uuidgen --sha1 --namespace @dns --name "www.example.com"
 
 == SEE ALSO
 
+*uuidparse*(1),
 *libuuid*(3),
 link:https://tools.ietf.org/html/rfc4122[RFC 4122]
 


### PR DESCRIPTION
Hi

This indication mirrors the one found in uuidparse.1.adoc, pointing back to uuidgen.1.adoc

Having this mention is particularly useful in man systems that automatically add hypertext links to ease navigation between related command documentations.

Thanks.