### PR TITLE
man pages: Fix punctuation, wording and markup

### DIFF
--- a/disk-utils/sfdisk.8.adoc
+++ b/disk-utils/sfdisk.8.adoc
@@ -257,7 +257,7 @@ where each line fills one partition descriptor.
 
 Fields are separated by whitespace, comma (recommended) or semicolon possibly followed by whitespace; initial and trailing whitespace is ignored. Numbers can be octal, decimal or hexadecimal; decimal is the default. When a field is absent, empty or specified as '-' a default value is used. But when the *-N* option (change a single partition) is given, the default for each field is its previous value.
 
-The default value of _start_ is the first non-assigned sector aligned according to device I/O limits. The default start offset for the first partition is 1 MiB. The offset may be followed by the multiplicative suffixes (KiB, MiB, GiB, TiB, PiB, EiB, ZiB and YiB) then the number is interpreted as offset in bytes. Since v2.38 when the -N option (change a single partition) is given, a '{plus}' can be used to enlarge partition by move start of the partition if there is a free space before the partition.
+The default value of _start_ is the first non-assigned sector aligned according to device I/O limits. The default start offset for the first partition is 1 MiB. The offset may be followed by the multiplicative suffixes (KiB, MiB, GiB, TiB, PiB, EiB, ZiB and YiB) then the number is interpreted as offset in bytes. Since v2.38 when the *-N* option (change a single partition) is given, a '{plus}' can be used to enlarge partition by move start of the partition if there is a free space before the partition.
 
 //TRANSLATORS: Keep {plus} untranslated.
 The default value of _size_ indicates "as much as possible"; i.e., until the next partition or end-of-device. A numerical argument is by default interpreted as a number of sectors, however if the size is followed by one of the multiplicative suffixes (KiB, MiB, GiB, TiB, PiB, EiB, ZiB and YiB) then the number is interpreted as the size of the partition in bytes and it is then aligned according to the device I/O limits. A '{plus}' can be used instead of a number to enlarge the partition as much as possible. Note '{plus}' is equivalent to the default behaviour for a new partition; existing partitions will be resized as required.
@@ -375,7 +375,7 @@ ____
 ____
 
 
-It's also possible to use the *--backup* option to create the same backup immediately after startup for other sfdisk commands. For example, backup partition table before deleting all partitions from partition table:
+It's also possible to use the *--backup* option to create the same backup immediately after startup for other *sfdisk* commands. For example, backup partition table before deleting all partitions from partition table:
 ____
 *sfdisk --backup --delete /dev/sda*
 ____
@@ -429,7 +429,7 @@ Create three Linux partitions, with the default start, the size of the first two
 The same as the previous example, but in named-fields format.
 
 *echo -e 'type=swap' | sfdisk -N 3 /dev/sdc*::
-Set typf of the 3rd partition to 'swap'.
+Set type of the 3rd partition to 'swap'.
 
 *sfdisk --part-type /dev/sdc 3 swap*::
 The same as the previous example, but without script use.

--- a/misc-utils/findmnt.8.adoc
+++ b/misc-utils/findmnt.8.adoc
@@ -56,7 +56,7 @@ Imitate the output of *df*(1). This option is equivalent to *-o SOURCE,FSTYPE,SI
 The search direction, either *forward* or *backward*.
 
 *-e*, *--evaluate*::
-Convert all tags (LABEL, UUID, PARTUUID, or PARTLABEL) to the corresponding device names for the SOURCE column.  It's an unusual situation, but the same tag may be duplicated (used for more devices). For this purpose, there is SOURCES (pl.) column. This column displays by multi-line cell all devices where the tag is detected by libblkid. This option makes sense for fstab only.
+Convert all tags (LABEL, UUID, PARTUUID, or PARTLABEL) to the corresponding device names for the SOURCE column.  It's an unusual situation, but the same tag may be duplicated (used for more devices). For this purpose, there is SOURCES (pl.) column. This column displays by multi-line cell all devices where the tag is detected by libblkid. This option makes sense for _fstab_ only.
 
 *-F*, *--tab-file* _path_::
 Search in an alternative file. If used with *--fstab*, *--mtab* or *--kernel*, then it overrides the default paths. If specified more than once, then tree-like output is disabled (see the *--list* option).
@@ -149,7 +149,7 @@ Define the mount target. If _path_ is not a mountpoint file or directory, then *
 Limit the set of printed filesystems. More than one type may be specified in a comma-separated list. The list of filesystem types can be prefixed with *no* to specify the filesystem types on which no action should be taken. For more details see *mount*(8).
 
 *--tree*::
-Enable tree-like output if possible. The options is silently ignored for tables where is missing child-parent relation (e.g., fstab).
+Enable tree-like output if possible. The options is silently ignored for tables where is missing child-parent relation (e.g., _fstab_).
 
 *--shadowed*::
 Print only filesystems over-mounted by another filesystem.
@@ -184,10 +184,10 @@ specification, or the device path or mountpoint does not exist).
 == ENVIRONMENT
 
 *LIBMOUNT_FSTAB*=<path>::
-overrides the default location of the fstab file
+overrides the default location of the _fstab_ file
 
 *LIBMOUNT_MTAB*=<path>::
-overrides the default location of the mtab file
+overrides the default location of the _mtab_ file
 
 *LIBMOUNT_DEBUG*=all::
 enables libmount debug output

--- a/misc-utils/hardlink.1.adoc
+++ b/misc-utils/hardlink.1.adoc
@@ -24,14 +24,7 @@ hardlink - link multiple copies of a file
 
 *hardlink* is a tool which replaces copies of a file with hardlinks or copy-on-write clones, therefore saving space.
 
-*hardlink* creates binary tree from file sizes and after that, it compares files with the
-same sizes. There are two basic content comparison methods. *memcmp* method directly reads
-data blocks from files and compares them. The other methods are based on checksums (like SHA256),
-in this case for each data block is calculated checksum by Linux kernel crypto API, and this
-checksum is stored in userspace and used for files comparison. For each file is also cached
-"intro" buffer (32 bytes), this buffer is used independently on the comparison method and requested
-cache-size and io-size. The "intro" buffer dramatically reduces operations with data content as
-files are very often different from the beginning.
+*hardlink* creates a binary tree from file sizes and after that, it compares files with the same sizes. There are two basic content comparison methods. *memcmp* method directly reads data blocks from files and compares them. The other method is based on checksums (like SHA256), in this case for each data block is calculated checksum by Linux kernel crypto API, and this checksum is stored in userspace and used for files comparison. For each file is also cached "intro" buffer (32 bytes), this buffer is used independently on the comparison method and requested cache-size and io-size. The "intro" buffer dramatically reduces operations with data content as files are very often different from the beginning.
 
 == OPTIONS
 
@@ -49,9 +42,9 @@ Do not act, just print what would happen.
 
 *-y*, *--method* _name_::
 Set the file content comparison method. The currently supported methods are
-sha256, sha1, crc32c and memcpy. The default is sha256 and memcmp if Linux
+sha256, sha1, crc32c and memcmp. The default is sha256, or memcmp if Linux
 Crypto API is not available. The methods based on checksums are implemented in
-zero-copy way, in this case file, content is not copied to the userspace and all
+zero-copy way, in this case file contents are not copied to the userspace and all
 calculation is done in kernel.
 
 *--reflink*[=_when_]::
@@ -61,9 +54,9 @@ to use it with *--ignore-owner* and *--ignore-mode* options. This option implies
 *--skip-reflinks* to ignore already cloned files.
 +
 The optional argument _when_ can be *never*, *always*, or *auto*. If the _when_ argument
-is omitted, it defaults to *"auto"*, in this case, hardlink checks filesystem type and
+is omitted, it defaults to *auto*, in this case, *hardlink* checks filesystem type and
 uses reflinks on BTRFS and XFS only, and fallback to hardlinks when creating reflink is impossible.
-The argumen *always* disables filesystem type detection and fallback to hardlinks, in this case,
+The argument *always* disables filesystem type detection and fallback to hardlinks, in this case,
 only reflinks are allowed.
 
 *--skip-reflinks*::
@@ -106,7 +99,7 @@ The minimum size to consider. By default this is 1, so empty files will not be l
 The maximum size to consider. By default this is 0 and 0 has the special meaning of unlimited. The _size_ argument may be followed by the multiplicative suffixes KiB (=1024), MiB (=1024*1024), and so on for GiB, TiB, PiB, EiB, ZiB and YiB (the "iB" is optional, e.g., "K" has the same meaning as "KiB").
 
 *-b*, *--io-size* _size_::
-The size of the read() or sendfile() buffer used when comparing file contents.
+The size of the *read*(2) or *sendfile*(2) buffer used when comparing file contents.
 The _size_ argument may be followed by the multiplicative suffixes KiB, MiB,
 etc.  The "iB" is optional, e.g., "K" has the same meaning as "KiB". The
 default is 8KiB for memcmp method and 1MiB for the other methods. The only
@@ -116,7 +109,7 @@ to fit a number of cached content checksums.
 
 *-r*, *--cache-size* _size_::
 The size of the cache for content checksums. All non-memcmp methods calculate checksum for each
-file content block (see --io-size), these checksums are cached for the next comparison. The
+file content block (see *--io-size*), these checksums are cached for the next comparison. The
 size is important for large files or a large sets of files of the same size. The default is
 10MiB.
 

--- a/misc-utils/lsfd.1.adoc
+++ b/misc-utils/lsfd.1.adoc
@@ -69,7 +69,7 @@ stage of processing than the *-Q* option.
 Print only the files matching the condition represented by the _expr_.
 See also *FILTER EXAMPLES*.
 
-*-C*, *--counter* _label_:_filter_expr_::
+*-C*, *--counter* __label__:__filter_expr__::
 Define a custom counter used in *--summary* output. *lsfd* makes a
 counter named _label_. During collect information, *lsfd* counts files
 matching _filter_expr_, and stores the counted number to the

--- a/sys-utils/adjtime_config.5.adoc
+++ b/sys-utils/adjtime_config.5.adoc
@@ -22,7 +22,7 @@ The file is usually located in _/etc_, but tools like *hwclock*(8) or *rtcwake*(
 
 The Hardware Clock is usually not very accurate. However, much of its inaccuracy is completely predictable - it gains or loses the same amount of time every day. This is called systematic drift. The util *hwclock*(8) keeps the file _/etc/adjtime_, that keeps some historical information. For more details see "*The Adjust Function*" and "*The Adjtime File*" sections from *hwclock*(8) man page.
 
-The format of the adjtime file is, in ASCII.
+The _adjtime_ file is formatted in ASCII.
 
 === First line
 

--- a/sys-utils/blkzone.8.adoc
+++ b/sys-utils/blkzone.8.adoc
@@ -77,7 +77,7 @@ The command *blkzone close* is used to close one or more zones. Unlike *sg_zone*
 
 The command *blkzone finish* is used to finish (transition to full condition) one or more zones. Unlike *sg_zone*(8), finish action, this command operates from the block layer and can finish a range of zones.
 
-By default, the reset, open, close and finish commands will operate from the zone at device sector 0 and operate on all zones. Options may be used to modify this behavior as explained below.
+By default, the *reset*, *open*, *close* and *finish* commands will operate from the zone at device sector 0 and operate on all zones. Options may be used to modify this behavior as explained below.
 
 == OPTIONS
 

--- a/sys-utils/fstrim.8.adoc
+++ b/sys-utils/fstrim.8.adoc
@@ -57,7 +57,7 @@ Verbose execution. With this option *fstrim* will output the number of bytes pas
 *fstrim* will report the same potential discard bytes each time, but only sectors which had been written to between the discards would actually be discarded by the storage device. Further, the kernel block layer reserves the right to adjust the discard ranges to fit raid stripe geometry, non-trim capable devices in a LVM setup, etc. These reductions would not be reflected in fstrim_range.len (the *--length* option).
 
 *--quiet-unsupported*::
-Suppress error messages if trim operation (ioctl) is unsupported. This option is meant to be used in systemd service file or in cron scripts to hide warnings that are result of known problems, such as NTFS driver reporting _Bad file descriptor_ when device is mounted read-only, or lack of file system support for ioctl FITRIM call. This option also cleans exit status when unsupported filesystem specified on fstrim command line.
+Suppress error messages if trim operation (ioctl) is unsupported. This option is meant to be used in *systemd* service file or in *cron*(8) scripts to hide warnings that are result of known problems, such as NTFS driver reporting _Bad file descriptor_ when device is mounted read-only, or lack of file system support for ioctl _FITRIM_ call. This option also cleans exit status when unsupported filesystem specified on *fstrim* command line.
 
 *-V*, *--version*::
 Display version information and exit.

--- a/sys-utils/hwclock.8.adoc
+++ b/sys-utils/hwclock.8.adoc
@@ -359,7 +359,7 @@ If this variable is set its value takes precedence over the system configured ti
 == FILES
 
 _{ADJTIME_PATH}_::
-The configuration and state file for hwclock. See also *adjtime_config*(5).
+The configuration and state file for *hwclock*. See also *adjtime_config*(5).
 
 _/etc/localtime_::
 The system timezone file.

--- a/sys-utils/irqtop.1.adoc
+++ b/sys-utils/irqtop.1.adoc
@@ -26,7 +26,7 @@ The default output is subject to change. So whenever possible, you should avoid 
 Specify which output columns to print. Use *--help* to get a list of all supported columns. The default list of columns may be extended if list is specified in the format _+list_.
 
 *-c*, *--cpu-stat* _mode_::
-Show per-cpu statistics by specified option, available options: auto, enable, disable. The default option *auto* detects the width of window, then shows the per-cpu statistics if the width of window is large enouth to show a full line of statistics.
+Show per-cpu statistics by specified mode. Available modes are: *auto*, *enable*, *disable*. The default option *auto* detects the width of window, then shows the per-cpu statistics if the width of window is large enouth to show a full line of statistics.
 
 *-d*, *--delay* _seconds_::
 Update interrupt output every _seconds_ intervals.

--- a/sys-utils/lsns.8.adoc
+++ b/sys-utils/lsns.8.adoc
@@ -65,10 +65,7 @@ Do not use multi-line text in columns.
 
 *-T*, *--tree* _rel_::
 Use tree-like output format.
-If *process* is given as _rel_, print proecss tree(s) in each name space. This is default when *--tree* is not specified.
-If *parent* is given, print tree(s) constructed by the parent/child relationship.
-If *owner* is given, print tree(s) constructed by the owner/owned relationship.
-*owner* is used as default when _rel_ is omitted.
+If *process* is given as _rel_, print process tree(s) in each name space. This is default when *--tree* is not specified. If *parent* is given, print tree(s) constructed by the parent/child relationship. If *owner* is given, print tree(s) constructed by the owner/owned relationship. *owner* is used as default when _rel_ is omitted.
 
 
 *-V*, *--version*::

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -301,11 +301,11 @@ Command-line options available for the *mount* command are:
 *-a*, *--all*::
 Mount all filesystems (of the given types) mentioned in _fstab_ (except for those whose line contains the *noauto* keyword). The filesystems are mounted following their order in _fstab_. The *mount* command compares filesystem source, target (and fs root for bind mount or btrfs) to detect already mounted filesystems. The kernel table with already mounted filesystems is cached during *mount --all*. This means that all duplicated _fstab_ entries will be mounted.
 +
-The correct functionality depends on /proc (to detect already mounted filesystems) and on /sys (to evaluate filesystem tags like UUID= or LABEL=). It's strongly recommended to mount /proc and /sys filesystems before *mount -a* is executed, or keep /proc and /sys at the beginning of fstab.
+The correct functionality depends on _/proc_ (to detect already mounted filesystems) and on _/sys_ (to evaluate filesystem tags like UUID= or LABEL=). It's strongly recommended to mount _/proc_ and _/sys_ filesystems before *mount -a* is executed, or keep /proc and /sys at the beginning of _fstab_.
 +
 The option *--all* is possible to use for remount operation too. In this case all filters (*-t* and *-O*) are applied to the table of already mounted filesystems.
 +
-Since version 2.35 is possible to use the command line option *-o* to alter mount options from _fstab_ (see also *--options-mode*).
+Since version 2.35 it is possible to use the command line option *-o* to alter mount options from _fstab_ (see also *--options-mode*).
 +
 Note that it is a bad practice to use *mount -a* for _fstab_ checking. The recommended solution is *findmnt --verify*.
 
@@ -571,7 +571,7 @@ Do not use the lazytime feature.
 Honor set-user-ID and set-group-ID bits or file capabilities when executing programs from this filesystem.
 
 *nosuid*::
-Do not honor set-user-ID and set-group-ID bits or file capabilities when executing programs from this filesystem. In addition, SELinux domain transitions require permission nosuid_transition, which in turn needs also policy capability nnp_nosuid_transition.
+Do not honor set-user-ID and set-group-ID bits or file capabilities when executing programs from this filesystem. In addition, SELinux domain transitions require permission _nosuid_transition_, which in turn needs also policy capability _nnp_nosuid_transition_.
 
 *silent*::
 Turn on the silent flag.
@@ -1103,7 +1103,7 @@ Note: the mount options __index=off,nfs_export=on__ are conflicting for a
 read-write mount and will result in an error.
 --
 
-*xinfo=*{**on**|**off**|**auto**}::
+*xino=*{**on**|**off**|**auto**}::
 The "xino" feature composes a unique object identifier from the real object st_ino and an underlying fsid index. The "xino" feature uses the high inode number bits for fsid, because the underlying filesystems rarely use the high inode number bits. In case the underlying inode number does overflow into the high xino bits, overlay filesystem will fall back to the non xino behavior for that inode.
 +
 For a detailed description of the effect of this option please refer to https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html?highlight=overlayfs

--- a/sys-utils/nsenter.1.adoc
+++ b/sys-utils/nsenter.1.adoc
@@ -119,7 +119,7 @@ Set the root directory. If no directory is specified, set the root directory to 
 Set the working directory. If no directory is specified, set the working directory to the working directory of the target process. If directory is specified, set the working directory to the specified directory. The specified _directory_ is open before it switches to the requested namespaces, it means the specified directory works as "tunnel" to the current namespace. See also *--wdns*.
 
 *-W*, *--wdns*[=_directory_]::
-Set the working directory. The _directory_ is open after switch to the requested namespaces and after chroot call. The options *--wd* and *--wdns* are mutually exclusive.
+Set the working directory. The _directory_ is open after switch to the requested namespaces and after *chroot*(2) call. The options *--wd* and *--wdns* are mutually exclusive.
 
 *-F*, *--no-fork*::
 Do not fork before exec'ing the specified program. By default, when entering a PID namespace, *nsenter* calls *fork* before calling *exec* so that any children will also be in the newly entered PID namespace.


### PR DESCRIPTION
With the latest man page changes and additions, some wrong punctuation, markup, wording and typos need to be fixed again.

From mount.8.adoc:

```
*exec*::
Permit execution of binaries.
```

I think it doesn't refer to binaries only; merely it also includes other types of executable files (scripts etc.). Then we should write something like:

*exec*::
Permit execution of binaries and other executable files like scripts.




