### PR TITLE
fdisk: open device in nonblock mode

### DIFF
--- a/disk-utils/fdisk-list.c
+++ b/disk-utils/fdisk-list.c
@@ -26,7 +26,7 @@ static int is_ide_cdrom_or_tape(char *device)
 {
 	int fd, ret;
 
-	if ((fd = open(device, O_RDONLY)) < 0)
+	if ((fd = open(device, O_RDONLY|O_NONBLOCK)) < 0)
 		return 0;
 	ret = blkdev_is_cdrom(fd);
 

--- a/lib/ismounted.c
+++ b/lib/ismounted.c
@@ -347,7 +347,7 @@ int check_mount_point(const char *device, int *mount_flags,
 		if ((stat(device, &st_buf) != 0) ||
 		    !S_ISBLK(st_buf.st_mode))
 			return 0;
-		fd = open(device, O_RDONLY|O_EXCL|O_CLOEXEC);
+		fd = open(device, O_RDONLY|O_EXCL|O_CLOEXEC|O_NONBLOCK);
 		if (fd < 0) {
 			if (errno == EBUSY)
 				*mount_flags |= MF_BUSY;


### PR DESCRIPTION
When autoclose is set (kernel default) opening a CD-rom
device causes the tray to close.

The fdisk command is also used extensively in scripts, so
it may also interfere with the user's operation of the CD-rom hardware.

Signed-off-by: changlianzhi <changlianzhi@uniontech.com>