### PR TITLE
Return immediately when quit is seen

### DIFF
--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -894,6 +894,7 @@ static struct number_command read_command(struct more_control *ctl)
 		case 'q':
 		case 'Q':
 			cmd.key = more_kc_quit;
+			return cmd;
 			break;
 		case 'f':
 		case CTRL('F'):


### PR DESCRIPTION
When a quit character is seen, immediately return that command, as it is the correct operation to perform in this case.

A bigger fix is needed here, in that we need to have a *queue* of operations to perform, rather than a single one