### PR TITLE
Remove duplicate 'setlocale' call in look.c

### DIFF
--- a/misc-utils/look.c
+++ b/misc-utils/look.c
@@ -102,8 +102,6 @@ main(int argc, char *argv[])
 	textdomain(PACKAGE);
 	close_stdout_atexit();
 
-	setlocale(LC_ALL, "");
-
 	if ((file = getenv("WORDLIST")) && !access(file, R_OK))
 		/* use the WORDLIST */;
 	else


### PR DESCRIPTION
Co-authored by: khaleesi <contact@khaleesicodes.com>
Co-authored by: stoeckmann <tobias@stoeckmann.org>