### PR TITLE
fdisk: when use fdisk -l, open device in nonblock mode

### DIFF
--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -806,7 +806,7 @@ static fdisk_sector_t get_dev_blocks(char *dev)
 	int fd, ret;
 	fdisk_sector_t size;
 
-	if ((fd = open(dev, O_RDONLY)) < 0)
+	if ((fd = open(dev, O_RDONLY|O_NONBLOCK)) < 0)
 		err(EXIT_FAILURE, _("cannot open %s"), dev);
 	ret = blkdev_get_sectors(fd, (unsigned long long *) &size);
 	close(fd);


### PR DESCRIPTION
When autoclose is set (kernel default) opening a CD-rom
device causes the tray to close.

Signed-off-by: lishengyu <lishengyu@uniontech.com>