### PR TITLE
agetty: resolve tty name when stdin is specified

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -2794,8 +2794,18 @@ static void output_special_char(struct issue *ie,
 		break;
 	}
 	case 'l':
-		fprintf (ie->output, "%s", op->tty);
+	{
+		const char *name = op->tty;
+		if (strcmp(op->tty, "-") == 0) {
+			/* try to resolve the name of the tty associated to standard input. */
+			const char *ttypath = ttyname(STDIN_FILENO);
+			if (ttypath != NULL) {
+				name = (strncmp(ttypath, "/dev/", 5) == 0) ? ttypath + 5 : ttypath;
+			}
+		}
+		fprintf (ie->output, "%s", name);
 		break;
+	}
 	case 'b':
 	{
 		const speed_t speed = cfgetispeed(tp);


### PR DESCRIPTION
Using a "\l" escape code in the issuers file should show the terminal name. However, when "-" (standard input) was specified as a tty port, agetty always showed a literal "-", even when stdin was associated to a /dev/ttyN device.

Try to resolve the name of the terminal associated with the standard input through `ttyname(STDIN_FILENO)`. Strip the "/dev/" prefix if possible, so `agetty tty2` and `agetty -` with `stdin = /dev/tty2` behave equivalently.

This is motivated by systemd v250, which always opens ttys by itself and passes them to agetty through stdin. This made terminals hard to differentiate, as agetty was not displaying the corresponding terminal name.
See: systemd/systemd@b4bf9007cbee7dc0b1356897344ae2a7890df84c

Fixes: #1546