### PR TITLE
losetup: Add missing pipe to man example for setting up loop device

### DIFF
--- a/sys-utils/losetup.8.adoc
+++ b/sys-utils/losetup.8.adoc
@@ -30,7 +30,7 @@ Detach all associated loop devices:
 
 Set up a loop device:
 
-*losetup* [*-o* _offset_] [*--sizelimit* _size_] [*--sector-size* _size_] [*-Pr*] [*--show*] *-f* _loopdev file_
+*losetup* [*-o* _offset_] [*--sizelimit* _size_] [*--sector-size* _size_] [*-Pr*] [*--show*] *-f*|_loopdev file_
 
 Resize a loop device:
 


### PR DESCRIPTION
"-f" and "loopdev" cannot be used together, the pipe was lost
when converting the man pages to asciidoc.