### PR TITLE
su: use LOG_PID for syslog

### DIFF
--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -288,7 +288,7 @@ static void log_syslog(struct su_context *su, bool successful)
 {
 	DBG(LOG, ul_debug("syslog logging"));
 
-	openlog(program_invocation_short_name, 0, LOG_AUTH);
+	openlog(program_invocation_short_name, LOG_PID, LOG_AUTH);
 	syslog(LOG_NOTICE, "%s(to %s) %s on %s",
 	       successful ? "" :
 	       su->runuser ? "FAILED RUNUSER " : "FAILED SU ",


### PR DESCRIPTION
Enable PID in syslog lines for `su`.

In Gentoo Linux, we recently switched `su` providers from
shadow to util-linux.

It was notiiced that syslog output differs slightly
with util-linux (no PID):
```
Jan  7 20:00:50 localhost su: (to root) root on pts/5
Jan  7 20:00:50 localhost su: pam_unix(su:session): session opened for user root(uid=0) by sam(uid=0)
```
... whereas shadow's `su` gave (with PID):
```
Jan  7 20:52:50 localhost su[22245]: Successful su for root by root
Jan  7 20:52:50 localhost su[22245]: + /dev/pts/5 root:root
```

This change enables PID logging to give shadow-like syslog
output for `su`:
```
Jan  7 20:54:32 localhost su[10827]: (to root) root on pts/6
Jan  7 20:54:32 localhost su[10827]: pam_unix(su:session): session opened for user root(uid=0) by sam(uid=0)
```

Signed-off-by: Sam James <sam@gentoo.org>