### PR TITLE
lspcu: Print dummy modelname if none present

### DIFF
--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -859,8 +859,7 @@ print_summary_cputype(struct lscpu_cxt *cxt,
 		     struct libscols_table *tb,
 		     struct libscols_line *sec)
 {
-	if (ct->modelname)
-		sec = add_summary_s(tb, sec, _("Model name:"), ct->modelname);
+	sec = add_summary_s(tb, sec, _("Model name:"), ct->modelname ? ct->modelname : "-");
 	if (ct->bios_modelname)
 		add_summary_s(tb, sec, _("BIOS Model name:"), ct->bios_modelname);
 	if (ct->bios_family)


### PR DESCRIPTION
The logic in print_summary_cputype() starts a new hierarchy level under
the CPUs "Model name" entry. If the model is unknown the hierarchy level
will be skipped. This is visually confusing in the human-readable
version and changes the schema of the JSON tree.