### PR TITLE
meson: do not generate fstrim.service if we do not have systemd

### DIFF
--- a/sys-utils/meson.build
+++ b/sys-utils/meson.build
@@ -220,12 +220,14 @@ if LINUX
   ]
 endif
 
-fstrim_service = configure_file(
-  input : 'fstrim.service.in',
-  output : 'fstrim.service',
-  configuration : conf)
+if systemd.found()
+  fstrim_service = configure_file(
+    input : 'fstrim.service.in',
+    output : 'fstrim.service',
+    configuration : conf)
 
-install_data(fstrim_service,
-             install_dir : systemdsystemunitdir)
-install_data('fstrim.timer',
-             install_dir : systemdsystemunitdir)
+  install_data(fstrim_service,
+               install_dir : systemdsystemunitdir)
+  install_data('fstrim.timer',
+               install_dir : systemdsystemunitdir)
+endif


### PR DESCRIPTION
When systemd is disabled, the variable `systemdsystemunitdir` is
missing, and thus we cannot install fstrim.service to it.

This commit simply disables installing this service if systemd is not
found or disabled.

Signed-off-by: Martin Roukala (né Peres) <martin.roukala@mupuf.org>