### PR TITLE
hwclock: implement getting/setting of RTC parameters

### DIFF
--- a/bash-completion/hwclock
+++ b/bash-completion/hwclock
@@ -19,6 +19,10 @@ _hwclock_module()
 			COMPREPLY=( $(compgen -W "year" -- $cur) )
 			return 0
 			;;
+		'--param-get')
+			COMPREPLY=( $(compgen -W "param" -- $cur) )
+			return 0
+			;;
 		'-h'|'-?'|'--help'|'-v'|'-V'|'--version')
 			return 0
 			;;
@@ -44,6 +48,7 @@ _hwclock_module()
 				--date
 				--delay
 				--epoch
+				--param-get
 				--update-drift
 				--noadjfile
 				--adjfile

--- a/bash-completion/hwclock
+++ b/bash-completion/hwclock
@@ -23,6 +23,10 @@ _hwclock_module()
 			COMPREPLY=( $(compgen -W "param" -- $cur) )
 			return 0
 			;;
+		'--param-set')
+			COMPREPLY=( $(compgen -W "param=value" -- $cur) )
+			return 0
+			;;
 		'-h'|'-?'|'--help'|'-v'|'-V'|'--version')
 			return 0
 			;;
@@ -49,6 +53,7 @@ _hwclock_module()
 				--delay
 				--epoch
 				--param-get
+				--param-set
 				--update-drift
 				--noadjfile
 				--adjfile

--- a/sys-utils/hwclock.8.adoc
+++ b/sys-utils/hwclock.8.adoc
@@ -48,6 +48,11 @@ The RTC driver attempts to guess the correct epoch value, so setting it may not 
 +
 This epoch value is used whenever *hwclock* reads or sets the Hardware Clock on an Alpha machine. For ISA machines the kernel uses the fixed Hardware Clock epoch of 1900.
 
+**--param-get=**__parameter__; **--param-set=**__parameter__=__value__::
+Read and set the RTC's parameter. This is useful, for example, to retrieve the RTC's feature or set the RTC's Backup Switchover Mode.
++
+_parameter_ is either a numeric RTC parameter value (see the Kernel's _include/uapi/linux/rtc.h_) or an alias. See *--help* for a list of valid aliases. _parameter_ and _value_, if prefixed with 0x, are interpreted as hexadecimal, otherwise decimal values.
+
 *--predict*::
 Predict what the Hardware Clock will read in the future based upon the time given by the *--date* option and the information in _{ADJTIME_PATH}_. This is useful, for example, to account for drift when setting a Hardware Clock wakeup (aka alarm). See *rtcwake*(8).
 +

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -1169,41 +1169,55 @@ usage(void)
 	puts(_("Time clocks utility."));
 
 	fputs(USAGE_FUNCTIONS, stdout);
-	puts(_(" -r, --show           display the RTC time"));
-	puts(_("     --get            display drift corrected RTC time"));
-	puts(_("     --set            set the RTC according to --date"));
-	puts(_(" -s, --hctosys        set the system time from the RTC"));
-	puts(_(" -w, --systohc        set the RTC from the system time"));
-	puts(_("     --systz          send timescale configurations to the kernel"));
-	puts(_(" -a, --adjust         adjust the RTC to account for systematic drift"));
+	puts(_(" -r, --show                      display the RTC time"));
+	puts(_("     --get                       display drift corrected RTC time"));
+	puts(_("     --set                       set the RTC according to --date"));
+	puts(_(" -s, --hctosys                   set the system time from the RTC"));
+	puts(_(" -w, --systohc                   set the RTC from the system time"));
+	puts(_("     --systz                     send timescale configurations to the kernel"));
+	puts(_(" -a, --adjust                    adjust the RTC to account for systematic drift"));
 #if defined(__linux__) && defined(__alpha__)
-	puts(_("     --getepoch       display the RTC epoch"));
-	puts(_("     --setepoch       set the RTC epoch according to --epoch"));
+	puts(_("     --getepoch                  display the RTC epoch"));
+	puts(_("     --setepoch                  set the RTC epoch according to --epoch"));
 #endif
-	puts(_("     --predict        predict the drifted RTC time according to --date"));
+	puts(_("     --predict                   predict the drifted RTC time according to --date"));
 	fputs(USAGE_OPTIONS, stdout);
-	puts(_(" -u, --utc            the RTC timescale is UTC"));
-	puts(_(" -l, --localtime      the RTC timescale is Local"));
+	puts(_(" -u, --utc                       the RTC timescale is UTC"));
+	puts(_(" -l, --localtime                 the RTC timescale is Local"));
 #ifdef __linux__
 	printf(_(
-	       " -f, --rtc <file>     use an alternate file to %1$s\n"), _PATH_RTC_DEV);
+	       " -f, --rtc <file>                use an alternate file to %1$s\n"), _PATH_RTC_DEV);
 #endif
 	printf(_(
-	       "     --directisa      use the ISA bus instead of %1$s access\n"), _PATH_RTC_DEV);
-	puts(_("     --date <time>    date/time input for --set and --predict"));
-	puts(_("     --delay <sec>    delay used when set new RTC time"));
+	       "     --directisa                 use the ISA bus instead of %1$s access\n"), _PATH_RTC_DEV);
+	puts(_("     --date <time>               date/time input for --set and --predict"));
+	puts(_("     --delay <sec>               delay used when set new RTC time"));
 #if defined(__linux__) && defined(__alpha__)
-	puts(_("     --epoch <year>   epoch input for --setepoch"));
+	puts(_("     --epoch <year>              epoch input for --setepoch"));
 #endif
-	puts(_("     --update-drift   update the RTC drift factor"));
+	puts(_("     --update-drift              update the RTC drift factor"));
 	printf(_(
-	       "     --noadjfile      do not use %1$s\n"), _PATH_ADJTIME);
+	       "     --noadjfile                 do not use %1$s\n"), _PATH_ADJTIME);
 	printf(_(
-	       "     --adjfile <file> use an alternate file to %1$s\n"), _PATH_ADJTIME);
-	puts(_("     --test           dry run; implies --verbose"));
-	puts(_(" -v, --verbose        display more details"));
+	       "     --adjfile <file>            use an alternate file to %1$s\n"), _PATH_ADJTIME);
+	puts(_("     --test                      dry run; implies --verbose"));
+	puts(_(" -v, --verbose                   display more details"));
+
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(22));
+	printf(USAGE_HELP_OPTIONS(33));
+
+	fputs(USAGE_ARGUMENTS, stdout);
+	puts(_(" <param> is either a numeric RTC parameter value or one of these aliases:"));
+
+	while (param->name) {
+		printf(_("   %1$s: %2$s (0x%3$x)\n"), param->name, param->help, param->id);
+		param++;
+	}
+
+	puts(_("   See Kernel's include/uapi/linux/rtc.h for paramters and values."));
+	fputs(USAGE_ARG_SEPARATOR, stdout);
+	puts(_(" <param> and <value> accept hexadecimal values if prefixed with 0x, otherwise decimal."));
+
 	printf(USAGE_MAN_TAIL("hwclock(8)"));
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/hwclock.h
+++ b/sys-utils/hwclock.h
@@ -31,6 +31,7 @@ struct hwclock_control {
 	char *rtc_dev_name;
 #endif
 	char *param_get_option;
+	char *param_set_option;
 	unsigned int
 		hwaudit_on:1,
 		adjust:1,
@@ -88,6 +89,7 @@ struct rtc_param {
 };
 
 #define RTC_PARAM_GET	_IOW('p', 0x13, struct rtc_param)
+#define RTC_PARAM_SET	_IOW('p', 0x14, struct rtc_param)
 
 #define RTC_PARAM_FEATURES		0
 #define RTC_PARAM_CORRECTION		1
@@ -107,6 +109,7 @@ static struct hwclock_param hwclock_params[] = {
 };
 
 extern int get_param_rtc(const struct hwclock_control *ctl, struct rtc_param *param);
+extern int set_param_rtc(const struct hwclock_control *ctl);
 
 extern void __attribute__((__noreturn__))
 hwclock_exit(const struct hwclock_control *ctl, int status);

--- a/sys-utils/hwclock.h
+++ b/sys-utils/hwclock.h
@@ -9,6 +9,7 @@
 
 #include "c.h"
 #include "debug.h"
+#include "nls.h"
 
 #define HWCLOCK_DEBUG_INIT		(1 << 0)
 #define HWCLOCK_DEBUG_RANDOM_SLEEP	(1 << 1)
@@ -29,6 +30,7 @@ struct hwclock_control {
 #ifdef __linux__
 	char *rtc_dev_name;
 #endif
+	char *param_get_option;
 	unsigned int
 		hwaudit_on:1,
 		adjust:1,
@@ -73,6 +75,38 @@ extern double time_diff(struct timeval subtrahend, struct timeval subtractor);
 extern int get_epoch_rtc(const struct hwclock_control *ctl, unsigned long *epoch);
 extern int set_epoch_rtc(const struct hwclock_control *ctl);
 #endif
+
+struct rtc_param {
+	uint64_t param;
+	union {
+		uint64_t uvalue;
+		int64_t svalue;
+		uint64_t ptr;
+	};
+	uint32_t index;
+	uint32_t __pad;
+};
+
+#define RTC_PARAM_GET	_IOW('p', 0x13, struct rtc_param)
+
+#define RTC_PARAM_FEATURES		0
+#define RTC_PARAM_CORRECTION		1
+#define RTC_PARAM_BACKUP_SWITCH_MODE	2
+
+struct hwclock_param {
+	int id;
+	const char *name;
+	const char *help;
+};
+
+static struct hwclock_param hwclock_params[] = {
+	{ RTC_PARAM_FEATURES,  "features", N_("supported features") },
+	{ RTC_PARAM_CORRECTION, "correction", N_("time correction") },
+	{ RTC_PARAM_BACKUP_SWITCH_MODE, "bsm", N_("backup switch mode") },
+	{ }
+};
+
+extern int get_param_rtc(const struct hwclock_control *ctl, struct rtc_param *param);
 
 extern void __attribute__((__noreturn__))
 hwclock_exit(const struct hwclock_control *ctl, int status);


### PR DESCRIPTION
Hi,

this is an attempt to implement the `RTC_PARAM_GET` and `RTC_PARAM_SET` RTC ioctls in hwclock. The ioctl interface was introduced with [[PATCH v2 0/7] rtc: add new ioctl interface and BSM support](https://lore.kernel.org/all/20211018151933.76865-1-alexandre.belloni@bootlin.com/), which went mainline in Kernel v5.16.

An example with a [Microcrystal RV3028 RTC](https://www.microcrystal.com/fileadmin/Media/Products/RTC/App.Manual/RV-3028-C7_App-Manual.pdf):

```console
$ hwclock --param-get features # query RTC_PARAM_FEATURES
The RTC parameter 0x0 is set to 0x60.
$ # RTC supports RTC_FEATURE_CORRECTION, RTC_FEATURE_BACKUP_SWITCH_MODE
```

```console
$ hwclock --param-get bsm # query RTC_PARAM_BACKUP_SWITCH_MODE
The RTC parameter 0x2 is set to 0x2.
$ # BSM is set to RTC_BSM_LEVEL
$ hwclock --param-set bsm=0x0 # set BSM to RTC_BSM_DISABLED
$ hwclock --param-get bsm # query RTC_PARAM_BACKUP_SWITCH_MODE again
The RTC parameter 0x2 is set to 0x0.
```