### PR TITLE
findmnt: properly exclude poll columns from --output-all

### DIFF
--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1492,10 +1492,11 @@ int main(int argc, char *argv[])
 			outarg = optarg;
 			break;
 		case FINDMNT_OPT_OUTPUT_ALL:
-			for (ncolumns = 0; ncolumns < ARRAY_SIZE(infos); ncolumns++) {
-				if (is_tabdiff_column(ncolumns))
+			ncolumns = 0;
+			for (int i = 0; i < ARRAY_SIZE(infos); i++) {
+				if (is_tabdiff_column(i))
 					continue;
-				columns[ncolumns] = ncolumns;
+				columns[ncolumns++] = i;
 			}
 			break;
 		case 'O':


### PR DESCRIPTION
Previously columns excluded from --output-all where in fact stored as
column index 0. This however is COL_ACTION which is a polled column
leading to the following error:

findmnt --output-all
findmnt: ACTION column is requested, but --poll is not enabled

Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>