### PR TITLE
lsfd: fix the way to print stat.st_nlink

### DIFF
--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -337,7 +337,7 @@ static bool file_fill_column(struct proc *proc,
 		if (file->association != -ASSOC_SHM
 		    && file->association != -ASSOC_MEM)
 			return true;
-		xasprintf(&str, "%lu", get_map_length(file));
+		xasprintf(&str, "%ju", (uintmax_t)get_map_length(file));
 		break;
 	default:
 		return false;

--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -289,7 +289,7 @@ static bool file_fill_column(struct proc *proc,
 		xasprintf(&str, "%d", (int)file->stat.st_uid);
 		break;
 	case COL_SIZE:
-		xasprintf(&str, "%ju", file->stat.st_size);
+		xasprintf(&str, "%jd", (intmax_t)file->stat.st_size);
 		break;
 	case COL_NLINK:
 		xasprintf(&str, "%ju", (unsigned long int)file->stat.st_nlink);

--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -292,7 +292,7 @@ static bool file_fill_column(struct proc *proc,
 		xasprintf(&str, "%jd", (intmax_t)file->stat.st_size);
 		break;
 	case COL_NLINK:
-		xasprintf(&str, "%ju", (unsigned long int)file->stat.st_nlink);
+		xasprintf(&str, "%ju", (uintmax_t)file->stat.st_nlink);
 		break;
 	case COL_DELETED:
 		xasprintf(&str, "%d", file->stat.st_nlink == 0);


### PR DESCRIPTION
The type used for casting the member was too small; for the
"%ju" format spec, we should use uintmax_t for the purpose.

This change may fix the bug reported in
https://github.com/util-linux/util-linux/issues/1511#issuecomment-1033697617
in GitHub#1511 by Anatoly Pugachev <matorola@gmail.com>.
Signed-off-by: Masatake YAMATO <yamato@redhat.com>