### PR TITLE
dmesg: Start colouring subsys delimiter only after trailing blank

### DIFF
--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -910,8 +910,8 @@ static const char *get_subsys_delimiter(const char *mesg, size_t mesg_size)
 			return NULL;
 		sz -= d - p + 1;
 		if (sz) {
-			if (isblank(*(d + 1)))
-				return d;
+			if (sz >= 2 && isblank(*(d + 1)))
+				return d + 2;
 			p = d + 1;
 		}
 	}


### PR DESCRIPTION
This improves colouring when certain message levels are configured to
display a background colour using terminal-colors.d. Previously the
background colour starts at ":" on messages with a subsystem present,
which looks pretty odd. Now it starts from the remaining message after
the subsys (if there is one).

If one only uses foreground colours, this largely makes no difference:
the colon is now coloured with the same subsys colour, but there's no
difference for the blank.

Signed-off-by: Chris Down <chris@chrisdown.name>