### PR TITLE
libuuid: fix buffer overrun in uuid_parse_range()

### DIFF
--- a/libuuid/src/parse.c
+++ b/libuuid/src/parse.c
@@ -58,16 +58,14 @@ int uuid_parse_range(const char *in_start, const char *in_end, uuid_t uu)
 
 	if ((in_end - in_start) != 36)
 		return -1;
-	for (i=0, cp = in_start; i <= 36; i++,cp++) {
+	for (i=0, cp = in_start; i < 36; i++,cp++) {
 		if ((i == 8) || (i == 13) || (i == 18) ||
 		    (i == 23)) {
 			if (*cp == '-')
 				continue;
 			return -1;
 		}
-		if (i== 36)
-			if (*cp == 0)
-				continue;
+
 		if (!isxdigit(*cp))
 			return -1;
 	}


### PR DESCRIPTION
It attempts to access in_start[36], despite 35 being the maximum
allowed index.