### PR TITLE
unshare: Fix PDEATHSIG race for --kill-child with --pid

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -96,6 +96,12 @@ static int setgroups_str2id(const char *str)
 	errx(EXIT_FAILURE, _("unsupported --setgroups argument '%s'"), str);
 }
 
+static void closedown_fd(int *fd)
+{
+	close(*fd);
+	*fd = -1;
+}
+
 static void setgroups_control(int action)
 {
 	const char *file = _PATH_PROC_SETGROUPS;
@@ -764,6 +770,8 @@ int main(int argc, char *argv[])
 	const char *newdir = NULL;
 	pid_t pid_bind = 0, pid_idmap = 0;
 	pid_t pid = 0;
+	int parent_wr[2] = { -1, -1 };
+	int child_wr[2] = { -1, -1 };
 	int fd_idmap, fd_bind = -1;
 	sigset_t sigset, oldsigset;
 	int status;
@@ -956,12 +964,16 @@ int main(int argc, char *argv[])
 
 		/* force child forking before mountspace binding
 		 * so pid_for_children is populated */
+		if (pipe(parent_wr) || pipe(child_wr))
+			err(EXIT_FAILURE, _("dead parent pipe creation failed"));
 		pid = fork();
 
 		switch(pid) {
 		case -1:
 			err(EXIT_FAILURE, _("fork failed"));
 		case 0:	/* child */
+			closedown_fd(&parent_wr[1]);
+			closedown_fd(&child_wr[0]);
 			if (sigprocmask(SIG_SETMASK, &oldsigset, NULL))
 				err(EXIT_FAILURE,
 					_("sigprocmask restore failed"));
@@ -969,7 +981,27 @@ int main(int argc, char *argv[])
 				close(fd_bind);
 			break;
 		default: /* parent */
-			break;
+			{
+				closedown_fd(&parent_wr[0]);
+				closedown_fd(&child_wr[1]);
+
+				char ready;
+				while (-1 == read(child_wr[0], &ready, 1)) {
+					if (EINTR != errno)
+						break;
+				}
+				closedown_fd(&child_wr[0]);
+
+				char died = 0;
+				while (-1 == write(parent_wr[1], &died, 1)) {
+					if (EINTR == errno)
+						continue;
+					err(EXIT_FAILURE,
+						_("dead parent sync write failed "));
+				}
+				closedown_fd(&parent_wr[1]);
+				break;
+			}
 		}
 	}
 
@@ -1007,8 +1039,34 @@ int main(int argc, char *argv[])
 		err(EXIT_FAILURE, _("child exit failed"));
 	}
 
-	if (kill_child_signo != 0 && prctl(PR_SET_PDEATHSIG, kill_child_signo) < 0)
-		err(EXIT_FAILURE, "prctl failed");
+	if (kill_child_signo != 0) {
+		if (prctl(PR_SET_PDEATHSIG, kill_child_signo) < 0)
+			err(EXIT_FAILURE, "prctl failed");
+
+		/* Use pipes to detect a dead parent because
+		 * getppid(2) returns 0 if the child runs
+		 * in a different pid namespace.
+		 */
+		closedown_fd(&child_wr[1]);
+
+		char died = 1;
+		while (-1 == read(parent_wr[0], &died, 1)) {
+			if (EINTR == errno)
+				continue;
+			err(EXIT_FAILURE,
+				_("dead parent sync read failed"));
+		}
+
+		closedown_fd(&parent_wr[0]);
+
+		/* The child be re-parented if the parent terminated
+		 * before sending a sync message. The new parent will
+		 * likely not be interested in the precise exit status
+		 * of the orphan.
+		 */
+		if (died)
+			exit(EXIT_FAILURE);
+	}
 
         if (mapuser != (uid_t) -1 && !usermap)
 		map_id(_PATH_PROC_UIDMAP, mapuser, real_euid);


### PR DESCRIPTION
Exit the child explicitly should the parent terminate just before the child invokes prctl(PR_SET_PDEATHSIG).

Note that if the child is created as pid 1 in a new pid namespace, getppid(2) will return 0 because the parent resides in a different namespace, and SIGKILL will only be delivered if sent from the ancestor namespace.

Instead of checking the pid of the parent, use pairs of pipes to both synchronise the actions of the parent and the child and allow each to detect the termination of the other.

The issue can be reproduced using the following script which must be run as root to permite the --pid option.
The script will sometimes print 0..9 despite the parent being killed:

```
  while : ; do
    cat /proc/uptime
    sh -c '
      unshare --kill-child --pid --fork bash -c "
        for X in {0..9} ; do echo \$X || break ; sleep 1 ; done" &
      sleep 0 # sleep 0.00$RANDOM
      kill -9 $! 2>/dev/null' |
    cat
  done
```
