### PR TITLE
Fix crash, when mount was not found on BSD systems

### DIFF
--- a/lib/ismounted.c
+++ b/lib/ismounted.c
@@ -242,7 +242,7 @@ static int check_getmntinfo(const char *file, int *mount_flags,
 		}
                 ++mp;
 	}
-	if (mtpt)
+	if (mtpt && n >= 0)
 		xstrncpy(mtpt, mp->f_mntonname, mtlen);
 	return 0;
 }
@@ -305,7 +305,7 @@ leave:
 
 
 /*
- * check_mount_point() fills determines if the device is mounted or otherwise
+ * check_mount_point() determines if the device is mounted or otherwise
  * busy, and fills in mount_flags with one or more of the following flags:
  * MF_MOUNTED, MF_ISROOT, MF_READONLY, MF_SWAP, and MF_BUSY.  If mtpt is
  * non-NULL, the directory where the device is mounted is copied to where mtpt


### PR DESCRIPTION
Following snippet proves that the program crashes on BSD systems:

```c
#include <stdio.h>

extern int check_mount_point(const char *device, int *mount_flags,
                             char *mtpt, int mtlen);

int
main(void)
{
        char buf[4096];
        int x;
        check_mount_point("not_mounted", &x, buf, sizeof(buf));
        return 0;
}
```

You might compile it with following instructions:
```console
user@host:util-linux$ cc -c poc.c
user@host:util-linux$ cc -o poc poc.o lib/is_mounted.o

# and trigger it with the MALLOC_OPTIONS
user@host:util-linux$ MALLOC_OPTIONS=JJ ./poc
```

Shoutout to [c3h2-ctf](https://twitter.com/c3h2_ctf)!