### PR TITLE
blkzone: Do not print zone capacity if not supported

### DIFF
--- a/sys-utils/blkzone.c
+++ b/sys-utils/blkzone.c
@@ -298,11 +298,19 @@ static int blkzone_report(struct blkzone_control *ctl)
 
 			if (only_capacity_sum) {
 				capacity_sum += cap;
-			} else {
+			} else if (has_zone_capacity(zi)) {
 				printf(_("  start: 0x%09"PRIx64", len 0x%06"PRIx64
 					", cap 0x%06"PRIx64", wptr 0x%06"PRIx64
 					" reset:%u non-seq:%u, zcond:%2u(%s) [type: %u(%s)]\n"),
 					start, len, cap, (type == 0x1) ? 0 : wp - start,
+					entry->reset, entry->non_seq,
+					cond, condition_str[cond & (ARRAY_SIZE(condition_str) - 1)],
+					type, type_text[type]);
+			} else {
+				printf(_("  start: 0x%09"PRIx64", len 0x%06"PRIx64
+					", wptr 0x%06"PRIx64
+					" reset:%u non-seq:%u, zcond:%2u(%s) [type: %u(%s)]\n"),
+					start, len, (type == 0x1) ? 0 : wp - start,
 					entry->reset, entry->non_seq,
 					cond, condition_str[cond & (ARRAY_SIZE(condition_str) - 1)],
 					type, type_text[type]);


### PR DESCRIPTION
If `blkzone` is built against kernel headers that do not define
`BLK_ZONE_REP_CAPACITY`, `blkzone report` will use zone size when printing zone
capacity. This patch changes the behavior of `blockzone report` in this case to
omit the capacity field instead of using the potentially wrong value.