### PR TITLE
Proof-of-concept for namei selinux context report

### DIFF
--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -62,6 +62,7 @@ usrbin_exec_PROGRAMS += namei
 MANPAGES += misc-utils/namei.1
 dist_noinst_DATA += misc-utils/namei.1.adoc
 namei_SOURCES = misc-utils/namei.c lib/strutils.c lib/idcache.c
+namei_LDADD = $(LDADD) -lselinux
 endif
 
 if BUILD_WHEREIS


### PR DESCRIPTION
Hello!  It'd be cool if `namei` supported showing selinux contexts.  I imagine it could use a `-Z`/`--context` option like `ls` does.

My C is extraordinarily rusty, but a *trivial* case, which probably ignores tons of corner cases and isn't really mergeworthy at all, is pretty straightforward.  I assume something making it into the util itself would have to be done with more care than I did this.

Among its problems:

- assumes libselinux is always available
- completely untested on selinuxless systems
- completely untested on filesystems which don't support selinux
- not tested for memory leaks, etc
- one TODO in there about how to handle blank selinux reporting

... and probably plenty else I'm not even thinking of at the moment.

(I'd originally put this in as Issue #1629 but was encouraged to put it in as a PR for easier collaboration, even though I don't think it's anywhere near merge-worthy)