### PR TITLE
tests: (lsfd) add missing dup2 calls to assign proper file descriptors

### DIFF
--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -393,8 +393,18 @@ static void open_rw_chrdev(const struct factory *factory, struct fdesc fdescs[],
 		err(EXIT_FAILURE, "failed to open: %s", ARG_STRING(chrdev));
 	free_arg(&chrdev);
 
+	if (fd != fdescs[0].fd) {
+		if (dup2(fd, fdescs[0].fd) < 0) {
+			int e = errno;
+			close(fd);
+			errno = e;
+			err(EXIT_FAILURE, "failed to dup %d -> %d", fd, fdescs[0].fd);
+		}
+		close(fd);
+	}
+
 	fdescs[0] = (struct fdesc){
-		.fd    = fd,
+		.fd    = fdescs[0].fd,
 		.close = close_fdesc,
 		.data  = NULL
 	};
@@ -450,8 +460,18 @@ static void open_with_opath(const struct factory *factory, struct fdesc fdescs[]
 		err(EXIT_FAILURE, "failed to open with O_PATH: %s", ARG_STRING(path));
 	free_arg(&path);
 
+	if (fd != fdescs[0].fd) {
+		if (dup2(fd, fdescs[0].fd) < 0) {
+			int e = errno;
+			close(fd);
+			errno = e;
+			err(EXIT_FAILURE, "failed to dup %d -> %d", fd, fdescs[0].fd);
+		}
+		close(fd);
+	}
+
 	fdescs[0] = (struct fdesc){
-		.fd    = fd,
+		.fd    = fdescs[0].fd,
 		.close = close_fdesc,
 		.data  = NULL
 	};
@@ -466,8 +486,18 @@ static void open_ro_blkdev(const struct factory *factory, struct fdesc fdescs[],
 		err(EXIT_FAILURE, "failed to open: %s", ARG_STRING(blkdev));
 	free_arg(&blkdev);
 
+	if (fd != fdescs[0].fd) {
+		if (dup2(fd, fdescs[0].fd) < 0) {
+			int e = errno;
+			close(fd);
+			errno = e;
+			err(EXIT_FAILURE, "failed to dup %d -> %d", fd, fdescs[0].fd);
+		}
+		close(fd);
+	}
+
 	fdescs[0] = (struct fdesc){
-		.fd    = fd,
+		.fd    = fdescs[0].fd,
 		.close = close_fdesc,
 		.data  = NULL,
 	};


### PR DESCRIPTION
Close #1637.

The test cases assumed the file descriptor #3 was not occupied. As
reported in #1637, the assumption was wrong. This new code assigns
the file descriptor #3 explicitly with dup2 as the other test cases
did.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>