### PR TITLE
lsfd: (filter): parse "" in filter expression correctly 

### DIFF
--- a/misc-utils/lsfd-filter.c
+++ b/misc-utils/lsfd-filter.c
@@ -438,9 +438,11 @@ static void parser_read_str(struct parser *parser, struct token *token, char del
 				return;
 			}
 			escape = false;
-		} else if (c == delimiter)
+		} else if (c == delimiter) {
+			if (token->val.str == NULL)
+				token->val.str = xstrdup("");
 			return;
-		else if (c == '\\')
+		} else if (c == '\\')
 			escape = true;
 		else
 			xstrputc(&token->val.str, c);

--- a/misc-utils/lsfd-filter.c
+++ b/misc-utils/lsfd-filter.c
@@ -438,8 +438,7 @@ static void parser_read_str(struct parser *parser, struct token *token, char del
 				return;
 			}
 			escape = false;
-		}
-		else if (c == delimiter)
+		} else if (c == delimiter)
 			return;
 		else if (c == '\\')
 			escape = true;


### PR DESCRIPTION
The original code cannot convert "" in filter expression to
a token correctly. The following command line exposes the
bug this change fixes:
```console
  # ./lsfd  -o+ENDPOINTS  -Q '(TYPE == "")'
  zsh: IOT instruction  sudo ./lsfd -Q '(TYPE == "")'
```