### PR TITLE
tests: fix misc/setarch run in a docker environment

### DIFF
--- a/tests/ts/misc/setarch
+++ b/tests/ts/misc/setarch
@@ -23,6 +23,7 @@ ts_check_test_command "$TS_CMD_SETARCH"
 ARCH=$(uname -m)
 
 ts_init_subtest options
+test -e /.dockerenv && ts_skip "unsupported in docker environment"
 ts_log_both "###### unknown arch"
 $TS_CMD_SETARCH qubit -v echo "success" >> $TS_OUTPUT 2>> $TS_ERRLOG
 echo "exit: $?" >>$TS_OUTPUT


### PR DESCRIPTION
`setarch` fails if run in a docker container, so exclude (ts_skip) misc/setarch from running in a docker.
   
Fixes: #601