### PR TITLE
tests: don't compile lsfd/mkfds helper on macos

### DIFF
--- a/tests/helpers/Makemodule.am
+++ b/tests/helpers/Makemodule.am
@@ -31,5 +31,7 @@ check_PROGRAMS += test_uuid_namespace
 test_uuid_namespace_SOURCES = tests/helpers/test_uuid_namespace.c \
 	libuuid/src/predefined.c libuuid/src/unpack.c libuuid/src/unparse.c
 
+if LINUX
 check_PROGRAMS += test_mkfds
 test_mkfds_SOURCES = tests/helpers/test_mkfds.c
+endif


### PR DESCRIPTION
macos is missing linux only `sys/prctl.h` header, so exclude `tests/helpers/test_mkfds.c`
on macos from `make check-programs` target

fixes fd81d3a558

```
util-linux$ make check-programs
  CC       tests/helpers/test_mkfds.o
tests/helpers/test_mkfds.c:29:10: fatal error: 'sys/prctl.h' file not found
#include <sys/prctl.h>
         ^~~~~~~~~~~~~
1 error generated.
make: *** [tests/helpers/test_mkfds.o] Error 1
util-linux$ uname -a
Darwin puga.local 21.4.0 Darwin Kernel Version 21.4.0: Fri Mar 18 00:45:05 PDT 2022; root:xnu-8020.101.4~15/RELEASE_X86_64 x86_64
```