### PR TITLE
Don't install uuidd service if systemd isn't present

### DIFF
--- a/misc-utils/meson.build
+++ b/misc-utils/meson.build
@@ -72,7 +72,7 @@ test_uuidd_sources = files(
   'test_uuidd.c',
 )
 
-if build_uuidd
+if build_uuidd and systemd.found()
   uuidd_service = configure_file(
     input : 'uuidd.service.in',
     output : 'uuidd.service',


### PR DESCRIPTION
I'm a Devuan user (with runit) and I had a problem building util-linux in Devuan.