### PR TITLE
mount: support X-mount.idmap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -495,6 +495,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 [AC_DEFINE([HAVE_TM_GMTOFF], [1], [Does struct tm have a field tm_gmtoff?])
 ])
 
+AC_CHECK_TYPES([struct mount_attr], [], [], [[#include <sys/mount.h>]])
+
 AC_CHECK_MEMBERS([struct termios.c_line],,,
     [[#include <termios.h>]])
 
@@ -557,8 +559,11 @@ AC_CHECK_FUNCS([ \
 	newlocale \
 	mempcpy \
 	mkostemp \
+	move_mount \
+	mount_setattr \
 	nanosleep \
 	ntp_gettime \
+	open_tree \
 	personality \
 	pidfd_open \
 	pidfd_send_signal \

--- a/include/Makemodule.am
+++ b/include/Makemodule.am
@@ -41,6 +41,7 @@ dist_noinst_HEADERS += \
 	include/md5.h \
 	include/minix.h \
 	include/monotonic.h \
+	include/mount-api-utils.h \
 	include/namespace.h \
 	include/nls.h \
 	include/optutils.h \

--- a/include/mount-api-utils.h
+++ b/include/mount-api-utils.h
@@ -1,0 +1,132 @@
+#ifndef UTIL_LINUX_MOUNT_API_UTILS
+#define UTIL_LINUX_MOUNT_API_UTILS
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+
+/*
+ * Scope all of this beneath mount_setattr(). If this syscall is available all
+ * other syscalls must as well. Otherwise we're dealing with a partial backport
+ * of syscalls.
+ */
+
+# if defined(SYS_mount_setattr)
+
+/* Accepted by both open_tree() and mount_setattr(). */
+#ifndef AT_RECURSIVE
+#define AT_RECURSIVE 0x8000
+#endif
+
+#ifndef OPEN_TREE_CLONE
+#define OPEN_TREE_CLONE 1
+#endif
+
+#ifndef OPEN_TREE_CLOEXEC
+#define OPEN_TREE_CLOEXEC O_CLOEXEC
+#endif
+
+#  ifndef HAVE_OPEN_TREE
+static inline int open_tree(int dfd, const char *filename, unsigned int flags)
+{
+	return syscall(__NR_open_tree, dfd, filename, flags);
+}
+#  endif
+
+#ifndef MOVE_MOUNT_F_SYMLINKS
+#define MOVE_MOUNT_F_SYMLINKS 0x00000001 /* Follow symlinks on from path */
+#endif
+
+#ifndef MOVE_MOUNT_F_AUTOMOUNTS
+#define MOVE_MOUNT_F_AUTOMOUNTS 0x00000002 /* Follow automounts on from path */
+#endif
+
+#ifndef MOVE_MOUNT_F_EMPTY_PATH
+#define MOVE_MOUNT_F_EMPTY_PATH 0x00000004 /* Empty from path permitted */
+#endif
+
+#ifndef MOVE_MOUNT_T_SYMLINKS
+#define MOVE_MOUNT_T_SYMLINKS 0x00000010 /* Follow symlinks on to path */
+#endif
+
+#ifndef MOVE_MOUNT_T_AUTOMOUNTS
+#define MOVE_MOUNT_T_AUTOMOUNTS 0x00000020 /* Follow automounts on to path */
+#endif
+
+#ifndef MOVE_MOUNT_T_EMPTY_PATH
+#define MOVE_MOUNT_T_EMPTY_PATH 0x00000040 /* Empty to path permitted */
+#endif
+
+#ifndef MOVE_MOUNT__MASK
+#define MOVE_MOUNT__MASK 0x00000077
+#endif
+
+#  ifndef HAVE_MOVE_MOUNT
+static inline int move_mount(int from_dfd, const char *from_pathname, int to_dfd,
+			     const char *to_pathname, unsigned int flags)
+{
+	return syscall(__NR_move_mount, from_dfd, from_pathname, to_dfd,
+		       to_pathname, flags);
+}
+#  endif
+
+#ifndef MOUNT_ATTR_RDONLY
+#define MOUNT_ATTR_RDONLY 0x00000001
+#endif
+
+#ifndef MOUNT_ATTR_NOSUID
+#define MOUNT_ATTR_NOSUID 0x00000002
+#endif
+
+#ifndef MOUNT_ATTR_NOEXEC
+#define MOUNT_ATTR_NOEXEC 0x00000008
+#endif
+
+#ifndef MOUNT_ATTR_NODIRATIME
+#define MOUNT_ATTR_NODIRATIME 0x00000080
+#endif
+
+#ifndef MOUNT_ATTR__ATIME
+#define MOUNT_ATTR__ATIME 0x00000070
+#endif
+
+#ifndef MOUNT_ATTR_RELATIME
+#define MOUNT_ATTR_RELATIME 0x00000000
+#endif
+
+#ifndef MOUNT_ATTR_NOATIME
+#define MOUNT_ATTR_NOATIME 0x00000010
+#endif
+
+#ifndef MOUNT_ATTR_STRICTATIME
+#define MOUNT_ATTR_STRICTATIME 0x00000020
+#endif
+
+#ifndef MOUNT_ATTR_IDMAP
+#define MOUNT_ATTR_IDMAP 0x00100000
+#endif
+
+#  ifndef HAVE_STRUCT_MOUNT_ATTR
+#  include <linux/types.h>
+struct mount_attr {
+	__u64 attr_set;
+	__u64 attr_clr;
+	__u64 propagation;
+	__u64 userns_fd;
+};
+#  endif
+
+#  ifndef HAVE_MOUNT_SETATTR
+static inline int mount_setattr(int dfd, const char *path, unsigned int flags,
+				struct mount_attr *attr, size_t size)
+{
+	return syscall(__NR_mount_setattr, dfd, path, flags, attr, size);
+}
+#  endif
+
+#define UL_HAVE_MOUNT_API 1
+
+# endif
+
+#endif /* __linux__ */
+#endif /* UTIL_LINUX_MOUNT_API_UTILS */
+

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -232,6 +232,12 @@ enum {
  * filesystem mounted, but subsequent X-mount.mode= chmod(2) failed
  */
 #define MNT_ERR_CHMOD    5012
+/**
+ * MNT_ERR_IDMAP:
+ *
+ * filesystem mounted, but subsequent X-mount.idmap= failed
+ */
+#define MNT_ERR_IDMAP    5013
 
 
 /*

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -642,6 +642,33 @@ Set _mountpoint_'s ownership after mounting. Names resolved in the target mount 
 *X-mount.mode*=_mode_::
 Set _mountpoint_'s mode after mounting.
 
+*X-mount.idmap*=__id-type__:__id-mount__:__id-host__:__id-range__ [__id-type__:__id-mount__:__id-host__:__id-range__], *X-mount.idmap*=__file__::
+Use this option to create an idmapped mount.
+An idmapped mount allows to change ownership of all files located under a mount according to the ID-mapping associated with a user namespace.
+The ownership change is tied to the lifetime and localized to the relevant mount.
+The relevant ID-mapping can be specified in two ways:
++
+* A user can specify the ID-mapping directly.
++
+The ID-mapping must be specified using the syntax __id-type__:__id-mount__:__id-host__:__id-range__.
+Specifying *u* as the __id-type__ prefix creates a UID-mapping, *g* creates a GID-mapping and omitting __id-type__ or specifying *b* creates both a UID- and GID-mapping.
+The __id-mount__ parameter indicates the starting ID in the new mount.
+The __id-host__ parameter indicates the starting ID in the filesystem.
+The __id-range__ parameter indicates how many IDs are to be mapped.
+It is possible to specify multiple ID-mappings.
+The individual ID-mappings must be separated by spaces.
++
+For example, the ID-mapping *X-mount.idmap=u:1000:0:1 g:1001:1:2 5000:1000:2* creates an idmapped mount where
+UID 0 is mapped to UID 1000, GID 1 is mapped to GUID 1001, GID 2 is mapped to GID 1002, UID and GID 1000 are mapped to 5000, and UID and GID 1001 are mapped to 5001 in the mount.
++
+When an ID-mapping is specified directly a new user namespace will be allocated with the requested ID-mapping.
+The newly created user namespace will be attached to the mount.
+* A user can specify a user namespace file.
++
+The user namespace will then be attached to the mount and the ID-mapping of the user namespace will become the ID-mapping of the mount.
++
+For example, *X-mount.idmap=/proc/PID/ns/user* will attach the user namespace of the process PID to the mount.
+
 *nosymfollow*::
 Do not follow symlinks when resolving paths. Symlinks can still be created, and *readlink*(1), *readlink*(2), *realpath*(1), and *realpath*(3) all still work properly.
 


### PR DESCRIPTION
This adds a new mount option X-mount.idmap. This mount option can be
used to create an idmapped mount.

An idmapped mount allows to change ownership of all files located under
a mount according to the ID-mapping associated with a user namespace.

The ownership change is tied to the lifetime and localized to the
relevant mount. The relevant ID-mapping can be specified in two ways:
* A user can specify the ID-mapping directly.
  The ID-mapping must be specified using the syntax
  id-type:id-mount:id-host:id-range
  Specifying "u" as the id-type prefix creates a UID-mapping, "g"
  creates a GID-mapping and omitting id-type or specifying "b"
  creates both a UID- and GID-mapping.
  The id-mount parameter indicates the starting ID in the new mount.
  The id-host parameter indicates the starting ID in the filesystem.
  The id-range parameter indicates how many IDs are to be mapped.
  It is possible to specify multiple ID-mappings.
  The individual ID-mappings must be separated by spaces.

  For example, the ID-mapping
  X-mount.idmap=u:1000:0:1 g:1001:1:2 5000:1000:2
  creates an idmapped mount where UID 0 is mapped to UID 1000, GID 1 is
  mapped to GUID 1001, GID 2 is mapped to GID 1002, UID and GID 1000 are
  mapped to 5000, and UID and GID 1001 are mapped to 5001 in the mount.

  When an ID-mapping is specified directly a new user namespace will be
  allocated with the requested ID-mapping.
  The newly created user namespace will be attached to the mount.

* A user can specify a user namespace file.
  The user namespace will then be attached to the mount and the
  ID-mapping of the user namespace will become the ID-mapping of the
  mount.
  For example, *X-mount.idmap=/proc/PID/ns/user* will attach the user
  namespace of the process PID to the mount.

Even more details about idmapped mounts can be found in the
mount_setattr(2) manpage of the linux-manpage project.

Signed-off-by: Christian Brauner (Microsoft) <brauner@kernel.org>