### PR TITLE
lib: allow safe_getenv to work for non-root users

### DIFF
--- a/lib/env.c
+++ b/lib/env.c
@@ -161,9 +161,7 @@ void sanitize_env(void)
 
 char *safe_getenv(const char *arg)
 {
-	uid_t ruid = getuid();
-
-	if (ruid != 0 || (ruid != geteuid()) || (getgid() != getegid()))
+	if ((getuid() != geteuid()) || (getgid() != getegid()))
 		return NULL;
 #ifdef HAVE_PRCTL
 	if (prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) == 0)


### PR DESCRIPTION
This allows users to override settings like BLKID_FILE, as is done in
the e2fsprogs test suite.

Bug: https://bugs.gentoo.org/839825
Fixes: 035507c84b53bceb143d0923e65916cbf90979c7
Signed-off-by: Mike Gilbert <floppym@gentoo.org>