### PR TITLE
meson: fix when HAVE_CLOCK_GETTIME is set

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -599,7 +599,7 @@ if not have
   have = cc.has_function('clock_gettime',
                          dependencies : realtime_libs)
 endif
-conf.set('HAVE_CLOCK_GETTIME', have_dirfd ? 1 : false)
+conf.set('HAVE_CLOCK_GETTIME', have ? 1 : false)
 
 thread_libs = dependency('threads')
 


### PR DESCRIPTION
I could be wrong, but 'have' should be used instead of 'have_dirfd' when HAVE_CLOCK_GETTIME is set.

Nicolas Caramelli