### PR TITLE
fstrim: check for ENOSYS when using --quiet-unsupported

### DIFF
--- a/sys-utils/fstrim.c
+++ b/sys-utils/fstrim.c
@@ -122,6 +122,7 @@ static int fstrim_filesystem(struct fstrim_control *ctl, const char *path, const
 		case EBADF:
 		case ENOTTY:
 		case EOPNOTSUPP:
+		case ENOSYS:
 			rc = 1;
 			break;
 		default:


### PR DESCRIPTION
Some filesystems like bindfs report ENOSYS (Function not implemented) for the trim ioctl, which should be caught by --quiet-unsupported.