### PR TITLE
hardlink: --help & man page fixes

### DIFF
--- a/misc-utils/hardlink.1.adoc
+++ b/misc-utils/hardlink.1.adoc
@@ -56,21 +56,6 @@ Crypto API is not available. The methods based on checksums are implemented in
 zero-copy way, in this case file contents are not copied to the userspace and all
 calculation is done in kernel.
 
-*--reflink*[=_when_]::
-Create copy-on-write clones (aka reflinks) rather than hardlinks. The reflinked files
-share only on-disk data, but the file mode and owner can be different. It's recommended
-to use it with *--ignore-owner* and *--ignore-mode* options. This option implies
-*--skip-reflinks* to ignore already cloned files.
-+
-The optional argument _when_ can be *never*, *always*, or *auto*. If the _when_ argument
-is omitted, it defaults to *auto*, in this case, *hardlink* checks filesystem type and
-uses reflinks on BTRFS and XFS only, and fallback to hardlinks when creating reflink is impossible.
-The argument *always* disables filesystem type detection and fallback to hardlinks, in this case,
-only reflinks are allowed.
-
-*--skip-reflinks*::
-Ignore already cloned files. This option may be used without *--reflink* when creating classic hardlinks.
-
 *-f*, *--respect-name*::
 Only try to link files with the same (base)name. It's strongly recommended to use long options rather than *-f* which is interpreted in a different way by other *hardlink* implementations.
 
@@ -88,6 +73,21 @@ Consider only file content, not attributes, when determining whether two files a
 
 *-X*, *--respect-xattrs*::
 Only try to link files with the same extended attributes.
+
+*--reflink*[=_when_]::
+Create copy-on-write clones (aka reflinks) rather than hardlinks. The reflinked files
+share only on-disk data, but the file mode and owner can be different. It's recommended
+to use it with *--ignore-owner* and *--ignore-mode* options. This option implies
+*--skip-reflinks* to ignore already cloned files.
++
+The optional argument _when_ can be *never*, *always*, or *auto*. If the _when_ argument
+is omitted, it defaults to *auto*, in this case, *hardlink* checks filesystem type and
+uses reflinks on BTRFS and XFS only, and fallback to hardlinks when creating reflink is impossible.
+The argument *always* disables filesystem type detection and fallback to hardlinks, in this case,
+only reflinks are allowed.
+
+*--skip-reflinks*::
+Ignore already cloned files. This option may be used without *--reflink* when creating classic hardlinks.
 
 *-m*, *--maximize*::
 Among equal files, keep the file with the highest link count.

--- a/misc-utils/hardlink.1.adoc
+++ b/misc-utils/hardlink.1.adoc
@@ -83,6 +83,9 @@ Link and compare files even if their owner information (user and group) differs.
 *-t*, *--ignore-time*::
 Link and compare files even if their time of modification is different. This is usually a good choice.
 
+*-c* *--content*::
+Consider only file content, not attributes, when determining whether two files are equal. Same as *-pot*.
+
 *-X*, *--respect-xattrs*::
 Only try to link files with the same extended attributes.
 

--- a/misc-utils/hardlink.1.adoc
+++ b/misc-utils/hardlink.1.adoc
@@ -41,7 +41,9 @@ are very often different from the beginning.
 == OPTIONS
 
 include::man-common/help-version.adoc[]
-If specified once, every hardlinked file is displayed, if specified twice, it also shows every comparison.
+
+*-v*, *--verbose*::
+Verbose output, explain to the user what is being done. If specified once, every hardlinked file is displayed. If specified twice, it also shows every comparison.
 
 *-q*, *--quiet*::
 Quiet mode, don't print anything.

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -1144,7 +1144,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -i, --include <regex>      regular expression to include files/dirs\n"), out);
 	fputs(_(" -s, --minimum-size <size>  minimum size for files.\n"), out);
 	fputs(_(" -S, --maximum-size <size>  maximum size for files.\n"), out);
-	fputs(_(" -b, --io-size <size>       I/O buffer size for file reading (speedup, using more RAM)\n"), out);
+	fputs(_(" -b, --io-size <size>       I/O buffer size for file reading\n"
+	        "                              (speedup, using more RAM)\n"), out);
 	fputs(_(" -r, --cache-size <size>    memory limit for cached file content data\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -1127,6 +1127,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -p, --ignore-mode          ignore changes of file mode\n"), out);
 	fputs(_(" -o, --ignore-owner         ignore owner changes\n"), out);
 	fputs(_(" -t, --ignore-time          ignore timestamps (when testing for equality)\n"), out);
+	fputs(_(" -c, --content              compare only file contents, same as -pot\n"), out);
 #ifdef USE_XATTR
 	fputs(_(" -X, --respect-xattrs       respect extended attributes\n"), out);
 #endif
@@ -1145,7 +1146,6 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -S, --maximum-size <size>  maximum size for files.\n"), out);
 	fputs(_(" -b, --io-size <size>       I/O buffer size for file reading (speedup, using more RAM)\n"), out);
 	fputs(_(" -r, --cache-size <size>    memory limit for cached file content data\n"), out);
-	fputs(_(" -c, --content              compare only file contents, same as -pot\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
 	printf(USAGE_HELP_OPTIONS(28));


### PR DESCRIPTION
This PR (five separate commits for now, but I can squash them on request) reconciles the output of `hardlink --help` and the `hardlink.1` man page so that:

1. All of the available options are documented in both Specifically

    * `-c` is added to the man page
    * the entry for `-v` is fixed.

1. All<sup>1</sup> of the options come in the same _order_ in both. Specifically:

    * The entry for `-c` in the `--help` output is moved to immediately follow `-p`, `-o`, and `-t`, the flags it acts as a shorthand  for. Its documentation was added at the same position in the man page.
    * The man page documentation for `--reflink` and `--skip-reflinks` is moved to come after the documentation for `-X`, the same position they appear in the `--help` output.

1. Are formatted properly in both. (The `--help` explanation for `-b` was previously wider than 80 columns, but is now wrapped.)

##### Notes
1. (`-h` and `-V` excepted. They appear last in the `--help` output, but first in the man page due to content inclusion.)