### PR TITLE
Fix German translation of message when shell gets killed

### DIFF
--- a/po-man/de.po
+++ b/po-man/de.po
@@ -11739,7 +11739,7 @@ msgstr ""
 #: ../login-utils/runuser.1.adoc:100
 #, no-wrap
 msgid "*runuser* normally returns the exit status of the command it executed. If the command was killed by a signal, *runuser* returns the number of the signal plus 128.\n"
-msgstr "*runuser* gibt normalerweise den Exit-Status des Befehls zurück, den es ausgeführt hat. Wenn der Befehl durch ein Signal abgewürgt wurde, gibt *runuser* die Nummer des Signals plus 128 zurück.\n"
+msgstr "*runuser* gibt normalerweise den Exit-Status des Befehls zurück, den es ausgeführt hat. Wenn der Befehl durch ein Signal beendet wurde, gibt *runuser* die Nummer des Signals plus 128 zurück.\n"
 
 #. type: Plain text
 #: ../login-utils/runuser.1.adoc:102

--- a/po/de.po
+++ b/po/de.po
@@ -9208,12 +9208,12 @@ msgid ""
 "Session terminated, killing shell..."
 msgstr ""
 "\n"
-"Sitzung beendet, Shell wird abgewürgt …"
+"Sitzung beendet, Shell wird beendet …"
 
 #: login-utils/su-common.c:625
 #, c-format
 msgid " ...killed.\n"
-msgstr " … abgewürgt.\n"
+msgstr " … beendet.\n"
 
 #: login-utils/su-common.c:722
 msgid "failed to set the PATH environment variable"
@@ -12705,12 +12705,12 @@ msgstr "Liste der UUIDs:\n"
 #: misc-utils/uuidd.c:762
 #, c-format
 msgid "couldn't kill uuidd running at pid %d"
-msgstr "uuidd laufend mit pid %d konnte nicht abgewürgt werden"
+msgstr "uuidd laufend mit pid %d konnte nicht beendet werden"
 
 #: misc-utils/uuidd.c:767
 #, c-format
 msgid "Killed uuidd running at pid %d.\n"
-msgstr "uuidd laufend mit pid %d abgewürgt.\n"
+msgstr "uuidd laufend mit pid %d beendet.\n"
 
 #: misc-utils/uuidgen.c:29
 msgid "Create a new UUID value.\n"


### PR DESCRIPTION
Replace "abgewürgt" with "beendet", which is a more appropriate word
to use when a process gets killed.

Related discussion at
https://bugzilla.redhat.com/show_bug.cgi?id=1665822