### PR TITLE
Fix hexdump's manpage for -v option

### DIFF
--- a/text-utils/hexdump.1.adoc
+++ b/text-utils/hexdump.1.adoc
@@ -90,7 +90,7 @@ _Two-byte octal display_. Display the input offset in hexadecimal, followed by e
 Skip _offset_ bytes from the beginning of the input.
 
 *-v*, *--no-squeezing*::
-The *-v* option causes *hexdump* to display all input data. Without the *-v* option, any number of groups of output lines which would be identical to the immediately preceding group of output lines (except for the input offsets), are replaced with a line comprised of a single asterisk.
+The *-v* option causes *hexdump* to display all output data. Without the *-v* option, any number of groups of output lines which would be identical to the immediately preceding group of output lines (except for the input offsets), are replaced with a line comprised of a single asterisk.
 
 *-x*, *--two-bytes-hex*::
 _Two-byte hexadecimal display_. Display the input offset in hexadecimal, followed by eight space-separated, four-column, zero-filled, two-byte quantities of input data, in hexadecimal, per line.


### PR DESCRIPTION
From what I understand this option controls output appearance.

When I had read the description saying "input" I've got confused and misunderstood what the option was for. I only understood it after I got some unexpected `*` in output which broke my pipeline, searched for "hexdump asterisk" and found https://superuser.com/a/494613/199573 :/