### PR TITLE
A little mistake in do_taskset() function in taskset.c.

### DIFF
--- a/schedutils/taskset.c
+++ b/schedutils/taskset.c
@@ -117,7 +117,7 @@ static void do_taskset(struct taskset *ts, size_t setsize, cpu_set_t *set)
 	/* read the current mask */
 	if (ts->pid) {
 		if (sched_getaffinity(ts->pid, ts->setsize, ts->set) < 0)
-			err_affinity(ts->pid, 1);
+			err_affinity(ts->pid, 0);
 		print_affinity(ts, FALSE);
 	}
 


### PR DESCRIPTION
The err_affinity() function outputs error information when sched_getaffinity() or sched_setaffinity() executes abnormally.
After calling sched_getaffinity(), we should call err_affinity() as err_affinity(ts->pid, 0) to output "failed to get pid %d's affinity" in the case sched_getaffinity() is failed.