### PR TITLE
hardlink: change the default comparison method on Mac OS

### DIFF
--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -186,7 +186,11 @@ static struct options {
 	size_t cache_size;
 } opts = {
 	/* default setting */
+#ifdef __APPLE__
+	.method = "memcmp",
+#else
 	.method = "sha256",
+#endif
 	.respect_mode = TRUE,
 	.respect_owner = TRUE,
 	.respect_time = TRUE,


### PR DESCRIPTION
This fixes #1712