### PR TITLE
added randomly colored hostname

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -2138,7 +2138,14 @@ again:
 					cn = res->ai_canonname;
 			}
 
-			write_all(STDOUT_FILENO, cn, strlen(cn));
+                        char ecode[12];
+                        srand(time(NULL));
+                        char code = rand();
+                        snprintf(ecode, sizeof(ecode), "\x1b[38;5;%dm", code);
+                        write_all(STDOUT_FILENO, ecode, strlen(ecode));
+                        write_all(STDOUT_FILENO, cn, strlen(cn));
+                        write_all(STDOUT_FILENO, "\x1b[0m", 4);
+
 			write_all(STDOUT_FILENO, " ", 1);
 
 			if (res)


### PR DESCRIPTION
Hey, 

how are you?


I have been noticing that my gentoo colors are very nice but the agetty prompt is so sad still in gray colors like UNIX-like old TTYs.

So I've coded this to randomly on each boot change the hostname color.

The cool thing would be to profile it on the OS but still too much dev and I don't know if will be accepted.


Please consider integrating this nice feature.

Thanks in advance.