### PR TITLE
update. Since the specified column is shifted by one column, subtract…

### DIFF
--- a/text-utils/column.c
+++ b/text-utils/column.c
@@ -358,7 +358,7 @@ static void apply_columnflag_from_list(struct column_control *ctl, const char *l
 		/* parse range (N-M) */
 		if (strchr(*one, '-') && parse_range(*one, &low, &up, 0) == 0) {
 			for (; low <= up; low++) {
-				cl = scols_table_get_column(ctl->tab, low);
+				cl = scols_table_get_column(ctl->tab, low-1);
 				if (cl)
 					column_set_flag(cl, flag);
 			}


### PR DESCRIPTION
#1723 .

Since the specified column is shifted by one column, subtract it.

```shell
$ # before
$ seq 1 5 150 | xargs -n 5 | ./column -t -R 2-3
1    6     11   16  21
26   31    36   41  46
51   56    61   66  71
76   81    86   91  96
101  106  111  116  121
126  131  136  141  146

$ # after
$ seq 1 5 150 | xargs -n 5 | ./column -t -R 2-3
1      6   11  16   21
26    31   36  41   46
51    56   61  66   71
76    81   86  91   96
101  106  111  116  121
126  131  136  141  146
```