### PR TITLE
tests: (lsfd) update the expected output for "test_mkfds symlink"

### DIFF
--- a/tests/expected/lsfd/mkfds-symlink
+++ b/tests/expected/lsfd/mkfds-symlink
@@ -1,2 +1,2 @@
-    3  --- LINK /dev/stdin  path
+    3  --- LINK /dev/stdin nofollow,path
 ASSOC,MODE,TYPE,NAME,FLAGS: 0


### PR DESCRIPTION
Though the code of lsfd was changed in 4b496e50ee4f6bd8256d082a85fc027a7eaa45cb,
the expected output of the test case was not updated.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>