### PR TITLE
lsns: fix the memory leak.

### DIFF
--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -1199,6 +1199,28 @@ static int show_namespace_processes(struct lsns *ls, struct lsns_namespace *ns)
 	return 0;
 }
 
+static void free_lsns_process(struct lsns_process *lsns_p)
+{
+	free(lsns_p);
+}
+
+static void free_netnsid_caches(struct netnsid_cache *cache)
+{
+	free(cache);
+}
+
+static void free_lsns_namespace(struct lsns_namespace *lsns_n)
+{
+	free(lsns_n);
+}
+
+static void free_all(struct lsns *ls)
+{
+	list_free(&ls->processes, struct lsns_process, processes, free_lsns_process);
+	list_free(&netnsids_cache, struct netnsid_cache, netnsids, free_netnsid_caches);
+	list_free(&ls->namespaces, struct lsns_namespace, namespaces, free_lsns_namespace);
+}
+
 static void __attribute__((__noreturn__)) usage(void)
 {
 	FILE *out = stdout;
@@ -1432,5 +1454,8 @@ int main(int argc, char *argv[])
 	if (netlink_fd >= 0)
 		close(netlink_fd);
 	free_idcache(uid_cache);
+
+	free_all(&ls);
+
 	return r == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
==28129== 96 bytes in 3 blocks are possibly lost in loss record 1 of 4
==28129==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==28129==    by 0x405C83: xcalloc (xalloc.h:60)
==28129==    by 0x405C83: netnsid_cache_add (lsns.c:389)
==28129==    by 0x405C83: get_netnsid (lsns.c:486)
==28129==    by 0x405C83: read_process (lsns.c:549)
==28129==    by 0x403FB4: read_processes (lsns.c:586)
==28129==    by 0x403FB4: main (lsns.c:1417)
==28129==
==28129== 119,664 (384 direct, 119,280 indirect) bytes in 1 blocks are definitely lost in loss record 4 of 4
==28129==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
==28129==    by 0x4055F5: xcalloc (xalloc.h:60)
==28129==    by 0x4055F5: read_process (lsns.c:516)
==28129==    by 0x403FB4: read_processes (lsns.c:586)
==28129==    by 0x403FB4: main (lsns.c:1417)