### PR TITLE
add padding to dates in issue file

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -2805,7 +2805,7 @@ static void output_special_char(struct issue *ie,
 		localtime_r(&now, &tm);
 
 		if (c == 'd') /* ISO 8601 */
-			fprintf(ie->output, "%s %s %d  %d",
+			fprintf(ie->output, "%s %s %2d  %d",
 				      nl_langinfo(ABDAY_1 + tm.tm_wday),
 				      nl_langinfo(ABMON_1 + tm.tm_mon),
 				      tm.tm_mday,


### PR DESCRIPTION
My issue file looks like this:
```
oooooo   oooooo     oooo           oooo
 `888.    `888.     .8'            `888
  `888.   .8888.   .8'    .ooooo.   888   .ooooo.   .ooooo.  ooo. .oo.  .oo.    .ooooo.
   `888  .8'`888. .8'    d88' `88b  888  d88' `"Y8 d88' `88b `888P"Y88bP"Y88b  d88' `88b
    `888.8'  `888.8'     888ooo888  888  888       888   888  888   888   888  888ooo888
     `888'    `888'      888    .o  888  888   .o8 888   888  888   888   888  888    .o
      `8'      `8'       `Y8bod8P' o888o `Y8bod8P' `Y8bod8P' o888o o888o o888o `Y8bod8P'

You're running                                                Today is: \d
\s \r                                                              Time: \t
```
It's just a cutesy message that prints your kernel version on the left and time and date on the right.
Problem is, when the day of the month is a single digit, the date's length gets shorter because the day of the month value isn't padded, so 3 weeks ago this issue file resulted in:
```
oooooo   oooooo     oooo           oooo
 `888.    `888.     .8'            `888
  `888.   .8888.   .8'    .ooooo.   888   .ooooo.   .ooooo.  ooo. .oo.  .oo.    .ooooo.
   `888  .8'`888. .8'    d88' `88b  888  d88' `"Y8 d88' `88b `888P"Y88bP"Y88b  d88' `88b
    `888.8'  `888.8'     888ooo888  888  888       888   888  888   888   888  888ooo888
     `888'    `888'      888    .o  888  888   .o8 888   888  888   888   888  888    .o
      `8'      `8'       `Y8bod8P' o888o `Y8bod8P' `Y8bod8P' o888o o888o o888o `Y8bod8P'

You're running                                                Today is: Fri Jun 3  2022
Linux 5.xx.xx                                                             Time: 12:00:00
```
This really bothers me, so I made this commit.