### PR TITLE
Add ARM Makalu/Makalu-ELP cores (A715/X3)

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -83,12 +83,14 @@ static const struct id_part arm_part[] = {
     { 0xd41, "Cortex-A78" },
     { 0xd42, "Cortex-A78AE" },
     { 0xd44, "Cortex-X1" },
-    { 0xd46, "Cortex-510" },
-    { 0xd47, "Cortex-710" },
+    { 0xd46, "Cortex-A510" },
+    { 0xd47, "Cortex-A710" },
     { 0xd48, "Cortex-X2" },
     { 0xd49, "Neoverse-N2" },
     { 0xd4a, "Neoverse-E1" },
     { 0xd4b, "Cortex-A78C" },
+    { 0xd4d, "Cortex-A715" },
+    { 0xd4e, "Cortex-X3" },
     { -1, "unknown" },
 };
 


### PR DESCRIPTION
ARM revealed recently that [their cores formerly known as Makalu/Makalu-ELP are A715 and X3 respectively](https://forums.anandtech.com/threads/arm-cortex-x3-cortex-a715-announcement.2605032/).

Also there are no Cortex-510/Cortex-710 but they still have an A in their name: https://review.trustedfirmware.org/plugins/gitiles/TF-A/trusted-firmware-a/+/refs/heads/master/include/lib/cpus/aarch64/