### PR TITLE
Adding Apple core names, distinguish by SoC/SiP name

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -167,7 +167,7 @@ static const struct id_part apple_part[] = {
     { 0x031, "Avalanche-T8110" },
     { 0x032, "Blizzard-T8112" },
     { 0x033, "Avalanche-T8112" },
-   { -1, "unknown" },
+    { -1, "unknown" },
 };
 
 static const struct id_part faraday_part[] = {

--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -159,9 +159,15 @@ static const struct id_part marvell_part[] = {
 };
 
 static const struct id_part apple_part[] = {
-    { 0x022, "Icestorm" },
-    { 0x023, "Firestorm" },
-    { -1, "unknown" },
+    { 0x020, "Icestorm-T8101" },
+    { 0x021, "Firestorm-T8101" },
+    { 0x022, "Icestorm-T8103" },
+    { 0x023, "Firestorm-T8103" },
+    { 0x030, "Blizzard-T8110" },
+    { 0x031, "Avalanche-T8110" },
+    { 0x032, "Blizzard-T8112" },
+    { 0x033, "Avalanche-T8112" },
+   { -1, "unknown" },
 };
 
 static const struct id_part faraday_part[] = {


### PR DESCRIPTION
Adding Apple core names, distinguish by SoC/SiP name [as suggested](https://github.com/util-linux/util-linux/pull/1737#issuecomment-1172068860).