### PR TITLE
Rename: improve handling of empty `from` argument

### DIFF
--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -57,8 +57,8 @@ static int string_replace(char *from, char *to, char *s, char *orig, char **newn
 	if (where == NULL)
 		return 1;
 	count++;
-	while ((all || last) && p) {
-		p = strstr(p + (last ? 1 : fromlen), from);
+	while ((all || last) && p && *p) {
+		p = strstr(p + (last ? 1 : max(fromlen, (size_t) 1)), from);
 		if (p) {
 			if (all)
 				count++;
@@ -75,8 +75,13 @@ static int string_replace(char *from, char *to, char *s, char *orig, char **newn
 		p = to;
 		while (*p)
 			*q++ = *p++;
-		p = where + fromlen;
-		where = strstr(p, from);
+		if (fromlen > 0) {
+			p = where + fromlen;
+			where = strstr(p, from);
+		} else {
+			p = where;
+			where += 1;
+		}
 	}
 	while (*p)
 		*q++ = *p++;

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -203,8 +203,13 @@ static int do_file(char *from, char *to, char *s, int verbose, int noact,
 		warn(_("stat of %s failed"), s);
 		return 2;
 	}
-	if (strchr(from, '/') == NULL && strchr(to, '/') == NULL)
+	if (strchr(from, '/') == NULL && strchr(to, '/') == NULL) {
 		file = strrchr(s, '/');
+                /* We're going to search for `from` in `file`. If `from` is
+                   empty, we don't want it to match before the '/'. */
+		if (file != NULL)
+			file++;
+	}
 	if (file == NULL)
 		file = s;
 	if (string_replace(from, to, file, s, &newname) != 0)

--- a/tests/expected/rename/basic
+++ b/tests/expected/rename/basic
@@ -16,3 +16,4 @@ what is rename_all* *.? doing here?
 `rename_zz_last_zzz.y' -> `rename_zz_last_zAAzzBB.y'
 `rename_zz_last_zzz.z' -> `rename_zz_last_zAAzzBB.z'
 what is rename*last* doing here?
+`rename_all_empty' -> `_r_e_n_a_m_e___a_l_l___e_m_p_t_y_'

--- a/tests/expected/rename/subdir
+++ b/tests/expected/rename/subdir
@@ -27,3 +27,8 @@ renxme/aa
 rename_path_a
 rename_path_b
 rename_path_b/test2
+== empty 'from' ==
+`rename_test' -> `_rename_test'
+`./rename_test' -> `./_rename_test'
+`rename_test' -> `rename_subdir/rename_test'
+`./rename_test' -> `rename_subdir/./rename_test'

--- a/tests/ts/rename/basic
+++ b/tests/ts/rename/basic
@@ -68,4 +68,8 @@ for i in rename*last* ; do
 	echo "what is $i doing here?" >> $TS_OUTPUT
 done
 
+touch rename_all_empty
+$TS_CMD_RENAME -v -a '' _ rename_all_empty >> $TS_OUTPUT 2>> $TS_ERRLOG
+rm -f _r_e_n_a_m_e___a_l_l___e_m_p_t_y_
+
 ts_finalize

--- a/tests/ts/rename/basic
+++ b/tests/ts/rename/basic
@@ -40,7 +40,7 @@ done
 
 
 touch rename_all\ file\ with\ spaces.{1..3}
-$TS_CMD_RENAME -v -a ' ' '_' rename_all*.? >> $TS_OUTPUT 2> $TS_ERRLOG
+$TS_CMD_RENAME -v -a ' ' '_' rename_all*.? >> $TS_OUTPUT 2>> $TS_ERRLOG
 
 for i in rename_all*\ *.?; do
 	echo "what is $i doing here?" >> $TS_OUTPUT
@@ -54,7 +54,7 @@ for i in rename_all_file_with_spaces.{1..3}; do
 done
 
 touch rename_zz_last_{z,z{,z{,z}}}.{x..z}
-$TS_CMD_RENAME -v -l zz AAzzBB rename_zz_last_* >> $TS_OUTPUT 2> $TS_ERRLOG
+$TS_CMD_RENAME -v -l zz AAzzBB rename_zz_last_* >> $TS_OUTPUT 2>> $TS_ERRLOG
 for i in rename_AAzzBB_last_z.x rename_AAzzBB_last_z.y rename_AAzzBB_last_z.z \
 	rename_zz_last_AAzzBB.x rename_zz_last_AAzzBB.y rename_zz_last_AAzzBB.z \
 	rename_zz_last_zAAzzBB.x rename_zz_last_zAAzzBB.y rename_zz_last_zAAzzBB.z ; do

--- a/tests/ts/rename/subdir
+++ b/tests/ts/rename/subdir
@@ -65,4 +65,24 @@ rm -f rename_path_a/test2 rename_path_b/test2
 
 rmdir rename_path_a rename_path_b
 
+echo "== empty 'from' ==" >> $TS_OUTPUT
+
+touch rename_test
+$TS_CMD_RENAME -v '' _ rename_test >> $TS_OUTPUT 2>> $TS_ERRLOG
+rm -f *rename_test
+
+touch rename_test
+$TS_CMD_RENAME -v '' _ ./rename_test >> $TS_OUTPUT 2>> $TS_ERRLOG
+rm -f *rename_test
+
+touch rename_test
+mkdir rename_subdir
+$TS_CMD_RENAME -v '' rename_subdir/ rename_test >> $TS_OUTPUT 2>> $TS_ERRLOG
+rm -rf rename_subdir
+
+touch rename_test
+mkdir rename_subdir
+$TS_CMD_RENAME -v '' rename_subdir/ ./rename_test >> $TS_OUTPUT 2>> $TS_ERRLOG
+rm -rf rename_subdir
+
 ts_finalize


### PR DESCRIPTION
This fixes two bugs when the `from` argument is the empty string.

* When the `to` argument doesn't contain a `/`, but the file path does, the `from` should be put at the beginning of the filename. Instead it was being put immediately before the final `/`:

      rename '' _ ./foo.txt 
      # previously would rename to ._/foo.txt (or fail if ._ doesn't exist as a folder)
      # now renames to ./_foo.txt

* Given `-a`, an empty `from` argument would hang, looping indefinitely in `string_replace`. It now places `to` in between every character of the filename, or every character of the full path if `to` contains a `/`.

      rename -a '' _ foo.txt
      # previously would hang
      # now renames to _f_o_o_._t_x_t_

I also replaced some `2> $TS_ERRLOG` with `2>> $TS_ERRLOG` in the rename tests, because that seemed correct. Fortunately there doesn't seem to have been any previous error output to clobber.

I could split these into three PRs if that's preferred, but they seemed related enough that I thought they might as well be one.