### PR TITLE
unshare: Fix "you (user xxxx) don't exist" error when uid differs from primary gid

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -864,14 +864,14 @@ int main(int argc, char *argv[])
 		case OPT_MAPGROUPS:
 			unshare_flags |= CLONE_NEWUSER;
 			if (!strcmp(optarg, "auto"))
-				groupmap = read_subid_range(_PATH_SUBGID, real_egid);
+				groupmap = read_subid_range(_PATH_SUBGID, real_euid);
 			else
 				groupmap = get_map_range(optarg);
 			break;
 		case OPT_MAPAUTO:
 			unshare_flags |= CLONE_NEWUSER;
 			usermap = read_subid_range(_PATH_SUBUID, real_euid);
-			groupmap = read_subid_range(_PATH_SUBGID, real_egid);
+			groupmap = read_subid_range(_PATH_SUBGID, real_euid);
 			break;
 		case OPT_SETGROUPS:
 			setgrpcmd = setgroups_str2id(optarg);


### PR DESCRIPTION
This problem affected the --map-auto and --map-groups=auto command-line switches.
The root cause is that /etc/subgid is indexed by user or uid, not by group or gid;
therefore, we should be using the effective uid to find entries in this file, just
as we do for /etc/subuid.

Signed-off-by: Sol Boucher <sboucher@cmu.edu>