### PR TITLE
lsfd: fix crash triggered by an empty filter expression

### DIFF
--- a/misc-utils/lsfd-filter.c
+++ b/misc-utils/lsfd-filter.c
@@ -869,8 +869,13 @@ static struct node *dparser_compile(struct parser *parser)
 			return NULL;
 		}
 
-		if (node == node0)
+		if (node == node0) {
+			if (node == NULL)
+				strncpy(parser->errmsg,
+					_("error: empty filter expression"),
+					ERRMSG_LEN - 1);
 			return node;
+		}
 		node = node0;
 	}
 }
@@ -1312,6 +1317,7 @@ struct lsfd_filter *lsfd_filter_new(const char *const expr, struct libscols_tabl
 		strcpy(filter->errmsg, parser.errmsg);
 		return filter;
 	}
+	assert(node);
 	if (parser.paren_level > 0) {
 		node_free(node);
 		strncpy(filter->errmsg, _("error: unbalanced parenthesis: ("), ERRMSG_LEN - 1);

--- a/tests/expected/lsfd/option-filter-broken-exp
+++ b/tests/expected/lsfd/option-filter-broken-exp
@@ -1,0 +1,7 @@
+lsfd: error: empty filter expression
+lsfd: error: empty filter expression
+lsfd: error: unbalanced parenthesis: )
+lsfd: error: unexpected token: garbage after OP2
+lsfd: error: bool expression is expected: FD
+lsfd: unknown column: NOSUCHCOLUMN
+lsfd: error: no such column: NOSUCHCOLUMN

--- a/tests/ts/lsfd/option-filter-broken-exp
+++ b/tests/ts/lsfd/option-filter-broken-exp
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="passing broken expressions to -Q option"
+
+. $TS_TOPDIR/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_LSFD"
+
+ts_cd "$TS_OUTDIR"
+
+{
+    $TS_CMD_LSFD -Q ''
+    $TS_CMD_LSFD -Q '('
+    $TS_CMD_LSFD -Q ')'
+    $TS_CMD_LSFD -Q '(FD == 1)garbage'
+    $TS_CMD_LSFD -Q 'FD' 
+    $TS_CMD_LSFD -Q 'NOSUCHCOLUMN'
+} > $TS_OUTPUT 2>&1
+
+ts_finalize


### PR DESCRIPTION
  $ lsfd -Q ''

or

  $ lsfd --filter ''

made lsfd process crash.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>