### PR TITLE
blkzone: make alignment check for zone size generic

### DIFF
--- a/sys-utils/blkzone.c
+++ b/sys-utils/blkzone.c
@@ -347,7 +347,7 @@ static int blkzone_action(struct blkzone_control *ctl)
 
 	fd = init_device(ctl, O_WRONLY | (ctl->force ? 0 : O_EXCL));
 
-	if (ctl->offset & (zonesize - 1))
+	if (ctl->offset % zonesize )
 		errx(EXIT_FAILURE, _("%s: offset %" PRIu64 " is not aligned "
 			"to zone size %lu"),
 			ctl->devname, ctl->offset, zonesize);
@@ -365,7 +365,7 @@ static int blkzone_action(struct blkzone_control *ctl)
 		zlen = ctl->total_sectors - ctl->offset;
 
 	if (ctl->length &&
-	    (zlen & (zonesize - 1)) &&
+	   (zlen % zonesize) &&
 	    ctl->offset + zlen != ctl->total_sectors)
 		errx(EXIT_FAILURE, _("%s: number of sectors %" PRIu64 " is not aligned "
 			"to zone size %lu"),


### PR DESCRIPTION
The zone offset and length alignment checks are based on a power-of-2(po2)
zone size assumption.

Make that calculation generic as there are ongoing efforts[1] to support
zoned devices with non-po2 zone sizes.

[1]
https://lore.kernel.org/all/20220803094801.177490-1-p.raghav@samsung.com/
Signed-off-by: Pankaj Raghav <p.raghav@samsung.com>