### PR TITLE
test: (lsfd) add a case for displaying PROTONAME column of mmap'ed AF…

### DIFF
--- a/tests/expected/lsfd/mkfds-mapped-packet-socket
+++ b/tests/expected/lsfd/mkfds-mapped-packet-socket
@@ -1,0 +1,2 @@
+   PACKET
+PROTONAME: 0

--- a/tests/ts/lsfd/mkfds-mapped-packet-socket
+++ b/tests/ts/lsfd/mkfds-mapped-packet-socket
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="mmap'ed AF_PACKET socket"
+
+. $TS_TOPDIR/functions.sh
+ts_init "$*"
+ts_skip_nonroot
+
+. $TS_SELF/lsfd-functions.bash
+
+ts_check_test_command "$TS_CMD_LSFD"
+
+ts_check_test_command "$TS_HELPER_MKFDS"
+
+ts_cd "$TS_OUTDIR"
+
+PID=
+FD=3
+EXPR=
+INTERFACE=lo
+
+{
+    coproc MKFDS { "$TS_HELPER_MKFDS" mapped-packet-socket $FD interface=${INTERFACE}; }
+    if read -u ${MKFDS[0]} PID; then
+	EXPR='(ASSOC == "shm") and (TYPE == "SOCK") and (MODE == "-w-")'
+	${TS_CMD_LSFD} -p "$PID" -n -o PROTONAME -Q "${EXPR}"
+	echo 'PROTONAME': $?
+    fi
+
+    kill -CONT ${PID}
+    wait ${MKFDS_PID}
+} > $TS_OUTPUT 2>&1
+
+ts_finalize


### PR DESCRIPTION
…_PACKET socket

Tools like tcpdump do mmap sockets!
This test case proves lsfd can extract information such a exotic
source of mmap.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>