### PR TITLE
meson: check for sys/pidfd.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -184,6 +184,7 @@ headers = '''
         sys/mkdev.h
         sys/mount.h
         sys/param.h
+        sys/pidfd.h
         sys/prctl.h
         sys/resource.h
 	sys/sendfile.h


### PR DESCRIPTION
84732a8849a introduced this check for autotools.

Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>