### PR TITLE
[build] fix compilation under macos, pipesz is linux only

### DIFF
--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -269,6 +269,7 @@ lsfd_LDADD = $(LDADD) libsmartcols.la libcommon.la
 lsfd_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
 endif
 
+if LINUX
 if BUILD_PIPESZ
 bin_PROGRAMS += pipesz
 MANPAGES += misc-utils/pipesz.1
@@ -276,4 +277,5 @@ dist_noinst_DATA += misc-utils/pipesz.1.adoc
 pipesz_SOURCES = misc-utils/pipesz.c
 pipesz_LDADD = $(LDADD) libcommon.la
 pipesz_CFLAGS = $(AM_CFLAGS)
+endif
 endif


### PR DESCRIPTION
Make `pipesz` linux only.

Fixes: #1772