### PR TITLE
configure.ac: Improve check for magic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1570,8 +1570,10 @@ AC_ARG_WITH([libmagic],
 )
 AS_IF([test "x$with_libmagic" = xno], [have_magic=no], [
   AC_CHECK_LIB([magic], [magic_open], [
-    AC_DEFINE([HAVE_MAGIC], [1], [Define to 1 if you have the libmagic present.])
-    MAGIC_LIBS="-lmagic"
+    AC_CHECK_HEADER(magic.h, [
+      AC_DEFINE([HAVE_MAGIC], [1], [Define to 1 if you have the libmagic present.])
+      MAGIC_LIBS="-lmagic"
+    ])
   ])
 ])
 AC_SUBST([MAGIC_LIBS])


### PR DESCRIPTION
Check whether magic.h header exists before defining HAVE_MAGIC.

Despite library availability there still can be missing header.
Current test doesn't cover that possibility which will lead compilation
to fail in case of separate sysroot.

Signed-off-by: Mateusz Marciniec <mateuszmar2@gmail.com>
Signed-off-by: Tomasz Dziendzielski <tomasz.dziendzielski@gmail.com>