### PR TITLE
Use "grep -E" instead of "egrep"

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -742,7 +742,7 @@ function ts_device_has {
 
 function ts_is_uuid()
 {
-	printf "%s\n" "$1" | egrep -q '^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$'
+	printf "%s\n" "$1" | grep -E -q '^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$'
 	return $?
 }
 

--- a/tests/ts/look/separator
+++ b/tests/ts/look/separator
@@ -22,8 +22,8 @@
 #
 # for example:
 #
-#	cat words.raw | egrep --invert-match "'s$" | \
-#		egrep  "^[[:alnum:]'&!,./-]+$" | \
+#	cat words.raw | grep -E --invert-match "'s$" | \
+#		grep -E "^[[:alnum:]'&!,./-]+$" | \
 #		sort --ignore-case --dictionary-order | \
 #		uniq >  words
 #

--- a/tests/ts/mount/remount
+++ b/tests/ts/mount/remount
@@ -42,7 +42,7 @@ mkfs.ext2 $DEVICE &> /dev/null || ts_die "Cannot make ext2 on $DEVICE"
 $TS_CMD_MOUNT $DEVICE $TS_MOUNTPOINT || ts_die "Cannot mount $TS_MOUNTPOINT"
 
 # check the mount
-egrep -q "^$DEVICE $TS_MOUNTPOINT" $MTAB_FILE \
+grep -E -q "^$DEVICE $TS_MOUNTPOINT" $MTAB_FILE \
  || ts_die "Cannot find $TS_MOUNTPOINT in $MTAB_FILE"
 
 # remount


### PR DESCRIPTION
The `egrep` command has been deprecated since GNU grep 2.5.3 (released in 2007).
In GNU grep 3.8, it issues an obsolescence warning:
https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a9515624709865d4

Use portable `grep -E` instead.