### PR TITLE
lib/path: ul_path_cpuparse: fix parsing of empty sysfs files

### DIFF
--- a/lib/path.c
+++ b/lib/path.c
@@ -1028,7 +1028,7 @@ static int ul_path_cpuparse(struct path_cxt *pc, cpu_set_t **set, int maxcpus, i
 	if (!f)
 		return -errno;
 
-	rc = fgets(buf, len, f) == NULL ? -errno : 0;
+	rc = fgets(buf, len, f) == NULL ? -EIO : 0;
 	fclose(f);
 
 	if (rc)


### PR DESCRIPTION
Kernel 5.15 returns empty content for topology/thread_siblings on aarch64 platform, which in conjunction of uninitialized `buf` memory buffer results in the garbage:

```
 (gdb) p buf
 $14 = " @\377\367\177\000\000\000\275\000\347j\032\236"
```

This garbage is then being later consumed by underlying helper functions like for example cpumask_parse() and this leads to the following crash later:

```
 in __libc_free (p=0x7ff7f67c00) at src/malloc/mallocng/free.c:105
 in free (p=<optimized out>) at src/malloc/free.c:5
 in add_cpuset_to_array (setsize=<optimized out>, set=<optimized out>, items=<optimized out>, ary=<optimized out>) at ../sys-utils/lscpu-topology.c:29
 in cputype_read_topology (cxt=cxt@entry=0x7ff7fffe70, ct=0x4298a0) at ../sys-utils/lscpu-topology.c:153
 in lscpu_read_topology (cxt=cxt@entry=0x7ff7fffe70) at ../sys-utils/lscpu-topology.c:629
 in main (argc=1, argv=0x7ffffffdb8) at ../sys-utils/lscpu.c:1341
```

So lets fix it by initializing the offending `buf` memory buffer.

```
root@OpenWrt:/# uname -a
Linux OpenWrt 5.15.68 #0 SMP Wed Sep 21 05:54:21 2022 aarch64 GNU/Linux

root@OpenWrt:/# lscpu 
Architecture:            aarch64
  CPU op-mode(s):        32-bit, 64-bit
  Byte Order:            Little Endian
CPU(s):                  2
  On-line CPU(s) list:   0,1
Vendor ID:               ARM
  Model name:            Cortex-A53
    Model:               4
    Thread(s) per core:  1
    Core(s) per cluster: 1
    Socket(s):           -
    Cluster(s):          1
    Stepping:            r0p4
    CPU(s) scaling MHz:  100%
    CPU max MHz:         1350.0000
    CPU min MHz:         437.5000
    BogoMIPS:            25.00
    Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
Vulnerabilities:         
  Itlb multihit:         Not affected
  L1tf:                  Not affected
  Mds:                   Not affected
  Meltdown:              Not affected
  Mmio stale data:       Not affected
  Retbleed:              Not affected
  Spec store bypass:     Not affected
  Spectre v1:            Mitigation; __user pointer sanitization
  Spectre v2:            Not affected
  Srbds:                 Not affected
  Tsx async abort:       Not affected
```

Fixes: #1810
Signed-off-by: Petr Štetiar <ynezz@true.cz>