### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -14,6 +14,9 @@ on:
       - 'Documentation/**'
       - 'lib*/docs/**'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,6 +41,10 @@ jobs:
       - name: Make install
         run: .github/workflows/cibuild.sh INSTALL
   coveralls:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      checks: write # to create new checks (coverallsapp/github-action)
+
     runs-on: ubuntu-latest
     if: github.repository == 'util-linux/util-linux'
     env:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -12,8 +12,15 @@ on:
       - master
     paths:
       - '**'
+permissions:
+  contents: read # to clone the repo (google/oss-fuzz/infra/cifuzz/actions/run_fuzzers)
+
 jobs:
   Fuzzing:
+    permissions:
+      actions: read # to fetch the artifacts (google/oss-fuzz/infra/cifuzz/actions/run_fuzzers)
+      contents: read # to clone the repo (google/oss-fuzz/infra/cifuzz/actions/run_fuzzers)
+
     runs-on: ubuntu-latest
     if: github.repository == 'util-linux/util-linux'
     strategy:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,6 +6,9 @@ on:
     # send data to Coverity daily at midnight
     - cron:  '0 0 * * *'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.