### PR TITLE
Add Kryo 3XX Gold core

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -131,6 +131,7 @@ static const struct id_part qcom_part[] = {
     { 0x211, "Kryo" },
     { 0x800, "Falkor V1/Kryo" },
     { 0x801, "Kryo V2" },
+    { 0x802, "Kryo 3XX Gold" },
     { 0x803, "Kryo 3XX Silver" },
     { 0x804, "Kryo 4XX Gold" },
     { 0x805, "Kryo 4XX Silver" },


### PR DESCRIPTION
Came accross a OnePlus 6T based on Snapdragon 845 featuring [Kryo 385 cores](https://en.wikipedia.org/wiki/Kryo#Kryo_385). `CPU part	: 0x802` was missing.

    processor	: 0
    BogoMIPS	: 38.40
    Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop
    CPU implementer	: 0x51
    CPU architecture: 8
    CPU variant	: 0x7
    CPU part	: 0x803
    CPU revision	: 12
    
    processor	: 1
    BogoMIPS	: 38.40
    Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop
    CPU implementer	: 0x51
    CPU architecture: 8
    CPU variant	: 0x7
    CPU part	: 0x803
    CPU revision	: 12
    
    processor	: 2
    BogoMIPS	: 38.40
    Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop
    CPU implementer	: 0x51
    CPU architecture: 8
    CPU variant	: 0x7
    CPU part	: 0x803
    CPU revision	: 12
    
    processor	: 3
    BogoMIPS	: 38.40
    Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop
    CPU implementer	: 0x51
    CPU architecture: 8
    CPU variant	: 0x7
    CPU part	: 0x803
    CPU revision	: 12
    
    processor	: 4
    BogoMIPS	: 38.40
    Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop
    CPU implementer	: 0x51
    CPU architecture: 8
    CPU variant	: 0x6
    CPU part	: 0x802
    CPU revision	: 13
    
    processor	: 5
    BogoMIPS	: 38.40
    Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop
    CPU implementer	: 0x51
    CPU architecture: 8
    CPU variant	: 0x6
    CPU part	: 0x802
    CPU revision	: 13
    
    processor	: 6
    BogoMIPS	: 38.40
    Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop
    CPU implementer	: 0x51
    CPU architecture: 8
    CPU variant	: 0x6
    CPU part	: 0x802
    CPU revision	: 13
    
    processor	: 7
    BogoMIPS	: 38.40
    Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop
    CPU implementer	: 0x51
    CPU architecture: 8
    CPU variant	: 0x6
    CPU part	: 0x802
    CPU revision	: 13