### PR TITLE
Added support of custom option separator for the cifs filesystem.

### DIFF
--- a/include/strutils.h
+++ b/include/strutils.h
@@ -394,6 +394,7 @@ extern char *ul_strchr_escaped(const char *s, int c);
 extern int skip_fline(FILE *fp);
 extern int ul_stralnumcmp(const char *p1, const char *p2);
 
-extern int ul_optstr_next(char **optstr, char **name, size_t *namesz, char **value, size_t *valsz);
+extern int ul_optstr_next(char **optstr, char **name, size_t *namesz,
+	char **value, size_t *valsz, char *opt_sep);
 
 #endif

--- a/libmount/src/context_loopdev.c
+++ b/libmount/src/context_loopdev.c
@@ -70,7 +70,8 @@ int mnt_context_is_loopdev(struct libmnt_context *cxt)
 		    st.st_size > 1024) {
 			DBG(LOOP, ul_debugobj(cxt, "automatically enabling loop= option"));
 			cxt->user_mountflags |= MNT_MS_LOOP;
-			mnt_optstr_append_option(&cxt->fs->user_optstr, "loop", NULL);
+			mnt_optstr_append_option_sep(&cxt->fs->user_optstr, "loop", NULL,
+				cxt->fs->opt_sep);
 			return 1;
 		}
 	}
@@ -133,7 +134,7 @@ is_mounted_same_loopfile(struct libmnt_context *cxt,
 			rc = loopdev_is_used((char *) src, bf, offset, 0, LOOPDEV_FL_OFFSET);
 
 		} else if (opts && (cxt->user_mountflags & MNT_MS_LOOP) &&
-		    mnt_optstr_get_option(opts, "loop", &val, &len) == 0 && val) {
+		    mnt_optstr_get_option_sep(opts, "loop", &val, &len, fs->opt_sep) == 0 && val) {
 
 			val = strndup(val, len);
 			rc = loopdev_is_used((char *) val, bf, offset, 0, LOOPDEV_FL_OFFSET);
@@ -179,7 +180,7 @@ int mnt_context_setup_loopdev(struct libmnt_context *cxt)
 	 * loop=
 	 */
 	if (rc == 0 && (cxt->user_mountflags & MNT_MS_LOOP) &&
-	    mnt_optstr_get_option(optstr, "loop", &val, &len) == 0 && val) {
+	    mnt_optstr_get_option_sep(optstr, "loop", &val, &len, cxt->fs->opt_sep) == 0 && val) {
 		loopval = strndup(val, len);
 		rc = loopval ? 0 : -ENOMEM;
 	}
@@ -188,7 +189,7 @@ int mnt_context_setup_loopdev(struct libmnt_context *cxt)
 	 * offset=
 	 */
 	if (rc == 0 && (cxt->user_mountflags & MNT_MS_OFFSET) &&
-	    mnt_optstr_get_option(optstr, "offset", &val, &len) == 0) {
+	    mnt_optstr_get_option_sep(optstr, "offset", &val, &len, cxt->fs->opt_sep) == 0) {
 		rc = mnt_parse_offset(val, len, &offset);
 		if (rc) {
 			DBG(LOOP, ul_debugobj(cxt, "failed to parse offset="));
@@ -200,7 +201,7 @@ int mnt_context_setup_loopdev(struct libmnt_context *cxt)
 	 * sizelimit=
 	 */
 	if (rc == 0 && (cxt->user_mountflags & MNT_MS_SIZELIMIT) &&
-	    mnt_optstr_get_option(optstr, "sizelimit", &val, &len) == 0) {
+	    mnt_optstr_get_option_sep(optstr, "sizelimit", &val, &len, cxt->fs->opt_sep) == 0) {
 		rc = mnt_parse_offset(val, len, &sizelimit);
 		if (rc) {
 			DBG(LOOP, ul_debugobj(cxt, "failed to parse sizelimit="));
@@ -212,7 +213,7 @@ int mnt_context_setup_loopdev(struct libmnt_context *cxt)
 	 * encryption=
 	 */
 	if (rc == 0 && (cxt->user_mountflags & MNT_MS_ENCRYPTION) &&
-	    mnt_optstr_get_option(optstr, "encryption", &val, &len) == 0) {
+	    mnt_optstr_get_option_sep(optstr, "encryption", &val, &len, cxt->fs->opt_sep) == 0) {
 		DBG(LOOP, ul_debugobj(cxt, "encryption no longer supported"));
 		rc = -MNT_ERR_MOUNTOPT;
 	}
@@ -382,7 +383,7 @@ success:
 			 */
 			DBG(LOOP, ul_debugobj(cxt, "removing unnecessary loop= from utab"));
 			cxt->user_mountflags &= ~MNT_MS_LOOP;
-			mnt_optstr_remove_option(&cxt->fs->user_optstr, "loop");
+			mnt_optstr_remove_option_sep(&cxt->fs->user_optstr, "loop", cxt->fs->opt_sep);
 		}
 
 		if (!(cxt->mountflags & MS_RDONLY) &&

--- a/libmount/src/context_umount.c
+++ b/libmount/src/context_umount.c
@@ -404,7 +404,7 @@ static int is_associated_fs(const char *devname, struct libmnt_fs *fs)
 	optstr = mnt_fs_get_user_options(fs);
 
 	if (optstr &&
-	    mnt_optstr_get_option(optstr, "offset", &val, &valsz) == 0) {
+	    mnt_optstr_get_option_sep(optstr, "offset", &val, &valsz, fs->opt_sep) == 0) {
 		flags |= LOOPDEV_FL_OFFSET;
 
 		if (mnt_parse_offset(val, valsz, &offset) != 0)
@@ -429,7 +429,7 @@ static int prepare_helper_from_options(struct libmnt_context *cxt,
 	if (!opts)
 		return 0;
 
-	if (mnt_optstr_get_option(opts, name, &suffix, &valsz))
+	if (mnt_optstr_get_option_sep(opts, name, &suffix, &valsz, cxt->fs->opt_sep))
 		return 0;
 
 	suffix = strndup(suffix, valsz);
@@ -593,8 +593,9 @@ static int evaluate_permissions(struct libmnt_context *cxt)
 	if (!optstr)
 		goto eperm;
 
-	if (mnt_optstr_get_flags(optstr, &u_flags,
-				mnt_get_builtin_optmap(MNT_USERSPACE_MAP)))
+	if (mnt_optstr_get_flags_sep(optstr, &u_flags,
+				mnt_get_builtin_optmap(MNT_USERSPACE_MAP),
+				cxt->fs->opt_sep))
 		goto eperm;
 
 	if (u_flags & MNT_MS_USERS) {
@@ -634,8 +635,8 @@ static int evaluate_permissions(struct libmnt_context *cxt)
 
 		/* get options from utab */
 		optstr = mnt_fs_get_user_options(cxt->fs);
-		if (optstr && !mnt_optstr_get_option(optstr,
-					"user", &utab_user, &sz) && sz)
+		if (optstr && !mnt_optstr_get_option_sep(optstr,
+					"user", &utab_user, &sz, cxt->fs->opt_sep) && sz)
 			ok = !strncmp(curr_user, utab_user, sz);
 
 		free(curr_user);

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -335,6 +335,9 @@ extern int mnt_fstype_is_pseudofs(const char *type);
 
 extern int mnt_match_fstype(const char *type, const char *pattern)
 			__ul_attribute__((warn_unused_result));
+extern int mnt_match_options_sep(const char *optstr, const char *pattern,
+			char *opt_sep)
+			__ul_attribute__((warn_unused_result));
 extern int mnt_match_options(const char *optstr, const char *pattern)
 			__ul_attribute__((warn_unused_result));
 extern const char *mnt_get_fstab_path(void);
@@ -382,29 +385,56 @@ extern char *mnt_pretty_path(const char *path, struct libmnt_cache *cache)
 			__ul_attribute__((warn_unused_result));
 
 /* optstr.c */
+extern int mnt_optstr_next_option_sep(char **optstr, char **name, size_t *namesz,
+				char **value, size_t *valuesz, char *opt_sep);
 extern int mnt_optstr_next_option(char **optstr, char **name, size_t *namesz,
 				char **value, size_t *valuesz);
+extern int mnt_optstr_append_option_sep(char **optstr, const char *name,
+				const char *value, const char *opt_sep);
 extern int mnt_optstr_append_option(char **optstr, const char *name,
 				const char *value);
+extern int mnt_optstr_prepend_option_sep(char **optstr, const char *name,
+				const char *value, const char *opt_sep);
 extern int mnt_optstr_prepend_option(char **optstr, const char *name,
 				const char *value);
 
+extern int mnt_optstr_get_option_sep(const char *optstr, const char *name,
+				char **value, size_t *valsz, char *opt_sep);
 extern int mnt_optstr_get_option(const char *optstr, const char *name,
 				char **value, size_t *valsz);
+extern int mnt_optstr_set_option_sep(char **optstr, const char *name,
+				const char *value, char *opt_sep);
 extern int mnt_optstr_set_option(char **optstr, const char *name,
 				const char *value);
+extern int mnt_optstr_remove_option_sep(char **optstr, const char *name,
+				char *opt_sep);
 extern int mnt_optstr_remove_option(char **optstr, const char *name);
+extern int mnt_optstr_deduplicate_option_sep(char **optstr, const char *name,
+				char *opt_sep);
 extern int mnt_optstr_deduplicate_option(char **optstr, const char *name);
+
+extern int mnt_split_optstr_sep(const char *optstr,
+			    char **user, char **vfs, char **fs,
+			    int ignore_user, int ignore_vfs, char *opt_sep);
 
 extern int mnt_split_optstr(const char *optstr,
 			    char **user, char **vfs, char **fs,
 			    int ignore_user, int ignore_vfs);
 
+extern int mnt_optstr_get_options_sep(const char *optstr, char **subset,
+				const struct libmnt_optmap *map, int ignore, char *opt_sep);
+
 extern int mnt_optstr_get_options(const char *optstr, char **subset,
                             const struct libmnt_optmap *map, int ignore);
 
+extern int mnt_optstr_get_flags_sep(const char *optstr, unsigned long *flags,
+				const struct libmnt_optmap *map, char *opt_sep);
+
 extern int mnt_optstr_get_flags(const char *optstr, unsigned long *flags,
 				const struct libmnt_optmap *map);
+
+extern int mnt_optstr_apply_flags_sep(char **optstr, unsigned long flags,
+                                const struct libmnt_optmap *map, char *opt_sep);
 
 extern int mnt_optstr_apply_flags(char **optstr, unsigned long flags,
                                 const struct libmnt_optmap *map);
@@ -477,6 +507,9 @@ extern const char *mnt_fs_get_options(struct libmnt_fs *fs)
 extern const char *mnt_fs_get_optional_fields(struct libmnt_fs *fs)
 			__ul_attribute__((warn_unused_result));
 extern int mnt_fs_get_propagation(struct libmnt_fs *fs, unsigned long *flags);
+
+extern int mnt_fs_set_options_separator(struct libmnt_fs *fs,
+	const char *opt_sep);
 
 extern int mnt_fs_set_options(struct libmnt_fs *fs, const char *optstr);
 extern int mnt_fs_append_options(struct libmnt_fs *fs, const char *optstr);

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -371,4 +371,17 @@ MOUNT_2_39 {
 	mnt_context_enable_onlyonce;
 	mnt_context_is_lazy;
 	mnt_context_get_mountinfo_userdata;
+	mnt_fs_set_options_separator;
+	mnt_match_options_sep;
+	mnt_optstr_next_option_sep;
+	mnt_optstr_append_option_sep;
+	mnt_optstr_prepend_option_sep;
+	mnt_optstr_get_option_sep;
+	mnt_optstr_set_option_sep;
+	mnt_optstr_remove_option_sep;
+	mnt_optstr_deduplicate_option_sep;
+	mnt_split_optstr_sep;
+	mnt_optstr_get_options_sep;
+	mnt_optstr_get_flags_sep;
+	mnt_optstr_apply_flags_sep;
 } MOUNT_2_38;

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -199,6 +199,7 @@ struct libmnt_fs {
 	char		*target;	/* mountinfo[5], fstab[2]: mountpoint */
 	char		*fstype;	/* mountinfo[9], fstab[3]: filesystem type */
 
+	char		opt_sep[2];	/* comma (",") or custom options separator */
 	char		*optstr;	/* fstab[4], merged options */
 	char		*vfs_optstr;	/* mountinfo[6]: fs-independent (VFS) options */
 	char		*opt_fields;	/* mountinfo[7]: optional fields */
@@ -404,11 +405,15 @@ extern const struct libmnt_optmap *mnt_optmap_get_entry(
 
 /* optstr.c */
 extern int mnt_optstr_get_uid(const char *optstr, const char *name, uid_t *uid);
-extern int mnt_optstr_remove_option_at(char **optstr, char *begin, char *end);
-extern int mnt_optstr_fix_gid(char **optstr, char *value, size_t valsz, char **next);
-extern int mnt_optstr_fix_uid(char **optstr, char *value, size_t valsz, char **next);
-extern int mnt_optstr_fix_secontext(char **optstr, char *value, size_t valsz, char **next);
-extern int mnt_optstr_fix_user(char **optstr);
+extern int mnt_optstr_remove_option_at(char **optstr, char *begin, char *end,
+	const char *opt_sep);
+extern int mnt_optstr_fix_gid(char **optstr, char *value, size_t valsz,
+	char **next, const char *opt_sep);
+extern int mnt_optstr_fix_uid(char **optstr, char *value, size_t valsz,
+	char **next, const char *opt_sep);
+extern int mnt_optstr_fix_secontext(char **optstr, char *value, size_t valsz,
+	char **next, const char *opt_sep);
+extern int mnt_optstr_fix_user(char **optstr, char *opt_sep);
 
 /* fs.c */
 extern struct libmnt_fs *mnt_copy_mtab_fs(const struct libmnt_fs *fs);

--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -287,9 +287,9 @@ static int utab_new_entry(struct libmnt_update *upd, struct libmnt_fs *fs,
 
 	if (o) {
 		/* remove non-mtab options */
-		rc = mnt_optstr_get_options(o, &u,
+		rc = mnt_optstr_get_options_sep(o, &u,
 				mnt_get_builtin_optmap(MNT_USERSPACE_MAP),
-				MNT_NOMTAB);
+				MNT_NOMTAB, fs->opt_sep);
 		if (rc)
 			goto err;
 	}

--- a/libsmartcols/src/column.c
+++ b/libsmartcols/src/column.c
@@ -659,13 +659,14 @@ int scols_column_set_properties(struct libscols_column *cl, const char *opts)
 	char *str = (char *) opts;
 	char *name, *value;
 	size_t namesz, valuesz;
+	char opt_sep[2] = ",";
 	unsigned int flags = 0;
 	int rc = 0;
 
 	DBG(COL, ul_debugobj(cl, "apply properties '%s'", opts));
 
 	while (rc == 0
-	       && !ul_optstr_next(&str, &name, &namesz, &value, &valuesz)) {
+	       && !ul_optstr_next(&str, &name, &namesz, &value, &valuesz, opt_sep)) {
 
 		if (strncmp(name, "trunc", namesz) == 0)
 			flags |= SCOLS_FL_TRUNC;

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -370,6 +370,9 @@ Use the specified mount options. The _opts_ argument is a comma-separated list. 
 +
 *mount LABEL=mydisk -o noatime,nodev,nosuid*
 +
+For the cifs filesystem, you can use your own options separator
+(see "sep" in mount.cifs(8)).
++
 For more details, see the *FILESYSTEM-INDEPENDENT MOUNT OPTIONS* and *FILESYSTEM-SPECIFIC MOUNT OPTIONS* sections.
 
 *--onlyonce*::


### PR DESCRIPTION
DESCRIPTION OF THE PROBLEM

Some users are accustomed to using shared folders in Windows with a comma in the name, for example: "//server3/Block 3,4".
When they try to migrate to Linux, they cannot mount such paths.

An example of the line generated by "mount.cifs" for the kernel when mounting "//server3/Block 3,4":
"ip=10.0.2.212,unc=\\server3\Block 3,4,iocharset=utf8,user=user1,domain=AD"
Accordingly, due to the extra comma, we have an error:
"Sep 7 21:57:18 S1 kernel: [ 795.604821] CIFS: Unknown mount option "4""


DOCUMENTATION

https://www.kernel.org/doc/html/latest/admin-guide/cifs/usage.html
The "sep" parameter is described here to specify a new delimiter instead of a comma.
I quote:
   "sep
   if first mount option (after the -o), overrides the comma as the separator between the mount parms. e.g.:
   -o user=myname,password=mypassword,domain=mydom
   could be passed instead with period as the separator by:
   -o sep=.user=myname.password=mypassword.domain=mydom
   this might be useful when comma is contained within username or password or domain."


RESEARCH WORK

I looked at the "mount.cifs" code. There is no provision for the use of a comma by the user, since the comma is used to form the parameter string to the kernel (man 2 mount). This line can be seen by adding the "--verbose" flag to the mount.
"mount.cifs --help" lists "sep" as a possible option, but does not implement it in the code and does not describe it in "man 8 mount.cifs".

I looked at the "pam-mount" code - the mount options are assembled with a wildcard comma. The result is a text line: "mount -t cifs ...".

The handling of options in the "mount" utility is based on the "libmount" library, which is hardcoded to use only a comma as a delimiter.

I tried to mount "//server3/Block 3,4" with my own program (man 2 mount) by specifying "sep=!" - successfully.


SOLUTION

It would be nice if we add in "mount.cifs", in "mount" utility and in "pam-mount" the ability to set a custom mount option separator. In other words, we need to implement the already documented "sep" option.

1. For "mount.cifs" I did it in: https://github.com/dmitry-telegin/cifs-utils in branch "custom_option_separator". Commit: https://github.com/dmitry-telegin/cifs-utils/commit/04325b842a82edf655a14174e763bc0b2a6870e1

2. For "mount" utility I did it in: https://github.com/dmitry-telegin/util-linux in branch "custom_option_separator". Commit: https://github.com/dmitry-telegin/util-linux/commit/5e0ecd2498edae0bf0bcab4ba6a68a9803b34ccf

3. For "pam-mount" I did it in: https://sourceforge.net/u/dmitry-t/pam-mount/ci/master/tree/ in branch "custom_option_separator". Commit: https://sourceforge.net/u/dmitry-t/pam-mount/ci/9860f9234977f1110230482b5d87bdcb8bc6ce03/

I checked the work on the Linux 5.10 kernel.