### PR TITLE
[WIP] Fix lsfd related failures reported in #1835

### DIFF
--- a/tests/ts/lsfd/column-ainodeclass
+++ b/tests/ts/lsfd/column-ainodeclass
@@ -20,9 +20,9 @@ TS_DESC="ainodeclass column"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
+. "$TS_SELF/lsfd-functions.bash"
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_HELPER_MKFDS"
-ts_skip_qemu_user
 
 ts_cd "$TS_OUTDIR"
 
@@ -38,7 +38,10 @@ EXPR="(FD == 3)"
 	    echo "$C"':ASSOC,STTYPE,AINODECLASS': $?
 
 	    kill -CONT "${PID}"
-	    wait "${MKFDS_PID}"
+	fi
+	wait "${MKFDS_PID}"
+	if [[ $? == "$UNSUPPORTED" ]]; then
+	    ts_skip "pidfs_open(2) is not available"
 	fi
     done
 } > "$TS_OUTPUT" 2>&1

--- a/tests/ts/lsfd/column-name
+++ b/tests/ts/lsfd/column-name
@@ -20,10 +20,10 @@ TS_DESC="NAME and KNAME column"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
+. "$TS_SELF/lsfd-functions.bash"
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_HELPER_MKFDS"
 ts_check_prog "sed"
-ts_skip_qemu_user
 
 ts_cd "$TS_OUTDIR"
 
@@ -51,7 +51,10 @@ EXPR="(FD == 3)"
 	    echo "$C"':ASSOC,KNAME,NAME': $?
 
 	    kill -CONT "${PID}"
-	    wait "${MKFDS_PID}"
+	fi
+	wait "${MKFDS_PID}"
+	if [[ $? == "$UNSUPPORTED" ]]; then
+	    ts_skip "pidfs_open(2) is not available"
 	fi
     done
 } > "$TS_OUTPUT" 2>&1

--- a/tests/ts/lsfd/column-type
+++ b/tests/ts/lsfd/column-type
@@ -20,9 +20,9 @@ TS_DESC="TYPE and STTYPE column"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
+. "$TS_SELF/lsfd-functions.bash"
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_HELPER_MKFDS"
-ts_skip_qemu_user
 
 ts_cd "$TS_OUTDIR"
 
@@ -46,7 +46,10 @@ EXPR="(FD == 3)"
 	    echo "$C"':ASSOC,STTYPE,TYPE': $?
 
 	    kill -CONT "${PID}"
-	    wait "${MKFDS_PID}"
+	fi
+	wait "${MKFDS_PID}"
+	if [[ $? == "$UNSUPPORTED" ]]; then
+	    ts_skip "pidfs_open(2) is not available"
 	fi
     done
 } > "$TS_OUTPUT" 2>&1

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -15,6 +15,8 @@
 # GNU General Public License for more details.
 #
 
+readonly UNSUPPORTED=17
+
 function lsfd_wait_for_pausing {
 	ts_check_prog "sleep"
 

--- a/tests/ts/lsfd/mkfds-mapped-packet-socket
+++ b/tests/ts/lsfd/mkfds-mapped-packet-socket
@@ -41,9 +41,9 @@ INTERFACE=lo
 	EXPR='(ASSOC == "shm") and (STTYPE == "SOCK") and (MODE == "-w-")'
 	${TS_CMD_LSFD} -p "$PID" -n -o SOCK.PROTONAME -Q "${EXPR}"
 	echo 'SOCK.PROTONAME': $?
+	kill -CONT ${PID}
     fi
 
-    kill -CONT ${PID}
     wait ${MKFDS_PID}
 } > $TS_OUTPUT 2>&1
 

--- a/tests/ts/lsfd/mkfds-mapped-packet-socket
+++ b/tests/ts/lsfd/mkfds-mapped-packet-socket
@@ -20,9 +20,8 @@ TS_DESC="mmap'ed AF_PACKET socket"
 . $TS_TOPDIR/functions.sh
 ts_init "$*"
 ts_skip_nonroot
-ts_skip_qemu_user
 
-. $TS_SELF/lsfd-functions.bash
+. "$TS_SELF/lsfd-functions.bash"
 
 ts_check_test_command "$TS_CMD_LSFD"
 
@@ -45,6 +44,9 @@ INTERFACE=lo
     fi
 
     wait ${MKFDS_PID}
+    if [[ $? == "$UNSUPPORTED" ]]; then
+	ts_skip "packet socket doesn't support attaching a buffer"
+    fi
 } > $TS_OUTPUT 2>&1
 
 ts_finalize

--- a/tests/ts/lsfd/mkfds-ro-block-device
+++ b/tests/ts/lsfd/mkfds-ro-block-device
@@ -20,6 +20,8 @@ TS_DESC="block device with O_RDONLY"
 . $TS_TOPDIR/functions.sh
 ts_init "$*"
 ts_skip_nonroot
+
+# losetup cannot find an unused loop device.
 ts_skip_qemu_user
 
 . $TS_SELF/lsfd-functions.bash

--- a/tests/ts/lsfd/mkfds-tcp
+++ b/tests/ts/lsfd/mkfds-tcp
@@ -22,6 +22,22 @@ ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_HELPER_MKFDS"
+
+# This test cases doesn't work well on Qemu user mode emulation.
+#
+# tests_mkfds command uses hton* functions when passing
+# IP addresses and TCP ports to Linux via bind(2) and connect(2).
+# On the other hand, Linux provides these information in host
+# byte order via /proc/net/tcp that lsfd reads.
+#
+# If Qemu emulates a big-endian architecture (e.g. s390) but its
+# host Linux runs on little-endian architecture (e.g. x86_64),
+# this test case doesn't work.
+#
+# test_mkfds built for s390 passes htonl(127.0.0.1) value to
+# x86_64 Linux. The linux may receive 1.0.0.127. The Linux
+# prints "1.0.0.127" in /proc/net/tcp. lsfd reads the string.
+# The string doesn't much 127.0.0.1.
 ts_skip_qemu_user
 
 ts_cd "$TS_OUTDIR"

--- a/tests/ts/lsfd/mkfds-unix-in-netns
+++ b/tests/ts/lsfd/mkfds-unix-in-netns
@@ -20,7 +20,8 @@ TS_DESC="UNIX sockets made in a differenct net namespace"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_skip_nonroot
-ts_skip_qemu_user
+
+. "$TS_SELF/lsfd-functions.bash"
 
 ts_check_test_command "$TS_CMD_LSFD"
 
@@ -68,8 +69,11 @@ compare_net_namespaces()
 	    compare_net_namespaces "$t" "${PID}"
 
 	    kill -CONT "${PID}"
-	    wait "${MKFDS_PID}"
 	fi
+	wait "${MKFDS_PID}"
+	if [[ $? == "$UNSUPPORTED" ]]; then
+	    ts_skip "unshare(2) is not permitted"
+        fi
 
 	coproc MKFDS { "$TS_HELPER_MKFDS" unix-in-netns $FDSELFNS $FDALTNS $FDSOCK \
 					  path=test_mkfds-unix-$t-ns \
@@ -84,8 +88,11 @@ compare_net_namespaces()
 	    compare_net_namespaces "abstract $t" "${PID}"
 
 	    kill -CONT "${PID}"
-	    wait "${MKFDS_PID}"
 	fi
+	wait "${MKFDS_PID}"
+	if [[ $? == "$UNSUPPORTED" ]]; then
+	    ts_skip "unshare(2) is not permitted"
+        fi
     done
 } > "$TS_OUTPUT" 2>&1
 


### PR DESCRIPTION
I'm inspecting lsfd related failures reported in #1835.

- [x] lsfd/column-ainodeclass (assignment: @masatake)
- [x] lsfd/column-name (assignment: @masatake)
- [x] lsfd/column-type (assignment: @masatake)
- [x] lsfd/mkfds-mapped-packet-socket (assignment: @masatake)
- [x] lsfd/mkfds-ro-block-device (assignment: @masatake)
- [x] lsfd/mkfds-tcp (assignment: @masatake)
- [x] lsfd/mkfds-unix-in-netns (assignment: @masatake)

When all the above sub issues are fixed, I will ask @t-8ch to cherry-pick my changes.

I merged #1835 to this branch because I want to test my changes on the s390 user emulation.