### PR TITLE
build-sys: sort the gitignore and add fadvise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,8 @@ GSYMS
 /cfdisk
 /chcpu
 /chfn
-/choom
 /chmem
+/choom
 /chrt
 /chsh
 /col
@@ -93,6 +93,7 @@ GSYMS
 /delpart
 /dmesg
 /eject
+/fadvise
 /fallocate
 /fdformat
 /fdisk
@@ -124,10 +125,10 @@ GSYMS
 /look
 /losetup
 /lsblk
+/lscpu
 /lsfd
 /lsipc
 /lsirq
-/lscpu
 /lslocks
 /lslogins
 /lsmem
@@ -162,8 +163,8 @@ GSYMS
 /runuser
 /sample-*
 /script
-/scriptreplay
 /scriptlive
+/scriptreplay
 /setarch
 /setpriv
 /setsid
@@ -178,6 +179,7 @@ GSYMS
 /taskset
 /test_*
 /tunelp
+/uclampset
 /ul
 /umount
 /unshare
@@ -192,5 +194,4 @@ GSYMS
 /wipefs
 /write
 /zramctl
-/uclampset
 /build*/


### PR DESCRIPTION
The fadvise binary was missing from the .gitignore, so it's been added.
At the same time I also sorted the binaries for those nice eye candy
points :)
