### PR TITLE
autotools: stop using AC_C_BIGENDIAN / WORDS_BIGENDIAN

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,7 +127,6 @@ AC_PROG_YACC
 AC_CANONICAL_HOST
 AC_C_CONST
 AC_C_VOLATILE
-AC_C_BIGENDIAN
 
 dnl Compiler warnings
 UL_WARN_ADD([-fno-common])

--- a/disk-utils/cramfs.h
+++ b/disk-utils/cramfs.h
@@ -36,11 +36,7 @@
 #define CRAMFS_OFFSET_WIDTH 26
 
 #ifndef HOST_IS_BIG_ENDIAN
-#ifdef WORDS_BIGENDIAN
-#define HOST_IS_BIG_ENDIAN 1
-#else
-#define HOST_IS_BIG_ENDIAN 0
-#endif
+#define HOST_IS_BIG_ENDIAN (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #endif
 
 /*

--- a/include/bitops.h
+++ b/include/bitops.h
@@ -87,7 +87,7 @@
 #endif
 
 #ifndef htobe16
-# if !defined(WORDS_BIGENDIAN)
+# if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #  define htobe16(x) bswap_16 (x)
 #  define htole16(x) (x)
 #  define be16toh(x) bswap_16 (x)

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -18,7 +18,7 @@
 
 #include "md5.h"
 
-#if !defined(WORDS_BIGENDIAN)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 # define byteReverse(buf, len)	/* Nothing */
 #else
 static void byteReverse(unsigned char *buf, unsigned longs);
@@ -38,7 +38,7 @@ static void byteReverse(unsigned char *buf, unsigned longs)
     } while (--longs);
 }
 #endif /* !ASM_MD5 */
-#endif /* !WORDS_BIGENDIAN */
+#endif /* __ORDER_LITTLE_ENDIAN__ */
 
 /*
  * Start MD5 accumulation.  Set bit count to 0 and buffer to mysterious

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -19,7 +19,7 @@
 #define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
 
 /* blk0() and blk() perform the initial expand. */
-#ifdef WORDS_BIGENDIAN
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 # define blk0(i) block->l[i]
 #else
 # define blk0(i) (block->l[i] = (rol(block->l[i],24)&0xFF00FF00) \

--- a/libblkid/src/superblocks/minix.c
+++ b/libblkid/src/superblocks/minix.c
@@ -61,7 +61,7 @@ static int get_minix_version(const unsigned char *data, int *other_endian)
 	if (!version)
 		return -1;
 
-#if defined(WORDS_BIGENDIAN)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 	endian = *other_endian ? "LE" : "BE";
 #else
 	endian = *other_endian ? "BE" : "LE";

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -999,7 +999,7 @@ static void print_summary(struct lscpu_cxt *cxt)
 	}
 	if (ct && ct->addrsz)
 		add_summary_s(tb, sec, _("Address sizes:"), ct->addrsz);
-#if !defined(WORDS_BIGENDIAN)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	add_summary_s(tb, sec, _("Byte Order:"), "Little Endian");
 #else
 	add_summary_s(tb, sec, _("Byte Order:"), "Big Endian");

--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -35,7 +35,7 @@ static int hlp_wordsize(void)
 
 static int hlp_endianness(void)
 {
-#if !defined(WORDS_BIGENDIAN)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	printf("LE\n");
 #else
 	printf("BE\n");


### PR DESCRIPTION
This define is specific to autotools. Not defining the macro will lead to silently miscompiled code as has happened with the meson build.

Instead use macros provided by the compiler itself. It does not need any support from the buildsystem and is supported by both gcc and clang.

If a compiler does not support this feature we will get a loud error instead of silent miscompilation.

Furthermore it probably better supports universal binaries on macOS which compiles multiple architectures in a single build.