### PR TITLE
fadvice: delete a unused struct definition

### DIFF
--- a/misc-utils/fadvise.c
+++ b/misc-utils/fadvise.c
@@ -68,14 +68,6 @@ static void __attribute__((__noreturn__)) usage(void)
 	exit(EXIT_SUCCESS);
 }
 
-struct fadvise_args {
-	int fd;
-	off_t offset;
-	off_t len;
-	int advice;
-};
-
-
 int main(int argc, char ** argv)
 {
 	int c;


### PR DESCRIPTION
I forgot deleting the struct definition in the last pull request.