### PR TITLE
libblkid: exfat - avoid undefined shift

### DIFF
--- a/libblkid/src/superblocks/exfat.c
+++ b/libblkid/src/superblocks/exfat.c
@@ -37,8 +37,8 @@ struct exfat_entry_label {
 	uint8_t reserved[8];
 } __attribute__((__packed__));
 
-#define BLOCK_SIZE(sb) (1u << (sb)->block_bits)
-#define CLUSTER_SIZE(sb) (BLOCK_SIZE(sb) << (sb)->bpc_bits)
+#define BLOCK_SIZE(sb) ((sb)->block_bits < 32 ? (1u << (sb)->block_bits) : 0)
+#define CLUSTER_SIZE(sb) ((sb)->bpc_bits < 32 ? (BLOCK_SIZE(sb) << (sb)->bpc_bits) : 0)
 #define EXFAT_FIRST_DATA_CLUSTER 2
 #define EXFAT_LAST_DATA_CLUSTER 0xffffff6
 #define EXFAT_ENTRY_SIZE 32


### PR DESCRIPTION
Exfat filesystem probe can use undefined shift if block_bits or bpc_bits is a bogus value. Avoid this by limiting shift size.

Reproducer found with OSS-Fuzz (issue 52571) running over cryptsetup project (blkid is used in header init).
