### PR TITLE
kill: Support mandating the presence of a userspace signal handler

### DIFF
--- a/misc-utils/kill.1.adoc
+++ b/misc-utils/kill.1.adoc
@@ -62,6 +62,8 @@ Similar to *-l*, but it will print signal names and their corresponding numbers.
 Do not restrict the command-name-to-PID conversion to processes with the same UID as the present process.
 *-p*, *--pid*::
 Only print the process ID (PID) of the named processes, do not send any signals.
+*-r*, *--require-handler*::
+Do not send the signal if it is not caught in userspace by the signalled process.
 *--verbose*::
 Print PID(s) that will be signaled with *kill* along with the signal.
 *-q*, *--queue* _value_::


### PR DESCRIPTION
In production we've had several incidents over the years where a process has a signal handler registered for SIGHUP or one of the SIGUSR signals which can be used to signal a request to reload configs, rotate log files, and the like. While this may seem harmless enough, what we've seen happen repeatedly is something like the following:

1. A process is using SIGHUP/SIGUSR[12] to request some application-handled state change -- reloading configs, rotating a log file, etc;
2. This kind of request is deprecated and removed, so the signal handler is removed. However, a site where the signal might be sent from is missed (often logrotate or a service manager);
3. Because the default disposition of these signals is terminal, sooner or later these applications are going to be sent SIGHUP or similar and end up unexpectedly killed.

I know for a fact that we're not the only organistion experiencing this: in general, signal use is pretty tricky to reason about and safely remove because of the fairly aggressive SIG_DFL behaviour for some common signals, especially for SIGHUP which has a particularly ambiguous meaning. Especially in a large, highly interconnected codebase, reasoning about signal interactions between system configuration and applications can be highly complex, and it's inevitable that on occasion a callsite will be missed.

In some cases the right call to avoid this will be to migrate services towards other forms of IPC for this purpose, but inevitably there will be some services which must continue using signals, so we need a safe way to support them.

This patch adds support for the -r/--require-handler flag, which checks if a userspace handler is present for the signal being sent. If it is not, the process will be skipped.

With this flag we can enforce that all SIGHUP reload cases and SIGUSR equivalents use --require-handler. This effectively mitigates the case we've seen time and time again where SIGHUP is used to rotate log files or reload configs, but the sending site is mistakenly left present after the removal of signal handler, resulting in unintended termination of the process.

Signed-off-by: Chris Down <chris@chrisdown.name>