### PR TITLE
libblkid: jfs - avoid undefined shift

### DIFF
--- a/libblkid/src/superblocks/jfs.c
+++ b/libblkid/src/superblocks/jfs.c
@@ -41,6 +41,8 @@ static int probe_jfs(blkid_probe pr, const struct blkid_idmag *mag)
 	js = blkid_probe_get_sb(pr, mag, struct jfs_super_block);
 	if (!js)
 		return errno ? -errno : 1;
+	if (le16_to_cpu(js->js_l2bsize) > 32 || le16_to_cpu(js->js_l2pbsize) > 32)
+		return 1;
 	if (le32_to_cpu(js->js_bsize) != (1U << le16_to_cpu(js->js_l2bsize)))
 		return 1;
 	if (le32_to_cpu(js->js_pbsize) != (1U << le16_to_cpu(js->js_l2pbsize)))


### PR DESCRIPTION
JFS probe can use undefined shift if stored log2 of block size is a bogus value. Avoid this by limiting shift size.

Reproducer found with OSS-Fuzz (issue 52643) running over cryptsetup project (blkid is used in header init).

Signed-off-by: Milan Broz <gmazyland@gmail.com>