### PR TITLE
libblkid: new fuzz target

### DIFF
--- a/libblkid/src/Makemodule.am
+++ b/libblkid/src/Makemodule.am
@@ -210,6 +210,19 @@ test_blkid_verify_CFLAGS = $(blkid_tests_cflags)
 test_blkid_verify_LDFLAGS = $(blkid_tests_ldflags)
 test_blkid_verify_LDADD = $(blkid_tests_ldadd)
 
+if FUZZING_ENGINE
+check_PROGRAMS += test_blkid_fuzz
+
+test_blkid_fuzz_SOURCES = libblkid/src/fuzz.c
+
+# https://google.github.io/oss-fuzz/getting-started/new-project-guide/#Requirements
+nodist_EXTRA_test_blkid_fuzz_SOURCES = dummy.cxx
+
+test_blkid_fuzz_CFLAGS = $(blkid_tests_cflags)
+test_blkid_fuzz_LDFLAGS = $(blkid_tests_ldflags) -lpthread
+test_blkid_fuzz_LDADD = $(blkid_tests_ldadd) $(LIB_FUZZING_ENGINE)
+endif
+
 endif # BUILD_LIBBLKID_TESTS
 
 

--- a/libblkid/src/fuzz.c
+++ b/libblkid/src/fuzz.c
@@ -1,0 +1,31 @@
+#include "blkidP.h"
+#include "fuzz.h"
+
+#include <stdlib.h>
+#include <unistd.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    int fd;
+    char name[] = "/tmp/test-script-fuzz.XXXXXX";
+
+    fd = mkostemp(name, O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC);
+    if (fd == -1)
+        err(EXIT_FAILURE, "mkostemp() failed");
+
+    if (write(fd, data, size) != (ssize_t)size)
+        goto out;
+
+    blkid_probe pr = blkid_new_probe_from_filename(name);
+    if (pr != NULL) {
+        blkid_probe_enable_partitions(pr, TRUE);
+        blkid_probe_set_partitions_flags(pr, FALSE);
+        blkid_probe_enable_superblocks(pr, TRUE);
+        blkid_probe_set_superblocks_flags(pr, BLKID_SUBLKS_DEFAULT | BLKID_SUBLKS_FSINFO | BLKID_SUBLKS_MAGIC | BLKID_SUBLKS_VERSION | BLKID_SUBLKS_BADCSUM);
+        blkid_do_safeprobe(pr);
+    }
+    blkid_free_probe(pr);
+out:
+    close(fd);
+    unlink(name);
+    return 0;
+}

--- a/tests/commands.sh
+++ b/tests/commands.sh
@@ -45,6 +45,7 @@ TS_HELPER_MBSENCODE="${ts_helpersdir}test_mbsencode"
 TS_HELPER_CAL="${ts_helpersdir}test_cal"
 TS_HELPER_LAST_FUZZ="${ts_helpersdir}test_last_fuzz"
 TS_HELPER_MKFDS="${ts_helpersdir}test_mkfds"
+TS_HELPER_BLKID_FUZZ="${ts_helpersdir}test_blkid_fuzz"
 
 # paths to commands
 TS_CMD_ADDPART=${TS_CMD_ADDPART:-"${ts_commandsdir}addpart"}

--- a/tests/ts/fuzzers/test_blkid_fuzz
+++ b/tests/ts/fuzzers/test_blkid_fuzz
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="test_blkid_fuzz"
+
+. $TS_TOPDIR/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_HELPER_BLKID_FUZZ"
+
+ASAN_RT_PATH="$(ts_get_asan_rt_path "$TS_HELPER_BLKID_FUZZ")"
+[ -n "$ASAN_RT_PATH" ] && export LD_PRELOAD="$ASAN_RT_PATH:$LD_PRELOAD"
+
+mkdir -p ${TS_OUTPUT}_workdir
+ts_run $TS_HELPER_BLKID_FUZZ ${TS_OUTPUT}_workdir ${TS_SCRIPT}_files -max_total_time=10 >$TS_OUTPUT 2>$TS_ERRLOG
+
+ts_finalize

--- a/tools/oss-fuzz.sh
+++ b/tools/oss-fuzz.sh
@@ -27,5 +27,9 @@ for d in "$(dirname $0)"/../tests/ts/fuzzers/test_*_fuzz_files; do
     zip -jqr $OUT/${fuzzer}_seed_corpus.zip "$d"
 done
 
+# create seed corpus for blkid fuzzing
+unxz -k "$(dirname $0)"/../tests/ts/blkid/images-*/*.xz
+zip -jqrm $OUT/test_blkid_fuzz_seed_corpus.zip "$(dirname $0)"/../tests/ts/blkid/images-*/*.img
+
 find . -maxdepth 1 -type f -executable -name "test_*_fuzz" -exec mv {} $OUT \;
 find . -type f -name "fuzz-*.dict" -exec cp {} $OUT \;


### PR DESCRIPTION
* Added new fuzz target calling blkid_do_safeprobe(), mainly based off of how libblkid is used in the cryptsetup project (same flags used etc.)
* Added the fuzz target to the Makemodule and all relevant scripts.
* Made as part of my upcoming bachelor thesis.

Signed-off-by: David Flor <493294@muni.cz>