### PR TITLE
agetty: always pass user name to login with --

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -558,8 +558,7 @@ int main(int argc, char **argv)
 		if (username) {
 			if (options.autolog)
 				login_argv[login_argc++] = "-f";
-			else
-				login_argv[login_argc++] = "--";
+			login_argv[login_argc++] = "--";
 			login_argv[login_argc++] = username;
 		}
 	}


### PR DESCRIPTION
I know it doesn't matter much in practice because nobody should create user names with leading hyphens anyway, but shouldn't `agetty` *always* pass the user name to `login` with a preceding `--`? To omit it with `-f` would make sense if `-f` took the user name as an optarg, but neither [util-linux](https://github.com/util-linux/util-linux/blob/96ccdc00e1fcf1684f9734a189baf90e00ff0c9a/login-utils/login.c#L1321) nor [shadow-utils](https://github.com/shadow-maint/shadow/blob/eaebea55a495a56317ed85e959b3599f73c6bdf2/src/login.c#L284) `login` seem to work like that

Note: I only tested this very briefly, by adding a drop-in for one of my `getty@.service` instances to make it call my modified `agetty` with `--autologin <user>`. That seemed to work as expected