### PR TITLE
mount: add rootcontext=@target

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -29,9 +29,9 @@
 #include "strutils.h"
 
 #if defined(HAVE_LIBSELINUX) || defined(HAVE_SMACK)
-static int is_option(const char *name, const char **names)
+static int is_option(const char *name, const char *const *names)
 {
-	const char **p;
+	const char *const *p;
 
 	for (p = names; p && *p; p++) {
 		if (strcmp(name, *p) == 0)
@@ -141,7 +141,7 @@ static int fix_optstr(struct libmnt_context *cxt)
 
 	/* Fix SELinux contexts */
 	if (se_rem || se_fix) {
-		static const char *selinux_options[] = {
+		static const char *const selinux_options[] = {
 			"context",
 			"fscontext",
 			"defcontext",
@@ -184,7 +184,7 @@ static int fix_optstr(struct libmnt_context *cxt)
 	if (access("/sys/fs/smackfs", F_OK) != 0) {
 		struct libmnt_iter itr;
 
-		static const char *smack_options[] = {
+		static const char *const smack_options[] = {
 			"smackfsdef",
 			"smackfsfloor",
 			"smackfshat",

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -508,7 +508,7 @@ The *fscontext=* option works for all filesystems, regardless of their xattr sup
 +
 You can set the default security context for unlabeled files using *defcontext=* option. This overrides the value set for unlabeled files in the policy and requires a filesystem that supports xattr labeling.
 +
-The *rootcontext=* option allows you to explicitly label the root inode of a FS being mounted before that FS or inode becomes visible to userspace. This was found to be useful for things like stateless Linux.
+The *rootcontext=* option allows you to explicitly label the root inode of a FS being mounted before that FS or inode becomes visible to userspace. This was found to be useful for things like stateless Linux. The special value *@target* can be used to assign the current context of the target mountpoint location.
 +
 Note that the kernel rejects any remount request that includes the context option, *even* when unchanged from the current context.
 +


### PR DESCRIPTION
Add a special value for rootcontext=, namely `@target`, to set the root
context of the new filesystem to the current context of the target
mountpoint.  Useful for in-memory filesystems, like tmpfs and ramfs.

Closes: #1830