### PR TITLE
libblkid: fix regression in setting BLOCK_SIZE value

### DIFF
--- a/libblkid/src/superblocks/superblocks.c
+++ b/libblkid/src/superblocks/superblocks.c
@@ -564,11 +564,6 @@ int blkid_probe_sprintf_version(blkid_probe pr, const char *fmt, ...)
 
 int blkid_probe_set_block_size(blkid_probe pr, unsigned block_size)
 {
-	struct blkid_chain *chn = blkid_probe_get_chain(pr);
-
-	if (!(chn->flags & BLKID_SUBLKS_FSINFO))
-		return 0;
-
 	return blkid_probe_sprintf_value(pr, "BLOCK_SIZE", "%u", block_size);
 }
 


### PR DESCRIPTION
In the stable version, the BLOCK_SIZE attribute is unconditionally set when probing the device.

Commit c9b2297eb1f357d9bc9989aacc874f218081fcb8 added a new FSINFO flag and conditionally set the BLOCK_SIZE attribute only when it is used.

This breaks the ABI interface. Cryptsetup reencrypt code depends on checking the minimal accessible FS block to prevent the destruction of the filesystem if a user requests reencryption to a larger sector than
the filesystem can handle.

This patch removes the condition to make ABI compatible again (as we cannot add FSINFO bit retrospectively).

Signed-off-by: Milan Broz <gmazyland@gmail.com>