### PR TITLE
Use https for project-related documentation.

### DIFF
--- a/Documentation/deprecated.txt
+++ b/Documentation/deprecated.txt
@@ -121,4 +121,4 @@ Copyright (C) 1997 The Open Group
 	line
 	pg
 
-  http://pubs.opengroup.org/onlinepubs/7908799/xcu/intro.html#tag_001_003_003
+  https://pubs.opengroup.org/onlinepubs/7908799/xcu/intro.html#tag_001_003_003

--- a/Documentation/howto-contribute.txt
+++ b/Documentation/howto-contribute.txt
@@ -32,7 +32,7 @@ Sending Patches
 	  Hint: use 'git clean -Xd'.
 
         * don't include po/ (translations) changes to the upstream patches.
-          The po/ stuff is maintained on http://translationproject.org/domain/util-linux.html
+          The po/ stuff is maintained on https://translationproject.org/domain/util-linux.html
           and updated always before the next release.
 
 	* neutrality: the files in util-linux should be distribution-neutral.
@@ -162,7 +162,7 @@ Coding Style
 	* the preferred coding style is based on the linux kernel coding-style.
 	  Available here:
 
-	http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/Documentation/process/coding-style.rst
+	https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/Documentation/process/coding-style.rst
 
 	* use 'FIXME:' with a good description, if you want to inform others
 	  that something is not quite right, and you are unwilling to fix the
@@ -244,5 +244,5 @@ Standards Compliance
 		The Single UNIX(TM) Specification, Version 2
 		Copyright (C) 1997 The Open Group
 
-		http://pubs.opengroup.org/onlinepubs/7908799/xcuix.html
+		https://pubs.opengroup.org/onlinepubs/7908799/xcuix.html
 

--- a/README
+++ b/README
@@ -45,7 +45,7 @@ BUG REPORTING:
 NLS (PO TRANSLATIONS):
 
       PO files are maintained by:
-	  http://translationproject.org/domain/util-linux.html
+	  https://translationproject.org/domain/util-linux.html
 
 VERSION SCHEMA:
 
@@ -77,7 +77,7 @@ SOURCE CODE:
 	  git clone git://github.com/util-linux/util-linux.git
 
     Web interfaces:
-	  http://git.kernel.org/cgit/utils/util-linux/util-linux.git
+	  https://git.kernel.org/cgit/utils/util-linux/util-linux.git
 	  https://github.com/util-linux/util-linux
 
       Note: the GitHub repository may contain temporary development branches too.

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_INIT([util-linux],
 	m4_esyscmd([tools/git-version-gen .tarball-version]),
 	[kzak@redhat.com], [],
-	[http://www.kernel.org/pub/linux/utils/util-linux/])
+	[https://www.kernel.org/pub/linux/utils/util-linux/])
 
 
 AC_PREREQ([2.64])

--- a/man-common/translation.adoc
+++ b/man-common/translation.adoc
@@ -2,7 +2,7 @@
 
 For the authors of this translation, see the header of the corresponding
 *.po file at GNU TP:
-http://translationproject.org/domain/util-linux-man.html
+https://translationproject.org/domain/util-linux-man.html
 
 ////
 TRANSLATORS: Please replace %1 with the address of the mailing list of your

--- a/util-linux.doap
+++ b/util-linux.doap
@@ -4,9 +4,9 @@
          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
          xmlns:foaf="http://xmlns.com/foaf/0.1/">
-  <Project rdf:about="http://www.kernel.org/pub/linux/utils/util-linux/">
+  <Project rdf:about="https://www.kernel.org/pub/linux/utils/util-linux/">
     <name>util-linux</name>
-    <homepage rdf:resource="http://www.kernel.org/pub/linux/utils/util-linux/" />
+    <homepage rdf:resource="https://www.kernel.org/pub/linux/utils/util-linux/" />
     <shortdesc>
       util-linux is a random collection of Linux utilities
     </shortdesc>
@@ -21,7 +21,7 @@
     <repository>
       <GitRepository>
         <location rdf:resource="git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git"/>
-        <browse rdf:resource="http://git.kernel.org/cgit/utils/util-linux/util-linux.git"/>
+        <browse rdf:resource="https://git.kernel.org/cgit/utils/util-linux/util-linux.git"/>
       </GitRepository>
     </repository>
     <maintainer>


### PR DESCRIPTION
Some browsers already force https use, fix links
for sites that can be easily redirected.

Signed-off-by: Milan Broz <gmazyland@gmail.com>