### PR TITLE
[tests] skip mount btrfs if kernel support for filesystem is missing

### DIFF
--- a/tests/ts/mount/fstab-btrfs
+++ b/tests/ts/mount/fstab-btrfs
@@ -51,6 +51,8 @@ DEVICE=$TS_LODEV
 [ -d "$TS_MOUNTPOINT_BIND" ] || mkdir -p "$TS_MOUNTPOINT_BIND"
 mkfs.btrfs -d single -m single $DEVICE &> /dev/null || ts_die "Cannot make btrfs on $DEVICE"
 
+btrfs device ready $DEVICE 2>/dev/null || ts_skip "btrfs kernel support is missing"
+
 $TS_CMD_MOUNT -o loop "$DEVICE" "$TS_MOUNTPOINT_CREATE" &> /dev/null
 pushd . >/dev/null
 cd "$TS_MOUNTPOINT_CREATE"


### PR DESCRIPTION
Fixes mount/fstab test failure on btrfs filesystem, if kernel support for btrfs is missing

before:
```
           ... OK (all 2 sub-tests PASSED)
        mount: btrfs (fstab)                  ...ERROR: not a btrfs filesystem: .
/1/mator/util-linux/tests/../tests/ts/mount/fstab-btrfs: line 61: cd: ./s1: No such file or directory
ERROR: not a btrfs filesystem: .
ERROR: cannot access 's2': No such file or directory
ERROR: Not a Btrfs filesystem: Invalid argument
ERROR: not a btrfs filesystem: /1/mator/util-linux/tests/output/mount/fstab-btrfs-mnt-create
ERROR: can't access '/1/mator/util-linux/tests/output/mount/fstab-btrfs-mnt-create'
ERROR: not a btrfs filesystem: .
umount: /1/mator/util-linux/tests/output/mount/fstab-btrfs-mnt-create: not mounted.

                : btrfs                       ... FAILED (mount/fstab-btrfs-btrfs)
                : auto                        ... FAILED (mount/fstab-btrfs-auto)
           ... FAILED (2 from 2 sub-tests)
        mount: by devname (fstab)             ...
```
after:
```
           ... OK (all 2 sub-tests PASSED)
        mount: btrfs (fstab)                  ... SKIPPED (btrfs kernel support is missing)
        mount: by devname (fstab)             ...
```