### PR TITLE
libblkid: ntfs - avoid undefined shift

### DIFF
--- a/libblkid/src/superblocks/ntfs.c
+++ b/libblkid/src/superblocks/ntfs.c
@@ -138,9 +138,11 @@ static int __probe_ntfs(blkid_probe pr, const struct blkid_idmag *mag, int save_
 	if (ns->clusters_per_mft_record > 0)
 		mft_record_size = ns->clusters_per_mft_record *
 				  sectors_per_cluster * sector_size;
-	else
-		mft_record_size = 1 << (0 - ns->clusters_per_mft_record);
-
+	else {
+        if ((0 - ns->clusters_per_mft_record) > 30)
+            return 1;
+        mft_record_size = 1 << (0 - ns->clusters_per_mft_record);
+    }
 	nr_clusters = le64_to_cpu(ns->number_of_sectors) / sectors_per_cluster;
 
 	if ((le64_to_cpu(ns->mft_cluster_location) > nr_clusters) ||


### PR DESCRIPTION
NTFS probe can evoke undefined shift if number of cluster per MFT record is a nonsense value

Found by OSS-fuzz (issue #53142)

Signed-off-by: David Flor <493294@muni.cz>