### PR TITLE
libblkid: iso9660 - avoid buffer overflow

### DIFF
--- a/libblkid/src/superblocks/iso9660.c
+++ b/libblkid/src/superblocks/iso9660.c
@@ -195,7 +195,7 @@ static size_t merge_utf16be_ascii(unsigned char *out, const unsigned char *utf16
 		}
 	}
 
-	for (; a < len; o += 2, a++) {
+	for (; o < (len * 2) - 1 && a < len; o += 2, a++) {
 		out[o] = 0x00;
 		out[o + 1] = ascii[a];
 	}


### PR DESCRIPTION
added check to prevent buffer overflow in merge_utf16be_ascii()

Found by OSS-fuzz (issue #53149)

Signed-off-by: David Flor <493294@muni.cz>