### PR TITLE
libblkid: fix unaligned accesses

### DIFF
--- a/libblkid/src/superblocks/bitlocker.c
+++ b/libblkid/src/superblocks/bitlocker.c
@@ -113,7 +113,7 @@ static int get_bitlocker_headers(blkid_probe pr,
 		goto nothing;
 	}
 
-	if (!off)
+	if (!off || off % 64)
 		goto nothing;
 	if (buf_hdr)
 		*buf_hdr = buf;

--- a/libblkid/src/superblocks/f2fs.c
+++ b/libblkid/src/superblocks/f2fs.c
@@ -62,6 +62,8 @@ static int f2fs_validate_checksum(blkid_probe pr, size_t sb_off,
 	uint32_t csum_off = le32_to_cpu(sb->checksum_offset);
 	if (!csum_off)
 		return 1;
+	if (csum_off % sizeof(uint32_t) != 0)
+		return 0;
 	if (csum_off + sizeof(uint32_t) > 4096)
 		return 0;
 


### PR DESCRIPTION
Note: There are no testfiles for bitlocker.