### PR TITLE
oss-fuzz: turn on the alignment check explicitly

### DIFF
--- a/tools/oss-fuzz.sh
+++ b/tools/oss-fuzz.sh
@@ -17,6 +17,13 @@ export CXXFLAGS=${CXXFLAGS:-$flags}
 export OUT=${OUT:-$(pwd)/out}
 mkdir -p $OUT
 
+if [[ "$SANITIZER" == undefined ]]; then
+    additional_ubsan_checks=alignment
+    UBSAN_FLAGS="-fsanitize=$additional_ubsan_checks -fno-sanitize-recover=$additional_ubsan_checks"
+    CFLAGS+=" $UBSAN_FLAGS"
+    CXXFLAGS+=" $UBSAN_FLAGS"
+fi
+
 ./autogen.sh
 ./configure --disable-all-programs --enable-libuuid --enable-libfdisk --enable-last --enable-fuzzing-engine --enable-libmount --enable-libblkid
 make -j$(nproc) V=1 check-programs


### PR DESCRIPTION
to somewhat cover architectures where unaligned access can lead to crashes and make it possible for OSS-Fuzz to catch issues like https://github.com/util-linux/util-linux/pull/1906.

With this patch applied the libblkid fuzz target built with the OSS-Fuzz toolchain triggers "runtime error: load of misaligned address" in `probe_exfat` so it seems to be working.