### PR TITLE
irqtop: improve delta-sort stability

### DIFF
--- a/sys-utils/irq-common.c
+++ b/sys-utils/irq-common.c
@@ -378,7 +378,9 @@ static inline int cmp_total(const struct irq_info *a,
 static inline int cmp_delta(const struct irq_info *a,
 		      const struct irq_info *b)
 {
-	return a->delta < b->delta;
+	if (a->delta != b->delta)
+		return a->delta < b->delta;
+	return cmp_name(a, b);
 }
 
 static inline int cmp_interrupts(const struct irq_info *a,


### PR DESCRIPTION
When sorting irqs by delta, sort first by delta, then by name. This helps interrupts occuring at the same rate reach a more stable display ordering.

Signed-off-by: Richard Allen <rsaxvc@gmail.com>