### PR TITLE
tests: wrap $TS_{TOPDIR,SELF} in "." cmdline with double quote chars

### DIFF
--- a/tests/ts/bitops/swapbytes
+++ b/tests/ts/bitops/swapbytes
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="swap bytes"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_BYTESWAP"

--- a/tests/ts/blkdiscard/offsets
+++ b/tests/ts/blkdiscard/offsets
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="offsets"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_BLKDISCARD"

--- a/tests/ts/blkid/dm-err
+++ b/tests/ts/blkid/dm-err
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="DM error"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_BLKID"

--- a/tests/ts/blkid/low-probe
+++ b/tests/ts/blkid/low-probe
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="superblocks probing"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/blkid/lowprobe-pt
+++ b/tests/ts/blkid/lowprobe-pt
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="partitions probing"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/blkid/md-raid0-whole
+++ b/tests/ts/blkid/md-raid0-whole
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="MD raid0 (whole-disks)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/blkid/md-raid1-part
+++ b/tests/ts/blkid/md-raid1-part
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="MD raid1 (last partition)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/blkid/md-raid1-whole
+++ b/tests/ts/blkid/md-raid1-whole
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="MD raid1 (whole-disks)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/build-sys/config
+++ b/tests/ts/build-sys/config
@@ -8,7 +8,7 @@ TS_DESC="config"
 # Don't execute this test by default, --force required
 TS_OPTIONAL="yes"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_prog "readelf"

--- a/tests/ts/cal/bigyear
+++ b/tests/ts/cal/bigyear
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="Year 2147483646"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_CAL"

--- a/tests/ts/cal/color
+++ b/tests/ts/cal/color
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="color"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_CAL"

--- a/tests/ts/cal/colorw
+++ b/tests/ts/cal/colorw
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="color with week numbers"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_CAL"

--- a/tests/ts/cal/jan1753
+++ b/tests/ts/cal/jan1753
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="January 1753"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_CAL"

--- a/tests/ts/cal/month
+++ b/tests/ts/cal/month
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="month"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_CAL"

--- a/tests/ts/cal/sep1752
+++ b/tests/ts/cal/sep1752
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="September 1752"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_CAL"

--- a/tests/ts/cal/vertical
+++ b/tests/ts/cal/vertical
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="vertical"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_CAL"

--- a/tests/ts/cal/weekarg
+++ b/tests/ts/cal/weekarg
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="week number given as argument"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_CAL"

--- a/tests/ts/cal/weeknum
+++ b/tests/ts/cal/weeknum
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="week number corner cases"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_CAL"

--- a/tests/ts/cal/year
+++ b/tests/ts/cal/year
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="year"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_CAL"

--- a/tests/ts/chfn/gecos
+++ b/tests/ts/chfn/gecos
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="gecos"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_skip_nonroot

--- a/tests/ts/col/io
+++ b/tests/ts/col/io
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="io effects"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_COL"

--- a/tests/ts/col/multibyte
+++ b/tests/ts/col/multibyte
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="multibyte input"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_COL"

--- a/tests/ts/col/newlines
+++ b/tests/ts/col/newlines
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="newline handling"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_COL"

--- a/tests/ts/col/options
+++ b/tests/ts/col/options
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="options"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_COL"

--- a/tests/ts/colcrt/functional
+++ b/tests/ts/colcrt/functional
@@ -18,7 +18,7 @@ TS_DESC="functional"
 
 export LC_CTYPE='C'
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_check_wcsspn
 

--- a/tests/ts/colcrt/regressions
+++ b/tests/ts/colcrt/regressions
@@ -16,7 +16,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="regressions"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_check_wcsspn
 

--- a/tests/ts/colrm/rm2-2
+++ b/tests/ts/colrm/rm2-2
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="basic check"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_COLRM"

--- a/tests/ts/column/columnate
+++ b/tests/ts/column/columnate
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="columnate"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_COLUMN"

--- a/tests/ts/column/invalid-multibyte
+++ b/tests/ts/column/invalid-multibyte
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="invalid multibyte"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_COLUMN"

--- a/tests/ts/column/multi-file
+++ b/tests/ts/column/multi-file
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="multiple files"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_COLUMN"

--- a/tests/ts/column/table
+++ b/tests/ts/column/table
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="table"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_check_wcsspn
 

--- a/tests/ts/cramfs/doubles
+++ b/tests/ts/cramfs/doubles
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mkfs doubles"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKCRAMFS"

--- a/tests/ts/cramfs/fsck-bad-header
+++ b/tests/ts/cramfs/fsck-bad-header
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fsck bad header"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKCRAMFS"

--- a/tests/ts/cramfs/fsck-endianness
+++ b/tests/ts/cramfs/fsck-endianness
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fsck endianness"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKCRAMFS"

--- a/tests/ts/cramfs/mkfs
+++ b/tests/ts/cramfs/mkfs
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mkfs checksums"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKCRAMFS"

--- a/tests/ts/cramfs/mkfs-endianness
+++ b/tests/ts/cramfs/mkfs-endianness
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mkfs endianness"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKCRAMFS"

--- a/tests/ts/dmesg/colors
+++ b/tests/ts/dmesg/colors
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="colors"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_DMESG"

--- a/tests/ts/dmesg/console-levels
+++ b/tests/ts/dmesg/console-levels
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="levels"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_DMESG"

--- a/tests/ts/dmesg/decode
+++ b/tests/ts/dmesg/decode
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="decode"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_DMESG"

--- a/tests/ts/dmesg/delta
+++ b/tests/ts/dmesg/delta
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="delta"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_DMESG"

--- a/tests/ts/dmesg/facilities
+++ b/tests/ts/dmesg/facilities
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="facilities"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_DMESG"

--- a/tests/ts/dmesg/indentation
+++ b/tests/ts/dmesg/indentation
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="indentation"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_DMESG"

--- a/tests/ts/eject/umount
+++ b/tests/ts/eject/umount
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="umount"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_skip_nonroot

--- a/tests/ts/fdisk/align-512-4K
+++ b/tests/ts/fdisk/align-512-4K
@@ -23,7 +23,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="align 512/4K"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/align-512-4K-63
+++ b/tests/ts/fdisk/align-512-4K-63
@@ -23,7 +23,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="align 512/4K +alignment_offset"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/align-512-4K-md
+++ b/tests/ts/fdisk/align-512-4K-md
@@ -23,7 +23,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="align 512/4K +MD"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/align-512-512
+++ b/tests/ts/fdisk/align-512-512
@@ -22,7 +22,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="align 512/512"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/align-512-512-topology
+++ b/tests/ts/fdisk/align-512-512-topology
@@ -23,7 +23,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="align 512/512 +topology"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/bsd
+++ b/tests/ts/fdisk/bsd
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="nested BSD"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/gpt
+++ b/tests/ts/fdisk/gpt
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="GPT"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/gpt-resize
+++ b/tests/ts/fdisk/gpt-resize
@@ -21,7 +21,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="gpt-resize"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_skip_nonroot

--- a/tests/ts/fdisk/id
+++ b/tests/ts/fdisk/id
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="MBR - id"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/mbr-dos-mode
+++ b/tests/ts/fdisk/mbr-dos-mode
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="MBR - dos mode"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/mbr-nondos-mode
+++ b/tests/ts/fdisk/mbr-nondos-mode
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="MBR - non-dos mode"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/mbr-sort
+++ b/tests/ts/fdisk/mbr-sort
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="MBR - sort"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/oddinput
+++ b/tests/ts/fdisk/oddinput
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="invalid input tests"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fdisk/sunlabel
+++ b/tests/ts/fdisk/sunlabel
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="sunlabel tests"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/fincore/count
+++ b/tests/ts/fincore/count
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="count file contents in core"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_SYSINFO"

--- a/tests/ts/findmnt/filter
+++ b/tests/ts/findmnt/filter
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="filter"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FINDMNT"

--- a/tests/ts/findmnt/outputs
+++ b/tests/ts/findmnt/outputs
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="outputs"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FINDMNT"

--- a/tests/ts/findmnt/target
+++ b/tests/ts/findmnt/target
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="target"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FINDMNT"

--- a/tests/ts/fsck/ismounted
+++ b/tests/ts/fsck/ismounted
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="is mounted"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/fuzzers/test_blkid_fuzz
+++ b/tests/ts/fuzzers/test_blkid_fuzz
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="test_blkid_fuzz"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_BLKID_FUZZ"

--- a/tests/ts/fuzzers/test_fdisk_script_fuzz
+++ b/tests/ts/fuzzers/test_fdisk_script_fuzz
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="test_fdisk_script_fuzz"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_LIBFDISK_SCRIPT_FUZZ"

--- a/tests/ts/fuzzers/test_last_fuzz
+++ b/tests/ts/fuzzers/test_last_fuzz
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="test_last_fuzz"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_LAST_FUZZ"

--- a/tests/ts/fuzzers/test_mount_fuzz
+++ b/tests/ts/fuzzers/test_mount_fuzz
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="test_mount_fuzz"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_LIBMOUNT_FUZZ"

--- a/tests/ts/getopt/basic
+++ b/tests/ts/getopt/basic
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="basic"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_GETOPT"

--- a/tests/ts/getopt/options
+++ b/tests/ts/getopt/options
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="options"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 ts_check_test_command "$TS_CMD_GETOPT"

--- a/tests/ts/hardlink/options
+++ b/tests/ts/hardlink/options
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="options"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/hexdump/format-strings
+++ b/tests/ts/hexdump/format-strings
@@ -19,7 +19,7 @@ FILES="$TS_TOPDIR/ts/hexdump/files"
 #for i in range(256):
 #	print(chr(i), end= ' ')
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_HEXDUMP"

--- a/tests/ts/hexdump/highlighting
+++ b/tests/ts/hexdump/highlighting
@@ -21,7 +21,7 @@ ADDRFMT='-e "%07.7_Ax\n"'
 #for i in range(256):
 #	print(chr(i), end= ' ')
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_HEXDUMP"

--- a/tests/ts/hwclock/systohc
+++ b/tests/ts/hwclock/systohc
@@ -20,7 +20,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="system to hw"
 NTP_SERVER="0.fedora.pool.ntp.org"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_HWCLOCK"

--- a/tests/ts/ipcs/headers
+++ b/tests/ts/ipcs/headers
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="headers"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_IPCS"

--- a/tests/ts/ipcs/limits
+++ b/tests/ts/ipcs/limits
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="limits overflow"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_IPCS"
@@ -28,7 +28,7 @@ ts_check_test_command "$TS_HELPER_SYSINFO"
 ts_skip_nonroot
 ts_check_prog "bc"
 
-. $TS_SELF/functions.sh
+. "$TS_SELF"/functions.sh
 
 ts_lock "ipcslimits"
 

--- a/tests/ts/ipcs/limits2
+++ b/tests/ts/ipcs/limits2
@@ -19,14 +19,14 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="basic limits"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_IPCS"
 ts_check_test_command "$TS_HELPER_SYSINFO"
 ts_check_prog "bc"
 
-. $TS_SELF/functions.sh
+. "$TS_SELF"/functions.sh
 
 ts_lock "ipcslimits"
 

--- a/tests/ts/ipcs/mk-rm-msg
+++ b/tests/ts/ipcs/mk-rm-msg
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mk-rm-msg"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_IPCS"
@@ -23,7 +23,7 @@ ts_check_test_command "$TS_CMD_IPCMK"
 ts_check_test_command "$TS_CMD_IPCRM"
 ts_check_test_command "$TS_HELPER_SYSINFO"
 
-. $TS_SELF/functions.sh
+. "$TS_SELF"/functions.sh
 
 rm -f $TS_OUTDIR/id-msg
 $TS_CMD_IPCMK -Q 2>>$TS_OUTPUT | ipcmk_output_handler $TS_OUTPUT $TS_OUTDIR/id-msg

--- a/tests/ts/ipcs/mk-rm-sem
+++ b/tests/ts/ipcs/mk-rm-sem
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mk-rm-sem"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_IPCS"
@@ -23,7 +23,7 @@ ts_check_test_command "$TS_CMD_IPCMK"
 ts_check_test_command "$TS_CMD_IPCRM"
 ts_check_test_command "$TS_HELPER_SYSINFO"
 
-. $TS_SELF/functions.sh
+. "$TS_SELF"/functions.sh
 
 rm -f $TS_OUTDIR/id-sem
 $TS_CMD_IPCMK -S 1 2>>$TS_OUTPUT | ipcmk_output_handler $TS_OUTPUT $TS_OUTDIR/id-sem

--- a/tests/ts/ipcs/mk-rm-shm
+++ b/tests/ts/ipcs/mk-rm-shm
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mk-rm-shm"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_IPCS"
@@ -23,7 +23,7 @@ ts_check_test_command "$TS_CMD_IPCMK"
 ts_check_test_command "$TS_CMD_IPCRM"
 ts_check_test_command "$TS_HELPER_SYSINFO"
 
-. $TS_SELF/functions.sh
+. "$TS_SELF"/functions.sh
 
 rm -f $TS_OUTDIR/id-shm
 $TS_CMD_IPCMK -M 1 2>>$TS_OUTPUT | ipcmk_output_handler $TS_OUTPUT $TS_OUTDIR/id-shm

--- a/tests/ts/isosize/print-size
+++ b/tests/ts/isosize/print-size
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="print-size"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_ISOSIZE"

--- a/tests/ts/libfdisk/gpt
+++ b/tests/ts/libfdisk/gpt
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="GPT"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBFDISK_GPT"

--- a/tests/ts/libfdisk/mkpart
+++ b/tests/ts/libfdisk/mkpart
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mkpart"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBFDISK_MKPART"

--- a/tests/ts/libfdisk/mkpart-full
+++ b/tests/ts/libfdisk/mkpart-full
@@ -20,7 +20,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mkpart-full"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBFDISK_MKPART_FULLSPEC"

--- a/tests/ts/libmount/context
+++ b/tests/ts/libmount/context
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="context"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/libmount/context-py
+++ b/tests/ts/libmount/context-py
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="context-py"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/libmount/context-utab
+++ b/tests/ts/libmount/context-utab
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="context (utab)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/libmount/context-utab-py
+++ b/tests/ts/libmount/context-utab-py
@@ -4,7 +4,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="context-py (utab)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FDISK"

--- a/tests/ts/libmount/debug
+++ b/tests/ts/libmount/debug
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="debugging"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBMOUNT_DEBUG"

--- a/tests/ts/libmount/lock
+++ b/tests/ts/libmount/lock
@@ -7,7 +7,7 @@ TS_DESC="lock"
 
 TS_OPTIONAL="yes"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBMOUNT_LOCK"

--- a/tests/ts/libmount/loop
+++ b/tests/ts/libmount/loop
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="losetup-loop"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/libmount/loop-overlay
+++ b/tests/ts/libmount/loop-overlay
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="loop overlay"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LOSETUP"

--- a/tests/ts/libmount/optstr
+++ b/tests/ts/libmount/optstr
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="options string"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBMOUNT_OPTSTR"

--- a/tests/ts/libmount/tabdiff
+++ b/tests/ts/libmount/tabdiff
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="table diffs"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBMOUNT_TABDIFF"

--- a/tests/ts/libmount/tabfiles
+++ b/tests/ts/libmount/tabfiles
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="tab files"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBMOUNT_TAB"

--- a/tests/ts/libmount/tabfiles-py
+++ b/tests/ts/libmount/tabfiles-py
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="tab files-py"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_init_py libmount
 

--- a/tests/ts/libmount/tabfiles-tags
+++ b/tests/ts/libmount/tabfiles-tags
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="tags"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_skip_nonroot

--- a/tests/ts/libmount/tabfiles-tags-py
+++ b/tests/ts/libmount/tabfiles-tags-py
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="tags-py"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_skip_nonroot

--- a/tests/ts/libmount/update
+++ b/tests/ts/libmount/update
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="tab update"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_skip_nonroot
 

--- a/tests/ts/libmount/update-py
+++ b/tests/ts/libmount/update-py
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="tab update-py"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_init_py libmount
 ts_skip_nonroot

--- a/tests/ts/libmount/utils
+++ b/tests/ts/libmount/utils
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="utils"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBMOUNT_UTILS"

--- a/tests/ts/libsmartcols/fromfile
+++ b/tests/ts/libsmartcols/fromfile
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fromfile"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBSMARTCOLS_FROMFILE"

--- a/tests/ts/libsmartcols/title
+++ b/tests/ts/libsmartcols/title
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="title"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 TESTPROG="$TS_HELPER_LIBSMARTCOLS_TITLE"

--- a/tests/ts/logger/errors
+++ b/tests/ts/logger/errors
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="errors"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/logger/formats
+++ b/tests/ts/logger/formats
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="formats"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/logger/journald
+++ b/tests/ts/logger/journald
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="journald"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/logger/options
+++ b/tests/ts/logger/options
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="options"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/login/islocal
+++ b/tests/ts/login/islocal
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="islocal"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_ISLOCAL"

--- a/tests/ts/login/logindefs
+++ b/tests/ts/login/logindefs
@@ -7,7 +7,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="defs"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_LOGINDEFS"

--- a/tests/ts/look/separator
+++ b/tests/ts/look/separator
@@ -31,7 +31,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="separator"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LOOK"

--- a/tests/ts/losetup/losetup
+++ b/tests/ts/losetup/losetup
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="losetup"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LOSETUP"

--- a/tests/ts/losetup/losetup-blkdev
+++ b/tests/ts/losetup/losetup-blkdev
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="losetup-blkdev"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LOSETUP"

--- a/tests/ts/losetup/losetup-loop
+++ b/tests/ts/losetup/losetup-loop
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="losetup-loop"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LOSETUP"

--- a/tests/ts/lsblk/lsblk
+++ b/tests/ts/lsblk/lsblk
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 TS_TOPDIR="${0%/*}/../.."
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/lscpu/lscpu
+++ b/tests/ts/lscpu/lscpu
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 TS_TOPDIR="${0%/*}/../.."
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/lsfd/column-kthread
+++ b/tests/ts/lsfd/column-kthread
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="kthread column"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_skip_nonroot
 

--- a/tests/ts/lsfd/mkfds-directory
+++ b/tests/ts/lsfd/mkfds-directory
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="directory"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LSFD"

--- a/tests/ts/lsfd/mkfds-mapped-packet-socket
+++ b/tests/ts/lsfd/mkfds-mapped-packet-socket
@@ -17,12 +17,12 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mmap'ed AF_PACKET socket"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_skip_nonroot
 ts_skip_qemu_user
 
-. $TS_SELF/lsfd-functions.bash
+. "$TS_SELF"/lsfd-functions.bash
 
 ts_check_test_command "$TS_CMD_LSFD"
 

--- a/tests/ts/lsfd/mkfds-pidfd
+++ b/tests/ts/lsfd/mkfds-pidfd
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="pidfd"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LSFD"

--- a/tests/ts/lsfd/mkfds-pipe-no-fork
+++ b/tests/ts/lsfd/mkfds-pipe-no-fork
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="pipe, no fork"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LSFD"

--- a/tests/ts/lsfd/mkfds-ro-block-device
+++ b/tests/ts/lsfd/mkfds-ro-block-device
@@ -17,12 +17,12 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="block device with O_RDONLY"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_skip_nonroot
 ts_skip_qemu_user
 
-. $TS_SELF/lsfd-functions.bash
+. "$TS_SELF"/lsfd-functions.bash
 
 ts_check_test_command "$TS_CMD_LSFD"
 

--- a/tests/ts/lsfd/mkfds-ro-regular-file
+++ b/tests/ts/lsfd/mkfds-ro-regular-file
@@ -17,10 +17,10 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="read-only regular file"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
-. $TS_SELF/lsfd-functions.bash
+. "$TS_SELF"/lsfd-functions.bash
 
 ts_check_test_command "$TS_CMD_LSFD"
 

--- a/tests/ts/lsfd/mkfds-rw-character-device
+++ b/tests/ts/lsfd/mkfds-rw-character-device
@@ -17,10 +17,10 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="character device with O_RDWR"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
-. $TS_SELF/lsfd-functions.bash
+. "$TS_SELF"/lsfd-functions.bash
 
 ts_check_test_command "$TS_CMD_LSFD"
 

--- a/tests/ts/lsfd/mkfds-socketpair
+++ b/tests/ts/lsfd/mkfds-socketpair
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="AF_UNIX socket pair created with socketpair(2)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LSFD"

--- a/tests/ts/lsfd/mkfds-symlink
+++ b/tests/ts/lsfd/mkfds-symlink
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="symbolic link itself opened with O_PATH"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LSFD"

--- a/tests/ts/lsfd/option-filter-broken-exp
+++ b/tests/ts/lsfd/option-filter-broken-exp
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="passing broken expressions to -Q option"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LSFD"

--- a/tests/ts/lsfd/option-pid
+++ b/tests/ts/lsfd/option-pid
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="--pid option"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_skip_nonroot
 

--- a/tests/ts/lsfd/option-summary
+++ b/tests/ts/lsfd/option-summary
@@ -17,10 +17,10 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="--summary option"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
-. $TS_SELF/lsfd-functions.bash
+. "$TS_SELF"/lsfd-functions.bash
 
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_HELPER_MKFDS"

--- a/tests/ts/lsmem/lsmem
+++ b/tests/ts/lsmem/lsmem
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 TS_TOPDIR="${0%/*}/../.."
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 
 ts_init "$*"
 

--- a/tests/ts/lsns/ioctl_ns
+++ b/tests/ts/lsns/ioctl_ns
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="ownership and hierarchy"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 # ts_skip_nonroot

--- a/tests/ts/lsns/netnsid
+++ b/tests/ts/lsns/netnsid
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="NETNSID compare to ip-link"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LSNS"

--- a/tests/ts/lsns/nsfs
+++ b/tests/ts/lsns/nsfs
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="NSFS for ip-netns-add"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_skip_nonroot

--- a/tests/ts/md5/md5
+++ b/tests/ts/md5/md5
@@ -17,7 +17,7 @@
 #
 TS_TOPDIR="${0%/*}/../.."
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_MD5"

--- a/tests/ts/minix/fsck
+++ b/tests/ts/minix/fsck
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mkfs fsck"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKMINIX"

--- a/tests/ts/minix/fsck-images
+++ b/tests/ts/minix/fsck-images
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fsck images"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 # inode contains UID and GID, use always UID=0 to get the same checksum

--- a/tests/ts/minix/mkfs
+++ b/tests/ts/minix/mkfs
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mkfs mount"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKMINIX"

--- a/tests/ts/misc/fallocate
+++ b/tests/ts/misc/fallocate
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fallocate"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FALLOCATE"

--- a/tests/ts/misc/flock
+++ b/tests/ts/misc/flock
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="flock"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_FLOCK"

--- a/tests/ts/misc/ionice
+++ b/tests/ts/misc/ionice
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="ionice"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_IONICE"

--- a/tests/ts/misc/line
+++ b/tests/ts/misc/line
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="line"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LINE"

--- a/tests/ts/misc/mbsencode
+++ b/tests/ts/misc/mbsencode
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mbsencode"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command $TS_HELPER_MBSENCODE

--- a/tests/ts/misc/mcookie
+++ b/tests/ts/misc/mcookie
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mcookie"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MCOOKIE"

--- a/tests/ts/misc/mountpoint
+++ b/tests/ts/misc/mountpoint
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mountpoint"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNTPOINT"

--- a/tests/ts/misc/pipesz
+++ b/tests/ts/misc/pipesz
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="pipesz"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_PIPESZ"

--- a/tests/ts/misc/rev
+++ b/tests/ts/misc/rev
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="rev"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_REV"

--- a/tests/ts/misc/setarch
+++ b/tests/ts/misc/setarch
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="setarch"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SETARCH"

--- a/tests/ts/misc/setsid
+++ b/tests/ts/misc/setsid
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="setsid"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SETSID"

--- a/tests/ts/misc/strtosize
+++ b/tests/ts/misc/strtosize
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="strtosize"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_STRUTILS"

--- a/tests/ts/misc/swaplabel
+++ b/tests/ts/misc/swaplabel
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="swaplabel"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKSWAP"

--- a/tests/ts/misc/whereis
+++ b/tests/ts/misc/whereis
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="whereis"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_WHEREIS"

--- a/tests/ts/more/regexp
+++ b/tests/ts/more/regexp
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="regexp"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_MORE"

--- a/tests/ts/more/squeeze
+++ b/tests/ts/more/squeeze
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="squeeze"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_MORE"

--- a/tests/ts/mount/devname
+++ b/tests/ts/mount/devname
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by devname"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/dm-verity
+++ b/tests/ts/mount/dm-verity
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="dm-verity support"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 VERITY_OUTPUT="$TS_OUTPUT.log"

--- a/tests/ts/mount/fslists
+++ b/tests/ts/mount/fslists
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fs lists"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-all
+++ b/tests/ts/mount/fstab-all
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="all (fstab)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-broken
+++ b/tests/ts/mount/fstab-broken
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="broken fstab"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-btrfs
+++ b/tests/ts/mount/fstab-btrfs
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="btrfs (fstab)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-devname
+++ b/tests/ts/mount/fstab-devname
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by devname (fstab)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-devname2label
+++ b/tests/ts/mount/fstab-devname2label
@@ -19,7 +19,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by devname (fstab label)"
 LABEL="testMountD2L"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-devname2uuid
+++ b/tests/ts/mount/fstab-devname2uuid
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by devname (fstab uuid)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-label
+++ b/tests/ts/mount/fstab-label
@@ -19,7 +19,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by label (fstab)"
 LABEL="testFstabLabel"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-label2devname
+++ b/tests/ts/mount/fstab-label2devname
@@ -19,7 +19,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by label (fstab devname)"
 LABEL="testMountL2D"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-label2uuid
+++ b/tests/ts/mount/fstab-label2uuid
@@ -20,7 +20,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by label (fstab uuid)"
 LABEL="testMountL2U"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-loop
+++ b/tests/ts/mount/fstab-loop
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="loop (fstab)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-none
+++ b/tests/ts/mount/fstab-none
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="none"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-symlink
+++ b/tests/ts/mount/fstab-symlink
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by devname (fstab symlink)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-uuid
+++ b/tests/ts/mount/fstab-uuid
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by uuid (fstab)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-uuid2devname
+++ b/tests/ts/mount/fstab-uuid2devname
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by uuid (fstab devname)"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/fstab-uuid2label
+++ b/tests/ts/mount/fstab-uuid2label
@@ -19,7 +19,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by uuid (fstab label)"
 LABEL="testMountU2L"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/label
+++ b/tests/ts/mount/label
@@ -20,7 +20,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by label"
 LABEL="testMountLabel"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/move
+++ b/tests/ts/mount/move
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="move"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/regfile
+++ b/tests/ts/mount/regfile
@@ -6,7 +6,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="regular file"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/remount
+++ b/tests/ts/mount/remount
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="remount"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/set_ugid_mode
+++ b/tests/ts/mount/set_ugid_mode
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="X-mount.{owner,group,mode}="
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/shared-subtree
+++ b/tests/ts/mount/shared-subtree
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="shared-subtree"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/special
+++ b/tests/ts/mount/special
@@ -19,7 +19,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="call mount.<type>"
 MOUNTER="/sbin/mount.mytest"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/umount-alltargets
+++ b/tests/ts/mount/umount-alltargets
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="umount-all-targets"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/umount-recursive
+++ b/tests/ts/mount/umount-recursive
@@ -5,7 +5,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="umount-recursive"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/mount/uuid
+++ b/tests/ts/mount/uuid
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by uuid"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MOUNT"

--- a/tests/ts/namei/logic
+++ b/tests/ts/namei/logic
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="basic functionality"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_NAMEI"

--- a/tests/ts/partx/partx
+++ b/tests/ts/partx/partx
@@ -20,7 +20,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="partitions probing"
 PARTS=3
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_PARTX"

--- a/tests/ts/partx/partx-image
+++ b/tests/ts/partx/partx-image
@@ -20,7 +20,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="show images"
 TS_IMGDIR="$TS_TOPDIR/ts/blkid/images-pt"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_PARTX"

--- a/tests/ts/paths/built-in
+++ b/tests/ts/paths/built-in
@@ -21,7 +21,7 @@ TS_DESC="built-in"
 # Don't execute this test by default, --force required
 TS_OPTIONAL="yes"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_PATHS"

--- a/tests/ts/rename/basic
+++ b/tests/ts/rename/basic
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="basic check"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_RENAME"

--- a/tests/ts/rename/exit_codes
+++ b/tests/ts/rename/exit_codes
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="exit codes"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_RENAME"

--- a/tests/ts/rename/overwrite
+++ b/tests/ts/rename/overwrite
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="overwrite"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_RENAME"

--- a/tests/ts/rename/subdir
+++ b/tests/ts/rename/subdir
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="subdir check"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_RENAME"

--- a/tests/ts/rename/symlink
+++ b/tests/ts/rename/symlink
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="symlink check"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_RENAME"

--- a/tests/ts/schedutils/chrt
+++ b/tests/ts/schedutils/chrt
@@ -16,7 +16,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="chrt"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_CHRT"

--- a/tests/ts/schedutils/chrt-non-root
+++ b/tests/ts/schedutils/chrt-non-root
@@ -16,7 +16,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="chrt-non-user"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_CHRT"

--- a/tests/ts/schedutils/cpuset
+++ b/tests/ts/schedutils/cpuset
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="cpuset"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_CPUSET"

--- a/tests/ts/script/buffering-race
+++ b/tests/ts/script/buffering-race
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="buffering race"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SCRIPT"

--- a/tests/ts/script/options
+++ b/tests/ts/script/options
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="options"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 export SCRIPT_TEST_SECOND_SINCE_EPOCH=1432489398

--- a/tests/ts/script/race
+++ b/tests/ts/script/race
@@ -19,7 +19,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="race conditions"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SCRIPT"

--- a/tests/ts/sfdisk/dos
+++ b/tests/ts/sfdisk/dos
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="MBR"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SFDISK"

--- a/tests/ts/sfdisk/dump
+++ b/tests/ts/sfdisk/dump
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="script"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SFDISK"

--- a/tests/ts/sfdisk/gpt
+++ b/tests/ts/sfdisk/gpt
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="GPT"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SFDISK"

--- a/tests/ts/sfdisk/movedata
+++ b/tests/ts/sfdisk/movedata
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="movedata"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SFDISK"

--- a/tests/ts/sfdisk/resize
+++ b/tests/ts/sfdisk/resize
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="resize"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SFDISK"

--- a/tests/ts/sfdisk/script
+++ b/tests/ts/sfdisk/script
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="script"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SFDISK"

--- a/tests/ts/sfdisk/wipe
+++ b/tests/ts/sfdisk/wipe
@@ -17,7 +17,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="wipe"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_SFDISK"

--- a/tests/ts/sha1/sha1
+++ b/tests/ts/sha1/sha1
@@ -17,7 +17,7 @@
 #
 TS_TOPDIR="${0%/*}/../.."
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_SHA1"

--- a/tests/ts/swapon/devname
+++ b/tests/ts/swapon/devname
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by devname"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKSWAP"

--- a/tests/ts/swapon/fixpgsz
+++ b/tests/ts/swapon/fixpgsz
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fix page size"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKSWAP"

--- a/tests/ts/swapon/fixsig
+++ b/tests/ts/swapon/fixsig
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fix signature"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKSWAP"

--- a/tests/ts/swapon/label
+++ b/tests/ts/swapon/label
@@ -19,7 +19,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by label"
 LABEL="testSwapLabel"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKSWAP"

--- a/tests/ts/swapon/uuid
+++ b/tests/ts/swapon/uuid
@@ -18,7 +18,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="by uuid"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_MKSWAP"

--- a/tests/ts/ul/basic
+++ b/tests/ts/ul/basic
@@ -19,7 +19,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="basic tests"
 
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_UL"

--- a/tests/ts/ul/ul
+++ b/tests/ts/ul/ul
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="ul"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_UL"

--- a/tests/ts/utmp/last
+++ b/tests/ts/utmp/last
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="last"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LAST"

--- a/tests/ts/utmp/last-ipv6
+++ b/tests/ts/utmp/last-ipv6
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="last ipv6"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_LAST"

--- a/tests/ts/utmp/utmpdump-circle
+++ b/tests/ts/utmp/utmpdump-circle
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="circle"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 # this test is arch independent, no need for utmp_functions.sh

--- a/tests/ts/utmp/utmpdump-subsecond
+++ b/tests/ts/utmp/utmpdump-subsecond
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="subsecond"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 # this test is arch independent, no need for utmp_functions.sh

--- a/tests/ts/utmp/utmpdump-tobin
+++ b/tests/ts/utmp/utmpdump-tobin
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="to binary"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 . "$TS_SELF/utmp_functions.sh"

--- a/tests/ts/utmp/utmpdump-tobin-ipv6
+++ b/tests/ts/utmp/utmpdump-tobin-ipv6
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="IPv6 to binary"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 . "$TS_SELF/utmp_functions.sh"

--- a/tests/ts/utmp/utmpdump-totxt
+++ b/tests/ts/utmp/utmpdump-totxt
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="to text"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 . "$TS_SELF/utmp_functions.sh"

--- a/tests/ts/utmp/utmpdump-totxt-ipv6
+++ b/tests/ts/utmp/utmpdump-totxt-ipv6
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="IPv6 to text"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 . "$TS_SELF/utmp_functions.sh"

--- a/tests/ts/uuid/namespace
+++ b/tests/ts/uuid/namespace
@@ -17,7 +17,7 @@
 #
 TS_TOPDIR="${0%/*}/../.."
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_UUID_NAMESPACE"

--- a/tests/ts/uuid/oids
+++ b/tests/ts/uuid/oids
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="oids"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 : . > $TS_OUTPUT

--- a/tests/ts/uuid/uuid_parser
+++ b/tests/ts/uuid/uuid_parser
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="uuid_parser"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_UUID_PARSER"

--- a/tests/ts/uuid/uuidd
+++ b/tests/ts/uuid/uuidd
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="uuidd"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_UUID_PARSER"

--- a/tests/ts/uuid/uuidgen
+++ b/tests/ts/uuid/uuidgen
@@ -15,7 +15,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="uuidgen"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_UUID_PARSER"

--- a/tests/ts/uuid/uuidparse
+++ b/tests/ts/uuid/uuidparse
@@ -16,7 +16,7 @@ TS_TOPDIR="${0%/*}/../.."
 TS_DESC="uuidparse"
 export TZ=GMT
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_UUIDPARSE"

--- a/tests/ts/wipefs/wipefs
+++ b/tests/ts/wipefs/wipefs
@@ -3,7 +3,7 @@
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="wipefs"
 
-. $TS_TOPDIR/functions.sh
+. "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
 ts_check_test_command "$TS_CMD_WIPEFS"


### PR DESCRIPTION
The command lines used for this change:
```
$ cd tests/ts
$ sed  -i -e 's|. $TS_SELF/|. "$TS_SELF"/|'  $(grep --exclude='*~' -lr -e '^\. \$TS_SELF/') 
$ sed -i -e 's|. $TS_TOPDIR/functions.sh|. "$TS_TOPDIR"/functions.sh|'  $(grep --exclude='*~' -lr -e '^\. \$TS_TOPDIR/functions.sh')
```
Signed-off-by: Masatake YAMATO <yamato@redhat.com>