### PR TITLE
autotools: show test failure diff

### DIFF
--- a/tests/Makemodule.am
+++ b/tests/Makemodule.am
@@ -13,7 +13,7 @@ clean-local-tests:
 
 CLEAN_LOCALS += clean-local-tests
 
-TESTS_OPTIONS = --nonroot
+TESTS_OPTIONS = --nonroot --show-diff
 TESTS_PARALLEL = --parallel
 TESTS_COMMAND = $(top_srcdir)/tests/run.sh \
 	--srcdir=$(abs_top_srcdir) \


### PR DESCRIPTION
This helps investigating issues, especially spurious errors only happening during CI like the failure of "hardlink/options-maximum-size-8192"