### PR TITLE
lsfd: consider 64bit addresses when scanning /proc/pid/map_files dir

### DIFF
--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -746,7 +746,7 @@ static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
 		file_set_path(f, &sb, path, -assoc);
 	} else {
 		/* As used in tcpdump, AF_PACKET socket can be mmap'ed. */
-		char map_file[sizeof("map_files/000000000000-ffffffffffff")];
+		char map_file[sizeof("map_files/0000000000000000-ffffffffffffffff")];
 		char sym[PATH_MAX] = { '\0' };
 
 	try_map_files:


### PR DESCRIPTION
Close #1930.

The original code assumed 48bit addresses. This assumption came from linux running on x86_64. As reported in #1930, Linux on sparc64 uses 64bit addresses.

Tested-by: Anatoly Pugachev <matorola@gmail.com>
Signed-off-by: Masatake YAMATO <yamato@redhat.com>