### PR TITLE
tests: allow paths in tests to contain '@' char

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -853,7 +853,9 @@ function ts_fdisk_clean {
 
 	# remove non comparable parts of fdisk output
 	if [ -n "${DEVNAME}" ]; then
-		sed -i -e "s@${DEVNAME}@<removed>@;" $TS_OUTPUT $TS_ERRLOG
+		# escape "@" with "@@" in $img. This way sed correctly
+		# replaces paths containing "@" characters
+		sed -i -e "s@${DEVNAME//\@/\\\@}@<removed>@;" $TS_OUTPUT $TS_ERRLOG
 	fi
 
 	sed -i \

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -853,7 +853,7 @@ function ts_fdisk_clean {
 
 	# remove non comparable parts of fdisk output
 	if [ -n "${DEVNAME}" ]; then
-		# escape "@" with "@@" in $img. This way sed correctly
+		# escape "@" with "@@" in $DEVNAME. This way sed correctly
 		# replaces paths containing "@" characters
 		sed -i -e "s@${DEVNAME//\@/\\\@}@<removed>@;" $TS_OUTPUT $TS_ERRLOG
 	fi

--- a/tests/ts/minix/fsck
+++ b/tests/ts/minix/fsck
@@ -50,7 +50,10 @@ done
 
 rm -f $img
 
-sed -i "s@$img@image@g" $TS_OUTPUT
+# escape "@" with "@@" in $img. This way sed correctly
+# replaces paths containing "@" characters
+sed -i "s@${img//\@/\\\@}@image@g" $TS_OUTPUT
+
 
 ts_finalize
 


### PR DESCRIPTION
Tests fail when the build directory contains 
'@' in its path, as its sent to 'sed' unescaped.

This patch allows to build in such environments,
which typically happen on automated systems (for
example, when building concurrently with Jenkins).