### PR TITLE
meson: use shells.c where needed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -856,6 +856,7 @@ exe = executable(
 exe2 = executable(
   'chsh',
   'login-utils/chsh.c',
+  'lib/shells.c',
   chfn_chsh_sources,
   include_directories : includes,
   link_with : lib_common,
@@ -939,6 +940,7 @@ exe = executable(
   'login-utils/su.c',
   'login-utils/su-common.c',
   'login-utils/su-common.h',
+  'lib/shells.c',
   pty_session_c,
   monotonic_c,
   include_directories : includes,
@@ -1013,6 +1015,7 @@ exe = executable(
   'login-utils/runuser.c',
   'login-utils/su-common.c',
   'login-utils/su-common.h',
+  'lib/shells.c',
   pty_session_c,
   monotonic_c,
   include_directories : includes,

--- a/meson.build
+++ b/meson.build
@@ -939,7 +939,6 @@ exe = executable(
   'login-utils/su.c',
   'login-utils/su-common.c',
   'login-utils/su-common.h',
-  'lib/logindefs.c',
   pty_session_c,
   monotonic_c,
   include_directories : includes,
@@ -974,7 +973,6 @@ opt = not get_option('build-lslogins').disabled()
 exe = executable(
   'lslogins',
   'login-utils/lslogins.c',
-  'lib/logindefs.c',
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols,
@@ -1015,7 +1013,6 @@ exe = executable(
   'login-utils/runuser.c',
   'login-utils/su-common.c',
   'login-utils/su-common.h',
-  'lib/logindefs.c',
   pty_session_c,
   monotonic_c,
   include_directories : includes,


### PR DESCRIPTION
Also drop a few unnecessary mentions of logindefs.c