### PR TITLE
lsns: report unsupported ioctl

### DIFF
--- a/sys-utils/lsns.8.adoc
+++ b/sys-utils/lsns.8.adoc
@@ -72,6 +72,17 @@ Use tree-like output format. If *process* is given as _rel_, print process tree(
 
 include::man-common/help-version.adoc[]
 
+== EXIT STATUS
+
+The *lsns* utility exits with one of the following values:
+
+*0*::
+Success.
+*1*::
+General error.
+*2*::
+An ioctl was unknown to the kernel.
+
 == AUTHORS
 
 mailto:kzak@redhat.com[Karel Zak]

--- a/tests/ts/lsns/ioctl_ns
+++ b/tests/ts/lsns/ioctl_ns
@@ -34,6 +34,11 @@ ts_check_prog "mkfifo"
 ts_check_prog "touch"
 ts_check_prog "uniq"
 
+"$TS_CMD_LSNS" > /dev/null 2>&1
+if [ $? -eq 2 ]; then
+	ts_skip "ioctl not supported"
+fi
+
 # 32bit userspace (NS ioctls) does not work as expected with 64bit kernel
 WORDSIZE=$($TS_HELPER_SYSINFO WORDSIZE)
 if [ $WORDSIZE -eq 32 ]; then


### PR DESCRIPTION
This skips the tests on setups were the nsfs ioctls are not functional.
(Old kernels, 32bit userland on 64 bit kernel, see #1924)