### PR TITLE
libblk: unify debug initialization

### DIFF
--- a/libblkid/src/cache.c
+++ b/libblkid/src/cache.c
@@ -97,8 +97,6 @@ int blkid_get_cache(blkid_cache *ret_cache, const char *filename)
 	if (!ret_cache)
 		return -BLKID_ERR_PARAM;
 
-	blkid_init_debug(0);
-
 	if (!(cache = calloc(1, sizeof(struct blkid_struct_cache))))
 		return -BLKID_ERR_MEM;
 

--- a/libblkid/src/evaluate.c
+++ b/libblkid/src/evaluate.c
@@ -236,9 +236,6 @@ char *blkid_evaluate_tag(const char *token, const char *value, blkid_cache *cach
 	if (!token)
 		return NULL;
 
-	if (!cache || !*cache)
-		blkid_init_debug(0);
-
 	DBG(EVALUATE, ul_debug("evaluating  %s%s%s", token, value ? "=" : "",
 		   value ? value : ""));
 
@@ -316,8 +313,6 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "usage: %s <tag> | <spec>\n", argv[0]);
 		return EXIT_FAILURE;
 	}
-
-	blkid_init_debug(0);
 
 	res = blkid_evaluate_spec(argv[1], &cache);
 	if (res)

--- a/libblkid/src/init.c
+++ b/libblkid/src/init.c
@@ -65,3 +65,8 @@ void blkid_init_debug(int mask)
 	ON_DBG(HELP, ul_debug_print_masks("LIBBLKID_DEBUG",
 				UL_DEBUG_MASKNAMES(libblkid)));
 }
+
+static void __attribute__ ((constructor)) blkid_init_default_debug(void)
+{
+	blkid_init_debug(0);
+}

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -139,7 +139,6 @@ blkid_probe blkid_new_probe(void)
 	int i;
 	blkid_probe pr;
 
-	blkid_init_debug(0);
 	pr = calloc(1, sizeof(struct blkid_struct_probe));
 	if (!pr)
 		return NULL;


### PR DESCRIPTION
Otherwise sometimes we have no debugging. For example in `lsblk`.