### PR TITLE
lsblk: read firmware revision from udev and use it for --nvme output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,7 +41,7 @@ AUTHORS (merged projects & commands):
       libmount:        Karel Zak <kzak@redhat.com>
       libuuid:         Theodore Ts'o <tytso@mit.edu>
       lscpu:           Cai Qian <qcai@redhat.com>
-      lsblk:           Milan Broz <mbroz@redhat.com>
+      lsblk:           Milan Broz <gmazyland@gmail.com>
                        Karel Zak <kzak@redhat.com>
       lsfd:            Masatake YAMATO <yamato@redhat.com>
       lsipc:           Ondrej Oprala <ooprala@redhat.com>
@@ -612,7 +612,7 @@ CONTRIBUTORS:
       Miklos Szeredi <mszeredi@suse.cz>
       Mikulas Patocka <mpatocka@redhat.com>
       Milan Bouchet-Valat <nalimilan@club.fr>
-      Milan Broz <mbroz@redhat.com>
+      Milan Broz <gmazyland@gmail.com>
       Ming Lei <tom.leiming@gmail.com>
       Miquel van Smoorenburg <miquels@maestro.htsa.aha.nl>
       Mister Me <gdg@localhost.localdomain>

--- a/libblkid/src/superblocks/lvm.c
+++ b/libblkid/src/superblocks/lvm.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2001 by Andreas Dilger
  * Copyright (C) 2004 Kay Sievers <kay.sievers@vrfy.org>
  * Copyright (C) 2008 Karel Zak <kzak@redhat.com>
- * Copyright (C) 2012 Milan Broz <mbroz@redhat.com>
+ * Copyright (C) 2012 Milan Broz <gmazyland@gmail.com>
  *
  * This file may be redistributed under the terms of the
  * GNU Lesser General Public License.

--- a/misc-utils/lsblk-properties.c
+++ b/misc-utils/lsblk-properties.c
@@ -38,6 +38,7 @@ void lsblk_device_free_properties(struct lsblk_devprop *p)
 	free(p->model);
 	free(p->partflags);
 	free(p->idlink);
+	free(p->revision);
 
 	free(p->mode);
 	free(p->owner);
@@ -129,6 +130,9 @@ static struct lsblk_devprop *get_properties_by_udev(struct lsblk_device *ld)
 		prop->serial = xstrdup(data);
 		normalize_whitespace((unsigned char *) prop->serial);
 	}
+
+	if ((data = udev_device_get_property_value(dev, "ID_REVISION")))
+		prop->revision = xstrdup(data);
 
 	if ((data = udev_device_get_property_value(dev, "ID_MODEL_ENC"))) {
 		prop->model = xstrdup(data);
@@ -254,6 +258,7 @@ static struct lsblk_devprop *get_properties_by_file(struct lsblk_device *ld)
 		else if (lookup(buf, "ID_SCSI_SERIAL", &prop->serial)) ;
 		else if (lookup(buf, "ID_SERIAL_SHORT", &prop->serial)) ;
 		else if (lookup(buf, "ID_SERIAL", &prop->serial)) ;
+		else if (lookup(buf, "ID_REVISION", &prop->revision)) ;
 
 		/* lsblk specific */
 		else if (lookup(buf, "MODE", &prop->mode)) ;

--- a/misc-utils/lsblk.8.adoc
+++ b/misc-utils/lsblk.8.adoc
@@ -168,7 +168,7 @@ The *lsblk* command needs to be able to look up each block device by major:minor
 
 == AUTHORS
 
-mailto:mbroz@redhat.com[Milan Broz],
+mailto:gmazyland@gmail.com[Milan Broz],
 mailto:kzak@redhat.com[Karel Zak]
 
 == SEE ALSO

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -1013,8 +1013,13 @@ static char *device_get_data(
 		}
 		break;
 	case COL_REV:
-		if (!device_is_partition(dev) && dev->nslaves == 0)
-			ul_path_read_string(dev->sysfs, &str, "device/rev");
+		if (!device_is_partition(dev) && dev->nslaves == 0) {
+			prop = lsblk_device_get_properties(dev);
+			if (prop && prop->revision)
+				str = xstrdup(prop->revision);
+			else
+				ul_path_read_string(dev->sysfs, &str, "device/rev");
+		}
 		break;
 	case COL_VENDOR:
 		if (!device_is_partition(dev) && dev->nslaves == 0)

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -2,7 +2,7 @@
  * lsblk(8) - list block devices
  *
  * Copyright (C) 2010-2018 Red Hat, Inc. All rights reserved.
- * Written by Milan Broz <mbroz@redhat.com>
+ * Written by Milan Broz <gmazyland@gmail.com>
  *            Karel Zak <kzak@redhat.com>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -2243,6 +2243,7 @@ int main(int argc, char *argv[])
 			add_uniq_column(COL_TYPE);
 			add_uniq_column(COL_MODEL);
 			add_uniq_column(COL_SERIAL);
+			add_uniq_column(COL_REV);
 			add_uniq_column(COL_TRANSPORT);
 			add_uniq_column(COL_RQ_SIZE);
 			add_uniq_column(COL_MQ);

--- a/misc-utils/lsblk.h
+++ b/misc-utils/lsblk.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010-2018 Red Hat, Inc. All rights reserved.
- * Written by Milan Broz <mbroz@redhat.com>
+ * Written by Milan Broz <gmazyland@gmail.com>
  *            Karel Zak <kzak@redhat.com>
  */
 #ifndef UTIL_LINUX_LSBLK_H

--- a/misc-utils/lsblk.h
+++ b/misc-utils/lsblk.h
@@ -79,6 +79,7 @@ struct lsblk_devprop {
 	char *serial;		/* disk serial number */
 	char *model;		/* disk model */
 	char *idlink;		/* /dev/disk/by-id/<name> */
+	char *revision;		/* firmware revision/version */
 
 	/* lsblk specific (for --sysroot only)  */
 	char *owner;		/* user name */


### PR DESCRIPTION
- ID_REVISION in udev supports more device types like NVMEs.
- add this to --nvme output list as in --scsi output.

There is still fallback to old sysfs device/rev read, so for non-udev systems it should do the same.

And update my email (drop this patch if it is not posssible :-)