### PR TITLE
Revert "tests: use KNOWN_FAIL for lsns/ioctl_ns"

### DIFF
--- a/tests/ts/lsns/ioctl_ns
+++ b/tests/ts/lsns/ioctl_ns
@@ -39,15 +39,6 @@ if [ $? -eq 2 ]; then
 	ts_skip "ioctl not supported"
 fi
 
-# 32bit userspace (NS ioctls) does not work as expected with 64bit kernel
-WORDSIZE=$($TS_HELPER_SYSINFO WORDSIZE)
-if [ $WORDSIZE -eq 32 ]; then
-	uname -m | grep -q 64
-	if [ $? -eq 0 ]; then
-		TS_KNOWN_FAIL="yes"
-	fi
-fi
-
 $TS_CMD_UNSHARE --user --pid --mount-proc --fork true &> /dev/null || ts_skip "no namespace support"
 
 ts_cd "$TS_OUTDIR"


### PR DESCRIPTION
The check introduced in 249ba69c introduced a proper feature check.

This reverts commit 857038d4512a5f2e9a1fd4a3d89c2c27eae456fd.