### PR TITLE
libblkid: partitions: use generic checksum handling

### DIFF
--- a/libblkid/src/partitions/gpt.c
+++ b/libblkid/src/partitions/gpt.c
@@ -241,7 +241,7 @@ static struct gpt_header *get_gpt_header(
 			offsetof(struct gpt_header, header_crc32),
 			sizeof(h->header_crc32));
 
-	if (crc != le32_to_cpu(h->header_crc32)) {
+	if (!blkid_probe_verify_csum(pr, crc, le32_to_cpu(h->header_crc32))) {
 		DBG(LOWPROBE, ul_debug("GPT header corrupted"));
 		return NULL;
 	}

--- a/libblkid/src/partitions/sgi.c
+++ b/libblkid/src/partitions/sgi.c
@@ -31,7 +31,7 @@ static int probe_sgi_pt(blkid_probe pr,
 		goto nothing;
 	}
 
-	if (sgi_pt_checksum(l)) {
+	if (!blkid_probe_verify_csum(pr, sgi_pt_checksum(l), 0)) {
 		DBG(LOWPROBE, ul_debug(
 			"detected corrupted sgi disk label -- ignore"));
 		goto nothing;

--- a/libblkid/src/partitions/sun.c
+++ b/libblkid/src/partitions/sun.c
@@ -33,7 +33,7 @@ static int probe_sun_pt(blkid_probe pr,
 		goto nothing;
 	}
 
-	if (sun_pt_checksum(l)) {
+	if (!blkid_probe_verify_csum(pr, sun_pt_checksum(l), 0)) {
 		DBG(LOWPROBE, ul_debug(
 			"detected corrupted sun disk label -- ignore"));
 		goto nothing;


### PR DESCRIPTION
This enables unified reporting and configuration.
In addition it provides checksum bypass for the fuzzers, so this code will be fuzzed properly.

It also includes new checksum handling for BSD partition tables.