### PR TITLE
libblkid: topoligy: sysfs: try parent device for all attributes

### DIFF
--- a/libblkid/src/topology/sysfs.c
+++ b/libblkid/src/topology/sysfs.c
@@ -43,7 +43,7 @@ static struct topology_val {
 static int probe_sysfs_tp(blkid_probe pr,
 		const struct blkid_idmag *mag __attribute__((__unused__)))
 {
-	dev_t dev;
+	dev_t dev, disk = 0;
 	int rc, set_parent = 1;
 	struct path_cxt *pc;
 	size_t i, count = 0;
@@ -63,9 +63,11 @@ static int probe_sysfs_tp(blkid_probe pr,
 
 		rc = 1;	/* nothing */
 
-		if (!ok && set_parent) {
-			dev_t disk = blkid_probe_get_wholedisk_devno(pr);
-			set_parent = 0;
+		if (!ok) {
+			if (set_parent) {
+				disk = blkid_probe_get_wholedisk_devno(pr);
+				set_parent = 0;
+			}
 
 			/*
 			 * Read attributes from "disk" if the current device is


### PR DESCRIPTION
The topology should try to final all attributes that are not found on the partition itself on the full disk.

Due to the way the conditionals were structured the fallback to the full disk was however only done for the first attribute not found on the partition.