### PR TITLE
meson: fix option value

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -193,7 +193,7 @@ option('use-tls',
 option('pg-bell',
        type : 'boolean', value : true,
        description : 'should pg ring the bell on invalid keys?')
-option('colors-default', type: 'boolean', value: 'true',
+option('colors-default', type: 'boolean', value: true,
        description: 'Enables colorized output from utils by default')
 
 option('fs-search-path',


### PR DESCRIPTION
This is a boolean, not a string.

Found with muon analyze.

Signed-off-by: Rosen Penev <rosenp@gmail.com>