### PR TITLE
`rename -s` treats paths the same as without `-s`.

### DIFF
--- a/misc-utils/rename.1.adoc
+++ b/misc-utils/rename.1.adoc
@@ -53,7 +53,7 @@ The renaming has no safeguards by default or without any one of the options *--n
 
 If the _expression_ is empty, then by default _replacement_ will be added to the start of the filename. With *--all*, _replacement_ will be inserted in between every two characters of the filename, as well as at the start and end.
 
-Normally, only the final path component of a filename is updated. But if either _expression_ or _replacement_ contains a _/_, the full path is updated. This can cause a file to be moved between folders. Creating folders, and moving files between filesystems, is not supported. With *--symlink*, the update is always applied to the link's full path.
+Normally, only the final path component of a filename is updated. (Or with *--symlink*, only the final path component of the link.) But if either _expression_ or _replacement_ contains a _/_, the full path is updated. This can cause a file to be moved between folders. Creating folders, and moving files between filesystems, is not supported.
 
 == INTERACTIVE MODE
 

--- a/tests/expected/rename/subdir
+++ b/tests/expected/rename/subdir
@@ -6,18 +6,18 @@ rename_aa/xa
 rename_ab
 rename_ab/xa
 == symlinks ==
-rename_aa/sublink.1: `rename/aa' -> `renxme/aa'
-rename_aa/sublink.2: `rename/aa' -> `renxme/aa'
-rename_aa/sublink.3: `rename/aa' -> `renxme/aa'
-rename_ab/sublink.1: `rename/aa' -> `renxme/aa'
-rename_ab/sublink.2: `rename/aa' -> `renxme/aa'
-rename_ab/sublink.3: `rename/aa' -> `renxme/aa'
-renxme/aa
-renxme/aa
-renxme/aa
-renxme/aa
-renxme/aa
-renxme/aa
+rename_aa/sublink.1: `rename/aa' -> `rename/xa'
+rename_aa/sublink.2: `rename/aa' -> `rename/xa'
+rename_aa/sublink.3: `rename/aa' -> `rename/xa'
+rename_ab/sublink.1: `rename/aa' -> `rename/xa'
+rename_ab/sublink.2: `rename/aa' -> `rename/xa'
+rename_ab/sublink.3: `rename/aa' -> `rename/xa'
+rename/xa
+rename/xa
+rename/xa
+rename/xa
+rename/xa
+rename/xa
 == fullpath ==
 `./rename_path1' -> `./rename_path2'
 ./rename_path2
@@ -27,6 +27,10 @@ renxme/aa
 rename_path_a
 rename_path_b
 rename_path_b/test2
+rename_link: `some/nonexistent/path' -> `some/nonexisten_ath'
+rename_link: `some/nonexisten_ath' -> `some/non/en_ath'
+rename_link: `some/non/en_ath' -> `some/non/xn_ath'
+some/non/xn_ath
 == empty 'from' ==
 `rename_test' -> `_rename_test'
 `./rename_test' -> `./_rename_test'

--- a/tests/ts/rename/subdir
+++ b/tests/ts/rename/subdir
@@ -65,6 +65,13 @@ rm -f rename_path_a/test2 rename_path_b/test2
 
 rmdir rename_path_a rename_path_b
 
+ln -s some/nonexistent/path rename_link
+$TS_CMD_RENAME -s -v t/p _ rename_link >> $TS_OUTPUT 2>> $TS_ERRLOG
+$TS_CMD_RENAME -s -v exist / rename_link >> $TS_OUTPUT 2>> $TS_ERRLOG
+$TS_CMD_RENAME -s -v e x rename_link >> $TS_OUTPUT 2>> $TS_ERRLOG
+readlink rename_link >> $TS_OUTPUT 2>> $TS_ERRLOG
+rm rename_link
+
 echo "== empty 'from' ==" >> $TS_OUTPUT
 
 touch rename_test


### PR DESCRIPTION
That is, it only updates the final path component, unless either the expression or the replacement contains a '/'.

As discussed in #1962.