### PR TITLE
build: track dependencies of manpage generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -229,7 +229,9 @@ asciidoc_man_cmd = $(ASCIIDOCTOR) \
 	-a 'release-version=$(VERSION)' \
 	-a 'package-docdir=$(docdir)' \
 	-a 'VERSION=$(VERSION)' \
-	-a 'ADJTIME_PATH=$(ADJTIME_PATH)'
+	-a 'ADJTIME_PATH=$(ADJTIME_PATH)' \
+	--load-path '$(abs_srcdir)/tools' \
+	--require asciidoctor-includetracker
 
 SUFFIXES = .1.adoc .3.adoc .5.adoc .8.adoc .1 .3 .5 .8
 .1.adoc.1 .3.adoc.3 .5.adoc.5 .8.adoc.8:
@@ -237,6 +239,12 @@ SUFFIXES = .1.adoc .3.adoc .5.adoc .8.adoc .1 .3 .5 .8
 		$(MKDIR_P) $$(dirname $@) && \
 		$(asciidoc_man_cmd) --base-dir=$(abs_srcdir) \
 				    --destination-dir $(abs_builddir)/$$(dirname $@) $<
+
+-include \
+	$(abs_builddir)/**.1.deps \
+	$(abs_builddir)/**.3.deps \
+	$(abs_builddir)/**.5.deps \
+	$(abs_builddir)/**.8.deps
 
 $(MANLINKS): $(MANPAGES)
 gen-man: $(man_MANS)

--- a/meson.build
+++ b/meson.build
@@ -3341,9 +3341,12 @@ if asciidoctor.found()
 	  '-a', 'package-docdir=' + docdir,
 	  '--base-dir=' + meson.current_source_dir(),
           '--destination-dir=' + meson.current_build_dir(),
+          '--load-path', '@SOURCE_ROOT@/tools',
+          '--require', 'asciidoctor-includetracker',
 	  '@INPUT@'],
       input : input,
       output : [page],
+      depfile : page + '.deps',
       install: true,
       install_dir : mandirn)
   endforeach

--- a/tools/asciidoctor-includetracker.rb
+++ b/tools/asciidoctor-includetracker.rb
@@ -1,0 +1,43 @@
+# Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>
+# Extensions for asciidoctor to write dependency files for include directives.
+
+module IncludeTracker
+
+  class Preprocessor < Asciidoctor::Extensions::Preprocessor
+    def process document, reader
+      document.attributes["include_dependencies"] = []
+      reader
+    end
+  end
+
+  class IncludeProcessor < Asciidoctor::Extensions::IncludeProcessor
+    def process doc, reader, target, attributes
+      docdir = doc.attributes["docdir"]
+      path = target
+      file = File.expand_path path, docdir
+      data = File.read file
+      reader.push_include data, file, path, 1, attributes
+      doc.attributes["include_dependencies"] << file
+      reader
+    end
+  end
+
+  class Postprocessor < Asciidoctor::Extensions::Postprocessor
+    def process document, output
+      outfile = document.attributes["outfile"]
+      fail if !outfile
+      File.open outfile + '.deps', 'w' do |f|
+        f.write outfile + ": " +
+          document.attributes["include_dependencies"].join(' ')
+      end
+      output
+    end
+  end
+
+  Asciidoctor::Extensions.register do
+    preprocessor Preprocessor
+    include_processor IncludeProcessor
+    postprocessor Postprocessor
+  end
+
+end


### PR DESCRIPTION
This will rerun the manpage generation if any of the involved files have been updated.