### PR TITLE
WIP: CI: update gcc to 12

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - { COMPILER: "gcc",   COMPILER_VERSION: "10", SANITIZE: "yes"  }
-          - { COMPILER: "gcc",   COMPILER_VERSION: "10", SANITIZE: "no"   }
+          - { COMPILER: "gcc",   COMPILER_VERSION: "12", SANITIZE: "yes"  }
+          - { COMPILER: "gcc",   COMPILER_VERSION: "12", SANITIZE: "no"   }
           - { COMPILER: "clang", COMPILER_VERSION: "15", SANITIZE: "yes"  }
           - { COMPILER: "clang", COMPILER_VERSION: "15", SANITIZE: "no"   }
     env: ${{ matrix.env }}


### PR DESCRIPTION
gcc 10 has false positives around null strings:

In file included from /usr/include/stdio.h:894,
                 from lib/strutils.c:8:
In function ‘printf’,
    inlined from ‘test_strutils_cstrcasecmp’ at lib/strutils.c:1324:2,
    inlined from ‘main’ at lib/strutils.c:1348:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:112:10: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  112 |   return __printf_chk (__USE_FORTIFY_LEVEL - 1, __fmt, __va_arg_pack ());
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors