### PR TITLE
lib/strutils: fix compiler error

### DIFF
--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -1322,6 +1322,9 @@ static int test_strutils_cstrcasecmp(int argc, char *argv[])
 	a = argv[1];
 	b = argv[2];
 
+	if (!a || !b)
+		return EXIT_FAILURE;
+
 	printf("cmp    '%s' '%s' = %d\n", a, b, strcasecmp(a, b));
 	printf("c_cmp  '%s' '%s' = %d\n", a, b, c_strcasecmp(a, b));
 	printf("c_ncmp '%s' '%s' = %d\n", a, b, c_strncasecmp(a, b, strlen(a)));


### PR DESCRIPTION
In file included from /usr/include/stdio.h:894,
                 from lib/strutils.c:8:
In function ‘printf’,
    inlined from ‘test_strutils_cstrcasecmp’ at lib/strutils.c:1324:2,
    inlined from ‘main’ at lib/strutils.c:1348:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:112:10: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  112 |   return __printf_chk (__USE_FORTIFY_LEVEL - 1, __fmt, __va_arg_pack ());
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors