### PR TITLE
schedutils: clarify the usage and behavior of the taskset command

### DIFF
--- a/schedutils/taskset.1.adoc
+++ b/schedutils/taskset.1.adoc
@@ -42,7 +42,7 @@ taskset - set or retrieve a process's CPU affinity
 
 == DESCRIPTION
 
-The *taskset* command is used to set or retrieve the CPU affinity of a running process given its _pid_, or to launch a new _command_ with a given CPU affinity. CPU affinity is a scheduler property that "bonds" a process to a given set of CPUs on the system. The Linux scheduler will honor the given CPU affinity and the process will not run on any other CPUs. Note that the Linux scheduler also supports natural CPU affinity: the scheduler attempts to keep processes on the same CPU as long as practical for performance reasons. Therefore, forcing a specific CPU affinity is useful only in certain applications.
+The *taskset* command is used to set or retrieve the CPU affinity of a running process given its _pid_, or to launch a new _command_ with a given CPU affinity. CPU affinity is a scheduler property that "bonds" a process to a given set of CPUs on the system. The Linux scheduler will honor the given CPU affinity and the process will not run on any other CPUs. Note that the Linux scheduler also supports natural CPU affinity: the scheduler attempts to keep processes on the same CPU as long as practical for performance reasons. Therefore, forcing a specific CPU affinity is useful only in certain applications.   The affinity of some processes like kernel per-CPU threads cannot be set.
 
 The CPU affinity is represented as a bitmask, with the lowest order bit corresponding to the first logical CPU and the highest order bit corresponding to the last logical CPU. Not all CPUs may exist on a given system but a mask may specify more CPUs than are present. A retrieved mask will reflect only the bits that correspond to CPUs physically on the system. If an invalid mask is given (i.e., one that corresponds to no valid CPUs on the current system) an error is returned. The masks may be specified in hexadecimal (with or without a leading "0x"), or as a CPU list with the *--cpu-list* option. For example,
 
@@ -96,6 +96,34 @@ Or set it{colon}::
 == PERMISSIONS
 
 A user can change the CPU affinity of a process belonging to the same user. A user must possess *CAP_SYS_NICE* to change the CPU affinity of a process belonging to another user. A user can retrieve the affinity mask of any process.
+
+== RETURN VALUE
+
+*Taskset* returns 0 in its affinity-getting mode as long as the provided PID exists.
+
+*Taskset* returns 0 in its affinity-setting mode as long as the underlying *sched_setaffinity()* system call does.     The success of the command does not guarantee that the specified thread has actually migrated to the indicated CPU(s), but only that the thread will not migrate to a CPU outside the new affinity mask.   For example, the affinity of the kernel thread kswapd can be set, but the thread may not immediately migrate and is not guaranteed to ever do so:
+
+$ ps ax -o comm,psr,pid | grep kswapd +
+kswapd0           4      82 +
+$ sudo taskset -p 1 82 +
+pid 82's current affinity mask: 1 +
+pid 82's new affinity mask: 1 +
+$ echo $? +
+0 +
+$ ps ax -o comm,psr,pid | grep kswapd +
+kswapd0           4      82 +
+$ taskset -p 82 +
+pid 82's current affinity mask: 1 +
+
+In contrast, when the user specifies an illegal affinity, taskset will print an error and return 1:
+
+$ ps ax -o comm,psr,pid | grep ksoftirqd/0 +
+ksoftirqd/0       0      14 +
+$ sudo taskset -p 1 14 +
+pid 14's current affinity mask: 1 +
+taskset: failed to set pid 14's affinity: Invalid argument +
+$ echo $? +
+1 +
 
 == AUTHORS
 

--- a/schedutils/taskset.1.adoc
+++ b/schedutils/taskset.1.adoc
@@ -52,10 +52,10 @@ is processor #0,
 *0x00000003*::
 is processors #0 and #1,
 
-*0xFFFFFFFF*::
+*FFFFFFFF*::
 is processors #0 through #31,
 
-*32*::
+*0x32*::
 is processors #1, #4, and #5,
 
 *--cpu-list 0-2,6*::

--- a/schedutils/taskset.1.adoc
+++ b/schedutils/taskset.1.adoc
@@ -93,6 +93,14 @@ You can also retrieve the CPU affinity of an existing task{colon}::
 Or set it{colon}::
 *taskset -p* _mask pid_
 
+//TRANSLATORS: Keep {colon} untranslated.
+When a cpu-list is specified for an existing process, the 'p' and 'c' options must be grouped together{colon}::
+*taskset -pc* _cpu-list pid_
+
+//TRANSLATORS: Keep {colon} untranslated.
+The *--cpu-list* form is applicable only for launching new commands{colon}::
+*taskset --cpu-list* _cpu-list command_
+
 == PERMISSIONS
 
 A user can change the CPU affinity of a process belonging to the same user. A user must possess *CAP_SYS_NICE* to change the CPU affinity of a process belonging to another user. A user can retrieve the affinity mask of any process.


### PR DESCRIPTION
Provide some minor improvements to the existing taskset man page, namely:

-- Illustrate the ability to specify cpumasks without a leading "0x" with an example that is clearly hexadecimal.

-- Clarify that a successful return code from the command does not mean that a process has actually migrated.

-- Provide a couple of examples to further explain the significance of the taskset return code.