### PR TITLE
login: never send signals to init

### DIFF
--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -203,12 +203,12 @@ static void timedout(int sig __attribute__((__unused__)))
  */
 static void sig_handler(int signal)
 {
-	if (child_pid)
+	if (child_pid > 0) {
 		kill(-child_pid, signal);
-	else
+		if (signal == SIGTERM)
+			kill(-child_pid, SIGHUP);	/* because the shell often ignores SIGTERM */
+	} else
 		got_sig = 1;
-	if (signal == SIGTERM)
-		kill(-child_pid, SIGHUP);	/* because the shell often ignores SIGTERM */
 }
 
 /*


### PR DESCRIPTION
If the signal handler is triggered after a failed fork attempt, then child_pid will be -1. This in turn leads to a positive test and a subsequent call of kill(1, signal). If signal was SIGTERM, then there will be also another kill(1, SIGHUP) call.

Test explicitly for a positive child_pid value to prevent these cases.

Signed-off-by: Samanta Navarro <ferivoz@riseup.net>