### PR TITLE
c.h: avoid undefined behavior in SINT_MAX macro

### DIFF
--- a/include/c.h
+++ b/include/c.h
@@ -526,6 +526,6 @@ static inline void print_features(const char **features, const char *prefix)
 # define MAP_ANONYMOUS  (MAP_ANON)
 #endif
 
-#define SINT_MAX(t) (((size_t) 1 << (sizeof(t) * 8 - 1)) - 1)
+#define SINT_MAX(t) ((t)((~(t) 0) ^ (t) 1 << (sizeof(t) * 8 - 1)))
 
 #endif /* UTIL_LINUX_C_H */


### PR DESCRIPTION
The previous implementation relied on signed-integer overflow. This is undefined behavior.

Instead use an implementation that only requires twos-complement representation. This is what everybody uses anyways and it will be required by C23.