### PR TITLE
lib/blkdev: better error handling

### DIFF
--- a/lib/blkdev.c
+++ b/lib/blkdev.c
@@ -31,6 +31,7 @@
 # define EBADFD 77		/* File descriptor in bad state */
 #endif
 
+#include "all-io.h"
 #include "blkdev.h"
 #include "c.h"
 #include "linux_version.h"
@@ -43,7 +44,7 @@ blkdev_valid_offset (int fd, off_t offset) {
 
 	if (lseek (fd, offset, 0) < 0)
 		return 0;
-	if (read (fd, &ch, 1) < 1)
+	if (read_all (fd, &ch, 1) < 1)
 		return 0;
 	return 1;
 }

--- a/lib/blkdev.c
+++ b/lib/blkdev.c
@@ -58,25 +58,25 @@ int is_blkdev(int fd)
 
 off_t
 blkdev_find_size (int fd) {
-	uintmax_t high, low = 0;
+	off_t high, low = 0;
 
 	for (high = 1024; blkdev_valid_offset (fd, high); ) {
-		if (high == UINTMAX_MAX) {
+		if (high == SINT_MAX(off_t)) {
 			errno = EFBIG;
 			return -1;
 		}
 
 		low = high;
 
-		if (high >= UINTMAX_MAX/2)
-			high = UINTMAX_MAX;
+		if (high >= SINT_MAX(off_t)/2)
+			high = SINT_MAX(off_t);
 		else
 			high *= 2;
 	}
 
 	while (low < high - 1)
 	{
-		uintmax_t mid = (low + high) / 2;
+		off_t mid = (low + high) / 2;
 
 		if (blkdev_valid_offset (fd, mid))
 			low = mid;

--- a/lib/blkdev.c
+++ b/lib/blkdev.c
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 #include <sys/ioctl.h>
+#include <errno.h>
 #include <unistd.h>
 #include <stdint.h>
 
@@ -60,8 +61,10 @@ blkdev_find_size (int fd) {
 	uintmax_t high, low = 0;
 
 	for (high = 1024; blkdev_valid_offset (fd, high); ) {
-		if (high == UINTMAX_MAX)
+		if (high == UINTMAX_MAX) {
+			errno = EFBIG;
 			return -1;
+		}
 
 		low = high;
 
@@ -167,8 +170,10 @@ blkdev_get_size(int fd, unsigned long long *bytes)
 			*bytes = st.st_size;
 			return 0;
 		}
-		if (!S_ISBLK(st.st_mode))
+		if (!S_ISBLK(st.st_mode)) {
+			errno = ENOTBLK;
 			return -1;
+		}
 	}
 
 	*bytes = blkdev_find_size(fd);


### PR DESCRIPTION
The code in blkdev_get_size should have a better error handling:

- the read system call might be interrupted by a signal. I don't think that it's a good idea to report a smaller disk size back to the application compared to giving an error return value
- an error return value should always set errno, because applications within util-linux evaluate errno for error messages
- last but not least: off_t is signed and the code should try to support block devices as large as possible by considering INTMAX_MAX instead of UINTMAX_MAX. I lack such a block device though for a proof of concept :)