### PR TITLE
mkswap: do not use uninitialized stack value

### DIFF
--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -345,8 +345,9 @@ static unsigned long long get_size(const struct mkswap_control *ctl)
 	fd = open(ctl->devname, O_RDONLY);
 	if (fd < 0)
 		err(EXIT_FAILURE, _("cannot open %s"), ctl->devname);
-	if (blkdev_get_size(fd, &size) == 0)
-		size /= ctl->pagesize;
+	if (blkdev_get_size(fd, &size) < 0)
+		err(EXIT_FAILURE, _("cannot determine size of %s"), ctl->devname);
+	size /= ctl->pagesize;
 
 	close(fd);
 	return size;


### PR DESCRIPTION
If blkdev_get_size fails, then size is not set. Exit with an error code and indicate what went wrong instead of continuing with random stack content.

Proof of Concept:

```
$ mkswap /dev/null
mkswap: warning: truncating swap area to 17179869180 KiB
mkswap: /dev/null: insecure permissions 0666, fix with: chmod 0600 /dev/null
mkswap: unable to assign device to libblkid probe
```

The first output line depends on stack content and sometimes does not show up at all. Abort operation if argument is neither regular file nor block device.

Signed-off-by: Samanta Navarro <ferivoz@riseup.net>