### PR TITLE
c.h: really avoid undefined behavior in SINT_MAX

### DIFF
--- a/include/c.h
+++ b/include/c.h
@@ -526,6 +526,6 @@ static inline void print_features(const char **features, const char *prefix)
 # define MAP_ANONYMOUS  (MAP_ANON)
 #endif
 
-#define SINT_MAX(t) ((t)((~(t) 0) ^ (t) 1 << (sizeof(t) * 8 - 1)))
+#define SINT_MAX(t) ((t) (1 << (sizeof(t) * 8 - 2)) - 1 + ((t) 1 << (sizeof(t) * 8 - 2)))
 
 #endif /* UTIL_LINUX_C_H */


### PR DESCRIPTION
The previous fix in #2013 still invoked undefined behavior by shifting
into the sign-bit.
    
Now we have a correct, albeit unwieldy solution that avoids undefined
behavior.
Instead of bit fiddling it uses plain addition and substraction.
    
We are looking for (in LaTeX notation):
   2^(n - 1) - 1
= 2 * 2^(n - 2) - 1
= 2^(n - 2) + 2^(n - 2) - 1
= 2^(n - 2) - 1 + 2^(n - 2)
