### PR TITLE
fix some Signal safety issues

### DIFF
--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -149,7 +149,7 @@ static FILE *report_stats_file;
 static int num_running;
 static int max_running;
 
-static volatile int cancel_requested;
+static volatile sig_atomic_t cancel_requested;
 static int kill_sent;
 static char *fstype;
 static struct fsck_instance *instance_list;

--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -1422,7 +1422,7 @@ static void __attribute__((__noreturn__)) usage(void)
 
 static void signal_cancel(int sig __attribute__((__unused__)))
 {
-	cancel_requested++;
+	cancel_requested = 1;
 }
 
 static void parse_argv(int argc, char *argv[])

--- a/lib/pager.c
+++ b/lib/pager.c
@@ -114,7 +114,9 @@ static int wait_or_whine(pid_t pid)
 		if (waiting < 0) {
 			if (errno == EINTR)
 				continue;
-			err(EXIT_FAILURE, _("waitpid failed (%s)"), strerror(errno));
+			/* Can't err() on signal handler */
+			ignore_result(write(STDERR_FILENO, "waitpid failed", 14));
+			_exit(EXIT_FAILURE);
 		}
 		if (waiting != pid)
 			return -1;
@@ -163,8 +165,6 @@ static void wait_for_pager(void)
 	if (pager_process.pid == 0)
 		return;
 
-	fflush(stdout);
-	fflush(stderr);
 	/* signal EOF to pager */
 	close(STDOUT_FILENO);
 	close(STDERR_FILENO);

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -267,23 +267,13 @@ static int uread(FILE *fp, struct utmpx *u,  int *quit, const char *filename)
 
 #ifndef FUZZ_TARGET
 /*
- *	Print a short date.
- */
-static char *showdate(void)
-{
-	static char s[CTIME_BUFSIZ];
-
-	ctime_r(&lastdate, s);
-	s[16] = 0;
-	return s;
-}
-
-/*
  *	SIGINT handler
  */
 static void int_handler(int sig __attribute__((unused)))
 {
-	errx(EXIT_FAILURE, _("Interrupted %s"), showdate());
+	/* can't use err on signal handler */
+	write(STDERR_FILENO, "Interrupted\n", sizeof("Interrupted\n")-1);
+	_exit(EXIT_FAILURE);
 }
 
 /*
@@ -291,7 +281,7 @@ static void int_handler(int sig __attribute__((unused)))
  */
 static void quit_handler(int sig __attribute__((unused)))
 {
-	warnx(_("Interrupted %s"), showdate());
+	write(STDERR_FILENO, "Interrupted\n", sizeof("Interrupted\n")-1);
 	signal(SIGQUIT, quit_handler);
 }
 #endif

--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -165,7 +165,7 @@ struct su_context {
 };
 
 
-static sig_atomic_t volatile caught_signal = false;
+static sig_atomic_t volatile caught_signal = 0;
 
 /* Signal handler for parent process.  */
 static void

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -342,12 +342,12 @@ static void tcfinal(struct console *con)
 static void alrm_handler(int sig __attribute__((unused)))
 {
 	/* Timeout expired */
-	alarm_rised++;
+	alarm_rised = 1;
 }
 
 static void chld_handler(int sig __attribute__((unused)))
 {
-	sigchild++;
+	sigchild = 1;
 }
 
 static void mask_signal(int signal, void (*handler)(int),

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -218,7 +218,7 @@ static void *files_by_ino;
  * The last signal we received. We store the signal here in order to be able
  * to break out of loops gracefully and to return from our nftw() handler.
  */
-static int last_signal;
+static volatile sig_atomic_t last_signal;
 
 
 #define is_log_enabled(_level)  (quiet == 0 && (_level) <= (unsigned int)opts.verbosity)

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -1380,7 +1380,8 @@ static void sighandler(int i)
 	if (last_signal != SIGINT)
 		last_signal = i;
 	if (i == SIGINT)
-		putchar('\n');
+		/* can't use stdio on signal handler */
+		ignore_result(write(STDOUT_FILENO, "\n", sizeof("\n")-1));
 }
 
 int main(int argc, char *argv[])

--- a/sys-utils/flock.c
+++ b/sys-utils/flock.c
@@ -75,7 +75,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	exit(EXIT_SUCCESS);
 }
 
-static sig_atomic_t timeout_expired = 0;
+static volatile sig_atomic_t timeout_expired = 0;
 
 static void timeout_handler(int sig __attribute__((__unused__)),
 			    siginfo_t *info,

--- a/term-utils/write.c
+++ b/term-utils/write.c
@@ -67,7 +67,7 @@
 #include "ttyutils.h"
 #include "xalloc.h"
 
-static sig_atomic_t signal_received = 0;
+static volatile sig_atomic_t signal_received = 0;
 
 struct write_control {
 	uid_t src_uid;

--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -219,7 +219,7 @@ static my_sighandler_t my_sigset(int sig, my_sighandler_t disp)
 /* Quit pg. */
 static void __attribute__((__noreturn__)) quit(int status)
 {
-	exit(status < 0100 ? status : 077);
+	_exit(status < 0100 ? status : 077);
 }
 
 /* Usage message and similar routines. */


### PR DESCRIPTION
Generally

- It is only warranted that writting to an static volatile sig_atomic_t works.
- You cannot use any function outside the signal-safety 7 list 
-  Most importantly if you call anything that ends calling stdio or malloc..kaboom.. 