### PR TITLE
lib/timeutils: parse_timestamp: bugfix, unittests and usec support

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v3
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC2034  # unused variable

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -324,10 +324,8 @@ static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 
 	tm = copy;
 	k = strptime(t, "%Y%m%d%H%M%S", &tm);
-	if (k && *k == 0) {
-		tm.tm_sec = 0;
+	if (k && *k == 0)
 		goto finish;
-	}
 
 	return -EINVAL;
 
@@ -600,6 +598,7 @@ static int run_unittest_timestamp(void)
 		{ "tomorrow"           , 1674259200000000 },
 		{ "+5min"              , 1674180727000000 },
 		{ "-5days"             , 1673748427000000 },
+		{ "20120922163422"     , 1348331662000000 },
 	};
 
 	if (unsetenv("TZ"))

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -147,7 +147,7 @@ static int parse_sec(const char *t, usec_t *usec)
 	return 0;
 }
 
-int parse_timestamp(const char *t, usec_t *usec)
+static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 {
 	static const struct {
 		const char *name;
@@ -171,7 +171,6 @@ int parse_timestamp(const char *t, usec_t *usec)
 
 	const char *k;
 	struct tm tm, copy;
-	time_t x;
 	usec_t plus = 0, minus = 0, ret;
 	int r, weekday = -1;
 	unsigned i;
@@ -198,7 +197,6 @@ int parse_timestamp(const char *t, usec_t *usec)
 	assert(t);
 	assert(usec);
 
-	x = time(NULL);
 	localtime_r(&x, &tm);
 	tm.tm_isdst = -1;
 
@@ -352,6 +350,11 @@ int parse_timestamp(const char *t, usec_t *usec)
 	*usec = ret;
 
 	return 0;
+}
+
+int parse_timestamp(const char *t, usec_t *usec)
+{
+	return parse_timestamp_reference(time(NULL), t, usec);
 }
 
 /* Returns the difference in seconds between its argument and GMT. If if TP is

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -147,6 +147,26 @@ static int parse_sec(const char *t, usec_t *usec)
 	return 0;
 }
 
+static int parse_subseconds(const char *t, usec_t *usec)
+{
+	usec_t ret = 0;
+	int factor = USEC_PER_SEC / 10;
+
+	if (*t != '.' && *t != ',')
+		return -1;
+
+	while (*(++t)) {
+		if (!isdigit(*t) || factor < 1)
+			return -1;
+
+		ret += ((usec_t) *t - '0') * factor;
+		factor /= 10;
+	}
+
+	*usec = ret;
+	return 0;
+}
+
 static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 {
 	static const struct {
@@ -171,26 +191,34 @@ static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 
 	const char *k;
 	struct tm tm, copy;
-	usec_t plus = 0, minus = 0, ret;
+	usec_t plus = 0, minus = 0, ret = 0;
 	int r, weekday = -1;
 	unsigned i;
 
 	/*
 	 * Allowed syntaxes:
 	 *
-	 *   2012-09-22 16:34:22
-	 *   2012-09-22T16:34:22
-	 *   @1348331662	  (seconds since the Epoch (1970-01-01 00:00 UTC))
-	 *   2012-09-22 16:34	  (seconds will be set to 0)
-	 *   2012-09-22		  (time will be set to 00:00:00)
-	 *   16:34:22		  (date will be set to today)
-	 *   16:34		  (date will be set to today, seconds to 0)
+	 *   2012-09-22 16:34:22 !
+	 *   2012-09-22T16:34:22 !
+	 *   20120922163422      !
+	 *   @1348331662	 ! (seconds since the Epoch (1970-01-01 00:00 UTC))
+	 *   2012-09-22 16:34	   (seconds will be set to 0)
+	 *   2012-09-22		   (time will be set to 00:00:00)
+	 *   16:34:22		 ! (date will be set to today)
+	 *   16:34		   (date will be set to today, seconds to 0)
 	 *   now
-	 *   yesterday		  (time is set to 00:00:00)
-	 *   today		  (time is set to 00:00:00)
-	 *   tomorrow		  (time is set to 00:00:00)
+	 *   yesterday		   (time is set to 00:00:00)
+	 *   today		   (time is set to 00:00:00)
+	 *   tomorrow		   (time is set to 00:00:00)
 	 *   +5min
 	 *   -5days
+	 *
+	 *   Syntaxes marked with '!' also optionally allow up to six digits of
+	 *   subsecond granularity, separated by '.' or ',':
+	 *
+	 *   2012-09-22 16:34:22.12
+	 *   2012-09-22 16:34:22.123456
+	 *
 	 *
 	 */
 
@@ -235,6 +263,8 @@ static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 		k = strptime(t + 1, "%s", &tm);
 		if (k && *k == 0)
 			goto finish;
+		else if (k && parse_subseconds(k, &ret) == 0)
+			goto finish;
 
 		return -EINVAL;
 	} else if (endswith(t, " ago")) {
@@ -271,15 +301,21 @@ static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 	k = strptime(t, "%y-%m-%d %H:%M:%S", &tm);
 	if (k && *k == 0)
 		goto finish;
+	else if (k && parse_subseconds(k, &ret) == 0)
+		goto finish;
 
 	tm = copy;
 	k = strptime(t, "%Y-%m-%d %H:%M:%S", &tm);
 	if (k && *k == 0)
 		goto finish;
+	else if (k && parse_subseconds(k, &ret) == 0)
+		goto finish;
 
 	tm = copy;
 	k = strptime(t, "%Y-%m-%dT%H:%M:%S", &tm);
 	if (k && *k == 0)
+		goto finish;
+	else if (k && parse_subseconds(k, &ret) == 0)
 		goto finish;
 
 	tm = copy;
@@ -314,6 +350,8 @@ static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 	k = strptime(t, "%H:%M:%S", &tm);
 	if (k && *k == 0)
 		goto finish;
+	else if (k && parse_subseconds(k, &ret) == 0)
+		goto finish;
 
 	tm = copy;
 	k = strptime(t, "%H:%M", &tm);
@@ -326,6 +364,8 @@ static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 	k = strptime(t, "%Y%m%d%H%M%S", &tm);
 	if (k && *k == 0)
 		goto finish;
+	else if (k && parse_subseconds(k, &ret) == 0)
+		goto finish;
 
 	return -EINVAL;
 
@@ -337,7 +377,7 @@ static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 	if (weekday >= 0 && tm.tm_wday != weekday)
 		return -EINVAL;
 
-	ret = (usec_t) x *USEC_PER_SEC;
+	ret += (usec_t) x * USEC_PER_SEC;
 
 	ret += plus;
 	if (ret > minus)
@@ -586,19 +626,24 @@ static int run_unittest_timestamp(void)
 		const char * const input;
 		usec_t expected;
 	} testcases[] = {
-		{ "2012-09-22 16:34:22", 1348331662000000 },
-		{ "@1348331662"        , 1348331662000000 },
-		{ "2012-09-22 16:34"   , 1348331640000000 },
-		{ "2012-09-22"         , 1348272000000000 },
-		{ "16:34:22"           , 1674232462000000 },
-		{ "16:34"              , 1674232440000000 },
-		{ "now"                , 1674180427000000 },
-		{ "yesterday"          , 1674086400000000 },
-		{ "today"              , 1674172800000000 },
-		{ "tomorrow"           , 1674259200000000 },
-		{ "+5min"              , 1674180727000000 },
-		{ "-5days"             , 1673748427000000 },
-		{ "20120922163422"     , 1348331662000000 },
+		{ "2012-09-22 16:34:22"    , 1348331662000000 },
+		{ "2012-09-22 16:34:22,012", 1348331662012000 },
+		{ "2012-09-22 16:34:22.012", 1348331662012000 },
+		{ "@1348331662"            , 1348331662000000 },
+		{ "@1348331662.234567"     , 1348331662234567 },
+		{ "2012-09-22 16:34"       , 1348331640000000 },
+		{ "2012-09-22"             , 1348272000000000 },
+		{ "16:34:22"               , 1674232462000000 },
+		{ "16:34:22,123456"        , 1674232462123456 },
+		{ "16:34:22.123456"        , 1674232462123456 },
+		{ "16:34"                  , 1674232440000000 },
+		{ "now"                    , 1674180427000000 },
+		{ "yesterday"              , 1674086400000000 },
+		{ "today"                  , 1674172800000000 },
+		{ "tomorrow"               , 1674259200000000 },
+		{ "+5min"                  , 1674180727000000 },
+		{ "-5days"                 , 1673748427000000 },
+		{ "20120922163422"         , 1348331662000000 },
 	};
 
 	if (unsetenv("TZ"))

--- a/tests/commands.sh
+++ b/tests/commands.sh
@@ -47,6 +47,7 @@ TS_HELPER_LAST_FUZZ="${ts_helpersdir}test_last_fuzz"
 TS_HELPER_MKFDS="${ts_helpersdir}test_mkfds"
 TS_HELPER_BLKID_FUZZ="${ts_helpersdir}test_blkid_fuzz"
 TS_HELPER_PROCFS="${ts_helpersdir}test_procfs"
+TS_HELPER_TIMEUTILS="${ts_helpersdir}test_timeutils"
 
 # paths to commands
 TS_CMD_ADDPART=${TS_CMD_ADDPART:-"${ts_commandsdir}addpart"}

--- a/tests/ts/lib/timeutils
+++ b/tests/ts/lib/timeutils
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>
+#
+# This file may be distributed under the terms of the
+# GNU Lesser General Public License.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="timeutils library"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_HELPER_TIMEUTILS"
+
+ts_init_subtest "timestamp"
+
+"$TS_HELPER_TIMEUTILS" --unittest-timestamp 2> "$TS_ERRLOG"
+
+ts_finalize_subtest
+
+ts_finalize


### PR DESCRIPTION
Edit: also contains some changes for the shellcheck lint.