### PR TITLE
libblkid: befs - avoid undefined shift

### DIFF
--- a/libblkid/src/superblocks/befs.c
+++ b/libblkid/src/superblocks/befs.c
@@ -502,6 +502,9 @@ static int probe_befs(blkid_probe pr, const struct blkid_idmag *mag)
 	    block_size != 1U << block_shift)
 		return BLKID_PROBE_NONE;
 
+	if (FS32_TO_CPU(bs->ag_shift, fs_le) > 64)
+		return BLKID_PROBE_NONE;
+
 	ret = get_uuid(pr, bs, &volume_id, fs_le);
 
 	if (ret != 0)


### PR DESCRIPTION
BEFS does not check maximal value for ag_shift leading to undefined behavior. Avoid this by limiting shift size.

Reproducer found with OSS-Fuzz (issue 55285) running over cryptsetup project (blkid is used in header init).

Signed-off-by: Milan Broz <gmazyland@gmail.com>