### PR TITLE
libblkid: add test_blkid_fuzz_sample

### DIFF
--- a/libblkid/src/Makemodule.am
+++ b/libblkid/src/Makemodule.am
@@ -219,12 +219,20 @@ test_blkid_fuzz_SOURCES = libblkid/src/fuzz.c
 # https://google.github.io/oss-fuzz/getting-started/new-project-guide/#Requirements
 nodist_EXTRA_test_blkid_fuzz_SOURCES = dummy.cxx
 
-test_blkid_fuzz_CFLAGS = $(blkid_tests_cflags)
+test_blkid_fuzz_CFLAGS = $(blkid_tests_cflags) -DFUZZ_TARGET
 test_blkid_fuzz_LDFLAGS = $(blkid_tests_ldflags) -lpthread
 test_blkid_fuzz_LDADD = $(blkid_tests_ldadd) $(LIB_FUZZING_ENGINE)
 endif
 
 endif # BUILD_LIBBLKID_TESTS
+
+check_PROGRAMS += test_blkid_fuzz_sample
+
+test_blkid_fuzz_sample_SOURCES = libblkid/src/fuzz.c
+
+test_blkid_fuzz_sample_CFLAGS = $(blkid_tests_cflags)
+test_blkid_fuzz_sample_LDFLAGS = $(blkid_tests_ldflags)
+test_blkid_fuzz_sample_LDADD = $(blkid_tests_ldadd)
 
 
 # move lib from $(usrlib_execdir) to $(libdir) if needed

--- a/libblkid/src/fuzz.c
+++ b/libblkid/src/fuzz.c
@@ -4,6 +4,21 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+static int process_file(const char *name)
+{
+    int rc = -1;
+    blkid_probe pr = blkid_new_probe_from_filename(name);
+    if (pr != NULL) {
+        blkid_probe_enable_partitions(pr, TRUE);
+        blkid_probe_set_partitions_flags(pr, FALSE);
+        blkid_probe_enable_superblocks(pr, TRUE);
+        blkid_probe_set_superblocks_flags(pr, BLKID_SUBLKS_DEFAULT | BLKID_SUBLKS_FSINFO | BLKID_SUBLKS_MAGIC | BLKID_SUBLKS_VERSION | BLKID_SUBLKS_BADCSUM);
+        rc = blkid_do_safeprobe(pr) == -1 ? -1 : 0;
+    }
+    blkid_free_probe(pr);
+    return rc;
+}
+
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     int fd;
     char name[] = "/tmp/test-script-fuzz.XXXXXX";
@@ -15,17 +30,23 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (write(fd, data, size) != (ssize_t)size)
         goto out;
 
-    blkid_probe pr = blkid_new_probe_from_filename(name);
-    if (pr != NULL) {
-        blkid_probe_enable_partitions(pr, TRUE);
-        blkid_probe_set_partitions_flags(pr, FALSE);
-        blkid_probe_enable_superblocks(pr, TRUE);
-        blkid_probe_set_superblocks_flags(pr, BLKID_SUBLKS_DEFAULT | BLKID_SUBLKS_FSINFO | BLKID_SUBLKS_MAGIC | BLKID_SUBLKS_VERSION | BLKID_SUBLKS_BADCSUM);
-        blkid_do_safeprobe(pr);
-    }
-    blkid_free_probe(pr);
+    process_file(name);
 out:
     close(fd);
     unlink(name);
     return 0;
 }
+
+#ifndef FUZZ_TARGET
+int main(int argc, char **argv)
+{
+    for (int i = 1; i < argc; i++) {
+        printf("%s ", argv[i]);
+        if (process_file(argv[i]) == 0)
+            printf(" OK\n");
+        else
+            printf(" FAILED\n");
+
+    }
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -2665,6 +2665,15 @@ if not is_disabler(exe)
   exes += exe
 endif
 
+exe = executable(
+  'test_blkid_fuzz_sample',
+  'libblkid/src/fuzz.c',
+  include_directories: includes,
+  link_with: lib_blkid)
+if not is_disabler(exe)
+  exes += exe
+endif
+
 ############################################################
 
 exe = executable(


### PR DESCRIPTION
This can be used to easily reproduce crashes produced by the fuzzers.