### PR TITLE
libblkid: try LUKS2 first when probing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -751,6 +751,11 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([extern char *__progname;],
 	   AC_MSG_RESULT([yes]),
 	   AC_MSG_RESULT([no]))
 
+AC_CHECK_DECL([IOC_OPAL_GET_STATUS],
+	[AC_DEFINE([HAVE_OPAL_GET_STATUS], [1],
+		[Define to 1 if OPAL status ioctl is defined])],,
+	      [#include <linux/sed-opal.h>])
+
 dnl Static compilation
 m4_define([UL_STATIC_PROGRAMS], [blkid, fdisk, losetup, mount, nsenter, sfdisk, umount, unshare])
 

--- a/libblkid/src/blkidP.h
+++ b/libblkid/src/blkidP.h
@@ -237,6 +237,7 @@ struct blkid_struct_probe
 #define BLKID_FL_CDROM_DEV	(1 << 3)	/* is a CD/DVD drive */
 #define BLKID_FL_NOSCAN_DEV	(1 << 4)	/* do not scan this device */
 #define BLKID_FL_MODIF_BUFF	(1 << 5)	/* cached buffers has been modified */
+#define BLKID_FL_OPAL_LOCKED	(1 << 6)	/* OPAL device is locked (I/O errors) */
 
 /* private per-probing flags */
 #define BLKID_PROBE_FL_IGNORE_PT (1 << 1)	/* ignore partition table */
@@ -405,6 +406,9 @@ extern int blkid_probe_is_tiny(blkid_probe pr)
 			__attribute__((nonnull))
 			__attribute__((warn_unused_result));
 extern int blkid_probe_is_cdrom(blkid_probe pr)
+			__attribute__((nonnull))
+			__attribute__((warn_unused_result));
+extern int blkdid_probe_is_opal_locked(blkid_probe pr)
 			__attribute__((nonnull))
 			__attribute__((warn_unused_result));
 

--- a/libblkid/src/superblocks/superblocks.c
+++ b/libblkid/src/superblocks/superblocks.c
@@ -94,6 +94,11 @@ static int blkid_probe_set_usage(blkid_probe pr, int usage);
  */
 static const struct blkid_idinfo *idinfos[] =
 {
+	/* In case the volume is locked with OPAL we are going to get
+	 * an I/O error when reading past the LUKS header, so try it
+	 * first. */
+	&luks_idinfo,
+
 	/* RAIDs */
 	&linuxraid_idinfo,
 	&ddfraid_idinfo,
@@ -119,7 +124,6 @@ static const struct blkid_idinfo *idinfos[] =
 	&snapcow_idinfo,
 	&verity_hash_idinfo,
 	&integrity_idinfo,
-	&luks_idinfo,
 	&vmfs_volume_idinfo,
 	&ubi_idinfo,
 	&vdo_idinfo,

--- a/meson.build
+++ b/meson.build
@@ -692,6 +692,9 @@ int main(void) {
 have = cc.compiles(code, name : 'using __progname')
 conf.set('HAVE___PROGNAME', have ? 1 : false)
 
+have_opal_get_status= cc.has_header_symbol('linux/sed-opal.h', 'IOC_OPAL_GET_STATUS')
+conf.set('HAVE_OPAL_GET_STATUS', have_opal_get_status ? 1 : false)
+
 build_plymouth_support = get_option('build-plymouth-support')
 have_tiocglcktrmios = cc.has_header_symbol(
   'sys/ioctl.h', 'TIOCGLCKTRMIOS',


### PR DESCRIPTION
If a device is locked with OPAL we'll get an I/O error when probing past the LUKS2 header. Try it first to avoid this issue.

Signed-off-by: Luca Boccassi <bluca@debian.org>