### PR TITLE
lsfd:  read the UNIX socket path including white spaces correctly

### DIFF
--- a/misc-utils/lsfd-sock-xinfo.c
+++ b/misc-utils/lsfd-sock-xinfo.c
@@ -347,7 +347,12 @@ static const struct sock_xinfo_class unix_xinfo_class = {
 	.free = NULL,
 };
 
-/* #define UNIX_LINE_LEN 54 + 21 + UNIX_LINE_LEN + 1 */
+/* #define UNIX_LINE_LEN 54 + 21 + UNIX_LINE_LEN + 1
+ *
+ * An actual number must be used in this definition
+ * since UNIX_LINE_LEN is specified as an argument for
+ * stringify_value().
+ */
 #define UNIX_LINE_LEN 256
 static void load_xinfo_from_proc_unix(ino_t netns_inode)
 {
@@ -370,10 +375,11 @@ static void load_xinfo_from_proc_unix(ino_t netns_inode)
 		unsigned int st;
 		unsigned long inode;
 		struct unix_xinfo *ux;
-		char path[UNIX_LINE_LEN] = { 0 };
+		char path[UNIX_LINE_LEN + 1] = { 0 };
 
 
-		if (sscanf(line, "%*x: %*x %*x %" SCNx64 " %x %x %lu %s",
+		if (sscanf(line, "%*x: %*x %*x %" SCNx64 " %x %x %lu %"
+			   stringify_value(UNIX_LINE_LEN) "[^\n]",
 			   &flags, &type, &st, &inode, path) < 4)
 			continue;
 

--- a/misc-utils/lsfd-sock-xinfo.c
+++ b/misc-utils/lsfd-sock-xinfo.c
@@ -370,7 +370,7 @@ static void load_xinfo_from_proc_unix(ino_t netns_inode)
 		unsigned int st;
 		unsigned long inode;
 		struct unix_xinfo *ux;
-		char path[ sizeof_member(struct unix_xinfo, path) ] = { 0 };
+		char path[UNIX_LINE_LEN] = { 0 };
 
 
 		if (sscanf(line, "%*x: %*x %*x %" SCNx64 " %x %x %lu %s",

--- a/tests/expected/lsfd/mkfds-unix-stream
+++ b/tests/expected/lsfd/mkfds-unix-stream
@@ -10,6 +10,10 @@ ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
     4   SOCK state=connected                                       connected    stream              0 
     5   SOCK state=connected path=test_mkfds-unix-stream-shutdown  connected    stream              0 test_mkfds-unix-stream-shutdown
 (shutdown) ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
+    3   SOCK state=listen path=test_mkfds-unix with spaces stream        listen    stream              1 test_mkfds-unix with spaces stream
+    4   SOCK state=connected                                          connected    stream              0 
+    5   SOCK state=connected path=test_mkfds-unix with spaces stream  connected    stream              0 test_mkfds-unix with spaces stream
+ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
     3   SOCK state=listen path=test_mkfds-unix-seqpacket type=seqpacket        listen seqpacket              1 test_mkfds-unix-seqpacket
     4   SOCK state=connected type=seqpacket                                 connected seqpacket              0 
     5   SOCK state=connected path=test_mkfds-unix-seqpacket type=seqpacket  connected seqpacket              0 test_mkfds-unix-seqpacket
@@ -22,3 +26,7 @@ ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
     4   SOCK state=connected type=seqpacket                                          connected seqpacket              0 
     5   SOCK state=connected path=test_mkfds-unix-seqpacket-shutdown type=seqpacket  connected seqpacket              0 test_mkfds-unix-seqpacket-shutdown
 (shutdown) ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
+    3   SOCK state=listen path=test_mkfds-unix with spaces seqpacket type=seqpacket        listen seqpacket              1 test_mkfds-unix with spaces seqpacket
+    4   SOCK state=connected type=seqpacket                                             connected seqpacket              0 
+    5   SOCK state=connected path=test_mkfds-unix with spaces seqpacket type=seqpacket  connected seqpacket              0 test_mkfds-unix with spaces seqpacket
+ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0

--- a/tests/ts/lsfd/mkfds-unix-stream
+++ b/tests/ts/lsfd/mkfds-unix-stream
@@ -76,6 +76,20 @@ EXPR='(((TYPE == "UNIX-STREAM") or (TYPE == "UNIX")) and (FD >= 3) and (FD <= 5)
 	    kill -CONT "${PID}"
 	    wait "${MKFDS_PID}"
 	fi
+
+	coproc MKFDS { "$TS_HELPER_MKFDS" unix-stream $FDS $FDC $FDA \
+					  path="test_mkfds-unix with spaces ${t}" \
+					  type=$t ; }
+	if read -r -u "${MKFDS[0]}" PID; then
+	    ${TS_CMD_LSFD} -n \
+			   -o ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH \
+			   -p "${PID}" -Q "${EXPR}"
+	    echo 'ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH': $?
+
+	    kill -CONT "${PID}"
+	    wait "${MKFDS_PID}"
+	fi
+
     done
 } > "$TS_OUTPUT" 2>&1
 


### PR DESCRIPTION
The original code uses '%s' scanf specifier to read lines in /proc/net/unix.
If white space is included in a path, lsfd could read only the first word of the path.
This pull request fixes the bug.