### PR TITLE
nsenter: add --env for allowing environment variables inheritance

### DIFF
--- a/bash-completion/nsenter
+++ b/bash-completion/nsenter
@@ -49,6 +49,7 @@ _nsenter_module()
 				--root=
 				--wd=
 				--wdns=
+				--env
 				--no-fork
 				--help
 				--version

--- a/include/all-io.h
+++ b/include/all-io.h
@@ -84,6 +84,36 @@ static inline ssize_t read_all(int fd, char *buf, size_t count)
 	return c;
 }
 
+static inline ssize_t read_all_alloc(int fd, char **buf)
+{
+	size_t size = 1024, c = 0;
+	ssize_t ret;
+
+	*buf = malloc(size);
+	if (!*buf)
+		return -1;
+
+	while (1) {
+		ret = read_all(fd, *buf + c, size - c);
+		if (ret < 0) {
+			free(*buf);
+			*buf = NULL;
+			return -1;
+		}
+
+		if (ret == 0)
+			return c;
+
+		c += ret;
+		if (c == size) {
+			size *= 2;
+			*buf = realloc(*buf, size);
+			if (!*buf)
+				return -1;
+		}
+	}
+}
+
 static inline ssize_t sendfile_all(int out, int in, off_t *off, size_t count)
 {
 #if defined(HAVE_SENDFILE) && defined(__linux__)

--- a/include/env.h
+++ b/include/env.h
@@ -11,6 +11,7 @@ extern void __sanitize_env(struct ul_env_list **org);
 
 extern int env_list_setenv(struct ul_env_list *ls);
 extern void env_list_free(struct ul_env_list *ls);
+extern struct ul_env_list *env_from_fd(int pid);
 
 extern char *safe_getenv(const char *arg);
 
@@ -32,4 +33,3 @@ static inline int remote_entry(char **argv, int remove, int last)
 }
 
 #endif /* UTIL_LINUX_ENV_H */
-

--- a/sys-utils/nsenter.1.adoc
+++ b/sys-utils/nsenter.1.adoc
@@ -121,6 +121,9 @@ Set the working directory. If no directory is specified, set the working directo
 *-W*, *--wdns*[=_directory_]::
 Set the working directory. The _directory_ is open after switch to the requested namespaces and after *chroot*(2) call. The options *--wd* and *--wdns* are mutually exclusive.
 
+*-e*, *--env*::
+Pass environment variables from the target process to the new process being created. If this option is not provided, the environment variables will remain the same as in the current namespace..
+
 *-F*, *--no-fork*::
 Do not fork before exec'ing the specified program. By default, when entering a PID namespace, *nsenter* calls *fork* before calling *exec* so that any children will also be in the newly entered PID namespace.
 


### PR DESCRIPTION
This commit adds support for the -e or --env option in nsenter, allowing a new process to inherit the environment variables from the target process.

If the option is not given, the environment variables will stay the same as in the current namespace.

Example:

    Setup the namespace:
        $ docker run -d -e PROJECT='util linux' --rm alpine sleep 10000
        cb0b69aa7aec
        $ docker inspect --format '{{ .State.Pid }}' cb0b69aa7aec
        470012

    Enter the namespace:
        $ nsenter --all -t 470012 --env env
        PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
        HOSTNAME=cb0b69aa7aec
        PROJECT=util linux
        HOME=/root