### PR TITLE
hardlink: (tests) do not assert amount of compared files

### DIFF
--- a/tests/expected/hardlink/options-maximum-size-8191
+++ b/tests/expected/hardlink/options-maximum-size-8191
@@ -4,7 +4,7 @@ Method: [Redacted]
 Files:                    26
 Linked:                   0 files
 Compared:                 0 xattrs
-Compared:                 0 files
+Compared: [Redacted] files
 Saved:                    0 B
 Duration: [Redacted]
 dir-1/sdir-1/file-a-1	1	8192	1540236330	644

--- a/tests/expected/hardlink/options-maximum-size-8192
+++ b/tests/expected/hardlink/options-maximum-size-8192
@@ -4,7 +4,7 @@ Method: [Redacted]
 Files:                    26
 Linked:                   18 files
 Compared:                 0 xattrs
-Compared:                 23 files
+Compared: [Redacted] files
 Saved:                    144 KiB
 Duration: [Redacted]
 dir-1/sdir-1/file-a-1	5	8192	1540236330	644

--- a/tests/ts/hardlink/options
+++ b/tests/ts/hardlink/options
@@ -45,6 +45,7 @@ summary_clean()
 	sed -i \
 		-e 's/^Duration:.*/Duration: [Redacted]/' \
 		-e 's/^Method:.*/Method: [Redacted]/' \
+		-e 's/^Compared:.*files/Compared: [Redacted] files/' \
 		$TS_OUTPUT
 }
 


### PR DESCRIPTION
Depending on external circumstances the exact amount of compared files can vary.
So don't test for this statistics as otherwise spurious test failures will occurr.