### PR TITLE
hardlink: don't determine master file based on inode number

### DIFF
--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -689,8 +689,6 @@ static inline int file_compare(const struct file *a, const struct file *b)
 	if (res == 0)
 		res = opts.keep_oldest ? CMP(b->st.st_mtime, a->st.st_mtime)
 		    : CMP(a->st.st_mtime, b->st.st_mtime);
-	if (res == 0)
-		res = CMP(b->st.st_ino, a->st.st_ino);
 
 	return res;
 }

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -689,6 +689,9 @@ static inline int file_compare(const struct file *a, const struct file *b)
 	if (res == 0)
 		res = opts.keep_oldest ? CMP(b->st.st_mtime, a->st.st_mtime)
 		    : CMP(a->st.st_mtime, b->st.st_mtime);
+	if (res == 0)
+		res = opts.keep_oldest ? CMP(b->st.st_ctime, a->st.st_ctime)
+		    : CMP(a->st.st_ctime, b->st.st_ctime);
 
 	return res;
 }

--- a/tests/expected/hardlink/options-maximum-size-8191
+++ b/tests/expected/hardlink/options-maximum-size-8191
@@ -3,7 +3,7 @@ Mode:                     real
 Method: [Redacted]
 Files:                    26
 Linked:                   0 files
-Compared: [Redacted] files
+Compared:                 0 files
 Saved:                    0 B
 Duration: [Redacted]
 dir-1/sdir-1/file-a-1	1	8192	1540236330	644

--- a/tests/expected/hardlink/options-maximum-size-8192
+++ b/tests/expected/hardlink/options-maximum-size-8192
@@ -3,7 +3,7 @@ Mode:                     real
 Method: [Redacted]
 Files:                    26
 Linked:                   18 files
-Compared:                 23 files
+Compared:                 22 files
 Saved:                    144 KiB
 Duration: [Redacted]
 dir-1/sdir-1/file-a-1	5	8192	1540236330	644

--- a/tests/expected/hardlink/options-maximum-size-8192
+++ b/tests/expected/hardlink/options-maximum-size-8192
@@ -3,7 +3,7 @@ Mode:                     real
 Method: [Redacted]
 Files:                    26
 Linked:                   18 files
-Compared: [Redacted] files
+Compared:                 23 files
 Saved:                    144 KiB
 Duration: [Redacted]
 dir-1/sdir-1/file-a-1	5	8192	1540236330	644

--- a/tests/ts/hardlink/options
+++ b/tests/ts/hardlink/options
@@ -103,6 +103,4 @@ summary_clean
 show_srcdir >> $TS_OUTPUT 2>> $TS_ERRLOG
 ts_finalize_subtest
 
-
-rm -rf "$SRCDIR"
 ts_finalize

--- a/tests/ts/hardlink/options
+++ b/tests/ts/hardlink/options
@@ -45,7 +45,6 @@ summary_clean()
 	sed -i \
 		-e 's/^Duration:.*/Duration: [Redacted]/' \
 		-e 's/^Method:.*/Method: [Redacted]/' \
-		-e 's/^Compared:.*files/Compared: [Redacted] files/' \
 		-e '/^Compared:.*xattrs/d' \
 		$TS_OUTPUT
 }


### PR DESCRIPTION
Inode numbers can be random, at least on certain filesystems like f2fs.
By using them for determination of the master file irreproducibility is
introduced.
This leads to fluctuations in the statistics and may confuse users.
    
The algorithm works just fine without comparing inode numbers.
