### PR TITLE
mount: fix "libblkid.so not found" link error when cross-compiling 

### DIFF
--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -357,12 +357,12 @@ dist_noinst_DATA += \
 	sys-utils/fstab.5.adoc \
 	sys-utils/umount.8.adoc
 mount_SOURCES = sys-utils/mount.c
-mount_LDADD = $(LDADD) libcommon.la libmount.la $(SELINUX_LIBS)
+mount_LDADD = $(LDADD) libcommon.la libmount.la libblkid.la $(SELINUX_LIBS)
 mount_CFLAGS = $(SUID_CFLAGS) $(AM_CFLAGS) -I$(ul_libmount_incdir)
 mount_LDFLAGS = $(SUID_LDFLAGS) $(AM_LDFLAGS)
 
 umount_SOURCES = sys-utils/umount.c
-umount_LDADD = $(LDADD) libcommon.la libmount.la
+umount_LDADD = $(LDADD) libcommon.la libmount.la libblkid.la
 umount_CFLAGS = $(AM_CFLAGS) $(SUID_CFLAGS) -I$(ul_libmount_incdir)
 umount_LDFLAGS = $(SUID_LDFLAGS) $(AM_LDFLAGS)
 


### PR DESCRIPTION
When cross-compiling via this command:

       ./autogen.sh && ./configure --build=x86_64-pc-linux-gnu --host=aarch64_be-none-linux-gnu CC=aarch64_be-none-linux-gnu-  && make mount

it will fail with:

      'WARNING: libblkid.so.1, required by ./.libs/libmount.so, not found (try using -rpath or -rpath-link)'
      './.libs/libmount.so: undefined reference to `blkid_evaluate_tag@BLKID_2.15'
      './.libs/libmount.so: undefined reference to `blkid_free_probe@BLKID_2.15'
      ...

This commit fixes the bug by adding libblkid to the "mount_LDADD" variable.