### PR TITLE
agetty: Load autologin user from agetty.autologin credential

### DIFF
--- a/login-utils/login.1.adoc
+++ b/login-utils/login.1.adoc
@@ -148,6 +148,14 @@ _/etc/pam.d/remote_,
 _/etc/hushlogins_,
 _$HOME/.hushlogin_
 
+== CREDENTIALS
+
+*login* supports configuration via systemd credentials (see https://systemd.io/CREDENTIALS/). *login* reads the following systemd credentials:
+
+*login.noauth* (boolean)::
+
+If set, configures *login* to skip login authentication, similarly to the *-f* option.
+
 == BUGS
 
 The undocumented BSD *-r* option is not supported. This may be required by some *rlogind*(8) programs.

--- a/term-utils/agetty.8.adoc
+++ b/term-utils/agetty.8.adoc
@@ -319,6 +319,14 @@ problem reports (if *syslog*(3) is not used).
 _/etc/inittab_::
 *init*(8) configuration file for SysV-style init daemon.
 
+== CREDENTIALS
+
+*agetty* supports configuration via systemd credentials (see https://systemd.io/CREDENTIALS/). *agetty* reads the following systemd credentials:
+
+*agetty.autologin* (string)::
+
+If set, configures *agetty* to automatically log in the specified user without asking for a username or password, similarly to the *--autologin* option.
+
 == BUGS
 
 The baud-rate detection feature (the *--extract-baud* option) requires that *agetty* be scheduled soon enough after completion of a dial-in call (within 30 ms with modems that talk at 2400 baud). For robustness, always use the *--extract-baud* option in combination with a multiple baud rate command-line argument, so that BREAK processing is enabled.


### PR DESCRIPTION
Let's check if we've been passed credentials by systemd and if so, try to read the user to autologin from the agetty.autologin credential.

Partially fixes #2012