### PR TITLE
tests: fclose(stdin) UB

### DIFF
--- a/tests/helpers/test_md5.c
+++ b/tests/helpers/test_md5.c
@@ -5,6 +5,8 @@
  */
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h>
+#include <err.h>
 
 #include "md5.h"
 
@@ -23,7 +25,9 @@ int main(void)
 			ul_MD5Update( &ctx, buf, ret );
 	}
 
-	fclose(stdin);
+	if(freopen ("/dev/null", "r", stdin) == NULL)
+		err(EXIT_FAILURE, "stdin->null failed!");
+
 	ul_MD5Final( digest, &ctx );
 
 	for (i = 0; i < UL_MD5LENGTH; i++)

--- a/tests/helpers/test_sha1.c
+++ b/tests/helpers/test_sha1.c
@@ -5,6 +5,8 @@
  */
 #include <stdio.h>
 #include <unistd.h>
+#include <err.h>
+#include <stdlib.h>
 
 #include "sha1.h"
 
@@ -23,7 +25,9 @@ int main(void)
 			ul_SHA1Update( &ctx, buf, ret );
 	}
 
-	fclose(stdin);
+	if(freopen ("/dev/null", "r", stdin) == NULL)
+		err(EXIT_FAILURE, "stdin->null failed!");
+
 	ul_SHA1Final( digest, &ctx );
 
 	for (i = 0; i < UL_SHA1LENGTH; i++)


### PR DESCRIPTION
The standard streams must not be closed unless it is the very last thing a program does before termination.

A warning about this was added to POSIX.1-2008 and later standards.

One must redirect stdin to /dev/null using freopen instead.