### PR TITLE
idmap: kill child when writing the idmap fails

### DIFF
--- a/libmount/src/hook_idmap.c
+++ b/libmount/src/hook_idmap.c
@@ -229,12 +229,16 @@ static int get_userns_fd_from_idmap(struct list_head *idmap)
 
 	/* Wait for child to set up a new namespace. */
 	rc = read_all(sock_fds[1], &c, 1);
-	if (rc != 1)
+	if (rc != 1) {
+		kill(pid, SIGKILL);
 		goto err_wait;
+	}
 
 	rc = map_ids(idmap, pid);
-	if (rc < 0)
+	if (rc < 0) {
+		kill(pid, SIGKILL);
 		goto err_wait;
+	}
 
 	snprintf(path, sizeof(path), "/proc/%d/ns/user", pid);
 	fd_userns = open(path, O_RDONLY | O_CLOEXEC | O_NOCTTY);


### PR DESCRIPTION
This fixes the second issues reported in [1] where calling mount -o 'X-mount.idmap=[...]' just hangs.

Fixes: https://github.com/util-linux/util-linux/issues/2130 [1]