### PR TITLE
Add `--user-parent` option to nsenter

### DIFF
--- a/bash-completion/nsenter
+++ b/bash-completion/nsenter
@@ -42,6 +42,7 @@ _nsenter_module()
 				--pid=
 				--cgroup=
 				--user=
+				--user-parent
 				--time=
 				--setuid
 				--setgid

--- a/sys-utils/nsenter.1.adoc
+++ b/sys-utils/nsenter.1.adoc
@@ -97,6 +97,10 @@ Enter the PID namespace. If no file is specified, enter the PID namespace of the
 *-U*, *--user*[=_file_]::
 Enter the user namespace. If no file is specified, enter the user namespace of the target process. If _file_ is specified, enter the user namespace specified by _file_. See also the *--setuid* and *--setgid* options.
 
+*--user-parent*::
+Enter the parent user namespace. Parent user namespace will be acquired from any other enabled namespace.
+If combined with *--user* option the parent user namespace will be fetched from the user namespace and replace it.
+
 *-C*, *--cgroup*[=_file_]::
 Enter the cgroup namespace. If no file is specified, enter the cgroup namespace of the target process. If _file_ is specified, enter the cgroup namespace specified by _file_.
 
@@ -138,6 +142,10 @@ Do not fork before exec'ing the specified program. By default, when entering a P
 Set the SELinux security context used for executing a new process according to already running process specified by *--target* PID. (The util-linux has to be compiled with SELinux support otherwise the option is unavailable.)
 
 include::man-common/help-version.adoc[]
+
+== NOTES
+
+The *--user-parent* option requires Linux 4.9 or higher, older kernels will raise inappropriate ioctl for device error.
 
 == AUTHORS
 


### PR DESCRIPTION
The issue is that some times the user namespaces can become unbound to any process. (for example bubblewrap) This will make the namespace unaccessible without using special ioctl.

Closes: #1592

When this option is used nsenter will fetch the parent user
namespace from any namespace file descriptors available.

It can be combined with existing `--user` option in which case
the parent user namespace will be fetched from the user namespace
and replace it.


How to test:

1. Use bwrap with `--dev` option: `bwrap --dev /test --dev-bind / / /bin/sh`
2. Using regular `nsenter` does not work: `nsenter --preserve-credentials --user --mount --target $PID bash`
3. Using new option will work: `./build/nsenter --preserve-credentials --user-parent --mount --target $PID bash`
