### PR TITLE
nsenter: use explicit argument to follow target PID/GID

### DIFF
--- a/bash-completion/nsenter
+++ b/bash-completion/nsenter
@@ -6,11 +6,11 @@ _nsenter_module()
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 	case $prev in
 		'-S'|'--uid')
-			COMPREPLY=( $(compgen -W "uid" -- $cur) )
+			COMPREPLY=( follow $(compgen -W "uid" -- $cur) )
 			return 0
 			;;
 		'-G'|'--gid')
-			COMPREPLY=( $(compgen -W "gid" -- $cur) )
+			COMPREPLY=( follow $(compgen -W "gid" -- $cur) )
 			return 0
 			;;
 		'-t'|'--target')

--- a/sys-utils/nsenter.1.adoc
+++ b/sys-utils/nsenter.1.adoc
@@ -103,15 +103,15 @@ Enter the cgroup namespace. If no file is specified, enter the cgroup namespace 
 *-T*, *--time*[=_file_]::
 Enter the time namespace. If no file is specified, enter the time namespace of the target process. If _file_ is specified, enter the time namespace specified by _file_.
 
-*-G*, *--setgid*[=_gid_]::
+*-G*, *--setgid* _gid_::
 Set the group ID which will be used in the entered namespace and drop supplementary groups.
 *nsenter* always sets GID for user namespaces, the default is 0.
-If no argument is specified the GID of the target process is used.
+If the argument _follow_ is specified the GID of the target process is used.
 
-*-S*, *--setuid*[=_uid_]::
+*-S*, *--setuid* _uid_::
 Set the user ID which will be used in the entered namespace.
 *nsenter* always sets UID for user namespaces, the default is 0.
-If no argument is specified the UID of the target process is used.
+If the argument _follow_ is specified the UID of the target process is used.
 
 *--preserve-credentials*::
 Don't modify UID and GID when enter user namespace. The default is to drops supplementary groups and sets GID and UID to 0.

--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -247,8 +247,8 @@ int main(int argc, char *argv[])
 		{ "user", optional_argument, NULL, 'U' },
 		{ "cgroup", optional_argument, NULL, 'C' },
 		{ "time", optional_argument, NULL, 'T' },
-		{ "setuid", optional_argument, NULL, 'S' },
-		{ "setgid", optional_argument, NULL, 'G' },
+		{ "setuid", required_argument, NULL, 'S' },
+		{ "setgid", required_argument, NULL, 'G' },
 		{ "root", optional_argument, NULL, 'r' },
 		{ "wd", optional_argument, NULL, 'w' },
 		{ "wdns", optional_argument, NULL, 'W' },
@@ -285,7 +285,7 @@ int main(int argc, char *argv[])
 	close_stdout_atexit();
 
 	while ((c =
-		getopt_long(argc, argv, "+ahVt:m::u::i::n::p::C::U::T::S::G::r::w::W::eFZ",
+		getopt_long(argc, argv, "+ahVt:m::u::i::n::p::C::U::T::S:G:r::w::W::eFZ",
 			    longopts, NULL)) != -1) {
 
 		err_exclusive_options(c, longopts, excl, excl_st);
@@ -347,17 +347,17 @@ int main(int argc, char *argv[])
 				namespaces |= CLONE_NEWTIME;
 			break;
 		case 'S':
-			if (optarg)
-				uid = strtoul_or_err(optarg, _("failed to parse uid"));
-			else
+			if (strcmp(optarg, "follow") == 0)
 				do_uid = true;
+			else
+				uid = strtoul_or_err(optarg, _("failed to parse uid"));
 			force_uid = true;
 			break;
 		case 'G':
-			if (optarg)
-				gid = strtoul_or_err(optarg, _("failed to parse gid"));
-			else
+			if (strcmp(optarg, "follow") == 0)
 				do_gid = true;
+			else
+				gid = strtoul_or_err(optarg, _("failed to parse gid"));
 			force_gid = true;
 			break;
 		case 'F':


### PR DESCRIPTION
Making the argument to -S and -G optional in #2092 broke the cli compatability.
So replace it with an explicit "follow" argument that provides the new functionality with a compatible interface.

Fixes #2143