### PR TITLE
libblkid: Compute CRC with sb_crc zeroed

### DIFF
--- a/include/crc32c.h
+++ b/include/crc32c.h
@@ -9,5 +9,9 @@
 #include <stdint.h>
 
 extern uint32_t crc32c(uint32_t crc, const void *buf, size_t size);
+extern uint32_t ul_crc32c_exclude_offset(uint32_t crc, const unsigned char *buf,
+					 size_t size, size_t exclude_off,
+					 size_t exclude_len);
+
 
 #endif /* UL_CRC32C_H */

--- a/lib/crc32c.c
+++ b/lib/crc32c.c
@@ -10,6 +10,7 @@
  *  code or tables extracted from it, as desired without restriction.
  */
 
+#include <assert.h>
 #include "crc32c.h"
 
 static const uint32_t crc32Table[256] = {
@@ -98,5 +99,22 @@ crc32c(uint32_t crc, const void *buf, size_t size)
 	while (size--)
 		crc = crc32Table[(crc ^ *p++) & 0xff] ^ (crc >> 8);
 
+	return crc;
+}
+
+uint32_t
+ul_crc32c_exclude_offset(uint32_t crc, const unsigned char *buf, size_t size,
+			 size_t exclude_off, size_t exclude_len)
+{
+	size_t i;
+	assert((exclude_off + exclude_len) < size);
+
+	crc = crc32c(crc, buf, exclude_off);
+	for (i = 0; i < exclude_len; i++) {
+		uint8_t zero = 0;
+		crc = crc32c(crc, &zero, 1);
+	}
+	crc = crc32c(crc, &buf[exclude_off + exclude_len],
+		     size - (exclude_off + exclude_len));
 	return crc;
 }


### PR DESCRIPTION
The Linux kernel computes the sb_crc by crcing the superblock with the CRC field set to 0. The code is trying to avoid doing this in three separate CRC calls like the kernel performs by simply zeroing the field and making a single call.

Except that the passed copy "ondisk" isn't the same as the returned copy "csummed" so the zeroing goes into the wrong buffer. Meaning that the CRC is computed incorrectly. This results in blkid returning:

/dev/sda4: PARTUUID="2f162043-63c2-d145-869b-e53f9db57476"

rather than:

/dev/sda4: UUID="45b931b7-592a-46dc-9c33-d38d5901ec29" BLOCK_SIZE="4096" TYPE="xfs" PARTUUID="2f162043-63c2-d145-869b-e53f9db57476"

Which can result in lots of failures including boot failures if XFS modules aren't placed into the initrd, or scripts/etc cannot determine the fs UUID.