### PR TITLE
libmount: safe_stat: support relative filenames

### DIFF
--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -116,7 +116,7 @@ static int safe_stat(const char *target, struct stat *st, int nofollow)
 		int rc;
 		struct statx stx = { 0 };
 
-		rc = statx(-1,	target,
+		rc = statx(AT_FDCWD, target,
 				/* flags */
 				AT_STATX_DONT_SYNC
 					| AT_NO_AUTOMOUNT

--- a/tests/ts/mount/fstab-all
+++ b/tests/ts/mount/fstab-all
@@ -121,6 +121,17 @@ $TS_CMD_UMOUNT ${MOUNTPOINT}{A,B,C,D}
 ts_finalize_subtest
 
 
+ts_init_subtest "relative-path"
+cd "$TS_OUTDIR" > /dev/null
+$TS_CMD_MOUNT --all --fstab $(basename "$MY_FSTAB") >> $TS_OUTPUT 2>> $TS_ERRLOG
+[ $? == 0 ] || ts_log "mount failed"
+udevadm settle
+$TS_CMD_UMOUNT ${MOUNTPOINT}{A,B,C,D}
+[ $? == 0 ] || ts_log "umount failed"
+cd - > /dev/null
+ts_finalize_subtest
+
+
 ts_init_subtest "prefix"
 MY_ROOT="$TS_OUTDIR/${TS_TESTNAME}-rootdir"
 [ -d "${MY_ROOT}" ] || mkdir -p ${MY_ROOT}


### PR DESCRIPTION
By using AT_CWFD the call to statx() can also handle relative filenames. Without this safe_stat() which is called on the fstab, source, target...