### PR TITLE
build-sys: remove open_memstream requirement for cfdisk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1292,7 +1292,6 @@ AM_CONDITIONAL([BUILD_SFDISK], [test "x$build_sfdisk" = xyes])
 UL_BUILD_INIT([cfdisk])
 UL_REQUIRES_BUILD([cfdisk], [libfdisk])
 UL_REQUIRES_BUILD([cfdisk], [libsmartcols])
-UL_REQUIRES_HAVE([cfdisk], [open_memstream], [open_memstream function])
 UL_REQUIRES_HAVE([cfdisk], [ncursesw,slang,ncurses], [ncursesw, ncurses or slang library])
 AM_CONDITIONAL([BUILD_CFDISK], [test "x$build_cfdisk" = xyes])
 


### PR DESCRIPTION
open_memstream is not supported on darwin, yet cfdisk builds fine for me without it.