### PR TITLE
mount: (tests) skip fstab-bind on qemu-user

### DIFF
--- a/tests/ts/mount/fstab-bind
+++ b/tests/ts/mount/fstab-bind
@@ -11,6 +11,7 @@ ts_check_test_command "$TS_CMD_UMOUNT"
 ts_check_test_command "$TS_CMD_FINDMNT"
 
 ts_skip_nonroot
+ts_skip_qemu_user
 
 MY_SOURCE="${TS_MOUNTPOINT}-src"
 


### PR DESCRIPTION
The necessary functionality is not implemented there.