### PR TITLE
libmount: check for errors from prep-options hooks

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -135,7 +135,7 @@ static int fix_optstr(struct libmnt_context *cxt)
 		}
 	}
 #endif
-	mnt_context_call_hooks(cxt, MNT_STAGE_PREP_OPTIONS);
+	rc = mnt_context_call_hooks(cxt, MNT_STAGE_PREP_OPTIONS);
 done:
 	DBG(CXT, ul_debugobj(cxt, "<-- preparing options done [rc=%d]", rc));
 	cxt->flags |= MNT_FL_MOUNTOPTS_FIXED;


### PR DESCRIPTION
fix_optstr() in context_mount.c calls the MNT_STAGE_PREP_OPTIONS hooks but discards returned errors. This suppresses error messages and can make invalid option strings 'fail open' in surprising ways. Handle error returns from these hooks correctly.

No other callers of mnt_context_call_hooks() discard the return value, so other hooks aren't affected.