### PR TITLE
lib: add call to release cur_term memory on exit

### DIFF
--- a/lib/colors.c
+++ b/lib/colors.c
@@ -552,6 +552,14 @@ static void termcolors_init_debug(void)
 	__UL_INIT_DEBUG_FROM_ENV(termcolors, TERMCOLORS_DEBUG_, 0, TERMINAL_COLORS_DEBUG);
 }
 
+#if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBNCURSESW)
+/* atexit() wrapper */
+static void colors_del_curterm(void)
+{
+	del_curterm(cur_term);
+}
+#endif
+
 static int colors_terminal_is_ready(void)
 {
 	int ncolors = -1;
@@ -560,8 +568,10 @@ static int colors_terminal_is_ready(void)
 	{
 		int ret;
 
-		if (setupterm(NULL, STDOUT_FILENO, &ret) == 0 && ret == 1)
+		if (setupterm(NULL, STDOUT_FILENO, &ret) == 0 && ret == 1) {
 			ncolors = tigetnum("colors");
+			atexit(colors_del_curterm);
+		}
 	}
 #endif
 	if (1 < ncolors) {


### PR DESCRIPTION
`colors_terminal_is_ready()` in context `lib/colors.c` calls `setupterm`.

As per `curs_terminfo` man page in the Releasing Memory section, to free memory allocated following a `setupterm` call, `del_curterm(cur_term)` needs to be called.

Added an `atexit` wrapper for `del_curterm` which gets called on a successful call to `setupterm`.