### PR TITLE
mount: (tests) run bind mount tests on qemu-user

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -110,6 +110,7 @@ jobs:
       - uses: uraimo/run-on-arch-action@v2
         with:
           arch: s390x
+          dockerRunArgs: --privileged -v /dev:/dev
           distro: ubuntu_latest
           run: |
             export COMPILER=gcc

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -485,13 +485,13 @@ struct libmnt_context
 			(_cxt)->syscall_status = -errno; \
 			(_cxt)->syscall_name = (_name); \
 		} else { \
-			DBG(CXT, ul_debug("syscall '%s' [succes]", _name)); \
+			DBG(CXT, ul_debug("syscall '%s' [success]", _name)); \
 			(_cxt)->syscall_status = 0; \
 		} \
 	})
 
 #define reset_syscall_status(_cxt)	__extension__ ({ \
-		DBG(CXT, ul_debug("reset sycall status")); \
+		DBG(CXT, ul_debug("reset syscall status")); \
 		(_cxt)->syscall_status = 0; \
 		(_cxt)->syscall_name = NULL; \
 	})

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -137,6 +137,15 @@ function ts_check_native_byteorder {
 	fi
 }
 
+function ts_check_enotty {
+	# https://lore.kernel.org/qemu-devel/20230426070659.80649-1-thomas@t-8ch.de/
+	if [ -e "$TS_HELPER_SYSINFO" ] &&
+		[ "$("$TS_HELPER_SYSINFO" enotty-ok)" = "0" ]; then
+
+		ts_skip "broken ENOTTY return"
+	fi
+}
+
 function ts_report_skip {
 	ts_report " SKIPPED ($1)"
 }

--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <wchar.h>
+#include <errno.h>
+#include <sys/ioctl.h>
 
 typedef struct {
 	const char	*name;
@@ -99,6 +101,15 @@ static int hlp_wcsspn_ok(void)
 	return 0;
 }
 
+static int hlp_enotty_ok(void)
+{
+	errno = 0;
+	ioctl(STDOUT_FILENO, 0);
+
+	printf("%d\n", errno != ENOSYS);
+	return 0;
+}
+
 static mntHlpfnc hlps[] =
 {
 	{ "WORDSIZE",	hlp_wordsize	},
@@ -111,6 +122,7 @@ static mntHlpfnc hlps[] =
 	{ "UINT64_MAX", hlp_u64_max     },
 	{ "byte-order", hlp_endianness  },
 	{ "wcsspn-ok",  hlp_wcsspn_ok   },
+	{ "enotty-ok",  hlp_enotty_ok   },
 	{ NULL, NULL }
 };
 

--- a/tests/ts/lsns/nsfs
+++ b/tests/ts/lsns/nsfs
@@ -23,6 +23,7 @@ ts_init "$*"
 
 ts_skip_nonroot
 
+ts_check_enotty
 ts_check_test_command "$TS_CMD_LSNS"
 ts_check_test_command "$TS_CMD_MOUNT"
 ts_check_test_command "$TS_CMD_UMOUNT"

--- a/tests/ts/mount/fstab-bind
+++ b/tests/ts/mount/fstab-bind
@@ -11,7 +11,6 @@ ts_check_test_command "$TS_CMD_UMOUNT"
 ts_check_test_command "$TS_CMD_FINDMNT"
 
 ts_skip_nonroot
-ts_skip_qemu_user
 
 MY_SOURCE="${TS_MOUNTPOINT}-src"
 

--- a/tests/ts/mount/fstab-broken
+++ b/tests/ts/mount/fstab-broken
@@ -26,7 +26,6 @@ ts_check_test_command "$TS_CMD_UMOUNT"
 ts_check_test_command "$TS_CMD_FINDMNT"
 
 ts_skip_nonroot
-ts_skip_qemu_user
 
 # Let's use the same mountpoint for all subtests
 MNT=$TS_MOUNTPOINT

--- a/tests/ts/mount/fstab-btrfs
+++ b/tests/ts/mount/fstab-btrfs
@@ -26,6 +26,7 @@ ts_check_test_command "$TS_CMD_UMOUNT"
 
 ts_skip_nonroot
 ts_check_losetup
+ts_check_enotty
 ts_check_prog "mkfs.btrfs"
 ts_check_prog "btrfs"
 

--- a/tests/ts/mount/fstab-none
+++ b/tests/ts/mount/fstab-none
@@ -11,7 +11,6 @@ ts_check_test_command "$TS_CMD_UMOUNT"
 ts_check_test_command "$TS_CMD_FINDMNT"
 
 ts_skip_nonroot
-ts_skip_qemu_user
 
 ts_fstab_add "none" "$TS_MOUNTPOINT" "tmpfs" "rw,nosuid,nodev,relatime"
 

--- a/tests/ts/mount/move
+++ b/tests/ts/mount/move
@@ -27,7 +27,6 @@ ts_check_test_command "$TS_CMD_FINDMNT"
 ts_check_test_command "$TS_CMD_MOUNTPOINT"
 
 ts_skip_nonroot
-ts_skip_qemu_user
 
 function mount_and_check {
 	# last arg must be an existing or to-be-mounted mountpoint

--- a/tests/ts/mount/subdir
+++ b/tests/ts/mount/subdir
@@ -27,7 +27,7 @@ ts_skip_nonroot
 ts_check_losetup
 
 prop=$($TS_CMD_FINDMNT --task "$$" -n -o PROPAGATION "/")
-[ "$prop" == "private" ] && ts_skip "unshared session"
+[[ "$prop" == *"private"* ]] && ts_skip "unshared session"
 
 ts_device_init
 DEVICE=$TS_LODEV


### PR DESCRIPTION
Since commit e828630a16c7 ("libmount: recover from ENOSYS for the new API") these work correctly.

Note: please wait for the CI to finish, as I don't really know that this works now.