### PR TITLE
Don't silently accept an X-mount.idmap with only whitespace

### DIFF
--- a/libmount/src/hook_idmap.c
+++ b/libmount/src/hook_idmap.c
@@ -387,9 +387,12 @@ static int hook_prepare_options(
 	opt = mnt_optlist_get_named(ol, "X-mount.idmap", cxt->map_userspace);
 	if (!opt)
 		return 0;
-	value = mnt_opt_get_value(opt);
 
-	if (!value)
+	value = mnt_opt_get_value(opt);
+	while (value && *value == ' ')
+		value++;
+
+	if (!value || !*value)
 		return errno = EINVAL, -MNT_ERR_MOUNTOPT;
 
 	hd = new_hook_data();


### PR DESCRIPTION
X-mount.idmap accepts a series of whitespace-separated tokens. We reject an empty argument but silently accept an argument consisting of whitespace with no tokens. Test for the empty case more thoroughly.