### PR TITLE
libmount: report failed syscall name

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1552,7 +1552,6 @@ int mnt_context_get_mount_excode(
 	 */
 	syserr = mnt_context_get_syscall_errno(cxt);
 
-
 	switch(syserr) {
 	case EPERM:
 		if (!buf)
@@ -1595,10 +1594,8 @@ int mnt_context_get_mount_excode(
 				return MNT_EX_SUCCESS;
 			if (buf)
 				snprintf(buf, bufsz, _("special device %s does not exist"), src);
-		} else if (buf) {
-			errno = syserr;
-			snprintf(buf, bufsz, _("mount(2) system call failed: %m"));
-		}
+		} else
+			goto generic_error;
 		break;
 
 	case ENOTDIR:
@@ -1611,10 +1608,8 @@ int mnt_context_get_mount_excode(
 			if (buf)
 				snprintf(buf, bufsz, _("special device %s does not exist "
 					 "(a path prefix is not a directory)"), src);
-		} else if (buf) {
-			errno = syserr;
-			snprintf(buf, bufsz, _("mount(2) system call failed: %m"));
-		}
+		} else
+			goto generic_error;
 		break;
 
 	case EINVAL:
@@ -1695,10 +1690,8 @@ int mnt_context_get_mount_excode(
 			snprintf(buf, bufsz, _("cannot remount %s read-write, is write-protected"), src);
 		else if (mflags & MS_BIND)
 			snprintf(buf, bufsz, _("bind %s failed"), src);
-		else {
-			errno = syserr;
-			snprintf(buf, bufsz, _("mount(2) system call failed: %m"));
-		}
+		else
+			goto generic_error;
 		break;
 
 	case ENOMEDIUM:
@@ -1718,9 +1711,11 @@ int mnt_context_get_mount_excode(
 		/* fallthrough */
 
 	default:
+	generic_error:
 		if (buf) {
 			errno = syserr;
-			snprintf(buf, bufsz, _("mount(2) system call failed: %m"));
+			snprintf(buf, bufsz, _("%s system call failed: %m"),
+					cxt->syscall_name ? : "mount");
 		}
 		break;
 	}


### PR DESCRIPTION
This affects already translated messages, so for v2.40