### PR TITLE
add return in supam_conv function

### DIFF
--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -344,6 +344,7 @@ static int supam_conv(	int num_msg,
 #elif defined(HAVE_SECURITY_OPENPAM_H)
 	return openpam_ttyconv(num_msg, msg, resp, data);
 #endif
+	return PAM_CONV_ERR;
 }
 
 static void supam_cleanup(struct su_context *su, int retcode)

--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -343,8 +343,9 @@ static int supam_conv(	int num_msg,
 	return misc_conv(num_msg, msg, resp, data);
 #elif defined(HAVE_SECURITY_OPENPAM_H)
 	return openpam_ttyconv(num_msg, msg, resp, data);
-#endif
+#else
 	return PAM_CONV_ERR;
+#endif
 }
 
 static void supam_cleanup(struct su_context *su, int retcode)


### PR DESCRIPTION
Added return statement to ensure that all execution paths end with a return statement.

Fix for #2190