### PR TITLE
tests: (test_sysinfo) include sys/mount.h

### DIFF
--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -26,6 +26,7 @@
 #include <wchar.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <sys/mount.h>
 
 #include "mount-api-utils.h"
 


### PR DESCRIPTION
When fsopen() is not provided by mount-api-utils.h it comes from sys/mount.h.