### PR TITLE
ci: build translated manpages during test

### DIFF
--- a/.github/workflows/cibuild-setup-ubuntu.sh
+++ b/.github/workflows/cibuild-setup-ubuntu.sh
@@ -37,6 +37,10 @@ if [[ "$QEMU_USER" != "1" ]]; then
 	PACKAGES+=(linux-modules-extra-$(uname -r))
 fi
 
+if [[ "$TRANSLATE_MANPAGES" == "yes" ]];then
+	PACKAGES+=(po4a)
+fi
+
 apt-get -y update --fix-missing
 apt install -y lsb-release software-properties-common
 

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -93,6 +93,7 @@ jobs:
       COMPILER: gcc
       COMPILER_VERSION: 10
       SANITIZE: no
+      TRANSLATE_MANPAGES: yes
     steps:
       - name: Repository checkout
         uses: actions/checkout@v1

--- a/po-man/.gitignore
+++ b/po-man/.gitignore
@@ -1,1 +1,6 @@
 de/
+es/
+fr/
+pt_BR/
+sr/
+uk/

--- a/po-man/Makefile.am
+++ b/po-man/Makefile.am
@@ -43,7 +43,7 @@ gen-mans: gen-trans
 	  for l in $(PO_LANGS); do \
 	  gendir="$(abs_builddir)/$$l"; \
 	  genfiles=`echo $${gendir}/*.adoc`; \
-	  if test "$$genfiles" != '$${gendir}/*.adoc'; then \
+	  if test "$$genfiles" != "$${gendir}/*.adoc"; then \
 	    for file in $${genfiles}; do \
 	      manname=`echo $$file | sed -e 's|^.*/||' -e 's|\.adoc||'`;  \
 	      test -f $${gendir}/$${manname} || { \
@@ -68,7 +68,7 @@ install-data-local: gen-mans
 	  mansrcdir="$(abs_builddir)/$$l"; \
 	  for s in $(MAN_SECTIONS); do \
 	    installfiles=`echo $${mansrcdir}/*.$$s`; \
-	    if test "$$installfiles" != '$${mansrcdir}/*.$$s'; then \
+	    if test "$$installfiles" != "$${mansrcdir}/*.$$s"; then \
 	      installdir="$(DESTDIR)$(mandir)/$$l/man$$s"; \
 	      $(MKDIR_P) "$${installdir}" || exit 1; \
 	      for file in $$installfiles; do \
@@ -85,7 +85,7 @@ uninstall-local:
 	  mansrcdir="$(abs_builddir)/$$l"; \
 	  for s in $(MAN_SECTIONS); do \
 	    installfiles=`echo $${mansrcdir}/*.$$s`; \
-	    if test "$$installfiles" != '$${mansrcdir}/*.$$s'; then \
+	    if test "$$installfiles" != "$${mansrcdir}/*.$$s"; then \
 	      installdir="$(DESTDIR)$(mandir)/$$l/man$$s"; \
 	      for file in $$installfiles; do \
 	        manname=`echo $$file | sed -e 's|^.*/||'`;  \

--- a/po-man/Makefile.am
+++ b/po-man/Makefile.am
@@ -7,6 +7,7 @@ MAN_SECTIONS = 1 3 5 8
 CLEANFILES = $(PO_STAMPS)
 
 EXTRA_DIST = README.md $(PO_FILES) po4a.cfg util-linux-man.pot
+DISTCLEANFILES = util-linux-man.pot $(PO_FILES)
 
 if ENABLE_POMAN
 util-linux-man.pot: Makefile

--- a/tools/asciidoctor-unicodeconverter.rb
+++ b/tools/asciidoctor-unicodeconverter.rb
@@ -11,7 +11,7 @@ module UnicodeConverter
       lines = reader.read_lines
       state = BEFORE_NAME_SECTION
       lines.map! do |line|
-        if state = IN_NAME_SECTION
+        if state == IN_NAME_SECTION
           line.sub! " \u2013 ", " - "
           line.sub! " \u2014 ", " - "
         end

--- a/tools/asciidoctor-unicodeconverter.rb
+++ b/tools/asciidoctor-unicodeconverter.rb
@@ -7,13 +7,20 @@ module UnicodeConverter
   AFTER_NAME_SECTION = 3
 
   class Preprocessor < Asciidoctor::Extensions::Preprocessor
+    include Asciidoctor::Logging
+
     def process document, reader
       lines = reader.read_lines
       state = BEFORE_NAME_SECTION
+      command = document.attributes['docname'].split('.', 2)[0]
       lines.map! do |line|
         if state == IN_NAME_SECTION
           line.sub! " \u2013 ", " - "
           line.sub! " \u2014 ", " - "
+          if line.start_with? command and not line.start_with? "#{command} - "
+            logger.warn "adding dash to name section of #{document.attributes['docfile']}"
+            line.sub! command, "#{command} - "
+          end
         end
 
         if line.start_with? '== '


### PR DESCRIPTION
Currently po4a is asciidoctor is rejecting quite a few translated manpages:
```
asciidoctor: ERROR: cal.1.adoc: line 28: non-conforming name section body
```

The problem is that asciidoctor expects a dash between the command and its short description:

```
== НАЗИВ

cal приказује календар
   ^ should have " - " here
```

It seems to affect most of the `sr` locale and some other pages.

We could probably also extend `tools/asciidoctor-unicodeconverter.rb`, which already preprocesses this part of the translated pages.

This is maybe something that needs to be fixed for next release or the translators may be unhappy.
(And the packagers, as it fails the build)