### PR TITLE
lib/pager: fix output truncation from buffered stdout

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -237,8 +237,11 @@ static void __setup_pager(void)
 
 	/* original process continues, but writes to the pipe */
 	dup2(pager_process.in, STDOUT_FILENO);
-	if (isatty(STDERR_FILENO))
+	setvbuf(stdout, NULL, _IOLBF, 0);
+	if (isatty(STDERR_FILENO)) {
 		dup2(pager_process.in, STDERR_FILENO);
+		setvbuf(stderr, NULL, _IOLBF, 0);
+	}
 	close(pager_process.in);
 
 	memset(&sa, 0, sizeof(sa));


### PR DESCRIPTION
Commit 518a0ad dropped `fflush(stdout)` and `fflush(stderr)` from `wait_for_pager()` before `STDOUT_FILENO` and `STDERR_FILENO` are closed because it is called from a signal handler and they are async-unsafe.

However, failure to flush output leads to unwanted truncation when stdout is fully buffered, which it is by default when we are linked against musl.

Ensure stdout and stderr are line-buffered before redirecting them to the pager subprocess to avoid this.

Addresses: https://github.com/util-linux/util-linux/issues/2218
Signed-off-by: Chris Webb <chris@arachsys.com>