### PR TITLE
lib/shells: Plug econf memory leak

### DIFF
--- a/lib/shells.c
+++ b/lib/shells.c
@@ -53,6 +53,7 @@ extern int is_known_shell(const char *shell_name)
 			break;
 		}
 	}
+	econf_free (keys);
 	econf_free (key_file);	
 #else
 	char *s;


### PR DESCRIPTION
You can see the memory leak with address sanitizer if util-linux is compiled with `--with-vendordir=/usr/etc`.

How to reproduce:

1. Prepare a custom shell file as root
```
mkdir -p /etc/shells.d
echo /bin/myshell > /etc/shells.d/custom
```

2. Run chsh as regular user
```
chsh
```