### PR TITLE
build-sys: add --disable-waitpid

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1847,7 +1847,11 @@ UL_BUILD_INIT([fadvise], [check])
 UL_REQUIRES_LINUX([fadvise])
 AM_CONDITIONAL([BUILD_FADVISE], [test "x$build_fadvise" = xyes])
 
-UL_BUILD_INIT([waitpid], [check])
+AC_ARG_ENABLE([waitpid],
+  AS_HELP_STRING([--disable-waitpid], [do not build waitpid]),
+  [], [UL_DEFAULT_ENABLE([waitpidd], [check])]
+)
+UL_BUILD_INIT([waitpid])
 UL_REQUIRES_LINUX([waitpid])
 AM_CONDITIONAL([BUILD_WAITPID], [test "x$build_waitpid" = xyes])
 


### PR DESCRIPTION
The new pidfd stuff waitpid uses is not compatible with older kernel headers, but the rest of the util-linux is still perfectly fine, so allow disabling just the waitpid utility to make the builds happy again.