### PR TITLE
po-man: fix incorrect command name translations

### DIFF
--- a/po-man/fr.po
+++ b/po-man/fr.po
@@ -9797,7 +9797,7 @@ msgstr "Commandes de l'utilisateur"
 #. type: Plain text
 #: ../login-utils/chfn.1.adoc:20
 msgid "chfn - change your finger information"
-msgstr "chfm - changer vos informations d'identification"
+msgstr "chfn - changer vos informations d'identification"
 
 #. type: Plain text
 #: ../login-utils/chfn.1.adoc:24

--- a/po-man/uk.po
+++ b/po-man/uk.po
@@ -44060,7 +44060,7 @@ msgstr "umount(8)"
 #. type: Plain text
 #: ../sys-utils/umount.8.adoc:37
 msgid "umount - unmount filesystems"
-msgstr "mount - демонтувати файлову систему"
+msgstr "umount - демонтувати файлову систему"
 
 #. type: Plain text
 #: ../sys-utils/umount.8.adoc:41


### PR DESCRIPTION

This should also be applied to 2.39