### PR TITLE
libblkid: constify cached disk data

### DIFF
--- a/include/pt-mbr.h
+++ b/include/pt-mbr.h
@@ -19,7 +19,7 @@ struct dos_partition {
 #define MBR_PT_OFFSET		0x1be
 #define MBR_PT_BOOTBITS_SIZE	440
 
-static inline struct dos_partition *mbr_get_partition(unsigned char *mbr, int i)
+static inline struct dos_partition *mbr_get_partition(const unsigned char *mbr, int i)
 {
 	return (struct dos_partition *)
 		(mbr + MBR_PT_OFFSET + (i * sizeof(struct dos_partition)));
@@ -42,7 +42,7 @@ static inline void __dos_store_4le(unsigned char *p, unsigned int val)
 	p[3] = ((val >> 24) & 0xff);
 }
 
-static inline unsigned int dos_partition_get_start(struct dos_partition *p)
+static inline unsigned int dos_partition_get_start(const struct dos_partition *p)
 {
 	return __dos_assemble_4le(&(p->start_sect[0]));
 }
@@ -52,7 +52,7 @@ static inline void dos_partition_set_start(struct dos_partition *p, unsigned int
 	__dos_store_4le(p->start_sect, n);
 }
 
-static inline unsigned int dos_partition_get_size(struct dos_partition *p)
+static inline unsigned int dos_partition_get_size(const struct dos_partition *p)
 {
 	return __dos_assemble_4le(&(p->nr_sects[0]));
 }

--- a/libblkid/src/blkidP.h
+++ b/libblkid/src/blkidP.h
@@ -412,12 +412,12 @@ extern int blkdid_probe_is_opal_locked(blkid_probe pr)
 			__attribute__((nonnull))
 			__attribute__((warn_unused_result));
 
-extern unsigned char *blkid_probe_get_buffer(blkid_probe pr,
+extern const unsigned char *blkid_probe_get_buffer(blkid_probe pr,
                                 uint64_t off, uint64_t len)
 			__attribute__((nonnull))
 			__attribute__((warn_unused_result));
 
-extern unsigned char *blkid_probe_get_sector(blkid_probe pr, unsigned int sector)
+extern const unsigned char *blkid_probe_get_sector(blkid_probe pr, unsigned int sector)
 			__attribute__((nonnull))
 			__attribute__((warn_unused_result));
 
@@ -434,7 +434,7 @@ extern int blkid_probe_get_idmag(blkid_probe pr, const struct blkid_idinfo *id,
 			__attribute__((nonnull(1)));
 
 /* returns superblock according to 'struct blkid_idmag' */
-extern unsigned char *blkid_probe_get_sb_buffer(blkid_probe pr, const struct blkid_idmag *mag, size_t size);
+extern const unsigned char *blkid_probe_get_sb_buffer(blkid_probe pr, const struct blkid_idmag *mag, size_t size);
 #define blkid_probe_get_sb(_pr, _mag, type) \
 			((type *) blkid_probe_get_sb_buffer((_pr), _mag, sizeof(type)))
 

--- a/libblkid/src/partitions/bsd.c
+++ b/libblkid/src/partitions/bsd.c
@@ -47,7 +47,7 @@ static int probe_bsd_pt(blkid_probe pr, const struct blkid_idmag *mag)
 	blkid_partition parent;
 	blkid_partlist ls;
 	int i, nparts = BSD_MAXPARTITIONS;
-	unsigned char *data;
+	const unsigned char *data;
 	int rc = BLKID_PROBE_NONE;
 	uint32_t abs_offset = 0;
 

--- a/libblkid/src/partitions/dos.c
+++ b/libblkid/src/partitions/dos.c
@@ -34,7 +34,7 @@ static const struct dos_subtypes {
 	{ MBR_MINIX_PARTITION, &minix_pt_idinfo }
 };
 
-static inline int is_extended(struct dos_partition *p)
+static inline int is_extended(const struct dos_partition *p)
 {
 	return (p->sys_ind == MBR_DOS_EXTENDED_PARTITION ||
 		p->sys_ind == MBR_W95_EXTENDED_PARTITION ||
@@ -46,7 +46,7 @@ static int parse_dos_extended(blkid_probe pr, blkid_parttable tab,
 {
 	blkid_partlist ls = blkid_probe_get_partlist(pr);
 	uint32_t cur_start = ex_start, cur_size = ex_size;
-	unsigned char *data;
+	const unsigned char *data;
 	int ct_nodata = 0;	/* count ext.partitions without data partitions */
 	int i;
 
@@ -57,7 +57,7 @@ static int parse_dos_extended(blkid_probe pr, blkid_parttable tab,
 	}
 
 	while (1) {
-		struct dos_partition *p, *p0;
+		const struct dos_partition *p, *p0;
 		uint32_t start = 0, size;
 
 		if (++ct_nodata > 100)
@@ -156,9 +156,9 @@ static inline int is_lvm(blkid_probe pr)
 	return (v && v->data && strcmp((char *) v->data, "LVM2_member") == 0);
 }
 
-static inline int is_empty_mbr(unsigned char *mbr)
+static inline int is_empty_mbr(const unsigned char *mbr)
 {
-	struct dos_partition *p = mbr_get_partition(mbr, 0);
+	const struct dos_partition *p = mbr_get_partition(mbr, 0);
 	int i, nparts = 0;
 
 	for (i = 0; i < 4; i++) {
@@ -177,8 +177,8 @@ static int probe_dos_pt(blkid_probe pr,
 	int ssf;
 	blkid_parttable tab = NULL;
 	blkid_partlist ls;
-	struct dos_partition *p0, *p;
-	unsigned char *data;
+	const struct dos_partition *p0, *p;
+	const unsigned char *data;
 	uint32_t start, size, id;
 	char idstr[UUID_STR_LEN];
 

--- a/libblkid/src/partitions/gpt.c
+++ b/libblkid/src/partitions/gpt.c
@@ -109,7 +109,7 @@ static inline uint32_t count_crc32(const unsigned char *buf, size_t len,
 	return (ul_crc32_exclude_offset(~0L, buf, len, exclude_off, exclude_len) ^ ~0L);
 }
 
-static inline unsigned char *get_lba_buffer(blkid_probe pr,
+static inline const unsigned char *get_lba_buffer(blkid_probe pr,
 					uint64_t lba, size_t bytes)
 {
 	return blkid_probe_get_buffer(pr,
@@ -161,8 +161,8 @@ static int last_lba(blkid_probe pr, uint64_t *lba)
 static int is_pmbr_valid(blkid_probe pr, int *has)
 {
 	int flags = blkid_partitions_get_flags(pr);
-	unsigned char *data;
-	struct dos_partition *p;
+	const unsigned char *data;
+	const struct dos_partition *p;
 	int i;
 
 	if (has)

--- a/libblkid/src/partitions/mac.c
+++ b/libblkid/src/partitions/mac.c
@@ -56,7 +56,7 @@ struct mac_driver_desc {
 	/* there is more stuff after this that we don't need */
 } __attribute__((packed));
 
-static inline unsigned char *get_mac_block(
+static inline const unsigned char *get_mac_block(
 					blkid_probe pr,
 					uint16_t block_size,
 					uint32_t num)

--- a/libblkid/src/partitions/minix.c
+++ b/libblkid/src/partitions/minix.c
@@ -17,11 +17,11 @@
 static int probe_minix_pt(blkid_probe pr,
 		const struct blkid_idmag *mag __attribute__((__unused__)))
 {
-	struct dos_partition *p;
+	const struct dos_partition *p;
 	blkid_parttable tab = NULL;
 	blkid_partition parent;
 	blkid_partlist ls;
-	unsigned char *data;
+	const unsigned char *data;
 	int i;
 
 	data = blkid_probe_get_sector(pr, 0);

--- a/libblkid/src/partitions/ultrix.c
+++ b/libblkid/src/partitions/ultrix.c
@@ -37,8 +37,8 @@ struct ultrix_disklabel {
 static int probe_ultrix_pt(blkid_probe pr,
 		const struct blkid_idmag *mag __attribute__((__unused__)))
 {
-	unsigned char *data;
-	struct ultrix_disklabel *l;
+	const unsigned char *data;
+	const struct ultrix_disklabel *l;
 	blkid_parttable tab = NULL;
 	blkid_partlist ls;
 	int i;
@@ -50,7 +50,7 @@ static int probe_ultrix_pt(blkid_probe pr,
 		goto nothing;
 	}
 
-	l = (struct ultrix_disklabel *) (data + ULTRIX_OFFSET);
+	l = (const struct ultrix_disklabel *) (data + ULTRIX_OFFSET);
 
 	if (l->pt_magic != ULTRIX_MAGIC || l->pt_valid != 1)
 		goto nothing;

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -669,7 +669,7 @@ static int hide_buffer(blkid_probe pr, uint64_t off, uint64_t len)
  * Note that @off is offset within probing area, the probing area is defined by
  * pr->off and pr->size.
  */
-unsigned char *blkid_probe_get_buffer(blkid_probe pr, uint64_t off, uint64_t len)
+const unsigned char *blkid_probe_get_buffer(blkid_probe pr, uint64_t off, uint64_t len)
 {
 	struct blkid_bufinfo *bf = NULL;
 	uint64_t real_off = pr->off + off;
@@ -1136,7 +1136,7 @@ int blkid_probe_set_dimension(blkid_probe pr, uint64_t off, uint64_t size)
 	return 0;
 }
 
-unsigned char *blkid_probe_get_sb_buffer(blkid_probe pr, const struct blkid_idmag *mag, size_t size)
+const unsigned char *blkid_probe_get_sb_buffer(blkid_probe pr, const struct blkid_idmag *mag, size_t size)
 {
 	uint64_t hint_offset;
 
@@ -1164,7 +1164,7 @@ int blkid_probe_get_idmag(blkid_probe pr, const struct blkid_idinfo *id,
 
 	/* try to detect by magic string */
 	while(mag && mag->magic) {
-		unsigned char *buf;
+		const unsigned char *buf;
 		uint64_t kboff;
 		uint64_t hint_offset;
 
@@ -1690,7 +1690,7 @@ done:
 }
 
 /* same sa blkid_probe_get_buffer() but works with 512-sectors */
-unsigned char *blkid_probe_get_sector(blkid_probe pr, unsigned int sector)
+const unsigned char *blkid_probe_get_sector(blkid_probe pr, unsigned int sector)
 {
 	return blkid_probe_get_buffer(pr, ((uint64_t) sector) << 9, 0x200);
 }

--- a/libblkid/src/superblocks/bcache.c
+++ b/libblkid/src/superblocks/bcache.c
@@ -118,7 +118,7 @@ struct bcachefs_super_block {
 static int bcache_verify_checksum(blkid_probe pr, const struct blkid_idmag *mag,
 		const struct bcache_super_block *bcs)
 {
-	unsigned char *csummed = blkid_probe_get_sb_buffer(pr, mag, BCACHE_SB_CSUMMED_END);
+	const unsigned char *csummed = blkid_probe_get_sb_buffer(pr, mag, BCACHE_SB_CSUMMED_END);
 	uint64_t csum = ul_crc64_we(csummed + BCACHE_SB_CSUMMED_START,
 			BCACHE_SB_CSUMMED_END - BCACHE_SB_CSUMMED_START);
 	return blkid_probe_verify_csum(pr, csum, le64_to_cpu(bcs->csum));
@@ -168,7 +168,7 @@ static void probe_bcachefs_sb_members(blkid_probe pr,
 	blkid_probe_set_fssize(pr, sectors * BCACHEFS_SECTOR_SIZE);
 }
 
-static int is_within_range(void *start, uint64_t size, void *end)
+static int is_within_range(const void *start, uint64_t size, const void *end)
 {
 	ptrdiff_t diff;
 
@@ -180,9 +180,9 @@ static int is_within_range(void *start, uint64_t size, void *end)
 }
 
 static void probe_bcachefs_sb_fields(blkid_probe pr, const struct bcachefs_super_block *bcs,
-				     unsigned char *sb_start, unsigned char *sb_end)
+				     const unsigned char *sb_start, const unsigned char *sb_end)
 {
-	unsigned char *field_addr = sb_start + BCACHEFS_SB_FIELDS_OFF;
+	const unsigned char *field_addr = sb_start + BCACHEFS_SB_FIELDS_OFF;
 
 	while (1) {
 		struct bcachefs_sb_field *field = (struct bcachefs_sb_field *) field_addr;
@@ -212,10 +212,10 @@ static void probe_bcachefs_sb_fields(blkid_probe pr, const struct bcachefs_super
 }
 
 static int bcachefs_validate_checksum(blkid_probe pr, const struct bcachefs_super_block *bcs,
-				      unsigned char *sb, unsigned char *sb_end)
+				      const unsigned char *sb, const unsigned char *sb_end)
 {
 	uint8_t checksum_type = be64_to_cpu(bcs->flags[0]) >> 58;
-	unsigned char *checksummed_data_start = sb + sizeof(bcs->csum);
+	const unsigned char *checksummed_data_start = sb + sizeof(bcs->csum);
 	size_t checksummed_data_size = sb_end - checksummed_data_start;
 
 	switch (checksum_type) {
@@ -242,7 +242,7 @@ static int bcachefs_validate_checksum(blkid_probe pr, const struct bcachefs_supe
 static int probe_bcachefs(blkid_probe pr, const struct blkid_idmag *mag)
 {
 	struct bcachefs_super_block *bcs;
-	unsigned char *sb, *sb_end;
+	const unsigned char *sb, *sb_end;
 	uint64_t sb_size, blocksize;
 
 	bcs = blkid_probe_get_sb(pr, mag, struct bcachefs_super_block);

--- a/libblkid/src/superblocks/befs.c
+++ b/libblkid/src/superblocks/befs.c
@@ -122,7 +122,7 @@ struct bplustree_node {
 	char		name[0];
 } __attribute__((packed));
 
-static unsigned char *get_block_run(blkid_probe pr, const struct befs_super_block *bs,
+static const unsigned char *get_block_run(blkid_probe pr, const struct befs_super_block *bs,
 					const struct block_run *br, int fs_le)
 {
 	return blkid_probe_get_buffer(pr,
@@ -135,7 +135,7 @@ static unsigned char *get_block_run(blkid_probe pr, const struct befs_super_bloc
 					<< FS32_TO_CPU(bs->block_shift, fs_le));
 }
 
-static unsigned char *get_custom_block_run(blkid_probe pr,
+static const unsigned char *get_custom_block_run(blkid_probe pr,
 				const struct befs_super_block *bs,
 				const struct block_run *br,
 				int64_t offset, uint32_t length, int fs_le)
@@ -154,7 +154,7 @@ static unsigned char *get_custom_block_run(blkid_probe pr,
 			length);
 }
 
-static unsigned char *get_tree_node(blkid_probe pr, const struct befs_super_block *bs,
+static const unsigned char *get_tree_node(blkid_probe pr, const struct befs_super_block *bs,
 				const struct data_stream *ds,
 				int64_t start, uint32_t length, int fs_le)
 {

--- a/libblkid/src/superblocks/cramfs.c
+++ b/libblkid/src/superblocks/cramfs.c
@@ -55,7 +55,7 @@ static int cramfs_verify_csum(blkid_probe pr, const struct blkid_idmag *mag,
 		struct cramfs_super *cs, int le)
 {
 	uint32_t crc, expected, csummed_size;
-	unsigned char *csummed;
+	const unsigned char *csummed;
 
 	expected = cfs32_to_cpu(le, cs->info.crc);
 	csummed_size = cfs32_to_cpu(le, cs->size);
@@ -67,9 +67,10 @@ static int cramfs_verify_csum(blkid_probe pr, const struct blkid_idmag *mag,
 	csummed = blkid_probe_get_sb_buffer(pr, mag, csummed_size);
 	if (!csummed)
 		return 0;
-	memset(csummed + offsetof(struct cramfs_super, info.crc), 0, sizeof(uint32_t));
 
-	crc = ~ul_crc32(~0LL, csummed, csummed_size);
+	crc = ~ul_crc32_exclude_offset(~0LL, csummed, csummed_size,
+			offsetof(struct cramfs_super, info.crc),
+			sizeof_member(struct cramfs_super, info.crc));
 
 	return blkid_probe_verify_csum(pr, crc, expected);
 }

--- a/libblkid/src/superblocks/ddf_raid.c
+++ b/libblkid/src/superblocks/ddf_raid.c
@@ -106,7 +106,7 @@ static int probe_ddf(blkid_probe pr,
 
 	if (lba > 0) {
 		/* check primary header */
-		unsigned char *buf;
+		const unsigned char *buf;
 
 		buf = blkid_probe_get_buffer(pr,
 					lba << 9, sizeof(ddf->signature));

--- a/libblkid/src/superblocks/erofs.c
+++ b/libblkid/src/superblocks/erofs.c
@@ -46,7 +46,7 @@ static int erofs_verify_checksum(blkid_probe pr, const struct blkid_idmag *mag,
 {
 	uint32_t expected, csum;
 	size_t csummed_size;
-	unsigned char *csummed;
+	const unsigned char *csummed;
 
 	if (!(le32_to_cpu(sb->feature_compat) & EROFS_FEATURE_SB_CSUM))
 		return 1;

--- a/libblkid/src/superblocks/exfat.c
+++ b/libblkid/src/superblocks/exfat.c
@@ -119,7 +119,7 @@ static struct exfat_entry_label *find_label(blkid_probe pr,
 }
 
 /* From https://docs.microsoft.com/en-us/windows/win32/fileio/exfat-specification#34-main-and-backup-boot-checksum-sub-regions */
-static uint32_t exfat_boot_checksum(unsigned char *sectors,
+static uint32_t exfat_boot_checksum(const unsigned char *sectors,
 				    size_t sector_size)
 {
 	uint32_t n_bytes = sector_size * 11;
@@ -141,7 +141,7 @@ static int exfat_validate_checksum(blkid_probe pr,
 {
 	size_t sector_size = BLOCK_SIZE(sb);
 	/* 11 sectors will be checksummed, the 12th contains the expected */
-	unsigned char *data = blkid_probe_get_buffer(pr, 0, sector_size * 12);
+	const unsigned char *data = blkid_probe_get_buffer(pr, 0, sector_size * 12);
 	if (!data)
 		return 0;
 

--- a/libblkid/src/superblocks/f2fs.c
+++ b/libblkid/src/superblocks/f2fs.c
@@ -67,14 +67,14 @@ static int f2fs_validate_checksum(blkid_probe pr, size_t sb_off,
 	if (csum_off + sizeof(uint32_t) > 4096)
 		return 0;
 
-	unsigned char *csum_data = blkid_probe_get_buffer(pr,
+	const unsigned char *csum_data = blkid_probe_get_buffer(pr,
 			sb_off + csum_off, sizeof(uint32_t));
 	if (!csum_data)
 		return 0;
 
 	uint32_t expected = le32_to_cpu(*(uint32_t *) csum_data);
 
-	unsigned char *csummed = blkid_probe_get_buffer(pr, sb_off, csum_off);
+	const unsigned char *csummed = blkid_probe_get_buffer(pr, sb_off, csum_off);
 	if (!csummed)
 		return 0;
 

--- a/libblkid/src/superblocks/hfs.c
+++ b/libblkid/src/superblocks/hfs.c
@@ -183,11 +183,11 @@ static int probe_hfs(blkid_probe pr, const struct blkid_idmag *mag)
 static int probe_hfsplus(blkid_probe pr, const struct blkid_idmag *mag)
 {
 	struct hfsplus_extent extents[HFSPLUS_EXTENT_COUNT];
-	struct hfsplus_bnode_descriptor *descr;
-	struct hfsplus_bheader_record *bnode;
-	struct hfsplus_catalog_key *key;
-	struct hfsplus_vol_header *hfsplus;
-	struct hfs_mdb *sbd;
+	const struct hfsplus_bnode_descriptor *descr;
+	const struct hfsplus_bheader_record *bnode;
+	const struct hfsplus_catalog_key *key;
+	const struct hfsplus_vol_header *hfsplus;
+	const struct hfs_mdb *sbd;
 	unsigned int alloc_block_size;
 	unsigned int alloc_first_block;
 	unsigned int embed_first_block;
@@ -203,7 +203,7 @@ static int probe_hfsplus(blkid_probe pr, const struct blkid_idmag *mag)
 	unsigned int leaf_block;
 	int ext;
 	uint64_t leaf_off;
-	unsigned char *buf;
+	const unsigned char *buf;
 
 	sbd = blkid_probe_get_sb(pr, mag, struct hfs_mdb);
 	if (!sbd)
@@ -225,7 +225,7 @@ static int probe_hfsplus(blkid_probe pr, const struct blkid_idmag *mag)
 		buf = blkid_probe_get_buffer(pr,
 				off + (mag->kboff * 1024),
 				sizeof(struct hfsplus_vol_header));
-		hfsplus = (struct hfsplus_vol_header *) buf;
+		hfsplus = (const struct hfsplus_vol_header *) buf;
 
 	} else
 		hfsplus = blkid_probe_get_sb(pr, mag,

--- a/libblkid/src/superblocks/iso9660.c
+++ b/libblkid/src/superblocks/iso9660.c
@@ -232,7 +232,7 @@ static int probe_iso9660(blkid_probe pr, const struct blkid_idmag *mag)
 		return probe_iso9660_hsfs(pr, mag);
 
 	for (i = 0, off += ISO_SUPERBLOCK_OFFSET; i < ISO_VD_MAX && (!boot || !pvd || !joliet); i++, off += ISO_SECTOR_SIZE) {
-		unsigned char *desc =
+		const unsigned char *desc =
 			blkid_probe_get_buffer(pr,
 					off,
 					max(sizeof(struct boot_record),

--- a/libblkid/src/superblocks/linux_raid.c
+++ b/libblkid/src/superblocks/linux_raid.c
@@ -187,14 +187,13 @@ static int raid1_verify_csum(blkid_probe pr, off_t off,
 {
 	size_t csummed_size = sizeof(struct mdp1_super_block)
 		+ le32_to_cpu(mdp1->max_dev) * sizeof(mdp1->dev_roles[0]);
-	unsigned char *csummed = blkid_probe_get_buffer(pr, off, csummed_size);
+	const unsigned char *csummed = blkid_probe_get_buffer(pr, off, csummed_size);
 	if (!csummed)
 		return 1;
 
-	memset(csummed + offsetof(struct mdp1_super_block, sb_csum), 0,
-			sizeof(mdp1->sb_csum));
-
 	uint64_t csum = 0;
+
+	csum -= le32_to_cpu(*(uint32_t *) (csummed + offsetof(struct mdp1_super_block, sb_csum)));
 
 	while (csummed_size >= 4) {
 		csum += le32_to_cpu(*(uint32_t *) csummed);

--- a/libblkid/src/superblocks/lvm.c
+++ b/libblkid/src/superblocks/lvm.c
@@ -76,7 +76,7 @@ static int probe_lvm2(blkid_probe pr, const struct blkid_idmag *mag)
 	int sector = mag->kboff << 1;
 	struct lvm2_pv_label_header *label;
 	char uuid[LVM2_ID_LEN + 7];
-	unsigned char *buf;
+	const unsigned char *buf;
 
 	buf = blkid_probe_get_buffer(pr,
 			mag->kboff << 10,

--- a/libblkid/src/superblocks/minix.c
+++ b/libblkid/src/superblocks/minix.c
@@ -74,7 +74,7 @@ static int get_minix_version(const unsigned char *data, int *other_endian)
 static int probe_minix(blkid_probe pr,
 		const struct blkid_idmag *mag __attribute__((__unused__)))
 {
-	unsigned char *ext;
+	const unsigned char *ext;
 	const unsigned char *data;
 	int version = 0, swabme = 0;
 	unsigned long zones, ninodes, imaps, zmaps;

--- a/libblkid/src/superblocks/ntfs.c
+++ b/libblkid/src/superblocks/ntfs.c
@@ -80,13 +80,13 @@ struct file_attribute {
 
 static int __probe_ntfs(blkid_probe pr, const struct blkid_idmag *mag, int save_info)
 {
-	struct ntfs_super_block *ns;
-	struct master_file_table_record *mft;
+	const struct ntfs_super_block *ns;
+	const struct master_file_table_record *mft;
 
 	uint32_t sectors_per_cluster, mft_record_size;
 	uint16_t sector_size;
 	uint64_t nr_clusters, off, attr_off;
-	unsigned char *buf_mft;
+	const unsigned char *buf_mft;
 
 	ns = blkid_probe_get_sb(pr, mag, struct ntfs_super_block);
 	if (!ns)

--- a/libblkid/src/superblocks/ocfs.c
+++ b/libblkid/src/superblocks/ocfs.c
@@ -100,7 +100,7 @@ struct oracle_asm_disk_label {
 
 static int probe_ocfs(blkid_probe pr, const struct blkid_idmag *mag)
 {
-	unsigned char *buf;
+	const unsigned char *buf;
 	struct ocfs_volume_header ovh;
 	struct ocfs_volume_label ovl;
 	uint32_t maj, min;

--- a/libblkid/src/superblocks/romfs.c
+++ b/libblkid/src/superblocks/romfs.c
@@ -29,7 +29,7 @@ static int romfs_verify_csum(blkid_probe pr, const struct blkid_idmag *mag,
 {
 	uint32_t csummed_size = min((uint32_t) 512,
 			be32_to_cpu(ros->ros_full_size));
-	unsigned char *csummed;
+	const unsigned char *csummed;
 	uint32_t csum;
 
 	if (csummed_size % sizeof(uint32_t) != 0)

--- a/libblkid/src/superblocks/stratis.c
+++ b/libblkid/src/superblocks/stratis.c
@@ -49,7 +49,7 @@ const char STRATIS_MAGIC[] = "!Stra0tis\x86\xff\x02^\x41rh";
 #define MAGIC_OFFSET_COPY_1 (FIRST_COPY_OFFSET + _MAGIC_OFFSET)
 #define MAGIC_OFFSET_COPY_2 (SECOND_COPY_OFFSET + _MAGIC_OFFSET)
 
-static int stratis_valid_sb(uint8_t *p)
+static int stratis_valid_sb(const uint8_t *p)
 {
 	const struct stratis_sb *stratis = (const struct stratis_sb *)p;
 	uint32_t crc = 0;
@@ -83,7 +83,7 @@ static int probe_stratis(blkid_probe pr,
 		const struct blkid_idmag *mag __attribute__((__unused__)))
 {
 	const struct stratis_sb *stratis = NULL;
-	uint8_t *buf = blkid_probe_get_buffer(pr, 0, SB_AREA_SIZE);
+	const uint8_t *buf = blkid_probe_get_buffer(pr, 0, SB_AREA_SIZE);
 	unsigned char uuid[STRATIS_UUID_STR_LEN];
 
 	if (!buf)

--- a/libblkid/src/superblocks/swap.c
+++ b/libblkid/src/superblocks/swap.c
@@ -91,7 +91,7 @@ static int swap_set_info(blkid_probe pr, const struct blkid_idmag *mag,
 
 static int probe_swap(blkid_probe pr, const struct blkid_idmag *mag)
 {
-	unsigned char *buf;
+	const unsigned char *buf;
 
 	if (!mag)
 		return 1;

--- a/libblkid/src/superblocks/vfat.c
+++ b/libblkid/src/superblocks/vfat.c
@@ -351,7 +351,7 @@ static int probe_vfat(blkid_probe pr, const struct blkid_idmag *mag)
 			version = "FAT16";
 
 	} else if (vs->vs_fat32_length) {
-		unsigned char *buf;
+		const unsigned char *buf;
 		uint16_t fsinfo_sect;
 		int maxloop = 100;
 

--- a/libblkid/src/superblocks/vmfs.c
+++ b/libblkid/src/superblocks/vmfs.c
@@ -49,7 +49,7 @@ static int probe_vmfs_fs(blkid_probe pr, const struct blkid_idmag *mag)
 static int probe_vmfs_volume(blkid_probe pr, const struct blkid_idmag *mag)
 {
 	struct vmfs_volume_info *header;
-	unsigned char *lvm_uuid;
+	const unsigned char *lvm_uuid;
 
 	header = blkid_probe_get_sb(pr, mag, struct vmfs_volume_info);
 	if (header == NULL)

--- a/libblkid/src/superblocks/xfs.c
+++ b/libblkid/src/superblocks/xfs.c
@@ -206,7 +206,7 @@ static int xfs_verify_sb(struct xfs_super_block *ondisk, blkid_probe pr,
 
 	if ((sbp->sb_versionnum & 0x0f) == 5) {
 		uint32_t expected, crc;
-		unsigned char *csummed;
+		const unsigned char *csummed;
 
 		if (!(sbp->sb_versionnum & XFS_SB_VERSION_MOREBITSBIT))
 			return 0;
@@ -331,7 +331,7 @@ static int probe_xfs_log(blkid_probe pr,
 {
 	int i;
 	struct xlog_rec_header *rhead;
-	unsigned char *buf;
+	const unsigned char *buf;
 
 	buf = blkid_probe_get_buffer(pr, 0, 256*1024);
 	if (!buf)

--- a/libblkid/src/superblocks/zfs.c
+++ b/libblkid/src/superblocks/zfs.c
@@ -71,13 +71,13 @@ struct nvlist {
 	struct nvpair	nvl_nvpair;
 };
 
-static void zfs_process_value(blkid_probe pr, char *name, size_t namelen,
-			     void *value, size_t max_value_size, unsigned directory_level)
+static void zfs_process_value(blkid_probe pr, const char *name, size_t namelen,
+			     const void *value, size_t max_value_size, unsigned directory_level)
 {
 	if (strncmp(name, "name", namelen) == 0 &&
 	    sizeof(struct nvstring) <= max_value_size &&
 	    !directory_level) {
-		struct nvstring *nvs = value;
+		const struct nvstring *nvs = value;
 		uint32_t nvs_type = be32_to_cpu(nvs->nvs_type);
 		uint32_t nvs_strlen = be32_to_cpu(nvs->nvs_strlen);
 
@@ -92,7 +92,7 @@ static void zfs_process_value(blkid_probe pr, char *name, size_t namelen,
 	} else if (strncmp(name, "guid", namelen) == 0 &&
 		   sizeof(struct nvuint64) <= max_value_size &&
 		   !directory_level) {
-		struct nvuint64 *nvu = value;
+		const struct nvuint64 *nvu = value;
 		uint32_t nvu_type = be32_to_cpu(nvu->nvu_type);
 		uint64_t nvu_value;
 
@@ -110,7 +110,7 @@ static void zfs_process_value(blkid_probe pr, char *name, size_t namelen,
 	} else if (strncmp(name, "pool_guid", namelen) == 0 &&
 		   sizeof(struct nvuint64) <= max_value_size &&
 		   !directory_level) {
-		struct nvuint64 *nvu = value;
+		const struct nvuint64 *nvu = value;
 		uint32_t nvu_type = be32_to_cpu(nvu->nvu_type);
 		uint64_t nvu_value;
 
@@ -128,7 +128,7 @@ static void zfs_process_value(blkid_probe pr, char *name, size_t namelen,
 					 "%"PRIu64, nvu_value);
 	} else if (strncmp(name, "ashift", namelen) == 0 &&
 		   sizeof(struct nvuint64) <= max_value_size) {
-		struct nvuint64 *nvu = value;
+		const struct nvuint64 *nvu = value;
 		uint32_t nvu_type = be32_to_cpu(nvu->nvu_type);
 		uint64_t nvu_value;
 
@@ -147,9 +147,9 @@ static void zfs_process_value(blkid_probe pr, char *name, size_t namelen,
 
 static void zfs_extract_guid_name(blkid_probe pr, loff_t offset)
 {
-	unsigned char *p;
-	struct nvlist *nvl;
-	struct nvpair *nvp;
+	const unsigned char *p;
+	const struct nvlist *nvl;
+	const struct nvpair *nvp;
 	size_t left = 4096;
 	unsigned directory_level = 0;
 
@@ -166,16 +166,16 @@ static void zfs_extract_guid_name(blkid_probe pr, loff_t offset)
 	DBG(LOWPROBE, ul_debug("zfs_extract: nvlist offset %jd",
 			       (intmax_t)offset));
 
-	nvl = (struct nvlist *) p;
+	nvl = (const struct nvlist *) p;
 	nvp = &nvl->nvl_nvpair;
-	left -= (unsigned char *)nvp - p; /* Already used up 12 bytes */
+	left -= (const unsigned char *)nvp - p; /* Already used up 12 bytes */
 
 	while (left > sizeof(*nvp)) {
 		uint32_t nvp_size = be32_to_cpu(nvp->nvp_size);
 		uint32_t nvp_namelen = be32_to_cpu(nvp->nvp_namelen);
 		uint64_t namesize = ((uint64_t)nvp_namelen + 3) & ~3;
 		size_t max_value_size;
-		void *value;
+		const void *value;
 
 		if (!nvp->nvp_size) {
 			if (!directory_level)
@@ -201,7 +201,7 @@ static void zfs_extract_guid_name(blkid_probe pr, loff_t offset)
 		value = nvp->nvp_name + namesize;
 
 		if (sizeof(struct nvdirectory) <= max_value_size) {
-			struct nvdirectory *nvu = value;
+			const struct nvdirectory *nvu = value;
 			if (be32_to_cpu(nvu->nvd_type) == DATA_TYPE_DIRECTORY) {
 				nvp_size = sizeof(*nvp) + namesize + sizeof(*nvu);
 				directory_level++;
@@ -259,7 +259,7 @@ static int probe_zfs(blkid_probe pr,
 	struct zfs_uberblock *ub = NULL;
 	loff_t offset = 0, ub_offset = 0;
 	int label_no, found = 0, found_in_label;
-	void *label;
+	const void *label;
 	loff_t blk_align = (pr->size % (256 * 1024ULL));
 
 	DBG(PROBE, ul_debug("probe_zfs"));

--- a/libfdisk/src/dos.c
+++ b/libfdisk/src/dos.c
@@ -792,7 +792,7 @@ static void get_partition_table_geometry(struct fdisk_context *cxt,
 	unsigned char *bufp = cxt->firstsector;
 	struct { unsigned int c, h, o, v; } t[8];
 	unsigned int n1, n2, n3, n4, n5, n6;
-	struct dos_partition *p;
+	const struct dos_partition *p;
 	unsigned int c, h, s, l;
 	unsigned int hh, ss;
 	unsigned int sects;


### PR DESCRIPTION
The data returned from blkid_probe_get_buffer() and friends may or may not be cached between different calls.
If one copy is modified this may not be visible in other copies.

This issue can be avoided by making any modification illegal.

See also #2165