### PR TITLE
enosys: include sys/syscall.h

### DIFF
--- a/misc-utils/enosys.c
+++ b/misc-utils/enosys.c
@@ -25,6 +25,7 @@
 #include <linux/seccomp.h>
 #include <linux/audit.h>
 #include <sys/prctl.h>
+#include <sys/syscall.h>
 
 #include "c.h"
 #include "exitcodes.h"


### PR DESCRIPTION
Otherwise there is no guarantee that all syscall numbers detected by tools/all_syscalls are actually available to enosys.c.


This should also be applied to 2.39