### PR TITLE
libmount: check for availability of mount_setattr

### DIFF
--- a/tests/expected/mount/fallback-mount_setattr
+++ b/tests/expected/mount/fallback-mount_setattr
@@ -1,0 +1,1 @@
+private

--- a/tests/ts/mount/fallback
+++ b/tests/ts/mount/fallback
@@ -68,5 +68,21 @@ $TS_CMD_UMOUNT $MOUNTPOINT
 ts_finalize_subtest
 
 
+ts_init_subtest "mount_setattr"
+"$TS_CMD_MOUNT" "$DEVICE" "$MOUNTPOINT"  >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_is_mounted $DEVICE || ts_log "Cannot find $DEVICE in /proc/mounts"
+$TS_CMD_ENOSYS -s mount_setattr -- \
+	"$TS_CMD_MOUNT" -o remount,ro "$MOUNTPOINT" \
+	>> $TS_OUTPUT 2>> $TS_ERRLOG
+$TS_CMD_FINDMNT --kernel --mountpoint "$MOUNTPOINT" --options "ro" &> /dev/null
+[ "$?" == "0" ] || ts_die "Cannot find read-only in $MOUNTPOINT in /proc/self/mountinfo"
+$TS_CMD_ENOSYS -s mount_setattr -- \
+ 	"$TS_CMD_MOUNT" --make-slave "$MOUNTPOINT" \
+ 	>> $TS_OUTPUT 2>> $TS_ERRLOG
+$TS_CMD_FINDMNT -n --kernel --mountpoint "$MOUNTPOINT" -o PROPAGATION >> $TS_OUTPUT
+$TS_CMD_UMOUNT $MOUNTPOINT
+ts_finalize_subtest
+
+
 ts_finalize
 


### PR DESCRIPTION
If mount_setattr is not available but needed fall back to the legacy mount API.

Fixes #2247

This should also be applied to 2.39 with the following changes:

* Use `$TS_HELPER_ENOSYS` in testcase
* Add `__NR_move_mount` to `test_enosys`