### PR TITLE
libmount: don't pass option "defaults" to helper

### DIFF
--- a/libmount/src/optmap.c
+++ b/libmount/src/optmap.c
@@ -147,7 +147,7 @@ static const struct libmnt_optmap linux_flags_map[] =
  */
 static const struct libmnt_optmap userspace_opts_map[] =
 {
-   { "defaults", 0, 0 },               /* default options */
+   { "defaults", 0, MNT_NOHLPS },      /* default options */
 
    { "auto",    MNT_MS_NOAUTO, MNT_NOHLPS | MNT_INVERT | MNT_NOMTAB },  /* Can be mounted using -a */
    { "noauto",  MNT_MS_NOAUTO, MNT_NOHLPS | MNT_NOMTAB },  /* Can only be mounted explicitly */

--- a/tests/expected/mount/special
+++ b/tests/expected/mount/special
@@ -1,1 +1,1 @@
-/sbin/mount.mytest called with "/foo /bar -o rw"
+/sbin/mount.mytest called with "/foo /bar -o rw,foo"

--- a/tests/ts/mount/special
+++ b/tests/ts/mount/special
@@ -35,7 +35,7 @@ echo "$0 called with \"$*\""
 EOF
 chmod +x $MOUNTER
 
-$TS_CMD_MOUNT -t mytest /foo /bar &> $TS_OUTPUT
+$TS_CMD_MOUNT -t mytest -o foo,defaults /foo /bar &> $TS_OUTPUT
 rm -f $MOUNTER
 
 ts_finalize


### PR DESCRIPTION
"defaults" is only a pseudo-option that expands to other options. It should not be passed to helpers.

Reported-by: Quentin Rameau <quinq@fifth.space>
Closes: https://lore.kernel.org/util-linux/20230521181814.0b0f2d38.quinq@fifth.space/


This should also be applied to 2.39