### PR TITLE
enosys: add support for ioctl blocking

### DIFF
--- a/bash-completion/enosys
+++ b/bash-completion/enosys
@@ -8,7 +8,13 @@ _waitpid_module()
 		'-s'|'--syscall')
 			return 0
 			;;
+		'-i'|'--ioctl')
+			return 0
+			;;
 		'-l'|'--list')
+			return 0
+			;;
+		'-m'|'--list-ioctl')
 			return 0
 			;;
 		'-h'|'--help'|'-V'|'--version')
@@ -18,7 +24,9 @@ _waitpid_module()
 	case $cur in
 		-*)
 			OPTS="--syscall
+			        --ioctl
 			        --list
+			        --list-ioctl
 				--help
 				--version"
 			COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )

--- a/misc-utils/enosys.1.adoc
+++ b/misc-utils/enosys.1.adoc
@@ -27,8 +27,14 @@ syscalls as would happen when running on old kernels.
 *-s*, *--syscall*::
 Syscall to block. Can be specified multiple times.
 
+*-i*, *--ioctl*::
+Ioctl to block. Can be specified multiple times.
+
 *-l*, *--list*::
 List syscalls known to *enosys*.
+
+*-m*, *--list-ioctl*::
+List ioctls known to *enosys*.
 
 include::man-common/help-version.adoc[]
 

--- a/misc-utils/enosys.c
+++ b/misc-utils/enosys.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
 			break;
 		case 'l':
 			for (i = 0; i < ARRAY_SIZE(syscalls); i++)
-				printf("%s\n", syscalls[i].name);
+				printf("%5ld %s\n", syscalls[i].number, syscalls[i].name);
 			return EXIT_SUCCESS;
 		case 'V':
 			print_version(EXIT_SUCCESS);

--- a/misc-utils/enosys.c
+++ b/misc-utils/enosys.c
@@ -58,6 +58,13 @@ struct syscall {
 	long number;
 };
 
+/* When the alias arrays are empty the compiler emits -Wtype-limits warnings.
+ * Avoid those by going through this function. */
+static inline bool lt(size_t a, size_t b)
+{
+	return a < b;
+}
+
 static const struct syscall syscalls[] = {
 #define UL_SYSCALL(name, nr) { name, nr },
 #include "syscalls.h"
@@ -124,7 +131,7 @@ int main(int argc, char **argv)
 		switch (c) {
 		case 's':
 			found = 0;
-			for (i = 0; i < ARRAY_SIZE(syscalls); i++) {
+			for (i = 0; lt(i, ARRAY_SIZE(syscalls)); i++) {
 				if (strcmp(optarg, syscalls[i].name) == 0) {
 					blocked_number = syscalls[i].number;
 					found = 1;
@@ -142,7 +149,7 @@ int main(int argc, char **argv)
 			break;
 		case 'i':
 			found = 0;
-			for (i = 0; i < ARRAY_SIZE(ioctls); i++) {
+			for (i = 0; lt(i, ARRAY_SIZE(ioctls)); i++) {
 				if (strcmp(optarg, ioctls[i].name) == 0) {
 					blocked_number = ioctls[i].number;
 					found = 1;
@@ -159,11 +166,11 @@ int main(int argc, char **argv)
 
 			break;
 		case 'l':
-			for (i = 0; i < ARRAY_SIZE(syscalls); i++)
+			for (i = 0; lt(i, ARRAY_SIZE(syscalls)); i++)
 				printf("%5ld %s\n", syscalls[i].number, syscalls[i].name);
 			return EXIT_SUCCESS;
 		case 'm':
-			for (i = 0; i < ARRAY_SIZE(ioctls); i++)
+			for (i = 0; lt(i, ARRAY_SIZE(ioctls)); i++)
 				printf("%5ld %s\n", ioctls[i].number, ioctls[i].name);
 			return EXIT_SUCCESS;
 		case 'V':

--- a/misc-utils/enosys.c
+++ b/misc-utils/enosys.c
@@ -63,12 +63,10 @@ static const struct syscall syscalls[] = {
 #include "syscalls.h"
 #undef UL_SYSCALL
 };
-static_assert(sizeof(syscalls) > 0, "no syscalls found");
 
 static const struct syscall ioctls[] = {
 	{ "FIOCLEX", FIOCLEX },
 };
-static_assert(sizeof(ioctls) > 0, "no ioctls found");
 
 static void __attribute__((__noreturn__)) usage(void)
 {

--- a/tests/expected/misc/enosys-ioctl
+++ b/tests/expected/misc/enosys-ioctl
@@ -1,0 +1,5 @@
+test_enosys: ioctl r=0 errno=Success
+test_enosys: ioctl r=-1 errno=Function not implemented
+test_enosys: ioctl r=-1 errno=Inappropriate ioctl for device
+test_enosys: ioctl r=-1 errno=Inappropriate ioctl for device
+test_enosys: ioctl r=-1 errno=Function not implemented

--- a/tests/helpers/test_enosys.c
+++ b/tests/helpers/test_enosys.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
 
 int main(int argc, char **argv)
 {
@@ -44,6 +45,9 @@ int main(int argc, char **argv)
 		};
 		execve(cmd[0], cmd, NULL);
 		err(EXIT_FAILURE, "exec failed");
+	} else if (strcmp(argv[1], "ioctl") == 0) {
+		r = ioctl(0, FIOCLEX);
+		errx(EXIT_SUCCESS, "ioctl r=%d errno=%s", r, strerror(errno));
 	}
 
 	errx(EXIT_FAILURE, "invalid mode %s", argv[1]);

--- a/tests/ts/misc/enosys
+++ b/tests/ts/misc/enosys
@@ -43,4 +43,16 @@ $FALLOCATE_TEST > /dev/null 2>> "$TS_OUTPUT"
 
 ts_finalize_subtest
 
+ts_init_subtest ioctl
+
+FALLOCATE_TEST="$TS_HELPER_ENOSYS ioctl"
+
+$FALLOCATE_TEST > /dev/null 2>> "$TS_OUTPUT"
+"$TS_CMD_ENOSYS" -s ioctl $FALLOCATE_TEST > /dev/null 2>> "$TS_OUTPUT"
+"$TS_CMD_ENOSYS" -i FIOCLEX $FALLOCATE_TEST > /dev/null 2>> "$TS_OUTPUT"
+"$TS_CMD_ENOSYS" -i "$("$TS_CMD_ENOSYS" -m | grep FIOCLEX | awk '{ print $1 }')" $FALLOCATE_TEST > /dev/null 2>> "$TS_OUTPUT"
+"$TS_CMD_ENOSYS" -s ioctl -i FIOCLEX $FALLOCATE_TEST > /dev/null 2>> "$TS_OUTPUT"
+
+ts_finalize_subtest
+
 ts_finalize


### PR DESCRIPTION
Ioctls are blocked with ENOTTY.

This is still missing a mechanism to discover ioctls at build time.
At the moment only `FIOCLEX` is supported.