### PR TITLE
agetty: include fileutils.h

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -49,6 +49,7 @@
 #include "color-names.h"
 #include "env.h"
 #include "path.h"
+#include "fileutils.h"
 
 #include "logindefs.h"
 


### PR DESCRIPTION
It is needed to access xreaddir()