### PR TITLE
lsfd: fill SOURCE column for sysvipc shmem mappings and nsfs files

### DIFF
--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -45,6 +45,8 @@
 
 static struct idcache *username_cache;
 
+static size_t pagesize;
+
 static const char *assocstr[N_ASSOCS] = {
 	[ASSOC_CWD]       = "cwd",
 	[ASSOC_EXE]       = "exe",
@@ -102,14 +104,8 @@ static uint64_t get_map_length(struct file *file)
 {
 	uint64_t res = 0;
 
-	if (is_association(file, SHM) || is_association(file, MEM)) {
-		static size_t pagesize = 0;
-
-		if (!pagesize)
-			pagesize = getpagesize();
-
+	if (is_association(file, SHM) || is_association(file, MEM))
 		res = (file->map_end - file->map_start) / pagesize;
-	}
 
 	return res;
 }
@@ -306,6 +302,9 @@ static void file_free_content(struct file *file)
 
 static void file_class_initialize(void)
 {
+	if (!pagesize)
+		pagesize = getpagesize();
+
 	username_cache = new_idcache();
 	if (!username_cache)
 		err(EXIT_FAILURE, _("failed to allocate UID cache"));

--- a/misc-utils/lsfd-sock-xinfo.c
+++ b/misc-utils/lsfd-sock-xinfo.c
@@ -212,8 +212,12 @@ void initialize_sock_xinfos(void)
 		load_sock_xinfo_no_nsswitch(NULL);
 	else {
 		if (fstat(self_netns_fd, &self_netns_sb) == 0) {
+			unsigned long m;
 			struct netns *nsobj = mark_sock_xinfo_loaded(self_netns_sb.st_ino);
 			load_sock_xinfo_no_nsswitch(nsobj);
+
+			m = minor(self_netns_sb.st_dev);
+			add_nodev(m, "nsfs");
 		}
 	}
 

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -747,7 +747,7 @@ static struct file *collect_file_symlink(struct path_cxt *pc,
 		     * other network namespaces. Besed on the information,
 		     * various columns of sockets can be filled.
 		     */
-		    && (class != &sock_class)&& (class != &nsfs_file_class))
+		    && (class != &sock_class) && (class != &nsfs_file_class))
 			return NULL;
 		f = new_file(proc, class);
 		file_set_path(f, &sb, sym, assoc);

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -742,9 +742,10 @@ static struct file *collect_file_symlink(struct path_cxt *pc,
 
 		class = stat2class(&sb);
 		if (sockets_only
-		    /* A nsfs is not a socket but the nsfs can be used to
-		     * collect information from other network namespaces.
-		     * Besed on the information, various columns of sockets.
+		    /* A nsfs file is not a socket but the nsfs file can
+		     * be used as a entry point to collect information from
+		     * other network namespaces. Besed on the information,
+		     * various columns of sockets can be filled.
 		     */
 		    && (class != &sock_class)&& (class != &nsfs_file_class))
 			return NULL;

--- a/misc-utils/lsfd.h
+++ b/misc-utils/lsfd.h
@@ -231,6 +231,7 @@ const char *get_blkdrv(unsigned long major);
 const char *get_chrdrv(unsigned long major);
 const char *get_miscdev(unsigned long minor);
 const char *get_nodev_filesystem(unsigned long minor);
+void add_nodev(unsigned long minor, const char *filesystem);
 
 static inline void xstrappend(char **a, const char *b)
 {

--- a/tests/expected/lsfd/column-source-namespace-ASSOC
+++ b/tests/expected/lsfd/column-source-namespace-ASSOC
@@ -1,0 +1,7 @@
+  ipc   nsfs
+  mnt   nsfs
+  net   nsfs
+  pid   nsfs
+pid4c   nsfs
+ user   nsfs
+  uts   nsfs

--- a/tests/expected/lsfd/column-source-with-root-SysVIPC-shmem
+++ b/tests/expected/lsfd/column-source-with-root-SysVIPC-shmem
@@ -1,0 +1,2 @@
+  shm  tmpfs
+ASSOC,SOURCE: 0

--- a/tests/ts/lsfd/column-source
+++ b/tests/ts/lsfd/column-source
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="SOURCE column"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+. "$TS_SELF/lsfd-functions.bash"
+ts_check_test_command "$TS_CMD_LSFD"
+
+ts_cd "$TS_OUTDIR"
+
+declare -a NAMESPACES=(
+    cgorup
+    ipc
+    mnt
+    net
+    pid
+    pid4c
+    # older kernel doesn't support time namespace.
+    # time
+    # time4c
+    user
+    uts
+)
+ts_init_subtest namespace-ASSOC
+{
+    EXPR="false"
+    for ns in "${NAMESPACES[@]}"; do
+	EXPR=${EXPR}' || (ASSOC == "'"$ns"'")'
+    done
+    ${TS_CMD_LSFD} -p $$ -n -o ASSOC,SOURCE -Q "$EXPR"
+} > "$TS_OUTPUT" 2>&1
+ts_finalize_subtest
+
+ts_finalize

--- a/tests/ts/lsfd/column-source-with-root
+++ b/tests/ts/lsfd/column-source-with-root
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="SOURCE column (requiring the root privilege)"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+ts_skip_nonroot
+
+. "$TS_SELF/lsfd-functions.bash"
+ts_check_test_command "$TS_CMD_LSFD"
+ts_check_test_command "$TS_HELPER_MKFDS"
+
+ts_cd "$TS_OUTDIR"
+
+EXPR='(NAME =~ "/SYSV.*")'
+ts_init_subtest SysVIPC-shmem
+{
+    coproc MKFDS { "$TS_HELPER_MKFDS" sysvshm; }
+    if read -u ${MKFDS[0]} PID; then
+	${TS_CMD_LSFD} -p "$PID" -n -o ASSOC,SOURCE -Q "${EXPR}"
+	echo 'ASSOC,SOURCE': $?
+	kill -CONT ${PID}
+    fi
+    wait ${MKFDS_PID}
+} > "$TS_OUTPUT" 2>&1
+ts_finalize_subtest
+
+ts_finalize


### PR DESCRIPTION
An example output:
```
COMMAND        PID USER  ASSOC MODE TYPE SOURCE MNTID      INODE NAME
test_mkfds 3428907  jet cgroup  ---  REG   nsfs     0 4026531835 cgroup:[4026531835]
test_mkfds 3428907  jet    ipc  ---  REG   nsfs     0 4026531839 ipc:[4026531839]
test_mkfds 3428907  jet    mnt  ---  REG   nsfs     0 4026531841 mnt:[4026531841]
test_mkfds 3428907  jet    net  ---  REG   nsfs     0 4026531840 net:[4026531840]
test_mkfds 3428907  jet    pid  ---  REG   nsfs     0 4026531836 pid:[4026531836]
test_mkfds 3428907  jet  pid4c  ---  REG   nsfs     0 4026531836 pid:[4026531836]
test_mkfds 3428907  jet   time  ---  REG   nsfs     0 4026531834 time:[4026531834]
test_mkfds 3428907  jet time4c  ---  REG   nsfs     0 4026531834 time:[4026531834]
test_mkfds 3428907  jet   user  ---  REG   nsfs     0 4026531837 user:[4026531837]
test_mkfds 3428907  jet    uts  ---  REG   nsfs     0 4026531838 uts:[4026531838]
test_mkfds 3428907  jet    shm  r--  REG  tmpfs     0   40173571 /SYSV00000000 (deleted)
```