### PR TITLE
ci: build with GCC 13 / clang 16

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -24,8 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - { COMPILER: "gcc",   COMPILER_VERSION: "10", SANITIZE: "yes"  }
-          - { COMPILER: "gcc",   COMPILER_VERSION: "10", SANITIZE: "no"   }
+          # gcc-13 has false-positives with ubsan
+          - { COMPILER: "gcc",   COMPILER_VERSION: "11", SANITIZE: "yes"  }
+          - { COMPILER: "gcc",   COMPILER_VERSION: "13", SANITIZE: "no"   }
           - { COMPILER: "clang", COMPILER_VERSION: "15", SANITIZE: "yes"  }
           - { COMPILER: "clang", COMPILER_VERSION: "15", SANITIZE: "no"   }
     env: ${{ matrix.env }}

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -27,8 +27,8 @@ jobs:
           # gcc-13 has false-positives with ubsan
           - { COMPILER: "gcc",   COMPILER_VERSION: "11", SANITIZE: "yes"  }
           - { COMPILER: "gcc",   COMPILER_VERSION: "13", SANITIZE: "no"   }
-          - { COMPILER: "clang", COMPILER_VERSION: "15", SANITIZE: "yes"  }
-          - { COMPILER: "clang", COMPILER_VERSION: "15", SANITIZE: "no"   }
+          - { COMPILER: "clang", COMPILER_VERSION: "16", SANITIZE: "yes"  }
+          - { COMPILER: "clang", COMPILER_VERSION: "16", SANITIZE: "no"   }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout


### PR DESCRIPTION
Newer releases of GCC 13 have reigned in the false positives, so use it for CI now.