### PR TITLE
Increase buffer size for read() of /dev/kmsg to match PRINTK_MESSAGE_MAX

### DIFF
--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -179,7 +179,13 @@ struct dmesg_control {
 
 	int		kmsg;		/* /dev/kmsg file descriptor */
 	ssize_t		kmsg_first_read;/* initial read() return code */
-	char		kmsg_buf[BUFSIZ];/* buffer to read kmsg data */
+	/*
+	 * the kernel will give EINVAL if we do read() on /proc/kmsg with
+	 * length insufficient for the next message. messages may be up to
+	 * PRINTK_MESSAGE_MAX, which is defined as 2048, so we must be
+	 * able to buffer at least that much in one call
+	 */
+	char		kmsg_buf[2048]; /* buffer to read kmsg data */
 
 	usec_t		since;		/* filter records by time */
 	usec_t		until;		/* filter records by time */


### PR DESCRIPTION
In Linux 6.3.4, with a kernel build with a relatively long kernel command-line, `dmesg` fails to print the `Kernel command line: ...` line and all subsequent lines of kernel logs. `strace dmesg` shows `read(3, 0xaaaae0150090, 1023)           = -1 EINVAL (Invalid argument)` at this point: passing a 1kB buffer is not sufficient to hold the line (using `strace cat /dev/kmsg` instead shows this `read()` call to read 1031B).

It seems dmesg hard-codes whatever the libc defines as `BUFSIZ`, but it should use a value that matches the kernel's idea of how large a kernel log message can be. I believe `PRINTK_MESSAGE_MAX` is the appropriate limit: per [this message](https://lore.kernel.org/lkml/20230105103735.880956-9-john.ogness@linutronix.de/):

> PRINTK_MESSAGE_MAX:
> 
> This is the maximum size for a formatted message on a console,
devkmsg, or syslog. It does not matter which format the message has
(normal or extended). It replaces the use of CONSOLE_EXT_LOG_MAX for
console and devkmsg. It replaces the use of CONSOLE_LOG_MAX for
syslog.
> 
> Historically, normal messages have been allowed to print up to 1kB,
whereas extended messages have been allowed to print up to 8kB.
However, the difference in lengths of these message types is not
significant and in multi-line records, normal messages are probably
larger. Also, because 1kB is only slightly above the allowed record
size, multi-line normal messages could be easily truncated during
formatting.
> 
> This new macro should be significantly larger than the allowed
record size to allow sufficient space for extended or multi-line
prefix text. A value of 2kB should be plenty of space. For normal
messages this represents a doubling of the historically allowed
amount. For extended messages it reduces the excessive 8kB size,
thus reducing memory usage needed for message formatting.
