### PR TITLE
test_enosys: fix build on old kernels

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -1158,3 +1158,9 @@ function ts_is_virt {
 	done
 	return 1
 }
+
+function ts_check_enosys_syscalls {
+	ts_check_test_command "$TS_CMD_ENOSYS"
+	"$TS_CMD_ENOSYS" ${@/#/-s } true 2> /dev/null
+	[ $? -ne 0 ] && ts_skip "test_enosys does not work: $*"
+}

--- a/tests/ts/misc/enosys
+++ b/tests/ts/misc/enosys
@@ -20,11 +20,8 @@ TS_DESC="enosys"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
-ts_check_test_command "$TS_CMD_ENOSYS"
 ts_check_test_command "$TS_HELPER_ENOSYS"
-
-"$TS_CMD_ENOSYS" true 2> /dev/null
-[ "$?" -eq "$TS_EXIT_NOTSUPP" ] && ts_skip "enosys does not work"
+ts_check_enosys_syscalls fallocate fsopen execve
 
 ts_init_subtest basic
 

--- a/tests/ts/mount/fallback
+++ b/tests/ts/mount/fallback
@@ -6,15 +6,13 @@ TS_DESC="fstab-fallback"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
-ts_check_test_command "$TS_CMD_ENOSYS"
 ts_check_test_command "$TS_CMD_MOUNT"
 ts_check_test_command "$TS_CMD_UMOUNT"
 ts_check_test_command "$TS_CMD_FINDMNT"
 ts_check_test_command "$TS_CMD_LOSETUP"
+ts_check_enosys_syscalls open_tree fsopen mount_setattr
 
 ts_skip_nonroot
-"$TS_CMD_ENOSYS" true 2> /dev/null
-[ "$?" -eq "$TS_EXIT_NOTSUPP" ] && ts_skip "enosys does not work"
 
 test_mount_fallback() {
 	ts_init_subtest "$1"


### PR DESCRIPTION
Fixes #2277

The same for 2.39:

https://github.com/t-8ch/util-linux/commit/c80840e3a4938a4d599ed0e84d673794e048d0b3