### PR TITLE
libblkid: jfs - avoid undefined shift

### DIFF
--- a/libblkid/src/superblocks/jfs.c
+++ b/libblkid/src/superblocks/jfs.c
@@ -41,7 +41,7 @@ static int probe_jfs(blkid_probe pr, const struct blkid_idmag *mag)
 	js = blkid_probe_get_sb(pr, mag, struct jfs_super_block);
 	if (!js)
 		return errno ? -errno : 1;
-	if (le16_to_cpu(js->js_l2bsize) > 32 || le16_to_cpu(js->js_l2pbsize) > 32)
+	if (le16_to_cpu(js->js_l2bsize) > 31 || le16_to_cpu(js->js_l2pbsize) > 31)
 		return 1;
 	if (le32_to_cpu(js->js_bsize) != (1U << le16_to_cpu(js->js_l2bsize)))
 		return 1;


### PR DESCRIPTION
Fix previous commit 04a0717b0b0faa1a8078dc6fad05183b8bada395 to avoid undefined shift if value is exactly 32.

  libblkid/src/superblocks/jfs.c:46:39: runtime error:
  shift exponent 32 is too large for 32-bit type 'unsigned int'

Reproducer found with OSS-Fuzz (issue 59284) running over cryptsetup project (blkid is used in header init).