### PR TITLE
test_enosys.c: support PPC, MIPS, MIPS64

### DIFF
--- a/tests/helpers/test_enosys.c
+++ b/tests/helpers/test_enosys.c
@@ -47,12 +47,18 @@
 # 	 define SECCOMP_ARCH_NATIVE AUDIT_ARCH_S390
 #elif __s390x__
 # 	 define SECCOMP_ARCH_NATIVE AUDIT_ARCH_S390X
+#elif __PPC__
+#        define SECCOMP_ARCH_NATIVE AUDIT_ARCH_PPC
 #elif __PPC64__
 #    if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 # 	 define SECCOMP_ARCH_NATIVE AUDIT_ARCH_PPC64
 #    else
 # 	 define SECCOMP_ARCH_NATIVE AUDIT_ARCH_PPC64LE
 #    endif
+#elif __mips__
+#        define SECCOMP_ARCH_NATIVE AUDIT_ARCH_MIPS
+#elif __mips64__
+#        define SECCOMP_ARCH_NATIVE AUDIT_ARCH_MIPS64
 #else
 #    error Unknown target architecture
 #endif


### PR DESCRIPTION
Currently, only PPC64 (not PPC) is listed in test_enosys.c, and MIPS/MIPS64 aren't present either. When attempting to build util-linux 2.39 into an image for one of these targets with the Yocto Project tools, errors like the following are encountered:

| mips-poky-linux-gcc  -meb -mabi=32 -mhard-float -march=mips32r2 -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64 --sysroot=/home/pokybuild/yocto-worker/qemumips/build/build/tmp/work/mips32r2-poky-linux/util-linux/2.39-r0/recipe-sysroot -DHAVE_CONFIG_H -I. -I../util-linux-2.39  -include config.h -I../util-linux-2.39/include -DLOCALEDIR=\"/usr/share/locale\" -D_PATH_RUNSTATEDIR=\"/run\" -D_PATH_SYSCONFSTATICDIR=\"/usr/lib\"    -fsigned-char -fno-common -Wall -Wextra -Waddress-of-packed-member -Wdiscarded-qualifiers -Wformat-security -Wimplicit-function-declaration -Wmissing-declarations -Wmissing-parameter-type -Wmissing-prototypes -Wnested-externs -Wno-missing-field-initializers -Wold-style-definition -Wpointer-arith -Wredundant-decls -Wsign-compare -Wstrict-prototypes -Wtype-limits -Wuninitialized -Wunused-but-set-parameter -Wunused-but-set-variable -Wunused-parameter -Wunused-result -Wunused-variable -Werror=sequence-point -O2 -pipe -g -feliminate-unused-debug-types -fcanon-prefix-map  -fmacro-prefix-map=/home/pokybuild/yocto-worker/qemumips/build/build/tmp/work/mips32r2-poky-linux/util-linux/2.39-r0/util-linux-2.39=/usr/src/debug/util-linux/2.39-r0  -fdebug-prefix-map=/home/pokybuild/yocto-worker/qemumips/build/build/tmp/work/mips32r2-poky-linux/util-linux/2.39-r0/util-linux-2.39=/usr/src/debug/util-linux/2.39-r0  -fmacro-prefix-map=/home/pokybuild/yocto-worker/qemumips/build/build/tmp/work/mips32r2-poky-linux/util-linux/2.39-r0/build=/usr/src/debug/util-linux/2.39-r0  -fdebug-prefix-map=/home/pokybuild/yocto-worker/qemumips/build/build/tmp/work/mips32r2-poky-linux/util-linux/2.39-r0/build=/usr/src/debug/util-linux/2.39-r0  -fdebug-prefix-map=/home/pokybuild/yocto-worker/qemumips/build/build/tmp/work/mips32r2-poky-linux/util-linux/2.39-r0/recipe-sysroot=  -fmacro-prefix-map=/home/pokybuild/yocto-worker/qemumips/build/build/tmp/work/mips32r2-poky-linux/util-linux/2.39-r0/recipe-sysroot=  -fdebug-prefix-map=/home/pokybuild/yocto-worker/qemumips/build/build/tmp/work/mips32r2-poky-linux/util-linux/2.39-r0/recipe-sysroot-native=  -c -o tests/helpers/test_enosys.o ../util-linux-2.39/tests/helpers/test_enosys.c
| ../util-linux-2.39/tests/helpers/test_enosys.c:57:6: error: #error Unknown target architecture
|    57 | #    error Unknown target architecture
|       |      ^~~~~
| make: *** [Makefile:10075: tests/helpers/test_enosys.o] Error 1
| ERROR: oe_runmake failed

This patch adds defines for these three architectures. No endianness check was added for PPC because PPCLE is not supported by audit.