### PR TITLE
move error messages to hooksets

### DIFF
--- a/include/strutils.h
+++ b/include/strutils.h
@@ -388,6 +388,8 @@ static inline void strrem(char *s, int rem)
 	*p = '\0';
 }
 
+extern int errsnprint(char *buf, size_t bufsz, int errnum, const char *fmt, ...);
+
 extern char *strnconcat(const char *s, const char *suffix, size_t b);
 extern char *strconcat(const char *s, const char *suffix);
 extern char *strfconcat(const char *s, const char *format, ...)

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -1217,6 +1217,27 @@ int ul_optstr_next(char **optstr, char **name, size_t *namesz,
 	return 1;				/* end of optstr */
 }
 
+int errsnprint(char *buf, size_t bufsz, int errnum, const char *fmt, ...)
+{
+	int errsv, re;
+	va_list ap;
+
+	if (!buf || !bufsz)
+		return 0;
+
+	va_start(ap, fmt);
+
+	errsv = errno;
+	errno = errnum;
+
+	re = vsnprintf(buf, bufsz, fmt, ap);
+
+	va_end(ap);
+	errno = errsv;
+
+	return re;
+}
+
 #ifdef TEST_PROGRAM_STRUTILS
 
 #include "cctype.h"

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -60,7 +60,7 @@ struct libmnt_context *mnt_new_context(void)
 	ruid = getuid();
 	euid = geteuid();
 
-	mnt_context_reset_status(cxt);
+	mnt_context_reset_failure(cxt);
 
 	cxt->ns_orig.fd = -1;
 	cxt->ns_tgt.fd = -1;
@@ -170,7 +170,7 @@ int mnt_reset_context(struct libmnt_context *cxt)
 	cxt->map_linux = mnt_get_builtin_optmap(MNT_LINUX_MAP);
 	cxt->map_userspace = mnt_get_builtin_optmap(MNT_USERSPACE_MAP);
 
-	mnt_context_reset_status(cxt);
+	mnt_context_reset_failure(cxt);
 	mnt_context_deinit_hooksets(cxt);
 
 	if (cxt->table_fltrcb)
@@ -283,7 +283,7 @@ struct libmnt_context *mnt_copy_context(struct libmnt_context *o)
 	n->map_linux = o->map_linux;
 	n->map_userspace = o->map_userspace;
 
-	mnt_context_reset_status(n);
+	mnt_context_reset_failure(n);
 
 	n->table_fltrcb = o->table_fltrcb;
 	n->table_fltrcb_data = o->table_fltrcb_data;
@@ -314,9 +314,7 @@ int mnt_context_reset_status(struct libmnt_context *cxt)
 	if (!cxt)
 		return -EINVAL;
 
-	cxt->syscall_status = 1;		/* means not called yet */
-	cxt->helper_exec_status = 1;
-	cxt->helper_status = 0;
+	mnt_context_reset_failure(cxt);
 	return 0;
 }
 
@@ -2570,6 +2568,8 @@ int mnt_context_set_syscall_status(struct libmnt_context *cxt, int status)
 	if (!cxt)
 		return -EINVAL;
 
+	mnt_context_reset_failure(cxt);
+
 	DBG(CXT, ul_debugobj(cxt, "syscall status set to: %d", status));
 	cxt->syscall_status = status;
 	return 0;
@@ -2589,7 +2589,6 @@ int mnt_context_strerror(struct libmnt_context *cxt __attribute__((__unused__)),
 			 char *buf __attribute__((__unused__)),
 			 size_t bufsiz __attribute__((__unused__)))
 {
-	/* TODO: based on cxt->syscall_errno or cxt->helper_status */
 	return 0;
 }
 

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1524,9 +1524,8 @@ int mnt_context_get_mount_excode(
 
 
 	/* generic fallback */
-	if (buf)
-		errsnprint(buf, bufsz, mnt_context_get_syscall_errno(cxt),
-				_("mount failed: %m"));
+	if (buf && cxt->failure_errno)
+		errsnprint(buf, bufsz, cxt->failure_errno, _("mount failed: %m"));
 
 	return MNT_EX_FAIL;
 }

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -508,7 +508,7 @@ static int do_mount(struct libmnt_context *cxt, const char *try_type)
 	assert(cxt->fs);
 	assert((cxt->flags & MNT_FL_MOUNTFLAGS_MERGED));
 
-	mnt_context_reset_status(cxt);
+	mnt_context_reset_failure(cxt);
 
 	if (try_type) {
 		rc = mnt_context_prepare_helper(cxt, "mount", try_type);
@@ -749,6 +749,7 @@ int mnt_context_prepare_mount(struct libmnt_context *cxt)
 	if (cxt->flags & MNT_FL_PREPARED)
 		return 0;
 
+	/* make sure not nothing executed yet */
 	assert(cxt->helper_exec_status == 1);
 	assert(cxt->syscall_status == 1);
 
@@ -1039,7 +1040,7 @@ again:
 			assert(!(cxt->flags & MNT_FL_FORCED_RDONLY));
 			DBG(CXT, ul_debugobj(cxt, "write-protected source, trying RDONLY."));
 
-			mnt_context_reset_status(cxt);
+			mnt_context_reset_failure(cxt);
 			mnt_context_set_mflags(cxt, mflags | MS_RDONLY);
 			cxt->flags |= MNT_FL_FORCED_RDONLY;
 			goto again;
@@ -1722,8 +1723,7 @@ int mnt_context_get_mount_excode(
 	generic_error:
 		if (buf) {
 			errno = syserr;
-			snprintf(buf, bufsz, _("%s system call failed: %m"),
-					cxt->syscall_name ? : "mount");
+			snprintf(buf, bufsz, _("mount failed: %m"));
 		}
 		break;
 	}

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1455,14 +1455,6 @@ int mnt_context_get_mount_excode(
 						_("failed to parse mount options"));
 			}
 			return MNT_EX_USAGE;
-		case -MNT_ERR_LOOPDEV:
-			if (buf)
-				snprintf(buf, bufsz, _("failed to setup loop device for %s"), src);
-			return MNT_EX_FAIL;
-		case -MNT_ERR_LOOPOVERLAP:
-			if (buf)
-				snprintf(buf, bufsz, _("overlapping loop device exists for %s"), src);
-			return MNT_EX_FAIL;
 		case -MNT_ERR_LOCK:
 			if (buf)
 				snprintf(buf, bufsz, _("locking failed"));

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1350,47 +1350,6 @@ int mnt_context_next_remount(struct libmnt_context *cxt,
 	return rc;
 }
 
-/*
- * Returns 1 if @dir parent is shared
- */
-static int is_shared_tree(struct libmnt_context *cxt, const char *dir)
-{
-	struct libmnt_table *tb = NULL;
-	struct libmnt_fs *fs;
-	unsigned long mflags = 0;
-	char *mnt = NULL, *p;
-	int rc = 0;
-	struct libmnt_ns *ns_old;
-
-	ns_old = mnt_context_switch_target_ns(cxt);
-	if (!ns_old)
-		return -MNT_ERR_NAMESPACE;
-
-	if (!dir)
-		return 0;
-	if (mnt_context_get_mountinfo(cxt, &tb) || !tb)
-		goto done;
-
-	mnt = strdup(dir);
-	if (!mnt)
-		goto done;
-	p = strrchr(mnt, '/');
-	if (!p)
-		goto done;
-	if (p > mnt)
-		*p = '\0';
-	fs = mnt_table_find_mountpoint(tb, mnt, MNT_ITER_BACKWARD);
-
-	rc = fs && mnt_fs_is_kernel(fs)
-		&& mnt_fs_get_propagation(fs, &mflags) == 0
-		&& (mflags & MS_SHARED);
-done:
-	free(mnt);
-	if (!mnt_context_switch_ns(cxt, ns_old))
-		return -MNT_ERR_NAMESPACE;
-	return rc;
-}
-
 int mnt_context_get_mount_excode(
 			struct libmnt_context *cxt,
 			int rc,
@@ -1628,7 +1587,7 @@ int mnt_context_get_mount_excode(
 			snprintf(buf, bufsz, _("mount point not mounted or bad option"));
 		else if (rc == -MNT_ERR_APPLYFLAGS)
 			snprintf(buf, bufsz, _("not mount point or bad option"));
-		else if ((mflags & MS_MOVE) && is_shared_tree(cxt, src))
+		else if ((mflags & MS_MOVE) && mnt_is_shared_tree(cxt, src))
 			snprintf(buf, bufsz,
 				_("bad option; moving a mount "
 				  "residing under a shared mount is unsupported"));

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1383,6 +1383,15 @@ int mnt_context_get_mount_excode(
 		return MNT_EX_SUCCESS;
 	}
 
+	/*
+	 * Errors from hooks
+	 */
+	if (cxt->failure_hookset && cxt->failure_hookset->mkerrmsg) {
+		rc = cxt->failure_hookset->mkerrmsg(cxt, cxt->failure_hookset, buf, bufsz);
+		if (rc >= 0)
+			return rc;
+	}
+
 	mnt_context_get_mflags(cxt, &mflags);		/* mount(2) flags */
 	mnt_context_get_user_mflags(cxt, &uflags);	/* userspace flags */
 

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -102,6 +102,8 @@ extern int mnt_valid_tagname(const char *tagname);
 extern const char *mnt_statfs_get_fstype(struct statfs *vfs);
 extern int is_file_empty(const char *name);
 
+extern int mnt_is_shared_tree(struct libmnt_context *cxt, const char *dir);
+
 extern int mnt_is_readonly(const char *path)
 			__attribute__((nonnull));
 

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -681,6 +681,8 @@ extern int mnt_context_get_mountinfo(struct libmnt_context *cxt, struct libmnt_t
 extern int mnt_context_get_mountinfo_for_target(struct libmnt_context *cxt,
 				    struct libmnt_table **mountinfo, const char *tgt);
 
+extern struct libmnt_fs *mnt_context_get_already_mounted(struct libmnt_context *cxt);
+
 extern int mnt_context_prepare_srcpath(struct libmnt_context *cxt);
 extern int mnt_context_guess_srcpath_fstype(struct libmnt_context *cxt, char **type);
 extern int mnt_context_guess_fstype(struct libmnt_context *cxt);

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -564,6 +564,8 @@ extern const struct libmnt_optmap *mnt_optmap_get_entry(
                              size_t namelen,
 			     const struct libmnt_optmap **mapent);
 
+extern const char *mnt_optmap_get_entry_name(struct libmnt_optmap const *map, int id);
+
 /* optstr.c */
 extern int mnt_optstr_remove_option_at(char **optstr, char *begin, char *end);
 

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -312,6 +312,8 @@ struct libmnt_hookset {
 	int firststage;
 	int (*firstcall)(struct libmnt_context *, const struct libmnt_hookset *, void *);
 
+	int (*mkerrmsg)(struct libmnt_context *, const struct libmnt_hookset *, char *buf, size_t bufsiz);
+
 	int (*deinit)(struct libmnt_context *, const struct libmnt_hookset *);	/* cleanup function */
 };
 

--- a/libmount/src/optmap.c
+++ b/libmount/src/optmap.c
@@ -270,3 +270,17 @@ const struct libmnt_optmap *mnt_optmap_get_entry(
 	return NULL;
 }
 
+const char *mnt_optmap_get_entry_name(struct libmnt_optmap const *map, int id)
+{
+	const struct libmnt_optmap *ent;
+
+	if (!map)
+		return NULL;
+
+	for (ent = map; ent && ent->name; ent++) {
+		if (ent->id == id)
+			return ent->name;
+	}
+	return NULL;
+}
+


### PR DESCRIPTION
Now libmount supports many syscalls, additional modules (etc.), and it does not make sense to maintain all error messages in one huge function. This PR adds the possibility to maintain code and error messages in "hooksets" in one place.

Later we can add more specific error messages to other places (id-mapping, verity, ...).