### PR TITLE
nsenter: add option `-c` to join the cgroup of target process

### DIFF
--- a/bash-completion/nsenter
+++ b/bash-completion/nsenter
@@ -53,6 +53,7 @@ _nsenter_module()
 				--wdns=
 				--env
 				--no-fork
+				--join-cgroup
 				--help
 				--version
 			"

--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -226,5 +226,7 @@
 #define _PATH_DEV_RFKILL	"/dev/rfkill"
 #define _PATH_SYS_RFKILL	"/sys/class/rfkill"
 
+/* cgroup path */
+#define _PATH_SYS_CGROUP	"/sys/fs/cgroup"
 
 #endif /* PATHNAMES_H */

--- a/sys-utils/nsenter.1.adoc
+++ b/sys-utils/nsenter.1.adoc
@@ -141,6 +141,9 @@ Do not fork before exec'ing the specified program. By default, when entering a P
 *-Z*, *--follow-context*::
 Set the SELinux security context used for executing a new process according to already running process specified by *--target* PID. (The util-linux has to be compiled with SELinux support otherwise the option is unavailable.)
 
+*-c*, *--join-cgroup*::
+Add the initiated process to the cgroup of the target process.
+
 include::man-common/help-version.adoc[]
 
 == NOTES


### PR DESCRIPTION
This commit adds support for the -c or --join-cgroup option in nsenter, allowing a new process to join the cgroup of target process.

```
Example:
    Setup the target process:
        $ podman run --rm -d docker.io/golang sleep 10000
        51a89deb6baf6d
        $ podman inspect --format '{{ .State.Pid }}' 51a89deb6baf6d6
        216054

    Enter the cgroup namespace of target process without option -c:
        $ sudo ./nsenter -C -U -t 216054 sh -c "cat /proc/self/cgroup"
        0::/../../../../session-899.scope

    Enter the cgroup namespace of target process with option -c:
        $ sudo ./nsenter -c -C -U -t 216054 sh -c "cat /proc/self/cgroup"
        0::/
```