### PR TITLE
More helpful message for losetup to display.

### DIFF
--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -552,7 +552,7 @@ static int create_loop(struct loopdev_cxt *lc,
 		 * loopcxt struct.
 		 */
 		if (!hasdev && (rc = loopcxt_find_unused(lc))) {
-			warnx(_("cannot find an unused loop device"));
+			warnx(_("cannot find an unused loop device or permision denied"));
 			break;
 		}
 		if (flags & LOOPDEV_FL_OFFSET)
@@ -878,7 +878,7 @@ int main(int argc, char **argv)
 			else
 				errno = errsv;
 
-			warn(_("cannot find an unused loop device"));
+			warn(_("cannot find an unused loop device or permission denied"));
 		} else
 			printf("%s\n", loopcxt_get_device(&lc));
 		break;


### PR DESCRIPTION
## Description

losetup emits a misleading error message which could be made more helpful.

To demonstrate that it's not just my issue:

* [losetup: cannot find an unused loop device](https://unix.stackexchange.com/questions/396765/losetup-cannot-find-an-unused-loop-device)
* [losetup: cannot find an unused loop device , kernel config](https://lists.debian.org/debian-user/2021/08/msg00363.html)
* [losetup: cannot find an unused loop device](https://askubuntu.com/questions/1424093/losetup-cannot-find-an-unused-loop-device)

I could go on but I'm hoping I made my point that this issue has widespread impact.

## Reproducing

```
$ losetup --show --find rootfs.ext3
losetup: cannot find an unused loop device

$ sudo losetup --show --find rootfs.ext3
/dev/loop15
```

## Expected

losetup emits a message that indicates permission was denied when permissions are insufficient

## Actual

losetup emits a message that suggests that there is a shortage of loop devices.
