### PR TITLE
tests: (run.sh) detect builddir from working directory

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -156,6 +156,8 @@ if [ -z "$top_builddir" ]; then
 	top_builddir="$TS_TOPDIR/.."
 	if [ -e "$top_builddir/build/meson.conf" ]; then
 		top_builddir="$TS_TOPDIR/../build"
+	elif [ -e "$PWD/meson.conf" ]; then
+		top_builddir="$PWD"
 	fi
 fi
 


### PR DESCRIPTION
This makes it easier to run test.sh from the build directory as everything will work without any parameters irrespective of the build directories name.