### PR TITLE
include/bitops.h: Remove bswap* compatibility hack for FreeBSD

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -31,7 +31,7 @@
 # define be16toh(x) betoh16(x)
 # define be32toh(x) betoh32(x)
 # define be64toh(x) betoh64(x)
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__NetBSD__) || defined(__DragonFly__)
 # define bswap_16(x) bswap16(x)
 # define bswap_32(x) bswap32(x)
 # define bswap_64(x) bswap64(x)


### PR DESCRIPTION
This is no longer needed on supported versions of FreeBSD and causes build failures