### PR TITLE
libmount: fix typo

### DIFF
--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -463,7 +463,7 @@ static int hook_set_propagation(struct libmnt_context *cxt,
 			(uint64_t) attr.propagation));
 
 		rc = mount_setattr(api->fd_tree, "", flgs, &attr, sizeof(attr));
-		set_syscall_status(cxt, "move_setattr", rc == 0);
+		set_syscall_status(cxt, "mount_setattr", rc == 0);
 
 		if (rc && errno == EINVAL)
 			return -MNT_ERR_APPLYFLAGS;


### PR DESCRIPTION
Similar to e80f8e46127e45907db25b4ffd58c699fdf4c35f and fallout from 6753e6f6912658e836966a6316df956e1af5fcae