### PR TITLE
libmount: update documentation for MNT_ERR_APPLYFLAGS

### DIFF
--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -188,7 +188,8 @@ enum {
 /**
  * MNT_ERR_APPLYFLAGS:
  *
- * failed to apply MS_PROPAGATION flags
+ * failed to apply MS_PROPAGATION flags, and MOUNT_ATTR_* attributes for
+ * mount_setattr(2)
  */
 #define MNT_ERR_APPLYFLAGS   5005
 /**


### PR DESCRIPTION
The implementation using the new FD based mount kernel API (ie., fsconfig/fsopen) uses MNT_ERR_APPLYFLAGS for failed mount_setattr(2) calls, which involves more mount attributes (eg., MOUNT_ATTR_RDONLY, MOUNT_ATTR_NOSUID, etc.) in addition to the MS_PROPAGATION flags (eg., MS_SHARED, MS_UNBINDABLE, etc.).

Note that mount_setattr(2) is part of the new FD based mount kernel API, and is not used by the classic mount(2) based version.

Fallout from 987d844cdbc0f91ca81de3c1e5d0628a60eb458f