### PR TITLE
prlimit: reject trailing junk in limits without ":"

### DIFF
--- a/sys-utils/prlimit.c
+++ b/sys-utils/prlimit.c
@@ -455,8 +455,10 @@ static int get_range(char *str, rlim_t *soft, rlim_t *hard, int *found)
 		}
 		*found |= PRLIMIT_SOFT | PRLIMIT_HARD;
 
-	} else						/* <value> */
+	} else if (!*end)				/* <value> */
 		*found |= PRLIMIT_SOFT | PRLIMIT_HARD;
+	else
+		return -1;
 
 	return 0;
 }


### PR DESCRIPTION
Before:

```console
$ prlimit --verbose --core=1x
New CORE limit for pid 42: <1:1>
```

After:

```console
$ prlimit --verbose --core=1x
prlimit: failed to parse CORE limit
```