### PR TITLE
lsclocks: implement REL_TIME column

### DIFF
--- a/bash-completion/lsclocks
+++ b/bash-completion/lsclocks
@@ -15,6 +15,9 @@ _lsclocks_module()
 		'-o'|'--output')
 			return 0
 			;;
+		'--output-all')
+			return 0
+			;;
 		'-r'|'--raw')
 			return 0
 			;;
@@ -32,6 +35,7 @@ _lsclocks_module()
 			OPTS="--json
 				--noheadings
 				--output
+				--output-all
 				--raw
 				--time
 				--help

--- a/include/timeutils.h
+++ b/include/timeutils.h
@@ -78,6 +78,7 @@ int strtimeval_iso(const struct timeval *tv, int flags, char *buf, size_t bufsz)
 int strtm_iso(const struct tm *tm, int flags, char *buf, size_t bufsz);
 int strtime_iso(const time_t *t, int flags, char *buf, size_t bufsz);
 int strtimespec_iso(const struct timespec *t, int flags, char *buf, size_t bufsz);
+int strtimespec_relative(const struct timespec *ts, char *buf, size_t bufsz);
 
 #define UL_SHORTTIME_THISYEAR_HHMM (1 << 1)
 

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -689,7 +689,7 @@ static int run_unittest_timestamp(void)
 
 int main(int argc, char *argv[])
 {
-	struct timeval tv = { 0 };
+	struct timespec ts = { 0 };
 	char buf[ISO_BUFSIZ];
 
 	if (argc < 2) {
@@ -705,25 +705,26 @@ int main(int argc, char *argv[])
 		usec_t usec = 0;
 
 		parse_timestamp(argv[2], &usec);
-		tv.tv_sec = (time_t) (usec / 1000000);
-		tv.tv_usec = usec % 1000000;
+		ts.tv_sec = (time_t) (usec / USEC_PER_SEC);
+		ts.tv_nsec = (usec % USEC_PER_SEC) * NSEC_PER_USEC;
 	} else {
-		tv.tv_sec = strtos64_or_err(argv[1], "failed to parse <time>");
+		ts.tv_sec = strtos64_or_err(argv[1], "failed to parse <time>");
 		if (argc == 3)
-			tv.tv_usec = strtos64_or_err(argv[2], "failed to parse <usec>");
+			ts.tv_nsec = strtos64_or_err(argv[2], "failed to parse <usec>")
+				     * NSEC_PER_USEC;
 	}
 
-	strtimeval_iso(&tv, ISO_DATE, buf, sizeof(buf));
+	strtimespec_iso(&ts, ISO_DATE, buf, sizeof(buf));
 	printf("Date: '%s'\n", buf);
 
-	strtimeval_iso(&tv, ISO_TIME, buf, sizeof(buf));
+	strtimespec_iso(&ts, ISO_TIME, buf, sizeof(buf));
 	printf("Time: '%s'\n", buf);
 
-	strtimeval_iso(&tv, ISO_DATE | ISO_TIME | ISO_COMMAUSEC | ISO_T,
+	strtimespec_iso(&ts, ISO_DATE | ISO_TIME | ISO_COMMAUSEC | ISO_T,
 		       buf, sizeof(buf));
 	printf("Full: '%s'\n", buf);
 
-	strtimeval_iso(&tv, ISO_TIMESTAMP_DOT, buf, sizeof(buf));
+	strtimespec_iso(&ts, ISO_TIMESTAMP_DOT, buf, sizeof(buf));
 	printf("Zone: '%s'\n", buf);
 
 	return EXIT_SUCCESS;

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -617,6 +617,63 @@ int strtime_short(const time_t *t, struct timeval *now, int flags, char *buf, si
 	return rc <= 0 ? -1 : 0;
 }
 
+int strtimespec_relative(const struct timespec *ts, char *buf, size_t bufsz)
+{
+	time_t secs = ts->tv_sec;
+	size_t i, parts = 0;
+	int rc;
+
+	if (bufsz)
+		buf[0] = '\0';
+
+	static const struct {
+		const char * const suffix;
+		int width;
+		int64_t secs;
+	} table[] = {
+		{ "y", 4, NSEC_PER_YEAR   / NSEC_PER_SEC },
+		{ "d", 3, NSEC_PER_DAY    / NSEC_PER_SEC },
+		{ "h", 2, NSEC_PER_HOUR   / NSEC_PER_SEC },
+		{ "m", 2, NSEC_PER_MINUTE / NSEC_PER_SEC },
+		{ "s", 2, NSEC_PER_SEC    / NSEC_PER_SEC },
+	};
+
+	for (i = 0; i < ARRAY_SIZE(table); i++) {
+		if (secs >= table[i].secs) {
+			rc = snprintf(buf, bufsz,
+				      "%*"PRId64"%s%s",
+				      parts ? table[i].width : 0,
+				      secs / table[i].secs, table[i].suffix,
+				      secs % table[i].secs ? " " : "");
+			if (rc < 0 || (size_t) rc > bufsz)
+				goto err;
+			parts++;
+			buf += rc;
+			bufsz -= rc;
+			secs %= table[i].secs;
+		}
+	}
+
+	if (ts->tv_nsec) {
+		if (ts->tv_nsec % NSEC_PER_MSEC) {
+			rc = snprintf(buf, bufsz, "%*luns",
+				      parts ? 10 : 0, ts->tv_nsec);
+			if (rc < 0 || (size_t) rc > bufsz)
+				goto err;
+		} else {
+			rc = snprintf(buf, bufsz, "%*llums",
+				      parts ? 4 : 0, ts->tv_nsec / NSEC_PER_MSEC);
+			if (rc < 0 || (size_t) rc > bufsz)
+				goto err;
+		}
+	}
+
+	return 0;
+ err:
+	warnx(_("format_reltime: buffer overflow."));
+	return -1;
+}
+
 #ifndef HAVE_TIMEGM
 time_t timegm(struct tm *tm)
 {
@@ -727,6 +784,53 @@ static int run_unittest_format(void)
 	return rc;
 }
 
+static int run_unittest_format_relative(void)
+{
+	int rc = EXIT_SUCCESS;
+	char buf[FORMAT_TIMESTAMP_MAX];
+	static const struct testcase {
+		struct timespec ts;
+		const char * const expected;
+	} testcases[] = {
+		{{}, "" },
+		{{         1 },                  "1s" },
+		{{        10 },                 "10s" },
+		{{       100 },              "1m 40s" },
+		{{      1000 },             "16m 40s" },
+		{{     10000 },          "2h 46m 40s" },
+		{{    100000 },      "1d  3h 46m 40s" },
+		{{   1000000 },     "11d 13h 46m 40s" },
+		{{  10000000 },    "115d 17h 46m 40s" },
+		{{ 100000000 }, "3y  61d 15h 46m 40s" },
+		{{        60 },                  "1m" },
+		{{      3600 },                  "1h" },
+
+		{{ 1,       1 }, "1s         1ns" },
+		{{ 0,       1 },            "1ns" },
+		{{ 0, 1000000 },            "1ms" },
+		{{ 0, 1000001 },      "1000001ns" },
+	};
+
+	setenv("TZ", "GMT", 1);
+	tzset();
+
+	for (size_t i = 0; i < ARRAY_SIZE(testcases); i++) {
+		struct testcase t = testcases[i];
+		int r = strtimespec_relative(&t.ts, buf, sizeof(buf));
+		if (r) {
+			fprintf(stderr, "Could not format '%s'\n", t.expected);
+			rc = EXIT_FAILURE;
+		}
+
+		if (strcmp(buf, t.expected)) {
+			fprintf(stderr, "#%02zu '%-20s' != '%-20s'\n", i, buf, t.expected);
+			rc = EXIT_FAILURE;
+		}
+	}
+
+	return rc;
+}
+
 int main(int argc, char *argv[])
 {
 	struct timespec ts = { 0 };
@@ -741,6 +845,8 @@ int main(int argc, char *argv[])
 		return run_unittest_timestamp();
 	else if (strcmp(argv[1], "--unittest-format") == 0)
 		return run_unittest_format();
+	else if (strcmp(argv[1], "--unittest-format-relative") == 0)
+		return run_unittest_format_relative();
 
 	if (strcmp(argv[1], "--timestamp") == 0) {
 		usec_t usec = 0;
@@ -767,6 +873,9 @@ int main(int argc, char *argv[])
 
 	strtimespec_iso(&ts, ISO_TIMESTAMP_DOT, buf, sizeof(buf));
 	printf("Zone: '%s'\n", buf);
+
+	strtimespec_relative(&ts, buf, sizeof(buf));
+	printf("Rel:  '%s'\n", buf);
 
 	return EXIT_SUCCESS;
 }

--- a/misc-utils/lsclocks.1.adoc
+++ b/misc-utils/lsclocks.1.adoc
@@ -63,7 +63,7 @@ Current clock timestamp as returned by *clock_gettime()*.
 ISO_TIME <``string``>::
 ISO8601 formatted version of *TIME*.
 
-RESOLUTION <``number``>::
+RESOL_RAW <``number``>::
 Clock resolution as returned by *clock_getres()*.
 
 REL_TIME <``string``>::

--- a/misc-utils/lsclocks.1.adoc
+++ b/misc-utils/lsclocks.1.adoc
@@ -33,6 +33,9 @@ Don't print headings.
 Specify which output columns to print. See the *OUTPUT COLUMNS*
 section for details of available columns.
 
+*--output-all*::
+Output all columns.
+
 *-r*, *--raw*::
 Use raw output format.
 

--- a/misc-utils/lsclocks.1.adoc
+++ b/misc-utils/lsclocks.1.adoc
@@ -66,6 +66,9 @@ ISO8601 formatted version of *TIME*.
 RESOL_RAW <``number``>::
 Clock resolution as returned by *clock_getres()*.
 
+RESOL <``number``>::
+Human readable version of *RESOL_RAW*.
+
 REL_TIME <``string``>::
 *TIME* time formatted as time range.
 

--- a/misc-utils/lsclocks.1.adoc
+++ b/misc-utils/lsclocks.1.adoc
@@ -66,6 +66,9 @@ ISO8601 formatted version of *TIME*.
 RESOLUTION <``number``>::
 Clock resolution as returned by *clock_getres()*.
 
+REL_TIME <``string``>::
+*TIME* time formatted as time range.
+
 
 == AUTHORS
 

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -289,11 +289,10 @@ int main(int argc, char **argv)
 
 	if (!ncolumns) {
 		columns[ncolumns++] = COL_ID;
-		columns[ncolumns++] = COL_CLOCK;
 		columns[ncolumns++] = COL_NAME;
 		columns[ncolumns++] = COL_TIME;
-		columns[ncolumns++] = COL_ISO_TIME;
 		columns[ncolumns++] = COL_RESOLUTION;
+		columns[ncolumns++] = COL_ISO_TIME;
 	}
 
 	if (outarg && string_add_to_idarray(outarg, columns, ARRAY_SIZE(columns),

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -146,6 +146,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -J, --json              use JSON output format\n"), out);
 	fputs(_(" -n, --noheadings        don't print headings\n"), out);
 	fputs(_(" -o, --output <list>     output columns\n"), out);
+	fputs(_("     --output-all        output all columns\n"), out);
 	fputs(_(" -r, --raw               use raw output format\n"), out);
 	fputs(_(" -t, --time <clock>      show current time of single clock\n"), out);
 
@@ -208,8 +209,7 @@ static clockid_t parse_clock(const char *name)
 int main(int argc, char **argv)
 {
 	size_t i, j;
-	char c;
-	int rc;
+	int c, rc;
 	const struct colinfo *colinfo;
 	const struct clockinfo *clockinfo;
 
@@ -226,9 +226,13 @@ int main(int argc, char **argv)
 	struct timespec resolution, now;
 	char buf[FORMAT_TIMESTAMP_MAX];
 
+	enum {
+		OPT_OUTPUT_ALL = CHAR_MAX + 1
+	};
 	static const struct option longopts[] = {
 		{ "noheadings", no_argument,       NULL, 'n' },
 		{ "output",     required_argument, NULL, 'o' },
+		{ "output-all",	no_argument,       NULL, OPT_OUTPUT_ALL },
 		{ "version",    no_argument,       NULL, 'V' },
 		{ "help",	no_argument,       NULL, 'h' },
 		{ "json",       no_argument,       NULL, 'J' },
@@ -249,6 +253,10 @@ int main(int argc, char **argv)
 			break;
 		case 'o':
 			outarg = optarg;
+			break;
+		case OPT_OUTPUT_ALL:
+			for (ncolumns = 0; ncolumns < ARRAY_SIZE(infos); ncolumns++)
+				columns[ncolumns] = ncolumns;
 			break;
 		case 'J':
 			json = true;

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -97,7 +97,7 @@ enum {
 	COL_NAME,
 	COL_TIME,
 	COL_ISO_TIME,
-	COL_RESOLUTION,
+	COL_RESOL_RAW,
 	COL_REL_TIME,
 };
 
@@ -117,7 +117,7 @@ static const struct colinfo infos[] = {
 	[COL_NAME]       = { "NAME",       1, 0,              SCOLS_JSON_STRING, N_("readable name") },
 	[COL_TIME]       = { "TIME",       1, SCOLS_FL_RIGHT, SCOLS_JSON_NUMBER, N_("numeric time") },
 	[COL_ISO_TIME]   = { "ISO_TIME",   1, SCOLS_FL_RIGHT, SCOLS_JSON_STRING, N_("human readable ISO time") },
-	[COL_RESOLUTION] = { "RESOLUTION", 1, SCOLS_FL_RIGHT, SCOLS_JSON_NUMBER, N_("resolution") },
+	[COL_RESOL_RAW]  = { "RESOL_RAW",  1, SCOLS_FL_RIGHT, SCOLS_JSON_NUMBER, N_("resolution") },
 	[COL_REL_TIME]   = { "REL_TIME",   1, SCOLS_FL_RIGHT, SCOLS_JSON_STRING, N_("human readable relative time") },
 };
 
@@ -293,7 +293,7 @@ int main(int argc, char **argv)
 		columns[ncolumns++] = COL_ID;
 		columns[ncolumns++] = COL_NAME;
 		columns[ncolumns++] = COL_TIME;
-		columns[ncolumns++] = COL_RESOLUTION;
+		columns[ncolumns++] = COL_RESOL_RAW;
 		columns[ncolumns++] = COL_ISO_TIME;
 	}
 
@@ -358,7 +358,7 @@ int main(int argc, char **argv)
 						errx(EXIT_FAILURE, _("failed to format iso time"));
 					scols_line_set_data(ln, j, buf);
 					break;
-				case COL_RESOLUTION:
+				case COL_RESOL_RAW:
 					rc = clock_getres(clockinfo->id, &resolution);
 					if (!rc)
 						scols_line_format_timespec(ln, j, &resolution);

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -98,6 +98,7 @@ enum {
 	COL_TIME,
 	COL_ISO_TIME,
 	COL_RESOLUTION,
+	COL_REL_TIME,
 };
 
 /* column names */
@@ -117,6 +118,7 @@ static const struct colinfo infos[] = {
 	[COL_TIME]       = { "TIME",       1, SCOLS_FL_RIGHT, SCOLS_JSON_NUMBER, N_("numeric time") },
 	[COL_ISO_TIME]   = { "ISO_TIME",   1, SCOLS_FL_RIGHT, SCOLS_JSON_STRING, N_("human readable ISO time") },
 	[COL_RESOLUTION] = { "RESOLUTION", 1, SCOLS_FL_RIGHT, SCOLS_JSON_NUMBER, N_("resolution") },
+	[COL_REL_TIME]   = { "REL_TIME",   1, SCOLS_FL_RIGHT, SCOLS_JSON_STRING, N_("human readable relative time") },
 };
 
 static int column_name_to_id(const char *name, size_t namesz)
@@ -224,7 +226,7 @@ int main(int argc, char **argv)
 	clockid_t clock = -1;
 
 	struct timespec resolution, now;
-	char buf[FORMAT_TIMESTAMP_MAX];
+	char buf[BUFSIZ];
 
 	enum {
 		OPT_OUTPUT_ALL = CHAR_MAX + 1
@@ -360,6 +362,14 @@ int main(int argc, char **argv)
 					rc = clock_getres(clockinfo->id, &resolution);
 					if (!rc)
 						scols_line_format_timespec(ln, j, &resolution);
+					break;
+				case COL_REL_TIME:
+					if (now.tv_nsec == -1)
+						break;
+					rc = strtimespec_relative(&now, buf, sizeof(buf));
+					if (rc)
+						errx(EXIT_FAILURE, _("failed to format relative time"));
+					scols_line_set_data(ln, j, buf);
 					break;
 			}
 		}

--- a/tests/ts/lib/timeutils
+++ b/tests/ts/lib/timeutils
@@ -23,4 +23,8 @@ ts_init_subtest "format"
 "$TS_HELPER_TIMEUTILS" --unittest-format 2> "$TS_ERRLOG" || ts_die "test failed"
 ts_finalize_subtest
 
+ts_init_subtest "format-relative"
+"$TS_HELPER_TIMEUTILS" --unittest-format-relative 2> "$TS_ERRLOG" || ts_die "test failed"
+ts_finalize_subtest
+
 ts_finalize

--- a/tests/ts/lib/timeutils
+++ b/tests/ts/lib/timeutils
@@ -16,9 +16,11 @@ ts_init "$*"
 ts_check_test_command "$TS_HELPER_TIMEUTILS"
 
 ts_init_subtest "timestamp"
+"$TS_HELPER_TIMEUTILS" --unittest-timestamp 2> "$TS_ERRLOG" || ts_die "test failed"
+ts_finalize_subtest
 
-"$TS_HELPER_TIMEUTILS" --unittest-timestamp 2> "$TS_ERRLOG"
-
+ts_init_subtest "format"
+"$TS_HELPER_TIMEUTILS" --unittest-format 2> "$TS_ERRLOG" || ts_die "test failed"
 ts_finalize_subtest
 
 ts_finalize


### PR DESCRIPTION
This also incorporates feedback from #2343 :
* Shorter default columns
* Human readable resolution