### PR TITLE
Revert "libblkid: try LUKS2 first when probing"

### DIFF
--- a/libblkid/src/superblocks/superblocks.c
+++ b/libblkid/src/superblocks/superblocks.c
@@ -94,11 +94,6 @@ static int blkid_probe_set_usage(blkid_probe pr, int usage);
  */
 static const struct blkid_idinfo *idinfos[] =
 {
-	/* In case the volume is locked with OPAL we are going to get
-	 * an I/O error when reading past the LUKS header, so try it
-	 * first. */
-	&luks_idinfo,
-
 	/* RAIDs */
 	&linuxraid_idinfo,
 	&ddfraid_idinfo,
@@ -124,6 +119,7 @@ static const struct blkid_idinfo *idinfos[] =
 	&snapcow_idinfo,
 	&verity_hash_idinfo,
 	&integrity_idinfo,
+	&luks_idinfo,
 	&vmfs_volume_idinfo,
 	&ubi_idinfo,
 	&vdo_idinfo,


### PR DESCRIPTION
mdadm superblocks before 1.1 are placed at the end of the device, which means that the data contained inside the array starts at offset 0. For LUKS inside MD, blkid falsely detects this as plain LUKS instead of a linux_raid_member. This causes e.g. dracut to not assemble the array during boot and system startup fails.

This reverts commit b8889c0a214aeb3dd47bf1ab280fe5534b64d2aa.

CC @bluca