### PR TITLE
ci: disable cpp/path-injection rule

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended,security-and-quality
+          config: |
+            query-filters:
+            - exclude:
+                id: cpp/path-injection
 
       - name: Install dependencies
         run: sudo -E .github/workflows/cibuild-setup-ubuntu.sh


### PR DESCRIPTION
This rule fires for file operations on user-specified paths. As this behavior is the very core of many util-linux utilities it is a false positive.

Note: I'm not completely sure if this is the correct syntax. The docs are fairly ambivalent...