### PR TITLE
lsfd: use sockdiag netlink interface for handling a newline in a unix socket path

### DIFF
--- a/misc-utils/lsfd-bdev.c
+++ b/misc-utils/lsfd-bdev.c
@@ -19,10 +19,6 @@
  * Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "xalloc.h"
-#include "nls.h"
-#include "libsmartcols.h"
-
 #include "lsfd.h"
 
 static struct list_head partitions;

--- a/misc-utils/lsfd-cdev.c
+++ b/misc-utils/lsfd-cdev.c
@@ -19,10 +19,6 @@
  * Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "xalloc.h"
-#include "nls.h"
-#include "libsmartcols.h"
-
 #include "lsfd.h"
 
 static struct list_head miscdevs;

--- a/misc-utils/lsfd-fifo.c
+++ b/misc-utils/lsfd-fifo.c
@@ -19,10 +19,6 @@
  * Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "xalloc.h"
-#include "nls.h"
-#include "libsmartcols.h"
-
 #include "lsfd.h"
 
 struct fifo {

--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -34,14 +34,11 @@
 #include <linux/sched.h>
 #include <sys/shm.h>
 
-#include "xalloc.h"
-#include "nls.h"
 #include "buffer.h"
 #include "idcache.h"
 #include "strutils.h"
 
 #include "procfs.h"
-#include "libsmartcols.h"
 
 #include "lsfd.h"
 

--- a/misc-utils/lsfd-sock-xinfo.c
+++ b/misc-utils/lsfd-sock-xinfo.c
@@ -549,7 +549,7 @@ enum l4_state {
 
 static const char *l4_decode_state(enum l4_state st)
 {
-	const char * table [] = {
+	const char * const table [] = {
 		[TCP_ESTABLISHED] = "established",
 		[TCP_SYN_SENT] = "syn-sent",
 		[TCP_SYN_RECV] = "syn-recv",

--- a/misc-utils/lsfd-sock-xinfo.c
+++ b/misc-utils/lsfd-sock-xinfo.c
@@ -283,9 +283,9 @@ static void add_sock_info(struct sock_xinfo *xinfo)
 		errx(EXIT_FAILURE, _("failed to allocate memory"));
 }
 
-struct sock_xinfo *get_sock_xinfo(ino_t netns_inode)
+struct sock_xinfo *get_sock_xinfo(ino_t inode)
 {
-	struct sock_xinfo **xinfo = tfind(&netns_inode, &xinfo_tree, xinfo_compare);
+	struct sock_xinfo **xinfo = tfind(&inode, &xinfo_tree, xinfo_compare);
 
 	if (xinfo)
 		return *xinfo;

--- a/misc-utils/lsfd-sock-xinfo.c
+++ b/misc-utils/lsfd-sock-xinfo.c
@@ -34,9 +34,6 @@
 #include <string.h>
 #include <sys/socket.h>		/* SOCK_* */
 
-#include "xalloc.h"
-#include "nls.h"
-#include "libsmartcols.h"
 #include "sysfs.h"
 #include "bitops.h"
 

--- a/misc-utils/lsfd-sock-xinfo.c
+++ b/misc-utils/lsfd-sock-xinfo.c
@@ -29,7 +29,7 @@
 #include <linux/netlink.h>	/* NETLINK_* */
 #include <linux/un.h>		/* UNIX_PATH_MAX */
 #include <sched.h>		/* for setns(2) */
-#include <search.h>
+#include <search.h>		/* tfind, tsearch */
 #include <stdint.h>
 #include <string.h>
 #include <sys/socket.h>		/* SOCK_* */

--- a/misc-utils/lsfd-sock.c
+++ b/misc-utils/lsfd-sock.c
@@ -22,10 +22,6 @@
 #include <sys/types.h>
 #include <sys/xattr.h>
 
-#include "xalloc.h"
-#include "nls.h"
-#include "libsmartcols.h"
-
 #include "lsfd.h"
 #include "lsfd-sock.h"
 

--- a/misc-utils/lsfd-sock.h
+++ b/misc-utils/lsfd-sock.h
@@ -67,6 +67,6 @@ struct sock_xinfo_class {
 void initialize_sock_xinfos(void);
 void finalize_sock_xinfos(void);
 
-struct sock_xinfo *get_sock_xinfo(ino_t netns_inode);
+struct sock_xinfo *get_sock_xinfo(ino_t inode);
 
 #endif /* UTIL_LINUX_LSFD_SOCK_H */

--- a/misc-utils/lsfd-unkn.c
+++ b/misc-utils/lsfd-unkn.c
@@ -22,10 +22,6 @@
 #include <sys/timerfd.h>
 #include <time.h>
 
-#include "xalloc.h"
-#include "nls.h"
-#include "libsmartcols.h"
-
 #include "signames.h"
 #include "timeutils.h"
 

--- a/misc-utils/lsfd-unkn.c
+++ b/misc-utils/lsfd-unkn.c
@@ -19,16 +19,17 @@
  * Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <sys/timerfd.h>
+#include <time.h>
+
 #include "xalloc.h"
 #include "nls.h"
 #include "libsmartcols.h"
+
 #include "signames.h"
 #include "timeutils.h"
 
 #include "lsfd.h"
-
-#include <sys/timerfd.h>
-#include <time.h>
 
 struct unkn {
 	struct file file;

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -46,8 +46,6 @@ static int kcmp(pid_t pid1, pid_t pid2, int type,
 #define PF_KTHREAD		0x00200000	/* I am a kernel thread */
 
 #include "c.h"
-#include "nls.h"
-#include "xalloc.h"
 #include "list.h"
 #include "closestream.h"
 #include "strutils.h"
@@ -55,8 +53,6 @@ static int kcmp(pid_t pid1, pid_t pid2, int type,
 #include "fileutils.h"
 #include "idcache.h"
 #include "pathnames.h"
-
-#include "libsmartcols.h"
 
 #include "lsfd.h"
 #include "lsfd-filter.h"

--- a/misc-utils/lsfd.h
+++ b/misc-utils/lsfd.h
@@ -29,9 +29,12 @@
 #include <dirent.h>
 #include <inttypes.h>
 
+#include "libsmartcols.h"
 #include "list.h"
+#include "nls.h"
 #include "path.h"
 #include "strutils.h"
+#include "xalloc.h"
 
 /*
  * column IDs

--- a/tests/expected/lsfd/mkfds-unix-stream
+++ b/tests/expected/lsfd/mkfds-unix-stream
@@ -14,6 +14,10 @@ ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
 4 SOCK state=connected                                         connected stream 0 
 5 SOCK state=connected path=test_mkfds-unix with spaces stream connected stream 0 test_mkfds-unix with spaces stream
 ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
+3 SOCK state=listen path=test_mkfds-unix with newline stream a\x0ab\x0ac       listen stream 1 test_mkfds-unix with newline stream a\x0ab\x0ac
+4 SOCK state=connected                                                      connected stream 0 
+5 SOCK state=connected path=test_mkfds-unix with newline stream a\x0ab\x0ac connected stream 0 test_mkfds-unix with newline stream a\x0ab\x0ac
+ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
 3 SOCK state=listen path=test_mkfds-unix-seqpacket type=seqpacket       listen seqpacket 1 test_mkfds-unix-seqpacket
 4 SOCK state=connected type=seqpacket                                connected seqpacket 0 
 5 SOCK state=connected path=test_mkfds-unix-seqpacket type=seqpacket connected seqpacket 0 test_mkfds-unix-seqpacket
@@ -29,4 +33,8 @@ ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
 3 SOCK state=listen path=test_mkfds-unix with spaces seqpacket type=seqpacket       listen seqpacket 1 test_mkfds-unix with spaces seqpacket
 4 SOCK state=connected type=seqpacket                                            connected seqpacket 0 
 5 SOCK state=connected path=test_mkfds-unix with spaces seqpacket type=seqpacket connected seqpacket 0 test_mkfds-unix with spaces seqpacket
+ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
+3 SOCK state=listen path=test_mkfds-unix with newline seqpacket a\x0ab\x0ac type=seqpacket       listen seqpacket 1 test_mkfds-unix with newline seqpacket a\x0ab\x0ac
+4 SOCK state=connected type=seqpacket                                                         connected seqpacket 0 
+5 SOCK state=connected path=test_mkfds-unix with newline seqpacket a\x0ab\x0ac type=seqpacket connected seqpacket 0 test_mkfds-unix with newline seqpacket a\x0ab\x0ac
 ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0

--- a/tests/ts/lsfd/mkfds-unix-stream
+++ b/tests/ts/lsfd/mkfds-unix-stream
@@ -92,6 +92,19 @@ EXPR='(((TYPE == "UNIX-STREAM") or (TYPE == "UNIX")) and (FD >= 3) and (FD <= 5)
 	fi
 	wait "${MKFDS_PID}"
 
+	coproc MKFDS { "$TS_HELPER_MKFDS" unix-stream $FDS $FDC $FDA \
+					  path="test_mkfds-unix with newline ${t} $(printf 'a\nb\nc')" \
+					  type=$t ; }
+	if read -r -u "${MKFDS[0]}" PID; then
+	    ${TS_CMD_LSFD} -n \
+			   -o ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH \
+			   -p "${PID}" -Q "${EXPR}" | lsfd_strip_type_stream
+	    echo 'ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH': ${PIPESTATUS[0]}
+
+	    kill -CONT "${PID}"
+	fi
+	wait "${MKFDS_PID}"
+
     done
 } > "$TS_OUTPUT" 2>&1
 


### PR DESCRIPTION
/proc/net/unix provides unix socket information in line oriented way.
The line oriented way can be a trouble because a unix socket path can have a newline char.
See https://github.com/util-linux/util-linux/pull/2067.

With this pull request, lsfd utilizes the sockdiag netlink interface
for getting the paths. The interface provides strings of paths as is.

The main commit (ed450a0ed1861234e0bc514d57498f6d5b0e4bc4) is mostly based on Thomas Weißschuh's work,
https://github.com/t-8ch/util-linux/commit/06030390a5e6a16cc4b914bbf5fcedd3b6d83608.

Unlike the original work, this commit keeps /proc related code.

Unlike /proc interface, the sockdiag information source doesn't provide
enough information for filling struct unix_xinfo::st member. So this
commit uses /proc interface to fill most unix_xinfo
members as before. The sockdiag netlink interface is used only
for re-filling the path member.
