### PR TITLE
tools/all_syscalls & meson depends simplification, program-tests option

### DIFF
--- a/libmount/meson.build
+++ b/libmount/meson.build
@@ -131,20 +131,22 @@ libmount_test_src_override = {
   'debug': 'init',
 }
 
-foreach libmount_test: libmount_tests
-  test_name = 'test_mount_' + libmount_test
-  exe = executable(
-    test_name,
-    'src/' + libmount_test_src_override.get(libmount_test, libmount_test) + '.c',
-    include_directories : [dir_include, dir_libblkid],
-    link_with : [lib__mount, lib_common, lib_blkid_static],
-    dependencies : lib__mount_deps,
-    c_args : ['-DTEST_PROGRAM'],
-  )
-  # the test-setup expects the helpers in the toplevel build-directory
-  link = meson.project_build_root() / test_name
-  run_command('ln', '-srf', exe.full_path(), link,
-    check : true)
-endforeach
+if program_tests
+  foreach libmount_test: libmount_tests
+    test_name = 'test_mount_' + libmount_test
+    exe = executable(
+      test_name,
+      'src/' + libmount_test_src_override.get(libmount_test, libmount_test) + '.c',
+      include_directories : [dir_include, dir_libblkid],
+      link_with : [lib__mount, lib_common, lib_blkid_static],
+      dependencies : lib__mount_deps,
+      c_args : ['-DTEST_PROGRAM'],
+    )
+    # the test-setup expects the helpers in the toplevel build-directory
+    link = meson.project_build_root() / test_name
+    run_command('ln', '-srf', exe.full_path(), link,
+      check : true)
+  endforeach
+endif
 
 subdir('python')

--- a/meson.build
+++ b/meson.build
@@ -808,6 +808,8 @@ endif
 sysvinit = get_option('sysvinit').enabled()
 sysvinitrcdir = sysconfdir + '/init.d'
 
+program_tests = get_option('program-tests')
+
 chfn_chsh_password = get_option('chfn-chsh-password') or lib_user.found()
 conf.set('CHFN_CHSH_PASSWORD', chfn_chsh_password ? 1 : false)
 
@@ -934,7 +936,8 @@ exe = executable(
   'test_islocal',
   test_islocal_sources,
   include_directories : includes,
-  c_args : '-DTEST_PROGRAM')
+  c_args : '-DTEST_PROGRAM',
+  build_by_default : program_tests)
 exes += exe
 
 exe = executable(
@@ -942,7 +945,8 @@ exe = executable(
   test_consoles_sources,
   c_args : ['-DTEST_PROGRAM'],
   include_directories : includes,
-  link_with : lib_common)
+  link_with : lib_common,
+  build_by_default : program_tests)
 exes += exe
 
 opt = not get_option('build-last').disabled()
@@ -1223,7 +1227,7 @@ exe2 = executable(
   dependencies : [lib_tinfo,
                   curses_libs,
 		  lib_magic],
-  build_by_default : opt)
+  build_by_default : opt and program_tests)
 exes += exe
 if opt and not is_disabler(exe)
   exes += [exe, exe2]
@@ -1429,7 +1433,8 @@ exe = executable(
   include_directories : dir_include,
   c_args : '-DTEST_DMESG',
   link_with : [lib_common,
-               lib_tcolors])
+               lib_tcolors],
+  build_by_default : program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -2075,7 +2080,7 @@ exe2 = executable(
   include_directories : includes,
   c_args : '-DTEST_SCRIPT',
   link_with : [lib_common],
-  build_by_default : opt)
+  build_by_default : opt and program_tests)
 exe3 = executable(
   'fsck.minix',
   fsck_minix_sources,
@@ -2320,7 +2325,8 @@ exe = executable(
   dependencies : [lib_util,
                   lib_utempter,
                   realtime_libs,
-                  math_libs])
+                  math_libs],
+  build_by_default : program_tests)
 exes += exe
 
 exe = executable(
@@ -2500,7 +2506,8 @@ exe = executable(
   include_directories : includes,
   c_args : '-DTEST_LOGGER',
   link_with : [lib_common],
-  dependencies : [lib_systemd])
+  dependencies : [lib_systemd],
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -2639,7 +2646,7 @@ exe2 = executable(
   link_with : [lib_common,
                lib_uuid],
   dependencies : thread_libs,
-  build_by_default : opt)
+  build_by_default : opt and program_tests)
 if not is_disabler(exe)
   exes += [exe, exe2]
   manadocs += ['misc-utils/uuidd.8.adoc']
@@ -2716,7 +2723,8 @@ exe = executable(
   'test_blkid_fuzz_sample',
   'libblkid/src/fuzz.c',
   include_directories: includes,
-  link_with: lib_blkid)
+  link_with: lib_blkid,
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -2851,7 +2859,8 @@ exe = executable(
   c_args : '-DTEST_CAL',
   link_with : [lib_common,
                lib_tcolors],
-  dependencies : [curses_libs])
+  dependencies : [curses_libs],
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -2975,7 +2984,8 @@ exe = executable(
   'lib/ttyutils.c',
   c_args : ['-DTEST_PROGRAM_TTYUTILS'],
   include_directories : dir_include,
-  link_with : lib_common)
+  link_with : lib_common,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
@@ -2983,7 +2993,8 @@ exe = executable(
   'lib/blkdev.c',
   c_args : ['-DTEST_PROGRAM_BLKDEV'],
   include_directories : dir_include,
-  link_with : lib_common)
+  link_with : lib_common,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
@@ -2991,21 +3002,24 @@ exe = executable(
   'lib/ismounted.c',
   c_args : ['-DTEST_PROGRAM_ISMOUNTED'],
   include_directories : dir_include,
-  link_with : lib_common)
+  link_with : lib_common,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_mangle',
   'lib/mangle.c',
   c_args : ['-DTEST_PROGRAM_MANGLE'],
-  include_directories : dir_include)
+  include_directories : dir_include,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_strutils',
   'lib/strutils.c',
   c_args : ['-DTEST_PROGRAM_STRUTILS'],
-  include_directories : dir_include)
+  include_directories : dir_include,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
@@ -3014,14 +3028,16 @@ exe = executable(
   'lib/color-names.c',
   c_args : ['-DTEST_PROGRAM_COLORS'],
   include_directories : dir_include,
-  link_with : [lib_common, lib_tcolors])
+  link_with : [lib_common, lib_tcolors],
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_randutils',
   'lib/randutils.c',
   c_args : ['-DTEST_PROGRAM_RANDUTILS'],
-  include_directories : dir_include)
+  include_directories : dir_include,
+  build_by_default: program_tests)
 exes += exe
 
 if conf.get('HAVE_OPENAT') != false and conf.get('HAVE_DIRFD') != false
@@ -3030,7 +3046,8 @@ if conf.get('HAVE_OPENAT') != false and conf.get('HAVE_DIRFD') != false
     'lib/procfs.c',
     c_args : ['-DTEST_PROGRAM_PROCFS'],
     include_directories : dir_include,
-    link_with : lib_common)
+    link_with : lib_common,
+    build_by_default: program_tests)
   exes += exe
 
   exe = executable(
@@ -3040,7 +3057,8 @@ if conf.get('HAVE_OPENAT') != false and conf.get('HAVE_DIRFD') != false
     have_cpu_set_t ? 'lib/cpuset.c' : [],
     c_args : ['-DTEST_PROGRAM_PATH'],
     include_directories : dir_include,
-    link_with : lib_common)
+    link_with : lib_common,
+    build_by_default: program_tests)
   exes += exe
 endif
 
@@ -3054,7 +3072,8 @@ if conf.get('HAVE_PTY') != false
     link_with : [lib_common],
     dependencies : [lib_m,
                     realtime_libs,
-                    lib_util])
+                    lib_util],
+    build_by_default: program_tests)
   exes += exe
 endif
 
@@ -3063,7 +3082,8 @@ if LINUX
     'test_cpuset',
     'lib/cpuset.c',
     c_args : ['-DTEST_PROGRAM_CPUSET'],
-    include_directories : dir_include)
+    include_directories : dir_include,
+    build_by_default: program_tests)
   exes += exe
 endif
 
@@ -3076,35 +3096,40 @@ exe = executable(
   'lib/fileutils.c',
   have_cpu_set_t ? 'lib/cpuset.c' : [],
   c_args : ['-DTEST_PROGRAM_SYSFS'],
-  include_directories : dir_include)
+  include_directories : dir_include,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_pager',
   'lib/pager.c',
   c_args : ['-DTEST_PROGRAM_PAGER'],
-  include_directories : dir_include)
+  include_directories : dir_include,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_linux_version',
   'lib/linux_version.c',
   c_args : ['-DTEST_PROGRAM_LINUXVERSION'],
-  include_directories : dir_include)
+  include_directories : dir_include,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_fileutils',
   'lib/fileutils.c',
   c_args : ['-DTEST_PROGRAM_FILEUTILS'],
-  include_directories : dir_include)
+  include_directories : dir_include,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_canonicalize',
   'lib/canonicalize.c',
   c_args : ['-DTEST_PROGRAM_CANONICALIZE'],
-  include_directories : dir_include)
+  include_directories : dir_include,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
@@ -3112,7 +3137,8 @@ exe = executable(
   'lib/timeutils.c',
   'lib/strutils.c',
   c_args : ['-DTEST_PROGRAM_TIMEUTILS'],
-  include_directories : dir_include)
+  include_directories : dir_include,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
@@ -3120,7 +3146,8 @@ exe = executable(
   'lib/pwdutils.c',
   c_args : ['-DTEST_PROGRAM'],
   include_directories : dir_include,
-  link_with : lib_common)
+  link_with : lib_common,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
@@ -3128,7 +3155,8 @@ exe = executable(
   'lib/logindefs.c',
   c_args : ['-DTEST_PROGRAM'],
   include_directories : dir_include,
-  link_with : [lib_common, logindefs_c])
+  link_with : [lib_common, logindefs_c],
+  build_by_default: program_tests)
 exes += exe
 
 
@@ -3139,7 +3167,8 @@ exe = executable(
   'libuuid/src/test_uuid.c',
   include_directories : [dir_include, dir_libuuid],
   link_with : lib_uuid,
-  dependencies : socket_libs)
+  dependencies : socket_libs,
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -3155,7 +3184,8 @@ exe = executable(
   'libfdisk/src/ask.c',
   c_args : libfdisk_tests_cflags,
   include_directories : lib_fdisk_includes,
-  link_with : libfdisk_tests_ldadd)
+  link_with : libfdisk_tests_ldadd,
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -3165,7 +3195,8 @@ exe = executable(
   'libfdisk/src/gpt.c',
   c_args : libfdisk_tests_cflags,
   include_directories : lib_fdisk_includes,
-  link_with : libfdisk_tests_ldadd)
+  link_with : libfdisk_tests_ldadd,
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -3175,7 +3206,8 @@ exe = executable(
   'libfdisk/src/utils.c',
   c_args : libfdisk_tests_cflags,
   include_directories : lib_fdisk_includes,
-  link_with : libfdisk_tests_ldadd)
+  link_with : libfdisk_tests_ldadd,
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -3185,7 +3217,8 @@ exe = executable(
   'libfdisk/src/script.c',
   c_args : libfdisk_tests_cflags,
   include_directories : lib_fdisk_includes,
-  link_with : libfdisk_tests_ldadd)
+  link_with : libfdisk_tests_ldadd,
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -3195,7 +3228,8 @@ exe = executable(
   'libfdisk/src/version.c',
   c_args : libfdisk_tests_cflags,
   include_directories : lib_fdisk_includes,
-  link_with : libfdisk_tests_ldadd)
+  link_with : libfdisk_tests_ldadd,
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -3205,7 +3239,8 @@ exe = executable(
   'libfdisk/src/item.c',
   c_args : libfdisk_tests_cflags,
   include_directories : lib_fdisk_includes,
-  link_with : libfdisk_tests_ldadd)
+  link_with : libfdisk_tests_ldadd,
+  build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
 endif
@@ -3239,58 +3274,67 @@ exe = executable(
   'test_mbsencode',
   'tests/helpers/test_mbsencode.c',
   include_directories : includes,
-  link_with : lib_common)
+  link_with : lib_common,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_byteswap',
   'tests/helpers/test_byteswap.c',
-  include_directories : includes)
+  include_directories : includes,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_md5',
   'tests/helpers/test_md5.c',
   md5_c,
-  include_directories : includes)
+  include_directories : includes,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_sha1',
   'tests/helpers/test_sha1.c',
   sha1_c,
-  include_directories : includes)
+  include_directories : includes,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_pathnames',
   'tests/helpers/test_pathnames.c',
-  include_directories : includes)
+  include_directories : includes,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_strerror',
   'tests/helpers/test_strerror.c',
-  include_directories : includes)
+  include_directories : includes,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_sysinfo',
   'tests/helpers/test_sysinfo.c',
-  include_directories : includes)
+  include_directories : includes,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_sigreceive',
   'tests/helpers/test_sigreceive.c',
   include_directories : includes,
-  link_with : lib_common)
+  link_with : lib_common,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
   'test_tiocsti',
   'tests/helpers/test_tiocsti.c',
-  include_directories : includes)
+  include_directories : includes,
+  build_by_default: program_tests)
 exes += exe
 
 exe = executable(
@@ -3299,7 +3343,8 @@ exe = executable(
   predefined_c,
   unpack_c,
   unparse_c,
-  include_directories : includes)
+  include_directories : includes,
+  build_by_default: program_tests)
 exes += exe
 
 mq_libs = []
@@ -3310,14 +3355,16 @@ if LINUX
     'test_mkfds',
     'tests/helpers/test_mkfds.c',
     include_directories : includes,
-    dependencies : mq_libs)
+    dependencies : mq_libs,
+    build_by_default: program_tests)
   exes += exe
 endif
 
 exe = executable(
   'test_enosys',
   'tests/helpers/test_enosys.c',
-  include_directories : includes)
+  include_directories : includes,
+  build_by_default: program_tests)
 exes += exe
 
 ############################################################
@@ -3327,7 +3374,8 @@ if conf.get('HAVE_OPENAT') != false
     'sample-scols-tree',
     'libsmartcols/samples/tree.c',
     include_directories : includes,
-    link_with : [lib_smartcols, lib_common])
+    link_with : [lib_smartcols, lib_common],
+    build_by_default: program_tests)
   if not is_disabler(exe)
     exes += exe
   endif

--- a/meson.build
+++ b/meson.build
@@ -41,16 +41,13 @@ conf.set_quoted('PACKAGE_VERSION', meson.project_version())
 package_string = '@0@ @1@'.format(meson.project_name(), meson.project_version())
 conf.set_quoted('PACKAGE_STRING', package_string)
 
-codes = [''' {print $1}  ''',
-         ''' {sub("-.*","",$2); print $2} ''',
-         ''' {sub("-.*","",$3); print $3 ~ /^[0-9]+$/ ? $3 : 0} ''']
 pc_version = []
-foreach code : codes
-  res = run_command('bash', '-c',
-                    '''echo '@0@' | awk -F. '@1@' '''.format(
-                      meson.project_version(), code), check: true)
-  pc_version += res.stdout().strip()
-endforeach
+pc_version = meson.project_version().split('-')[0].split('.')
+
+if pc_version.length() < 3
+    pc_version += '0'
+endif
+
 pc_version = '.'.join(pc_version)
 
 conf.set_quoted('LIBBLKID_VERSION', libblkid_version)
@@ -2890,7 +2887,7 @@ endif
 syscalls_h = custom_target('syscalls.h',
   input : 'tools/all_syscalls',
   output : 'syscalls.h',
-  command : ['bash', '@INPUT@', cc.cmd_array()],
+  command : ['tools/all_syscalls', cc.cmd_array()] 
 )
 
 if cc.compiles(fs.read('include/audit-arch.h'), name : 'has AUDIT_ARCH_NATIVE')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -177,6 +177,10 @@ option('static-programs', type : 'array',
 
 # feature selection and other configuration
 
+option('program-tests',
+       type: 'boolean', value : true,
+       description : 'build test programs')
+
 option('chfn-chsh-password',
        type : 'boolean', value : true,
        description : 'require the user to enter the password in chfn and chsh')

--- a/tools/all_syscalls
+++ b/tools/all_syscalls
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -9,7 +9,9 @@ SYSCALL_INCLUDES="
 
 trap 'rm $OUTPUT $OUTPUT.deps' ERR
 
-"$@" -MD -MF "$OUTPUT.deps" <<< "$SYSCALL_INCLUDES" -dM -E - \
-	| gawk 'match($0, /^#define __NR_([^ ]+)/, res) { print "UL_SYSCALL(\"" res[1] "\", __NR_" res[1] ")" }' \
+echo "$SYSCALL_INCLUDES" \
+	| "$@" -MD -MF "$OUTPUT.deps" -dM -E - \
+	| grep '^#define __NR_' \
+	| sed 's/#define __NR_\([^[:space:]]*\).*/UL_SYSCALL("\1", __NR_\1)/' \
 	| sort \
 	> "$OUTPUT"

--- a/tools/all_syscalls
+++ b/tools/all_syscalls
@@ -1,17 +1,17 @@
 #!/bin/sh
 
-set -e
-
 OUTPUT=syscalls.h
 SYSCALL_INCLUDES="
 #include <sys/syscall.h>
 "
 
-trap 'rm $OUTPUT $OUTPUT.deps' ERR
+# pipefail is part of modern POSIX
+# shellcheck disable=SC3040
+set -o pipefail
 
 echo "$SYSCALL_INCLUDES" \
 	| "$@" -MD -MF "$OUTPUT.deps" -dM -E - \
 	| grep '^#define __NR_' \
 	| sed 's/#define __NR_\([^[:space:]]*\).*/UL_SYSCALL("\1", __NR_\1)/' \
 	| sort \
-	> "$OUTPUT"
+	> "$OUTPUT" || { rm $OUTPUT $OUTPUT.deps; return 1; }


### PR DESCRIPTION
using sh removes the bash dependencies, for those who don't have
bash on their system, and replaced the GNU awk with a portable
grep and sed.

as for the meson, I've done the same and used the beginner meson book. since all_syscalls utility will always right syscalls.h, theres no point to have it be an output and launched by bash, if meson has this feature already called `run_command`.