### PR TITLE
fincore: (tests) fix double log output

### DIFF
--- a/tests/ts/fincore/count
+++ b/tests/ts/fincore/count
@@ -119,11 +119,11 @@ check_dd_fs_feat
 INPUT=
 input=
 
+ts_log_both "[ NO EXCITING FILE ]"
 {
     input=no_such_file
     INPUT="${INPUT} ${input}"
 
-    ts_log_both "[ NO EXCITING FILE ]"
     $TS_CMD_FINCORE --output $OUT_COLUMNS --bytes --noheadings $input
     footer "$?"
 } >> $TS_OUTPUT 2>> $TS_ERRLOG
@@ -220,8 +220,8 @@ input=
 		   "oflag=append seek=$hole_count"
 } >> $TS_OUTPUT 2>> $TS_ERRLOG
 
+ts_log_both "[ MULTIPLE FILES ]"
 {
-    ts_log_both "[ MULTIPLE FILES ]"
     $TS_CMD_FINCORE --output $OUT_COLUMNS --bytes $INPUT
     footer "$?"
 } >> $TS_OUTPUT 2>> $TS_ERRLOG


### PR DESCRIPTION
The fincore tests call ts_log_both inside an output redirection of both stdout and stderr, leading to the ts_log_both output ending up twice in both stdout and stderr.
Call ts_log_both before setting up the output redirection.

Debian patch (for 2.39.1) https://salsa.debian.org/debian/util-linux/-/blob/master/debian/patches/fincore-tests-fix-double-log-output.patch