### PR TITLE
tests: (lsfd::option-inet) get child-processes' pids via fifo

### DIFF
--- a/tests/ts/lsfd/option-inet
+++ b/tests/ts/lsfd/option-inet
@@ -25,23 +25,54 @@ ts_skip_docker
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_HELPER_MKFDS"
 
+ts_check_prog "mkfifo"
+
 ts_cd "$TS_OUTDIR"
 
+FIFO=./test_mkfds-option-inet.fifo
 {
-    "$TS_HELPER_MKFDS" -q tcp  3 4 5 server-port=34567 client-port=23456 &
-    PID0=$!
+    rm -f "${FIFO}"
+    if ! mkfifo "${FIFO}"; then
+	ts_finalize  "failed in creating a fifo"
+    fi
 
-    "$TS_HELPER_MKFDS" -q tcp6 3 4 5 server-port=34567 client-port=23456 &
-    PID1=$!
+    "$TS_HELPER_MKFDS" tcp  3 4 5 server-port=34567 client-port=23456 > "${FIFO}" &
+    if ! read PID0 < "${FIFO}"; then
+	rm "${FIFO}"
+	ts_finalize  "$TS_HELPER_MKFDS tcp...doesn't report its pid"
+    fi
 
-    "$TS_HELPER_MKFDS" -q ro-regular-file 3 file=/etc/passwd &
-    PID2=$!
+    "$TS_HELPER_MKFDS" tcp6 3 4 5 server-port=34567 client-port=23456 > "${FIFO}" &
+    if ! read PID1  < "${FIFO}"; then
+	kill -CONT "${PID0}"
+	wait       "${PID0}"
+	rm "${FIFO}"
+	ts_finalize  "$TS_HELPER_MKFDS tcp6...doesn't report its pid"
+    fi
 
-    "$TS_HELPER_MKFDS" -q udp 3 4 server-port=34567 client-port=23456 server-do-bind=1 client-do-bind=1 client-do-connect=1&
-    PID3=$!
+    "$TS_HELPER_MKFDS" ro-regular-file 3 file=/etc/passwd > "${FIFO}" &
+    if ! read PID2  < "${FIFO}"; then
+	kill -CONT "${PID0}" "${PID1}"
+	wait       "${PID0}" "${PID1}"
+	rm "${FIFO}"
+	ts_finalize  "$TS_HELPER_MKFDS ro-regular-file...doesn't report its pid"
+    fi
 
-    "$TS_HELPER_MKFDS" -q udp6 3 4 lite=1 server-port=34567 client-port=23456 server-do-bind=1 client-do-bind=1 client-do-connect=1&
-    PID4=$!
+    "$TS_HELPER_MKFDS" udp 3 4 server-port=34567 client-port=23456 server-do-bind=1 client-do-bind=1 client-do-connect=1 > "${FIFO}" &
+    if ! read PID3  < "${FIFO}"; then
+	kill -CONT "${PID0}" "${PID1}" "${PID2}"
+	wait       "${PID0}" "${PID1}" "${PID2}"
+	rm "${FIFO}"
+	ts_finalize  "$TS_HELPER_MKFDS udp...doesn't report its pid"
+    fi
+
+    "$TS_HELPER_MKFDS" udp6 3 4 lite=1 server-port=34567 client-port=23456 server-do-bind=1 client-do-bind=1 client-do-connect=1 > "${FIFO}" &
+    if ! read PID4  < "${FIFO}"; then
+	kill -CONT "${PID0}" "${PID1}" "${PID2}" "${PID3}"
+	wait       "${PID0}" "${PID1}" "${PID2}" "${PID3}"
+	rm "${FIFO}"
+	ts_finalize  "$TS_HELPER_MKFDS udp6 lite=1...doesn't report its pid"
+    fi
 
     OPT='--inet'
     echo "# $OPT"
@@ -87,6 +118,7 @@ ts_cd "$TS_OUTDIR"
 
     kill -CONT "${PID0}" "${PID1}" "${PID2}" "${PID3}" "${PID4}"
     wait       "${PID0}" "${PID1}" "${PID2}" "${PID3}" "${PID4}"
+    rm "${FIFO}"
 } > "$TS_OUTPUT" 2>&1
 
 ts_finalize


### PR DESCRIPTION
Close #2399.

The original code assumes the background processes prepare sockets enough fast. #2399 showed the assumption was wrong; lsfd reported half-cooked sockets.

To avoid the timing issue, the test case with this change uses a fifo to receive pids from the child test_mkfds processes. test_mkfds reports its pid after cooking the sockets. When the option-inet script recives the pid, we can expect the sockets are ready.

Note: bash's coproc cannot be used here; it supports only one co-process at once.

Analysed-by: Alexander Kanavin <alex.kanavin@gmail.com>