### PR TITLE
tests: (lsfd) don't run the unix-stream testcase including newlines in the path on qemu-user

### DIFF
--- a/tests/expected/lsfd/mkfds-unix-stream
+++ b/tests/expected/lsfd/mkfds-unix-stream
@@ -14,10 +14,6 @@ ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
 4 SOCK state=connected                                         connected stream 0 
 5 SOCK state=connected path=test_mkfds-unix with spaces stream connected stream 0 test_mkfds-unix with spaces stream
 ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
-3 SOCK state=listen path=test_mkfds-unix with newline stream a\x0ab\x0ac       listen stream 1 test_mkfds-unix with newline stream a\x0ab\x0ac
-4 SOCK state=connected                                                      connected stream 0 
-5 SOCK state=connected path=test_mkfds-unix with newline stream a\x0ab\x0ac connected stream 0 test_mkfds-unix with newline stream a\x0ab\x0ac
-ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
 3 SOCK state=listen path=test_mkfds-unix-seqpacket type=seqpacket       listen seqpacket 1 test_mkfds-unix-seqpacket
 4 SOCK state=connected type=seqpacket                                connected seqpacket 0 
 5 SOCK state=connected path=test_mkfds-unix-seqpacket type=seqpacket connected seqpacket 0 test_mkfds-unix-seqpacket
@@ -33,8 +29,4 @@ ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
 3 SOCK state=listen path=test_mkfds-unix with spaces seqpacket type=seqpacket       listen seqpacket 1 test_mkfds-unix with spaces seqpacket
 4 SOCK state=connected type=seqpacket                                            connected seqpacket 0 
 5 SOCK state=connected path=test_mkfds-unix with spaces seqpacket type=seqpacket connected seqpacket 0 test_mkfds-unix with spaces seqpacket
-ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
-3 SOCK state=listen path=test_mkfds-unix with newline seqpacket a\x0ab\x0ac type=seqpacket       listen seqpacket 1 test_mkfds-unix with newline seqpacket a\x0ab\x0ac
-4 SOCK state=connected type=seqpacket                                                         connected seqpacket 0 
-5 SOCK state=connected path=test_mkfds-unix with newline seqpacket a\x0ab\x0ac type=seqpacket connected seqpacket 0 test_mkfds-unix with newline seqpacket a\x0ab\x0ac
 ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0

--- a/tests/expected/lsfd/mkfds-unix-stream-requiring-sockdiag
+++ b/tests/expected/lsfd/mkfds-unix-stream-requiring-sockdiag
@@ -1,0 +1,8 @@
+3 SOCK state=listen path=test_mkfds-unix with newline stream a\x0ab\x0ac       listen stream 1 test_mkfds-unix with newline stream a\x0ab\x0ac
+4 SOCK state=connected                                                      connected stream 0 
+5 SOCK state=connected path=test_mkfds-unix with newline stream a\x0ab\x0ac connected stream 0 test_mkfds-unix with newline stream a\x0ab\x0ac
+ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0
+3 SOCK state=listen path=test_mkfds-unix with newline seqpacket a\x0ab\x0ac type=seqpacket       listen seqpacket 1 test_mkfds-unix with newline seqpacket a\x0ab\x0ac
+4 SOCK state=connected type=seqpacket                                                         connected seqpacket 0 
+5 SOCK state=connected path=test_mkfds-unix with newline seqpacket a\x0ab\x0ac type=seqpacket connected seqpacket 0 test_mkfds-unix with newline seqpacket a\x0ab\x0ac
+ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH: 0

--- a/tests/ts/lsfd/mkfds-unix-stream
+++ b/tests/ts/lsfd/mkfds-unix-stream
@@ -92,19 +92,6 @@ EXPR='(((TYPE == "UNIX-STREAM") or (TYPE == "UNIX")) and (FD >= 3) and (FD <= 5)
 	fi
 	wait "${MKFDS_PID}"
 
-	coproc MKFDS { "$TS_HELPER_MKFDS" unix-stream $FDS $FDC $FDA \
-					  path="test_mkfds-unix with newline ${t} $(printf 'a\nb\nc')" \
-					  type=$t ; }
-	if read -r -u "${MKFDS[0]}" PID; then
-	    ${TS_CMD_LSFD} -n \
-			   -o ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH \
-			   -p "${PID}" -Q "${EXPR}" | lsfd_strip_type_stream
-	    echo 'ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH': ${PIPESTATUS[0]}
-
-	    kill -CONT "${PID}"
-	fi
-	wait "${MKFDS_PID}"
-
     done
 } > "$TS_OUTPUT" 2>&1
 

--- a/tests/ts/lsfd/mkfds-unix-stream-requiring-sockdiag
+++ b/tests/ts/lsfd/mkfds-unix-stream-requiring-sockdiag
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="UNIX stream sockets"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+ts_skip_qemu_user
+
+. "$TS_SELF/lsfd-functions.bash"
+
+ts_check_test_command "$TS_CMD_LSFD"
+ts_check_test_command "$TS_HELPER_MKFDS"
+
+ts_cd "$TS_OUTDIR"
+
+PID=
+FDS=3
+FDC=4
+FDA=5
+EXPR='(((TYPE == "UNIX-STREAM") or (TYPE == "UNIX")) and (FD >= 3) and (FD <= 5))'
+
+{
+    for t in stream seqpacket; do
+
+	coproc MKFDS { "$TS_HELPER_MKFDS" unix-stream $FDS $FDC $FDA \
+					  path="test_mkfds-unix with newline ${t} $(printf 'a\nb\nc')" \
+					  type=$t ; }
+	if read -r -u "${MKFDS[0]}" PID; then
+	    ${TS_CMD_LSFD} -n \
+			   -o ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH \
+			   -p "${PID}" -Q "${EXPR}" | lsfd_strip_type_stream
+	    echo 'ASSOC,STTYPE,NAME,SOCK.STATE,SOCK.TYPE,SOCK.LISTENING,UNIX.PATH': ${PIPESTATUS[0]}
+
+	    kill -CONT "${PID}"
+	fi
+	wait "${MKFDS_PID}"
+
+    done
+} > "$TS_OUTPUT" 2>&1
+
+ts_finalize


### PR DESCRIPTION
Close #2402.
    
In the current implementation of lsfd, the communication code for retrieving unix socket information doesn't consider the byteorder.

NOTE: The second commit doesn't require the first.
