### PR TITLE
wall: do not error for ttys that do not exist

### DIFF
--- a/term-utils/ttymsg.c
+++ b/term-utils/ttymsg.c
@@ -100,7 +100,7 @@ ttymsg(struct iovec *iov, size_t iovcnt, char *line, int tmout) {
 	 * if not running as root; not an error.
 	 */
 	if ((fd = open(device, O_WRONLY|O_NONBLOCK, 0)) < 0) {
-		if (errno == EBUSY || errno == EACCES)
+		if (errno == EBUSY || errno == EACCES || errno == ENOENT)
 			return NULL;
 
 		len = snprintf(errbuf, sizeof(errbuf), "%s: %m", device);


### PR DESCRIPTION
Some wayland display managers (GDM) put strings like "seat0" in the ut_line field of utmp entries. These are not valid tty devices.

Avoid writing a confusing error message for ttys that do not exist.

Bug: https://bugs.gentoo.org/911336