### PR TITLE
libmount: (utils) fix statx fallback

### DIFF
--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -133,7 +133,8 @@ static int safe_stat(const char *target, struct stat *st, int nofollow)
 			st->st_mode = stx.stx_mode;
 		}
 
-		if (rc == 0 || errno != EOPNOTSUPP)
+		if (rc == 0 ||
+		    (errno != EOPNOTSUPP && errno != ENOSYS && errno != EINVAL))
 			return rc;
 	}
 #endif


### PR DESCRIPTION
If the systemcall is not available ENOSYS is returned.

Under glibc the statx implementation also has its own fallback logic. As AT_STATX_DONT_SYNC can't be implemented correctly in that fallback logic the wrapper will return EINVAL in case the emulation is needed and AT_STATX_DONT_SYNC is set.
So also use our own fallback in that case.

Fixes: #2409