### PR TITLE
meson: properly handle gettext non-existence

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -1,4 +1,4 @@
-if not find_program('gettext').found()
+if not find_program('gettext', required : false).found()
   subdir_done()
 endif
 


### PR DESCRIPTION
Commit e91a49c9747f ("meson: don't build po if no gettext") tried to add the possibility to build util-linux without gettext.

Unfortunately by default the call to find_program() would abort the build if the program is not found.
Avoid aborting the build.