### PR TITLE
fincore: (tests) adapt alternative testcases to new header format

### DIFF
--- a/tests/expected/fincore/count.65536
+++ b/tests/expected/fincore/count.65536
@@ -1,36 +1,36 @@
 [ NO EXCITING FILE ]
 return value: 1
-    0    0 i_EMPTY_FILE
+0     0 i_EMPTY_FILE
 return value: 0
-    1 65535 i_PAGESIZE_-1__incore_
+1 65535 i_PAGESIZE_-1__incore_
 return value: 0
-    1 65536 i_JUST_PAGESIZE_incore_
+1 65536 i_JUST_PAGESIZE_incore_
 return value: 0
-    0 65536 i_JUST_PAGESIZE_directio_
+0 65536 i_JUST_PAGESIZE_directio_
 return value: 0
-    2 131072 i_TWO_PAGES_incore_
+2 131072 i_TWO_PAGES_incore_
 return value: 0
-    0 131072 i_TWO_PAGES_directio_
+0 131072 i_TWO_PAGES_directio_
 return value: 0
-    1 131072 i_TWO_PAGES_mixed_directio_incore_
+1 131072 i_TWO_PAGES_mixed_directio_incore_
 return value: 0
-    1 131072 i_TWO_PAGES_mixed_incore_directio_
+1 131072 i_TWO_PAGES_mixed_incore_directio_
 return value: 0
-    2 2147418112 i_WINDOW_SIZE_incore-sparse-incore_
+2 2147418112 i_WINDOW_SIZE_incore-sparse-incore_
 return value: 0
-    0 2147418112 i_WINDOW_SIZE_directio-sparse-directio_
+0 2147418112 i_WINDOW_SIZE_directio-sparse-directio_
 return value: 0
-    1 2147418112 i_WINDOW_SIZE_incore-sparse-directio_
+1 2147418112 i_WINDOW_SIZE_incore-sparse-directio_
 return value: 0
-    1 2147418112 i_WINDOW_SIZE_directio-sparse-incore_
+1 2147418112 i_WINDOW_SIZE_directio-sparse-incore_
 return value: 0
-    2 2147483648 i_WINDOW_SIZE_+_1_page_incore-sparse-incore_
+2 2147483648 i_WINDOW_SIZE_+_1_page_incore-sparse-incore_
 return value: 0
-    0 2147483648 i_WINDOW_SIZE_+_1_page_directio-sparse-directio_
+0 2147483648 i_WINDOW_SIZE_+_1_page_directio-sparse-directio_
 return value: 0
-    1 2147483648 i_WINDOW_SIZE_+_1_page_incore-sparse-directio_
+1 2147483648 i_WINDOW_SIZE_+_1_page_incore-sparse-directio_
 return value: 0
-    1 2147483648 i_WINDOW_SIZE_+_1_page_directio-sparse-incore_
+1 2147483648 i_WINDOW_SIZE_+_1_page_directio-sparse-incore_
 return value: 0
 [ MULTIPLE FILES ]
 PAGES       SIZE FILE

--- a/tests/expected/fincore/count.nosize
+++ b/tests/expected/fincore/count.nosize
@@ -1,36 +1,36 @@
 [ NO EXCITING FILE ]
 return value: 1
-    0 i_EMPTY_FILE
+0 i_EMPTY_FILE
 return value: 0
-    1 i_PAGESIZE_-1__incore_
+1 i_PAGESIZE_-1__incore_
 return value: 0
-    1 i_JUST_PAGESIZE_incore_
+1 i_JUST_PAGESIZE_incore_
 return value: 0
-    0 i_JUST_PAGESIZE_directio_
+0 i_JUST_PAGESIZE_directio_
 return value: 0
-    2 i_TWO_PAGES_incore_
+2 i_TWO_PAGES_incore_
 return value: 0
-    0 i_TWO_PAGES_directio_
+0 i_TWO_PAGES_directio_
 return value: 0
-    1 i_TWO_PAGES_mixed_directio_incore_
+1 i_TWO_PAGES_mixed_directio_incore_
 return value: 0
-    1 i_TWO_PAGES_mixed_incore_directio_
+1 i_TWO_PAGES_mixed_incore_directio_
 return value: 0
-    2 i_WINDOW_SIZE_incore-sparse-incore_
+2 i_WINDOW_SIZE_incore-sparse-incore_
 return value: 0
-    0 i_WINDOW_SIZE_directio-sparse-directio_
+0 i_WINDOW_SIZE_directio-sparse-directio_
 return value: 0
-    1 i_WINDOW_SIZE_incore-sparse-directio_
+1 i_WINDOW_SIZE_incore-sparse-directio_
 return value: 0
-    1 i_WINDOW_SIZE_directio-sparse-incore_
+1 i_WINDOW_SIZE_directio-sparse-incore_
 return value: 0
-    2 i_WINDOW_SIZE_+_1_page_incore-sparse-incore_
+2 i_WINDOW_SIZE_+_1_page_incore-sparse-incore_
 return value: 0
-    0 i_WINDOW_SIZE_+_1_page_directio-sparse-directio_
+0 i_WINDOW_SIZE_+_1_page_directio-sparse-directio_
 return value: 0
-    1 i_WINDOW_SIZE_+_1_page_incore-sparse-directio_
+1 i_WINDOW_SIZE_+_1_page_incore-sparse-directio_
 return value: 0
-    1 i_WINDOW_SIZE_+_1_page_directio-sparse-incore_
+1 i_WINDOW_SIZE_+_1_page_directio-sparse-incore_
 return value: 0
 [ MULTIPLE FILES ]
 PAGES FILE


### PR DESCRIPTION
For #2380 the testcases for 4k pages were adapted to the new output format, but the other testcases were missed.

CC @mator 