### PR TITLE
verity: use <roothash>-verity as the device mapper name instead of libmnt_<image>

### DIFF
--- a/libmount/src/hook_veritydev.c
+++ b/libmount/src/hook_veritydev.c
@@ -349,25 +349,8 @@ static int setup_veritydev(	struct libmnt_context *cxt,
 	backing_file = mnt_fs_get_srcpath(cxt->fs);
 	if (!backing_file)
 		return -EINVAL;
-	else {
-		/* To avoid clashes, prefix libmnt_ to all mapper devices */
-		char *p, *path = strdup(backing_file);
-		if (!path)
-			return -ENOMEM;
 
-		p = stripoff_last_component(path);
-		if (p)
-			mapper_device = calloc(strlen(p) + sizeof("libmnt_"), sizeof(char));
-		if (mapper_device) {
-			strcat(mapper_device, "libmnt_");
-			strcat(mapper_device, p);
-		}
-		free(path);
-		if (!mapper_device)
-			return -ENOMEM;
-	}
-
-	DBG(HOOK, ul_debugobj(hs, "verity: setup for %s [%s]", backing_file, mapper_device));
+	DBG(HOOK, ul_debugobj(hs, "verity: setup for %s", backing_file));
 
 	/* verity.hashdevice= */
 	if (!rc && (opt = mnt_optlist_get_opt(ol, MNT_MS_HASH_DEVICE, cxt->map_userspace)))
@@ -467,6 +450,13 @@ static int setup_veritydev(	struct libmnt_context *cxt,
 		rc = -EINVAL;
 	}
 
+	/* To avoid clashes, use the roothash as the device name. This allows us to reuse already open devices, saving
+	 * a lot of time and resources when there are duplicated mounts. If the roothash is the same, then the volumes
+	 * are also guaranteed to be identical. This is what systemd also does, so we can deduplicate across the whole
+	 * system. */
+	if (asprintf(&mapper_device, "%s-verity", root_hash) < 0)
+		rc = -ENOMEM;
+
 	if (!rc)
 		rc = verity_call( crypt_init_data_device(&crypt_dev, hash_device, backing_file) );
 	if (rc)
@@ -506,7 +496,9 @@ static int setup_veritydev(	struct libmnt_context *cxt,
 	 * If the mapper device already exists, and if libcryptsetup supports it, get the root
 	 * hash associated with the existing one and compare it with the parameter passed by
 	 * the user. If they match, then we can be sure the user intended to mount the exact
-	 * same device, and simply reuse it and return success.
+	 * same device, and simply reuse it and return success. Although we use the roothash
+	 * as the device mapper name, and root privileges are required to open them, better be
+	 * safe than sorry, so double check that the actual root hash used matches.
 	 * The kernel does the refcounting for us.
 	 * If libcryptsetup does not support getting the root hash out of an existing device,
 	 * then return an error and tell the user that the device is already in use.

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1542,13 +1542,12 @@ Supported since util-linux v2.35.
 For example commands:
 
 ....
-mksquashfs /etc /tmp/etc.squashfs
-dd if=/dev/zero of=/tmp/etc.hash bs=1M count=10
-veritysetup format /tmp/etc.squashfs /tmp/etc.hash
-openssl smime -sign -in <hash> -nocerts -inkey private.key \
+mksquashfs /etc /tmp/etc.raw
+veritysetup format /tmp/etc.raw /tmp/etc.verity --root-hash-file=/tmp/etc.roothash
+openssl smime -sign -in /tmp/etc.roothash -nocerts -inkey private.key \
 -signer private.crt -noattr -binary -outform der -out /tmp/etc.roothash.p7s
-mount -o verity.hashdevice=/tmp/etc.hash,verity.roothash=<hash>,\
-verity.roothashsig=/tmp/etc.roothash.p7s /tmp/etc.squashfs /mnt
+mount -o verity.hashdevice=/tmp/etc.verity,verity.roothashfile=/tmp/etc.roothash,\
+verity.roothashsig=/tmp/etc.roothash.p7s /tmp/etc.raw /mnt
 ....
 
 create squashfs image from _/etc_ directory, verity hash device and mount verified filesystem image to _/mnt_. The kernel will verify that the root hash is signed by a key from the kernel keyring if roothashsig is used.


### PR DESCRIPTION
If the roothash is the same among two volumes, then the images are guaranteed
to be equivalent. The filename of the image on the other hand does not imply
that the images are equivalent.
In systemd we open verity devices as '<roothash>-verity', so that we know for
sure we can reuse them. Do the same here, so that we are a bit more confident
that images can be reused before the safety check, and also so that we can
take advantage of the kernel refcounting together with images used by systemd,
as setting up verity is expensive.