### PR TITLE
libblkid: use unsigned long long in struct blkid_struct_topology

### DIFF
--- a/libblkid/src/topology/topology.c
+++ b/libblkid/src/topology/topology.c
@@ -62,13 +62,13 @@ static int topology_set_logical_sector_size(blkid_probe pr);
  * Binary interface
  */
 struct blkid_struct_topology {
-	unsigned long	alignment_offset;
-	unsigned long	minimum_io_size;
-	unsigned long	optimal_io_size;
-	unsigned long	logical_sector_size;
-	unsigned long	physical_sector_size;
-	unsigned long   dax;
-	uint64_t	diskseq;
+	unsigned long long	alignment_offset;
+	unsigned long long	minimum_io_size;
+	unsigned long long	optimal_io_size;
+	unsigned long long	logical_sector_size;
+	unsigned long long	physical_sector_size;
+	unsigned long long	dax;
+	unsigned long long	diskseq;
 };
 
 /*


### PR DESCRIPTION
Since https://github.com/util-linux/util-linux/commit/3ab9e699a8d90f55e0447516b7e05a8686180467 topology_set_value() is taking a unsigned long long value, but writing it into a struct with unsigned long fields. On 32 bit systems this results in corrupting the structure, as the two types are 8 and 4 bytes respectively.