### PR TITLE
losetup: cleanup device node modes

### DIFF
--- a/.github/workflows/cibuild-setup-ubuntu.sh
+++ b/.github/workflows/cibuild-setup-ubuntu.sh
@@ -41,9 +41,7 @@ PACKAGES_OPTIONAL=(
 if [[ "$QEMU_USER" != "1" ]]; then
 	MODULES_PACKAGE="linux-modules-extra-$(uname -r)"
 	# may not exist anymore
-	APT_CACHE_OUTPUT=$(apt-cache show "$MODULES_PACKAGE")
-	APT_CACHE_STATUS=$?
-	if [[ "${APT_CACHE_STATUS}" == 0 && -n "${APT_CACHE_OUTPUT}" ]]; then
+	if APT_CACHE_OUTPUT=$(apt-cache show "$MODULES_PACKAGE") && [[ -n "$APT_CACHE_OUTPUT" ]]; then
 		PACKAGES+=("$MODULES_PACKAGE")
 	fi
 fi

--- a/include/loopdev.h
+++ b/include/loopdev.h
@@ -112,7 +112,7 @@ struct loopdev_cxt {
 	char		device[128];	/* device path (e.g. /dev/loop<N>) */
 	char		*filename;	/* backing file for loopcxt_set_... */
 	int		fd;		/* open(/dev/looo<N>) */
-	int		mode;		/* fd mode O_{RDONLY,RDWR} */
+	mode_t		mode;		/* fd mode O_{RDONLY,RDWR} */
 	uint64_t	blocksize;	/* used by loopcxt_setup_device() */
 
 	int		flags;		/* LOOPDEV_FL_* flags */
@@ -132,8 +132,6 @@ struct loopdev_cxt {
  * loopdev_cxt.flags
  */
 enum {
-	LOOPDEV_FL_RDONLY	= (1 << 0),	/* open(/dev/loop) mode; default */
-	LOOPDEV_FL_RDWR		= (1 << 1),	/* necessary for loop setup only */
 	LOOPDEV_FL_OFFSET	= (1 << 4),
 	LOOPDEV_FL_NOSYSFS	= (1 << 5),
 	LOOPDEV_FL_NOIOCTL	= (1 << 6),
@@ -176,7 +174,7 @@ extern const char *loopcxt_get_device(struct loopdev_cxt *lc);
 extern struct loop_info64 *loopcxt_get_info(struct loopdev_cxt *lc);
 
 extern int loopcxt_get_fd(struct loopdev_cxt *lc);
-extern int loopcxt_set_fd(struct loopdev_cxt *lc, int fd, int mode);
+extern int loopcxt_set_fd(struct loopdev_cxt *lc, int fd, mode_t mode);
 
 extern int loopcxt_init_iterator(struct loopdev_cxt *lc, int flags);
 extern int loopcxt_deinit_iterator(struct loopdev_cxt *lc);


### PR DESCRIPTION
The current code follows ro/rw mode not only set mode of the new device, but also to open the device node for ioctls.

Linux kernel does not care and it seems O_RDONLY is good enough for all cases (ioctls).

Unfortunately, udevd is sensitive as it monitors devices by inotify and IN_CLOSE_WRITE event is expected to apply udev rules for the device.

Changes:

* remove LOOPDEV_FL_{RDONLY,RDWR} private flags, it's too complex and unnecessary

* use mode_t for open() modes (rater than int)

* re-open only if O_RDWR requested otherwise default to O_RDONLY

* make sure O_RDWR is used on device setup

Fixes: https://github.com/util-linux/util-linux/issues/2434