### PR TITLE
github: check apt-cache in more robust way (v2)

### DIFF
--- a/.github/workflows/cibuild-setup-ubuntu.sh
+++ b/.github/workflows/cibuild-setup-ubuntu.sh
@@ -41,9 +41,7 @@ PACKAGES_OPTIONAL=(
 if [[ "$QEMU_USER" != "1" ]]; then
 	MODULES_PACKAGE="linux-modules-extra-$(uname -r)"
 	# may not exist anymore
-	APT_CACHE_OUTPUT=$(apt-cache show "$MODULES_PACKAGE")
-	APT_CACHE_STATUS=$?
-	if [[ "${APT_CACHE_STATUS}" == 0 && -n "${APT_CACHE_OUTPUT}" ]]; then
+	if APT_CACHE_OUTPUT=$(apt-cache show "$MODULES_PACKAGE") && [[ -n "$APT_CACHE_OUTPUT" ]]; then
 		PACKAGES+=("$MODULES_PACKAGE")
 	fi
 fi


### PR DESCRIPTION
The original change (86d5c4dbf6e62c52fe9295f4e55eb629d8e26cfb) didn't consider "set -e" at the beginning of the script.