### PR TITLE
libblkid: limit read buffer size

### DIFF
--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -688,6 +688,11 @@ const unsigned char *blkid_probe_get_buffer(blkid_probe pr, uint64_t off, uint64
 		return NULL;
 	}
 
+	if (len > 8388608 /* 8 Mib */ ) {
+		DBG(BUFFER, ul_debug("\t  too large read request (ignore)"));
+		return NULL;
+	}
+
 	if (len == 0
 	    || (!S_ISCHR(pr->mode) && (pr->size < off || pr->size < len))
 	    || (!S_ISCHR(pr->mode) && (pr->off + pr->size < real_off + len))) {


### PR DESCRIPTION
Many probers read data from disk bounded by some field from the probed disk itself.
The probers should validate the read length before using. Add a fallback that kicks in when the proper does not check the length epxlicitly.

See #2427
Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>