### PR TITLE
Add  -T (tab-separated) Option to  last  Command

### DIFF
--- a/login-utils/last.1.adoc
+++ b/login-utils/last.1.adoc
@@ -75,6 +75,9 @@ Display the state of logins since the specified _time_. This is useful, e.g., to
 *-t*, *--until* _time_::
 Display the state of logins until the specified _time_.
 
+*-T*, *--tab-separated*::
+Use ASCII *tab* characters to separate the columns in the output instead of spaces.
+
 *--time-format* _format_::
 Define the output timestamp _format_ to be one of _notime_, _short_, _full_, or _iso_. The _notime_ variant will not print any timestamps at all, _short_ is the default, and _full_ is the same as the *--fulltimes* option. The _iso_ variant will display the timestamp in ISO-8601 format. The ISO format contains timezone information, making it preferable when printouts are investigated outside of the system.
 


### PR DESCRIPTION
Greetings,

This patch introduces a  -T  option to the  last  command. 

This  -T  option allows for tab-separated output, enhancing  awk  parsing without altering the default behavior. By introducing this option, we provide a more efficient solution while preserving the simplicity of the  last  command.

During the development of a diagnostic data aggregator for servers, the lack of reliable  awk  piping with  last  became evident, leading to a workaround of directly parsing the wtmp file.

Here are the changes in the commit below.

Signed-off-by: Cristian Zmole <chiarel@tragdate.ninja>