### PR TITLE
libmount: fix statx() includes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -326,7 +326,6 @@ AC_CHECK_HEADERS([ \
 	linux/nsfs.h \
 	linux/pr.h \
 	linux/raw.h \
-	linux/stat.h \
 	linux/securebits.h \
 	linux/tiocl.h \
 	linux/version.h \
@@ -518,7 +517,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 ])
 
 AC_CHECK_TYPES([struct mount_attr], [], [], [[#include <linux/mount.h>]])
-AC_CHECK_TYPES([struct statx], [], [], [[#include <linux/stat.h>]])
 AC_CHECK_TYPES([enum fsconfig_command], [], [], [[#include <linux/mount.h>]])
 
 AC_CHECK_MEMBERS([struct termios.c_line],,,
@@ -527,8 +525,9 @@ AC_CHECK_MEMBERS([struct termios.c_line],,,
 AC_CHECK_MEMBERS([struct stat.st_mtim.tv_nsec],,,
     [[#include <sys/stat.h>]])
 
+AC_CHECK_TYPES([struct statx], [], [], [[#include <sys/stat.h>]])
 AC_CHECK_MEMBERS([struct statx.stx_mnt_id],,,
-    [[#include <linux/stat.h>]])
+    [[#include <sys/stat.h>]])
 
 AC_CHECK_DECLS([_NL_TIME_WEEK_1STDAY],[],[],[[#include <langinfo.h>]])
 

--- a/include/fileutils.h
+++ b/include/fileutils.h
@@ -94,13 +94,13 @@ static inline int close_range(unsigned int first, unsigned int last, int flags)
 #  define HAVE_CLOSE_RANGE 1
 # endif	/* SYS_close_range */
 
-# if !defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(SYS_statx) && defined(HAVE_LINUX_STAT_H)
-#  include <linux/stat.h>
+# if !defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(SYS_statx)
 static inline int statx(int fd, const char *restrict path, int flags,
 		    unsigned int mask, struct statx *stx)
 {
 	return syscall(SYS_statx, fd, path, flags, mask, stx);
 }
+#  define HAVE_STATX 1
 # endif /* SYS_statx */
 
 #endif	/* HAVE_SYS_SYSCALL_H */

--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -299,12 +299,13 @@ static int hook_create_mount(struct libmnt_context *cxt,
 		struct statx st;
 
 		rc = statx(api->fd_tree, "", AT_EMPTY_PATH, STATX_MNT_ID, &st);
-		cxt->fs->id = (int) st.stx_mnt_id;
-
-		if (cxt->update) {
-			struct libmnt_fs *fs = mnt_update_get_fs(cxt->update);
-			if (fs)
-				fs->id = cxt->fs->id;
+		if (rc == 0) {
+			cxt->fs->id = (int) st.stx_mnt_id;
+			if (cxt->update) {
+				struct libmnt_fs *fs = mnt_update_get_fs(cxt->update);
+				if (fs)
+					fs->id = cxt->fs->id;
+			}
 		}
 	}
 #endif

--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -294,7 +294,7 @@ static int hook_create_mount(struct libmnt_context *cxt,
 		/* cleanup after fail (libmount may only try the FS type) */
 		close_sysapi_fds(api);
 
-#if defined(HAVE_STRUCT_STATX) && defined(HAVE_STRUCT_STATX_STX_MNT_ID)
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(HAVE_STRUCT_STATX_STX_MNT_ID)
 	if (!rc && cxt->fs) {
 		struct statx st;
 

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -111,7 +111,7 @@ static int safe_stat(const char *target, struct stat *st, int nofollow)
 
 	memset(st, 0, sizeof(struct stat));
 
-#if defined(AT_STATX_DONT_SYNC) && defined (HAVE_STRUCT_STATX)
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(AT_STATX_DONT_SYNC)
 	{
 		int rc;
 		struct statx stx = { 0 };

--- a/libmount/src/version.c
+++ b/libmount/src/version.c
@@ -44,6 +44,9 @@ static const char *lib_features[] = {
 #ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
 	"fd-based-mount",
 #endif
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(AT_STATX_DONT_SYNC)
+	"statx",
+#endif
 #if !defined(NDEBUG)
 	"assert",	/* libc assert.h stuff */
 #endif

--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,7 @@ have_mountfd_api = cc.sizeof('struct mount_attr', prefix : '#include <linux/moun
 conf.set('HAVE_STRUCT_MOUNT_ATTR', have_mountfd_api ? 1 : false)
 conf.set('HAVE_MOUNTFD_API', have_mountfd_api ? 1 : false)
 
-have_struct_statx = cc.sizeof('struct statx', prefix : '#include <linux/stat.h>') > 0
+have_struct_statx = cc.sizeof('struct statx', prefix : '#include <sys/stat.h>') > 0
 conf.set('HAVE_STRUCT_STATX', have_struct_statx ? 1 : false)
 
 build_libmount = not get_option('build-libmount').disabled()
@@ -177,7 +177,6 @@ headers = '''
         linux/nsfs.h
         linux/mount.h
         linux/pr.h
-        linux/stat.h
         linux/securebits.h
         linux/tiocl.h
         linux/version.h
@@ -640,7 +639,7 @@ have = cc.has_member('struct stat', 'st_mtim.tv_nsec',
 conf.set('HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC', have ? 1 : false)
 
 have = cc.has_member('struct statx', 'stx_mnt_id',
-                     prefix : '#include <linux/stat.h>')
+                     prefix : '#include <sys/stat.h>')
 conf.set('HAVE_STRUCT_STATX_STX_MNT_ID', have ? 1 : false)
 
 # replacement for AC_STRUCT_TIMEZONE


### PR DESCRIPTION
Using sys/stat.h and linux/stat is too tricky.h together. It seems better to rely on libc and use sys/stat.h only. Users affected by old libc must update to use recent util-linux.

Fixes: https://github.com/util-linux/util-linux/issues/2448