### PR TITLE
waitpid: warn of "exited" only when --verbose is given

### DIFF
--- a/misc-utils/waitpid.c
+++ b/misc-utils/waitpid.c
@@ -64,7 +64,8 @@ static int *open_pidfds(size_t n_pids, pid_t *pids)
 		pidfds[i] = pidfd_open(pids[i], 0);
 		if (pidfds[i] == -1) {
 			if (allow_exited && errno == ESRCH) {
-				warnx(_("PID %d has exited, skipping"), pids[i]);
+				if (verbose)
+					warnx(_("PID %d has exited, skipping"), pids[i]);
 				continue;
 			}
 			err_nosys(EXIT_FAILURE, _("could not open pid %u"), pids[i]);

--- a/tests/ts/misc/waitpid
+++ b/tests/ts/misc/waitpid
@@ -44,7 +44,7 @@ echo $? >> "$TS_OUTPUT"
 ts_finalize_subtest
 
 ts_init_subtest exited
-"$TS_CMD_WAITPID" -e 2147483647 >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+"$TS_CMD_WAITPID" -v -e 2147483647 >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 echo $? >> "$TS_ERRLOG"
 ts_finalize_subtest
 


### PR DESCRIPTION
With this change, we can reduce the number of keystrokes, "2> /dev/null".