### PR TITLE
Revise/add HiSilicon core names

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -258,8 +258,10 @@ static const struct id_part fujitsu_part[] = {
 };
 
 static const struct id_part hisi_part[] = {
-    { 0xd01, "Kunpeng-920" },	/* aka tsv110 */
+    { 0xd01, "TaiShan-v110" },	/* used in Kunpeng-920 SoC */
+    { 0xd02, "TaiShan-v120" },	/* used in Kirin 990A and 9000S SoCs */
     { 0xd40, "Cortex-A76" },	/* HiSilicon uses this ID though advertises A76 */
+    { 0xd41, "Cortex-A77" },	/* HiSilicon uses this ID though advertises A77 */
     { -1, "unknown" },
 };
 


### PR DESCRIPTION
The core with ID `0xd01` was wrongly named as the SoC it appeared in. `0xd02` is a newer variant of the TaiShan architecture used at least in Kirin 990A and 9000S and HiSilicon also has another custom core advertised as a Cortex-A77 variant.

In recently appeared Kirin 9000S `cpu4`-`cpu6` are yet unknown custom cores with ID `0xd42`, most probably an A78AE derivate that is SMT capable. But I'll try to get more insights first and send this in a separate PR later.