### PR TITLE
libblkid: prune unneeded buffers 

### DIFF
--- a/libblkid/src/blkidP.h
+++ b/libblkid/src/blkidP.h
@@ -220,6 +220,7 @@ struct blkid_struct_probe
 	struct blkid_chain	*wipe_chain;	/* superblock, partition, ... */
 
 	struct list_head	buffers;	/* list of buffers */
+	struct list_head	prunable_buffers;	/* list of prunable buffers */
 	struct list_head	hints;
 
 	struct blkid_chain	chains[BLKID_NCHAINS];	/* array of chains */
@@ -432,6 +433,8 @@ extern int blkid_probe_set_dimension(blkid_probe pr,
 extern int blkid_probe_get_idmag(blkid_probe pr, const struct blkid_idinfo *id,
 			uint64_t *offset, const struct blkid_idmag **res)
 			__attribute__((nonnull(1)));
+
+extern void blkid_probe_prune_buffers(blkid_probe pr);
 
 /* returns superblock according to 'struct blkid_idmag' */
 extern const unsigned char *blkid_probe_get_sb_buffer(blkid_probe pr, const struct blkid_idmag *mag, size_t size);

--- a/libblkid/src/partitions/partitions.c
+++ b/libblkid/src/partitions/partitions.c
@@ -556,6 +556,7 @@ static int idinfo_probe(blkid_probe pr, const struct blkid_idinfo *id,
 		DBG(LOWPROBE, ul_debug(
 			"%s: ---> call probefunc()", id->name));
 		rc = id->probefunc(pr, mag);
+		blkid_probe_prune_buffers(pr);
 		if (rc < 0) {
 			/* reset after error */
 			reset_partlist(blkid_probe_get_partlist(pr));

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -544,6 +544,16 @@ int __blkid_probe_filter_types(blkid_probe pr, int chain, int flag, char *names[
 	return 0;
 }
 
+static void remove_buffer(struct blkid_bufinfo *bf)
+{
+	list_del(&bf->bufs);
+
+	DBG(BUFFER, ul_debug(" remove buffer: [off=%"PRIu64", len=%"PRIu64"]",
+				bf->off, bf->len));
+	munmap(bf->data, bf->len);
+	free(bf);
+}
+
 static struct blkid_bufinfo *read_buffer(blkid_probe pr, uint64_t real_off, uint64_t len)
 {
 	ssize_t ret;
@@ -585,8 +595,7 @@ static struct blkid_bufinfo *read_buffer(blkid_probe pr, uint64_t real_off, uint
 	ret = read(pr->fd, bf->data, len);
 	if (ret != (ssize_t) len) {
 		DBG(LOWPROBE, ul_debug("\tread failed: %m"));
-		munmap(bf->data, bf->len);
-		free(bf);
+		remove_buffer(bf);
 
 		/* I/O errors on CDROMs are non-fatal to work with hybrid
 		 * audio+data disks */
@@ -776,12 +785,10 @@ int blkid_probe_reset_buffers(blkid_probe pr)
 						struct blkid_bufinfo, bufs);
 		ct++;
 		len += bf->len;
-		list_del(&bf->bufs);
 
 		DBG(BUFFER, ul_debug(" remove buffer: [off=%"PRIu64", len=%"PRIu64"]",
 		                     bf->off, bf->len));
-		munmap(bf->data, bf->len);
-		free(bf);
+		remove_buffer(bf);
 	}
 
 	DBG(LOWPROBE, ul_debug(" buffers summary: %"PRIu64" bytes by %"PRIu64" read() calls",

--- a/libblkid/src/superblocks/superblocks.c
+++ b/libblkid/src/superblocks/superblocks.c
@@ -418,6 +418,7 @@ static int superblocks_probe(blkid_probe pr, struct blkid_chain *chn)
 		if (id->probefunc) {
 			DBG(LOWPROBE, ul_debug("\tcall probefunc()"));
 			rc = id->probefunc(pr, mag);
+			blkid_probe_prune_buffers(pr);
 			if (rc != BLKID_PROBE_OK) {
 				blkid_probe_chain_reset_values(pr, chn);
 				if (rc < 0)

--- a/libblkid/src/topology/topology.c
+++ b/libblkid/src/topology/topology.c
@@ -146,6 +146,7 @@ blkid_topology blkid_probe_get_topology(blkid_probe pr)
 static int topology_probe(blkid_probe pr, struct blkid_chain *chn)
 {
 	size_t i;
+	int rc;
 
 	if (chn->idx < -1)
 		return -1;
@@ -182,7 +183,9 @@ static int topology_probe(blkid_probe pr, struct blkid_chain *chn)
 
 		if (id->probefunc) {
 			DBG(LOWPROBE, ul_debug("%s: call probefunc()", id->name));
-			if (id->probefunc(pr, NULL) != 0)
+			rc = id->probefunc(pr, NULL);
+			blkid_probe_prune_buffers(pr);
+			if (rc != 0)
 				continue;
 		}
 


### PR DESCRIPTION
When a new buffer is cached that is a superset of another existing
buffer the old buffer can be removed as future requests can be satisfied
by the new one.
    
As probe functions can have local references to buffered data, delay the
cleanup until the probefunc is finished to avoid accessing freed data.
    
For the bcachefs.img testfile this reduces the final (maximal) cache
from 34338 bytes in 54 buffers  to 24760 bytes in 40 buffers.
