### PR TITLE
scriptreplay: support ctrl+s and ctrl+g

### DIFF
--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -134,6 +134,7 @@ setterm(struct termios *backup)
 	tattr = *backup;
 	cfmakeraw(&tattr);
 	tattr.c_lflag |= ISIG;
+	tattr.c_iflag |= IXON;
 	tcsetattr(STDOUT_FILENO, TCSANOW, &tattr);
 	return 1;
 }


### PR DESCRIPTION
The old scriptreplay supported XON/XOFF flow control. The new implementation uses cfmakeraw() and it disables it by default. Let's enable it by IXON iflag.

Fixes: https://github.com/util-linux/util-linux/issues/2480
References: https://github.com/util-linux/util-linux/pull/1101