### PR TITLE
tests: fix capability testing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3301,6 +3301,14 @@ endif
 ############################################################
 
 exe = executable(
+  'test_cap',
+  'tests/helpers/test_cap.c',
+  include_directories : includes,
+  dependencies : [lib_cap_ng],
+  build_by_default: program_tests)
+exes += exe
+
+exe = executable(
   'test_mbsencode',
   'tests/helpers/test_mbsencode.c',
   include_directories : includes,

--- a/tests/commands.sh
+++ b/tests/commands.sh
@@ -4,6 +4,7 @@ TS_TESTUSER=${TS_TESTUSER:-"nobody"}
 # helpers
 TS_HELPER_BYTESWAP="${ts_helpersdir}test_byteswap"
 TS_HELPER_CPUSET="${ts_helpersdir}test_cpuset"
+TS_HELPER_CAP="${ts_helpersdir}test_cap"
 TS_HELPER_DMESG="${ts_helpersdir}test_dmesg"
 TS_HELPER_ENOSYS="${ts_helpersdir}test_enosys"
 TS_HELPER_ISLOCAL="${ts_helpersdir}test_islocal"

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -168,22 +168,11 @@ function ts_skip_nonroot {
 #	ts_skip_capability cap_wake_alarm
 #
 function ts_skip_capability {
-	local self=$$
-	local cap=$1
+	ts_check_prog "$TS_HELPER_CAP"
 
-	# On Fedora, libcap package provides getpcaps command.
-	ts_check_prog "getpcaps"
-
-	local caps=$(getpcaps "$self" 2>&1)
-	if [[ "$caps" == "${self}: =ep" || "$caps" == 'Capabilities for `'"${self}': =ep" ]]; then
-		return 0
+	if ! "$TS_HELPER_CAP" "$1"; then
+		ts_skip "no capability: $1"
 	fi
-
-	if [[ "$caps" =~ .*${cap}.* ]]; then
-		return 0
-	fi
-
-	ts_skip "no capability: ${cap}"
 }
 
 function ts_skip_qemu_user {

--- a/tests/helpers/Makemodule.am
+++ b/tests/helpers/Makemodule.am
@@ -39,3 +39,9 @@ test_mkfds_LDADD = $(LDADD) $(MQ_LIBS)
 check_PROGRAMS += test_enosys
 test_enosys_SOURCES = tests/helpers/test_enosys.c
 endif
+
+if HAVE_CAP_NG
+check_PROGRAMS += test_cap
+test_cap_SOURCES = tests/helpers/test_cap.c
+test_cap_LDADD = -lcap-ng
+endif

--- a/tests/helpers/test_cap.c
+++ b/tests/helpers/test_cap.c
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <cap-ng.h>
+
+int main(int argc, char **argv)
+{
+	int cap, r;
+
+	if (argc != 2)
+		return EXIT_FAILURE;
+
+	cap = capng_name_to_capability(argv[1]);
+	if (cap < 0) {
+		fprintf(stderr, "capng_name_to_capability(%s) failed\n", argv[1]);
+		return EXIT_FAILURE;
+	}
+
+	r = capng_get_caps_process();
+	if (r) {
+		fprintf(stderr, "capng_get_caps_process() failed\n");
+		return EXIT_FAILURE;
+	}
+
+	r = capng_have_capability(CAPNG_EFFECTIVE, cap);
+	return r ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/ts/lsfd/mkfds-timerfd-alarm
+++ b/tests/ts/lsfd/mkfds-timerfd-alarm
@@ -20,7 +20,7 @@ TS_DESC="timerfd associating alarm"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
-ts_skip_capability cap_wake_alarm
+ts_skip_capability WAKE_ALARM
 
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_HELPER_MKFDS"


### PR DESCRIPTION
The old capability testing logic would incorrectly interpret the following output from getpcaps as cap_wake_alarm being supported:

$ getpcaps 0
0: cap_wake_alarm=i

Instead of relying on brittle command output parsing at a test helper to detect capabilities.

Note: I also have an implementation that just fixes the shell parsing logic if that is better.

Cc @masatake 