### PR TITLE
lscpu: Use larger buffer size for lscpu_read_cpuinfo

### DIFF
--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -462,7 +462,9 @@ static int cpuinfo_parse_cache(struct lscpu_cxt *cxt, int keynum, char *data)
 int lscpu_read_cpuinfo(struct lscpu_cxt *cxt)
 {
 	FILE *fp;
-	char buf[BUFSIZ];
+	/* Used to be BUFSIZ which is small on some platforms e.g, musl,
+	 * therefore hardcode to 4K */
+	char buf[4096];
 	size_t i;
 	struct lscpu_cputype *ct;
 	struct cpuinfo_parser _pr = { .cxt = cxt }, *pr = &_pr;


### PR DESCRIPTION
BUFSIZ can vary quite a bit  e.g. glibc/linux systems its 8192 but on musl/linux and OSX its 1024, on mingW it is 256, some tests e.g. x86_64-64cpu-linux6.2.tar.gz has added really long line for cpu flags line which is greater than 1024 characters and hence this test fails on musl because lscpu -s reports truncated string