### PR TITLE
lsfd: collect the device number for mqueue fs in the initialization stage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2615,12 +2615,16 @@ if not is_disabler(exe)
   bashcompletions += ['lsblk']
 endif
 
+mq_libs = []
+mq_libs += cc.find_library('rt', required : true)
+
 exe = executable(
   'lsfd',
   lsfd_sources,
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols],
+  dependencies : mq_libs,
   install_dir : usrbin_exec_dir,
   install : true)
 if not is_disabler(exe)
@@ -3376,9 +3380,6 @@ exe = executable(
   include_directories : includes,
   build_by_default: program_tests)
 exes += exe
-
-mq_libs = []
-mq_libs += cc.find_library('rt', required : true)
 
 if LINUX
   exe = executable(

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -267,7 +267,7 @@ lsfd_SOURCES = \
 	misc-utils/lsfd-sock-xinfo.c \
 	misc-utils/lsfd-unkn.c \
 	misc-utils/lsfd-fifo.c
-lsfd_LDADD = $(LDADD) libsmartcols.la libcommon.la
+lsfd_LDADD = $(LDADD) $(MQ_LIBS) libsmartcols.la libcommon.la
 lsfd_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
 endif
 

--- a/tests/ts/lsfd/mkfds-mqueue
+++ b/tests/ts/lsfd/mkfds-mqueue
@@ -72,6 +72,7 @@ ENDPOINTS=
 	    echo 'ENDPOINTS[STR]:' $?
 	    echo 'ENDPOINTS:' "$ENDPOINTS"
 	    echo 'lsfd:' "$tmp"
+	    grep mqueue /proc/self/mountinfo
 	fi
 
 	echo DONE >&"${MKFDS[1]}"


### PR DESCRIPTION
Though lsfd reads device minor numbers for file-systems having "nodev"
from /proc/$pid/mountinfo, we observed lsfd failed to resolve the
values of SOURCE column for mqueue files on s390 CI/CD env. It seems
that /proc/$pid/mountinfo doesn't provide enough information.
    
This change makes lsfd open a mqueue file in lsfd's initialization
stage as a new data source for resolving; lsfd can collect an
actually-used minor number from the file descriptor with fstat(2).
  