### PR TITLE
treewide: use (x)reallocarray() when applicable

### DIFF
--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -495,7 +495,7 @@ static unsigned int write_directory_structure(struct entry *entry, char *base, u
 			if (entry->child) {
 				if (stack_entries >= stack_size) {
 					stack_size *= 2;
-					entry_stack = xrealloc(entry_stack, stack_size * sizeof(struct entry *));
+					entry_stack = xreallocarray(entry_stack, stack_size, sizeof(struct entry *));
 				}
 				entry_stack[stack_entries] = entry;
 				stack_entries++;

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -49,7 +49,7 @@ int ul_buffer_is_empty(struct ul_buffer *buf)
 int ul_buffer_save_pointer(struct ul_buffer *buf, unsigned short ptr_idx)
 {
 	if (ptr_idx >= buf->nptrs) {
-		char **tmp = realloc(buf->ptrs, (ptr_idx + 1) * sizeof(char *));
+		char **tmp = reallocarray(buf->ptrs, ptr_idx + 1, sizeof(char *));
 
 		if (!tmp)
 			return -EINVAL;

--- a/lib/colors.c
+++ b/lib/colors.c
@@ -380,8 +380,8 @@ static int colors_add_scheme(struct ul_color_ctl *cc,
 
 	/* enlarge the array */
 	if (cc->nschemes == cc->schemes_sz) {
-		void *tmp = realloc(cc->schemes, (cc->nschemes + 10)
-					* sizeof(struct ul_color_scheme));
+		void *tmp = reallocarray(cc->schemes, cc->nschemes + 10,
+					 sizeof(struct ul_color_scheme));
 		if (!tmp)
 			goto err;
 		cc->schemes = tmp;

--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -495,7 +495,7 @@ static int loop_scandir(const char *dirname, int **ary, int hasprefix)
 
 			arylen += 1;
 
-			tmp = realloc(*ary, arylen * sizeof(int));
+			tmp = reallocarray(*ary, arylen, sizeof(int));
 			if (!tmp) {
 				free(*ary);
 				*ary = NULL;

--- a/lib/strv.c
+++ b/lib/strv.c
@@ -265,7 +265,7 @@ int strv_push(char ***l, char *value) {
         if (m < n)
                 return -ENOMEM;
 
-        c = realloc(*l, sizeof(char *) * m);
+        c = reallocarray(*l, m, sizeof(char *));
         if (!c)
                 return -ENOMEM;
 

--- a/libblkid/src/partitions/partitions.c
+++ b/libblkid/src/partitions/partitions.c
@@ -436,8 +436,8 @@ static blkid_partition new_partition(blkid_partlist ls, blkid_parttable tab)
 		/* Linux kernel has DISK_MAX_PARTS=256, but it's too much for
 		 * generic Linux machine -- let start with 32 partitions.
 		 */
-		void *tmp = realloc(ls->parts, (ls->nparts_max + 32) *
-					sizeof(struct blkid_struct_partition));
+		void *tmp = reallocarray(ls->parts, ls->nparts_max + 32,
+					 sizeof(struct blkid_struct_partition));
 		if (!tmp)
 			return NULL;
 		ls->parts = tmp;

--- a/libmount/src/cache.c
+++ b/libmount/src/cache.c
@@ -202,7 +202,7 @@ static int cache_add_entry(struct libmnt_cache *cache, char *key,
 	if (cache->nents == cache->nallocs) {
 		size_t sz = cache->nallocs + MNT_CACHE_CHUNKSZ;
 
-		e = realloc(cache->ents, sz * sizeof(struct mnt_cache_entry));
+		e = reallocarray(cache->ents, sz, sizeof(struct mnt_cache_entry));
 		if (!e)
 			return -ENOMEM;
 		cache->ents = e;

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -2850,7 +2850,7 @@ static int mnt_context_add_child(struct libmnt_context *cxt, pid_t pid)
 	if (!cxt)
 		return -EINVAL;
 
-	pids = realloc(cxt->children, sizeof(pid_t) * cxt->nchildren + 1);
+	pids = reallocarray(cxt->children, cxt->nchildren + 1, sizeof(pid_t));
 	if (!pids)
 		return -ENOMEM;
 

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -526,7 +526,7 @@ static int add_filesystem(char ***filesystems, char *name)
 
 	if (n == 0 || !((n + 1) % MYCHUNK)) {
 		size_t items = ((n + 1 + MYCHUNK) / MYCHUNK) * MYCHUNK;
-		char **x = realloc(*filesystems, items * sizeof(char *));
+		char **x = reallocarray(*filesystems, items, sizeof(char *));
 
 		if (!x)
 			goto err;

--- a/libsmartcols/src/grouping.c
+++ b/libsmartcols/src/grouping.c
@@ -278,7 +278,7 @@ static struct libscols_group **grpset_locate_freespace(struct libscols_table *tb
 	DBG(TAB, ul_debugobj(tb, "   realocate grpset [sz: old=%zu, new=%zu, new_chunks=%d]",
 				tb->grpset_size, tb->grpset_size + wanted, chunks));
 
-	tmp = realloc(tb->grpset, (tb->grpset_size + wanted) * sizeof(struct libscols_group *));
+	tmp = reallocarray(tb->grpset, tb->grpset_size + wanted, sizeof(struct libscols_group *));
 	if (!tmp)
 		return NULL;
 

--- a/libsmartcols/src/line.c
+++ b/libsmartcols/src/line.c
@@ -136,7 +136,7 @@ int scols_line_alloc_cells(struct libscols_line *ln, size_t n)
 
 	DBG(LINE, ul_debugobj(ln, "alloc %zu cells", n));
 
-	ce = realloc(ln->cells, n * sizeof(struct libscols_cell));
+	ce = reallocarray(ln->cells, n, sizeof(struct libscols_cell));
 	if (!ce)
 		return -errno;
 

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -505,7 +505,7 @@ static int parse_utmpx(const char *path, size_t *nrecords, struct utmpx **record
 			break;
 		}
 		if (i == imax)
-			ary = xrealloc(ary, (imax *= 2) * sizeof(struct utmpx));
+			ary = xreallocarray(ary, imax *= 2, sizeof(struct utmpx));
 		ary[i] = *u;
 	}
 
@@ -993,7 +993,7 @@ static int get_ulist(struct lslogins_control *ctl, char *logins, char *groups)
 			(*ar)[i++] = xstrdup(u);
 
 			if (i == *arsiz)
-				*ar = xrealloc(*ar, sizeof(char *) * (*arsiz += 32));
+				*ar = xreallocarray(*ar, *arsiz += 32, sizeof(char *));
 		}
 		ctl->ulist_on = 1;
 	}
@@ -1018,7 +1018,7 @@ static int get_ulist(struct lslogins_control *ctl, char *logins, char *groups)
 				(*ar)[i++] = xstrdup(u);
 
 				if (i == *arsiz)
-					*ar = xrealloc(*ar, sizeof(char *) * (*arsiz += 32));
+					*ar = xreallocarray(*ar, *arsiz += 32, sizeof(char *));
 			}
 		}
 		ctl->ulist_on = 1;

--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -1019,7 +1019,7 @@ static gid_t add_supp_group(const char *name, gid_t **groups, size_t *ngroups)
 
 	DBG(MISC, ul_debug("add %s group [name=%s, GID=%d]", name, gr->gr_name, (int) gr->gr_gid));
 
-	*groups = xrealloc(*groups, sizeof(gid_t) * (*ngroups + 1));
+	*groups = xreallocarray(*groups, *ngroups + 1, sizeof(gid_t));
 	(*groups)[*ngroups] = gr->gr_gid;
 	(*ngroups)++;
 

--- a/misc-utils/findmnt-verify.c
+++ b/misc-utils/findmnt-verify.c
@@ -301,7 +301,7 @@ static int add_filesystem(struct verify_context *vfy, const char *name)
 
 	if (vfy->fs_alloc == 0 || vfy->fs_num + 1 <= vfy->fs_alloc) {
 		vfy->fs_alloc = ((vfy->fs_alloc + 1 + MYCHUNK) / MYCHUNK) * MYCHUNK;
-		vfy->fs_ary = xrealloc(vfy->fs_ary, vfy->fs_alloc * sizeof(char *));
+		vfy->fs_ary = xreallocarray(vfy->fs_ary, vfy->fs_alloc, sizeof(char *));
 	}
 
 	vfy->fs_ary[vfy->fs_num] = xstrdup(name);

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -901,7 +901,7 @@ static int parser_errcb(struct libmnt_table *tb __attribute__ ((__unused__)),
 
 static char **append_tabfile(char **files, int *nfiles, char *filename)
 {
-	files = xrealloc(files, sizeof(char *) * (*nfiles + 1));
+	files = xreallocarray(files, *nfiles + 1, sizeof(char *));
 	files[(*nfiles)++] = filename;
 	return files;
 }

--- a/misc-utils/getopt.c
+++ b/misc-utils/getopt.c
@@ -256,9 +256,9 @@ static void add_longopt(struct getopt_control *ctl, const char *name, int has_ar
 
 	if (ctl->long_options_nr == ctl->long_options_length) {
 		ctl->long_options_length += REALLOC_INCREMENT;
-		ctl->long_options = xrealloc(ctl->long_options,
-					     sizeof(struct option) *
-					     ctl->long_options_length);
+		ctl->long_options = xreallocarray(ctl->long_options,
+						  ctl->long_options_length,
+						  sizeof(struct option));
 	}
 	if (name) {
 		/* Not for init! */

--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -375,7 +375,7 @@ static int journald_entry(struct logger_ctl *ctl, FILE *fp)
 			vectors *= 2;
 			if (IOV_MAX < vectors)
 				errx(EXIT_FAILURE, _("maximum input lines (%d) exceeded"), IOV_MAX);
-			iovec = xrealloc(iovec, vectors * sizeof(struct iovec));
+			iovec = xreallocarray(iovec, vectors, sizeof(struct iovec));
 		}
 		iovec[lines].iov_base = buf;
 		iovec[lines].iov_len = sz;

--- a/misc-utils/lsblk-mnt.c
+++ b/misc-utils/lsblk-mnt.c
@@ -60,8 +60,7 @@ static void add_filesystem(struct lsblk_device *dev, struct libmnt_fs *fs)
 	assert(dev);
 	assert(fs);
 
-	dev->fss = xrealloc(dev->fss, (dev->nfss + 1)
-					* sizeof(struct libmnt_fs *));
+	dev->fss = xreallocarray(dev->fss, dev->nfss + 1, sizeof(struct libmnt_fs *));
 	dev->fss[dev->nfss] = fs;
 	dev->nfss++;
 	dev->is_mounted = 1;

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -598,8 +598,8 @@ static void add_mnt_ns(ino_t id)
 		nmax = (nspaces + 16) / 16 * 16;
 	if (nmax <= nspaces + 1) {
 		nmax += 16;
-		mnt_namespaces = xrealloc(mnt_namespaces,
-					sizeof(ino_t) * nmax);
+		mnt_namespaces = xreallocarray(mnt_namespaces,
+					       nmax, sizeof(ino_t));
 	}
 	mnt_namespaces[nspaces++] = id;
 }
@@ -1687,7 +1687,7 @@ static void parse_pids(const char *str, pid_t **pids, int *count)
 		errx(EXIT_FAILURE, _("out of range value for pid specification: %ld"), v);
 
 	(*count)++;
-	*pids = xrealloc(*pids, (*count) * sizeof(**pids));
+	*pids = xreallocarray(*pids, *count, sizeof(**pids));
 	(*pids)[*count - 1] = (pid_t)v;
 
 	while (next && *next != '\0'

--- a/sys-utils/irq-common.c
+++ b/sys-utils/irq-common.c
@@ -328,8 +328,8 @@ static struct irq_stat *get_irqinfo(int softirq, size_t setsize, cpu_set_t *cpus
 
 		if (stat->nr_irq == stat->nr_irq_info) {
 			stat->nr_irq_info *= 2;
-			stat->irq_info = xrealloc(stat->irq_info,
-						  sizeof(*stat->irq_info) * stat->nr_irq_info);
+			stat->irq_info = xreallocarray(stat->irq_info, stat->nr_irq_info,
+						       sizeof(*stat->irq_info));
 		}
 	}
 	fclose(irqfile);

--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -109,8 +109,8 @@ struct lscpu_cputype *lscpu_cputype_get_default(struct lscpu_cxt *cxt)
 struct lscpu_cputype *lscpu_add_cputype(struct lscpu_cxt *cxt, struct lscpu_cputype *ct)
 {
 	DBG(TYPE, ul_debugobj(ct, "add new"));
-	cxt->cputypes = xrealloc(cxt->cputypes, (cxt->ncputypes + 1)
-				* sizeof(struct lscpu_cputype *));
+	cxt->cputypes = xreallocarray(cxt->cputypes, cxt->ncputypes + 1,
+				      sizeof(struct lscpu_cputype *));
 	cxt->cputypes[cxt->ncputypes] = ct;
 	cxt->ncputypes++;
 	lscpu_ref_cputype(ct);
@@ -434,8 +434,8 @@ static int cpuinfo_parse_cache(struct lscpu_cxt *cxt, int keynum, char *data)
 		return 0;
 
 	cxt->necaches++;
-	cxt->ecaches = xrealloc(cxt->ecaches,
-				cxt->necaches * sizeof(struct lscpu_cache));
+	cxt->ecaches = xreallocarray(cxt->ecaches,
+				     cxt->necaches, sizeof(struct lscpu_cache));
 	cache = &cxt->ecaches[cxt->necaches - 1];
 	memset(cache, 0 , sizeof(*cache));
 

--- a/sys-utils/lscpu-topology.c
+++ b/sys-utils/lscpu-topology.c
@@ -274,8 +274,8 @@ static struct lscpu_cache *add_cache(struct lscpu_cxt *cxt,
 	struct lscpu_cache *ca;
 
 	cxt->ncaches++;
-	cxt->caches = xrealloc(cxt->caches,
-			       cxt->ncaches * sizeof(*cxt->caches));
+	cxt->caches = xreallocarray(cxt->caches,
+				    cxt->ncaches, sizeof(*cxt->caches));
 
 	ca = &cxt->caches[cxt->ncaches - 1];
 	memset(ca, 0 , sizeof(*ca));

--- a/sys-utils/lsmem.c
+++ b/sys-utils/lsmem.c
@@ -477,7 +477,7 @@ static void read_info(struct lsmem *lsmem)
 			continue;
 		}
 		lsmem->nblocks++;
-		lsmem->blocks = xrealloc(lsmem->blocks, lsmem->nblocks * sizeof(blk));
+		lsmem->blocks = xreallocarray(lsmem->blocks, lsmem->nblocks, sizeof(blk));
 		*&lsmem->blocks[lsmem->nblocks - 1] = blk;
 	}
 }

--- a/sys-utils/swapon-common.c
+++ b/sys-utils/swapon-common.c
@@ -85,7 +85,7 @@ static size_t ulct;
 
 void add_label(const char *label)
 {
-	llist = xrealloc(llist, (++llct) * sizeof(char *));
+	llist = xreallocarray(llist, ++llct, sizeof(char *));
 	llist[llct - 1] = label;
 }
 
@@ -101,7 +101,7 @@ size_t numof_labels(void)
 
 void add_uuid(const char *uuid)
 {
-	ulist = xrealloc(ulist, (++ulct) * sizeof(char *));
+	ulist = xreallocarray(ulist, ++ulct, sizeof(char *));
 	ulist[ulct - 1] = uuid;
 }
 

--- a/term-utils/script-playutils.c
+++ b/term-utils/script-playutils.c
@@ -165,7 +165,7 @@ static struct replay_log *replay_new_log(struct replay_setup *stp,
 	assert(streams);
 	assert(filename);
 
-	stp->logs = xrealloc(stp->logs, (stp->nlogs + 1) *  sizeof(*log));
+	stp->logs = xreallocarray(stp->logs, stp->nlogs + 1,  sizeof(*log));
 	log = &stp->logs[stp->nlogs];
 	stp->nlogs++;
 

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -260,8 +260,8 @@ static struct script_log *log_associate(struct script_control *ctl,
 	}
 
 	/* add log to the stream */
-	stream->logs = xrealloc(stream->logs,
-			(stream->nlogs + 1) * sizeof(log));
+	stream->logs = xreallocarray(stream->logs,
+			stream->nlogs + 1, sizeof(log));
 	stream->logs[stream->nlogs] = log;
 	stream->nlogs++;
 

--- a/text-utils/col.c
+++ b/text-utils/col.c
@@ -244,11 +244,11 @@ static void flush_line(struct col_ctl *ctl, struct col_line *l)
 		 */
 		if (sorted_size < l->l_lsize) {
 			sorted_size = l->l_lsize;
-			sorted = xrealloc(sorted, sizeof(struct col_char) * sorted_size);
+			sorted = xreallocarray(sorted, sorted_size, sizeof(struct col_char));
 		}
 		if (count_size <= l->l_max_col) {
 			count_size = l->l_max_col + 1;
-			count = xrealloc(count, sizeof(size_t) * count_size);
+			count = xreallocarray(count, count_size, sizeof(size_t));
 		}
 		memset(count, 0, sizeof(size_t) * l->l_max_col + 1);
 		for (i = nchars, c = l->l_line; c && 0 < i; i--, c++)

--- a/text-utils/column.c
+++ b/text-utils/column.c
@@ -585,7 +585,7 @@ static void add_entry(struct column_control *ctl, size_t *maxents, wchar_t *wcs)
 {
 	if (ctl->nents <= *maxents) {
 		*maxents += 1000;
-		ctl->ents = xrealloc(ctl->ents, *maxents * sizeof(wchar_t *));
+		ctl->ents = xreallocarray(ctl->ents, *maxents, sizeof(wchar_t *));
 	}
 	ctl->ents[ctl->nents] = wcs;
 	ctl->nents++;

--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -359,7 +359,7 @@ static void env_argscan(struct more_control *ctl, const char *s)
 		env_argv[env_argc++] = tok;
 		if (size < env_argc) {
 			size *= 2;
-			env_argv = xrealloc(env_argv, sizeof(char *) * size);
+			env_argv = xreallocarray(env_argv, size, sizeof(char *));
 		}
 	}
 

--- a/text-utils/rev.c
+++ b/text-utils/rev.c
@@ -182,7 +182,7 @@ int main(int argc, char *argv[])
 				/* So now we double the buffer size */
 				bufsiz *= 2;
 
-				buf = xrealloc(buf, bufsiz * sizeof(wchar_t));
+				buf = xreallocarray(buf, bufsiz, sizeof(wchar_t));
 
 				/* And fill the rest of the buffer */
 				len += read_line(sep, &buf[len], bufsiz/2, fp);

--- a/text-utils/ul.c
+++ b/text-utils/ul.c
@@ -141,7 +141,7 @@ static void need_column(struct ul_ctl *ctl, size_t new_max)
 
 	while (new_max >= ctl->buflen) {
 		ctl->buflen *= 2;
-		ctl->buf = xrealloc(ctl->buf, sizeof(struct ul_char) * ctl->buflen);
+		ctl->buf = xreallocarray(ctl->buf, ctl->buflen, sizeof(struct ul_char));
 	}
 }
 


### PR DESCRIPTION
reallocarray() prevents overflow of the multiplication. It also avoids issues with operator precedence like in libmount/src/context.c:

    pids = realloc(cxt->children, sizeof(pid_t) * cxt->nchildren + 1);

This only allocated one additional byte, and not enough space for another child.