### PR TITLE
libblkid: refactor drbd prober

### DIFF
--- a/include/c.h
+++ b/include/c.h
@@ -213,6 +213,14 @@
 	(type *)( (char *)__mptr - offsetof(type,member) );})
 #endif
 
+#define read_unaligned_member(p, m) __extension__ ({          \
+	size_t offset = offsetof(__typeof__(* p), m);         \
+	__typeof__(p->m) v;                                   \
+	memcpy(&v, ((unsigned char *)p) + offset, sizeof(v)); \
+	v; })
+
+#define member_ptr(p, m) (((unsigned char *)p) + offsetof(__typeof__(*p), m))
+
 #ifndef HAVE_PROGRAM_INVOCATION_SHORT_NAME
 # ifdef HAVE___PROGNAME
 extern char *__progname;

--- a/libblkid/src/blkidP.h
+++ b/libblkid/src/blkidP.h
@@ -146,6 +146,7 @@ struct blkid_idmag
 {
 	const char	*magic;		/* magic string */
 	unsigned int	len;		/* length of magic */
+	unsigned int	hint;		/* hint for prober */
 
 	const char	*hoff;		/* hint which contains byte offset to kboff */
 	long		kboff;		/* kilobyte offset of superblock */

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -823,8 +823,6 @@ int blkid_probe_reset_buffers(blkid_probe pr)
 		ct++;
 		len += bf->len;
 
-		DBG(BUFFER, ul_debug(" remove buffer: [off=%"PRIu64", len=%"PRIu64"]",
-		                     bf->off, bf->len));
 		remove_buffer(bf);
 	}
 

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -1200,12 +1200,18 @@ int blkid_probe_set_dimension(blkid_probe pr, uint64_t off, uint64_t size)
 
 const unsigned char *blkid_probe_get_sb_buffer(blkid_probe pr, const struct blkid_idmag *mag, size_t size)
 {
-	uint64_t hint_offset;
+	uint64_t hint_offset, off;
 
-	if (!mag->hoff || blkid_probe_get_hint(pr, mag->hoff, &hint_offset) < 0)
-		hint_offset = 0;
+	if (mag->kboff >= 0) {
+		if (!mag->hoff || blkid_probe_get_hint(pr, mag->hoff, &hint_offset) < 0)
+			hint_offset = 0;
 
-	return blkid_probe_get_buffer(pr, hint_offset + (mag->kboff << 10), size);
+		off = hint_offset + (mag->kboff << 10);
+	} else {
+		off = pr->size - (-mag->kboff << 10);
+	}
+
+	return blkid_probe_get_buffer(pr, off, size);
 }
 
 /*
@@ -1227,7 +1233,7 @@ int blkid_probe_get_idmag(blkid_probe pr, const struct blkid_idinfo *id,
 	/* try to detect by magic string */
 	while(mag && mag->magic) {
 		const unsigned char *buf;
-		uint64_t kboff;
+		long kboff;
 		uint64_t hint_offset;
 
 		if (!mag->hoff || blkid_probe_get_hint(pr, mag->hoff, &hint_offset) < 0)
@@ -1244,7 +1250,10 @@ int blkid_probe_get_idmag(blkid_probe pr, const struct blkid_idinfo *id,
 		else
 			kboff = ((mag->zonenum * pr->zone_size) >> 10) + mag->kboff_inzone;
 
-		off = hint_offset + ((kboff + (mag->sboff >> 10)) << 10);
+		if (kboff >= 0)
+			off = hint_offset + ((kboff + (mag->sboff >> 10)) << 10);
+		else
+			off = pr->size - (-kboff << 10);
 		buf = blkid_probe_get_buffer(pr, off, 1024);
 
 		if (!buf && errno)
@@ -1253,7 +1262,7 @@ int blkid_probe_get_idmag(blkid_probe pr, const struct blkid_idinfo *id,
 		if (buf && !memcmp(mag->magic,
 				buf + (mag->sboff & 0x3ff), mag->len)) {
 
-			DBG(LOWPROBE, ul_debug("\tmagic sboff=%u, kboff=%" PRIu64,
+			DBG(LOWPROBE, ul_debug("\tmagic sboff=%u, kboff=%ld",
 				mag->sboff, kboff));
 			if (offset)
 				*offset = off + (mag->sboff & 0x3ff);

--- a/libblkid/src/superblocks/adaptec_raid.c
+++ b/libblkid/src/superblocks/adaptec_raid.c
@@ -79,9 +79,6 @@ static int probe_adraid(blkid_probe pr,
 	uint64_t off;
 	struct adaptec_metadata *ad;
 
-	if (pr->size < 0x10000)
-		return BLKID_PROBE_NONE;
-
 	if (!S_ISREG(pr->mode) && !blkid_probe_is_wholedisk(pr))
 		return BLKID_PROBE_NONE;
 
@@ -109,6 +106,7 @@ static int probe_adraid(blkid_probe pr,
 const struct blkid_idinfo adraid_idinfo = {
 	.name		= "adaptec_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x10000,
 	.probefunc	= probe_adraid,
 	.magics		= BLKID_NONE_MAGIC
 };

--- a/libblkid/src/superblocks/cramfs.c
+++ b/libblkid/src/superblocks/cramfs.c
@@ -37,12 +37,6 @@ struct cramfs_super
 
 #define CRAMFS_FLAG_FSID_VERSION_2	0x00000001	/* fsid version #2 */
 
-static int cramfs_is_little_endian(const struct blkid_idmag *mag)
-{
-	assert(mag->len == 4);
-	return memcmp(mag->magic, "\x45\x3d\xcd\x28", 4) == 0;
-}
-
 static uint32_t cfs32_to_cpu(int le, uint32_t value)
 {
 	if (le)
@@ -83,7 +77,7 @@ static int probe_cramfs(blkid_probe pr, const struct blkid_idmag *mag)
 	if (!cs)
 		return errno ? -errno : 1;
 
-	int le = cramfs_is_little_endian(mag);
+	int le = mag->hint == BLKID_ENDIANNESS_LITTLE;
 	int v2 = cfs32_to_cpu(le, cs->flags) & CRAMFS_FLAG_FSID_VERSION_2;
 
 	if (v2 && !cramfs_verify_csum(pr, mag, cs, le))
@@ -92,8 +86,7 @@ static int probe_cramfs(blkid_probe pr, const struct blkid_idmag *mag)
 	blkid_probe_set_label(pr, cs->name, sizeof(cs->name));
 	blkid_probe_set_fssize(pr, cfs32_to_cpu(le, cs->size));
 	blkid_probe_sprintf_version(pr, "%d", v2 ? 2 : 1);
-	blkid_probe_set_fsendianness(pr,
-			le ? BLKID_ENDIANNESS_LITTLE : BLKID_ENDIANNESS_BIG);
+	blkid_probe_set_fsendianness(pr, mag->hint);
 	return 0;
 }
 
@@ -104,8 +97,10 @@ const struct blkid_idinfo cramfs_idinfo =
 	.probefunc	= probe_cramfs,
 	.magics		=
 	{
-		{ .magic = "\x45\x3d\xcd\x28", .len = 4 },
-		{ .magic = "\x28\xcd\x3d\x45", .len = 4 },
+		{ .magic = "\x45\x3d\xcd\x28", .len = 4,
+		  .hint = BLKID_ENDIANNESS_LITTLE },
+		{ .magic = "\x28\xcd\x3d\x45", .len = 4,
+		  .hint = BLKID_ENDIANNESS_BIG },
 		{ NULL }
 	}
 };

--- a/libblkid/src/superblocks/ddf_raid.c
+++ b/libblkid/src/superblocks/ddf_raid.c
@@ -80,9 +80,6 @@ static int probe_ddf(blkid_probe pr,
 	char version[DDF_REV_LENGTH + 1];
 	uint64_t off = 0, lba;
 
-	if (pr->size < 0x30000)
-		return 1;
-
 	for (i = 0; i < ARRAY_SIZE(hdrs); i++) {
 		off = ((pr->size / 0x200) - hdrs[i]) * 0x200;
 
@@ -134,6 +131,7 @@ static int probe_ddf(blkid_probe pr,
 const struct blkid_idinfo ddfraid_idinfo = {
 	.name		= "ddf_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x30000,
 	.probefunc	= probe_ddf,
 	.magics		= BLKID_NONE_MAGIC
 };

--- a/libblkid/src/superblocks/drbd.c
+++ b/libblkid/src/superblocks/drbd.c
@@ -131,10 +131,6 @@ static int probe_drbd_84(blkid_probe pr)
 
 	off = pr->size - DRBD_MD_OFFSET;
 
-	/* Small devices cannot be drbd (?) */
-	if (pr->size < 0x10000)
-		return 1;
-
 	md = (struct md_on_disk_08 *)
 			blkid_probe_get_buffer(pr,
 					off,
@@ -171,14 +167,6 @@ static int probe_drbd_90(blkid_probe pr)
 	off_t off;
 
 	off = pr->size - DRBD_MD_OFFSET;
-
-	/*
-	 * Smaller ones are certainly not DRBD9 devices.
-	 * Recent utils even refuse to generate larger ones,
-	 * keep this as a sufficient lower bound.
-	 */
-	if (pr->size < 0x10000)
-		return 1;
 
 	md = (struct meta_data_on_disk_9 *)
 			blkid_probe_get_buffer(pr,
@@ -226,6 +214,12 @@ const struct blkid_idinfo drbd_idinfo =
 	.name		= "drbd",
 	.usage		= BLKID_USAGE_RAID,
 	.probefunc	= probe_drbd,
+	/*
+	 * Smaller ones are certainly not DRBD9 devices.
+	 * Recent utils even refuse to generate larger ones,
+	 * keep this as a sufficient lower bound.
+	 */
+	.minsz		= 0x10000,
 	.magics		= BLKID_NONE_MAGIC
 };
 

--- a/libblkid/src/superblocks/drbd.c
+++ b/libblkid/src/superblocks/drbd.c
@@ -137,8 +137,8 @@ static int probe_drbd_84(blkid_probe pr, const struct blkid_idmag *mag)
 	 * notion of uuids (64 bit, see struct above)
 	 */
 	blkid_probe_sprintf_uuid(pr,
-		(unsigned char *) &md->device_uuid, sizeof(md->device_uuid),
-		"%" PRIx64, be64_to_cpu(md->device_uuid));
+		member_ptr(md, device_uuid), sizeof(md->device_uuid),
+		"%" PRIx64, be64_to_cpu(read_unaligned_member(md, device_uuid)));
 
 	blkid_probe_set_version(pr, "v08");
 
@@ -158,8 +158,8 @@ static int probe_drbd_90(blkid_probe pr, const struct blkid_idmag *mag)
 	 * notion of uuids (64 bit, see struct above)
 	 */
 	blkid_probe_sprintf_uuid(pr,
-		(unsigned char *) &md->device_uuid, sizeof(md->device_uuid),
-		"%" PRIx64, be64_to_cpu(md->device_uuid));
+		member_ptr(md, device_uuid), sizeof(md->device_uuid),
+		"%" PRIx64, be64_to_cpu(read_unaligned_member(md, device_uuid)));
 
 	blkid_probe_set_version(pr, "v09");
 

--- a/libblkid/src/superblocks/highpoint_raid.c
+++ b/libblkid/src/superblocks/highpoint_raid.c
@@ -29,8 +29,6 @@ static int probe_highpoint45x(blkid_probe pr,
 	uint64_t off;
 	uint32_t magic;
 
-	if (pr->size < 0x10000)
-		return 1;
 	if (!S_ISREG(pr->mode) && !blkid_probe_is_wholedisk(pr))
 		return 1;
 
@@ -62,6 +60,7 @@ static int probe_highpoint37x(blkid_probe pr,
 const struct blkid_idinfo highpoint45x_idinfo = {
 	.name		= "hpt45x_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x10000,
 	.probefunc	= probe_highpoint45x,
 	.magics		= BLKID_NONE_MAGIC
 };

--- a/libblkid/src/superblocks/isw_raid.c
+++ b/libblkid/src/superblocks/isw_raid.c
@@ -32,8 +32,6 @@ static int probe_iswraid(blkid_probe pr,
 	unsigned int sector_size;
 	struct isw_metadata *isw;
 
-	if (pr->size < 0x10000)
-		return 1;
 	if (!S_ISREG(pr->mode) && !blkid_probe_is_wholedisk(pr))
 		return 1;
 
@@ -60,6 +58,7 @@ static int probe_iswraid(blkid_probe pr,
 const struct blkid_idinfo iswraid_idinfo = {
 	.name		= "isw_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x10000,
 	.probefunc	= probe_iswraid,
 	.magics		= BLKID_NONE_MAGIC
 };

--- a/libblkid/src/superblocks/jmicron_raid.c
+++ b/libblkid/src/superblocks/jmicron_raid.c
@@ -75,8 +75,6 @@ static int probe_jmraid(blkid_probe pr,
 	uint64_t off;
 	const struct jm_metadata *jm;
 
-	if (pr->size < 0x10000)
-		return 1;
 	if (!S_ISREG(pr->mode) && !blkid_probe_is_wholedisk(pr))
 		return 1;
 
@@ -109,6 +107,7 @@ static int probe_jmraid(blkid_probe pr,
 const struct blkid_idinfo jmraid_idinfo = {
 	.name		= "jmicron_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x10000,
 	.probefunc	= probe_jmraid,
 	.magics		= BLKID_NONE_MAGIC
 };

--- a/libblkid/src/superblocks/lsi_raid.c
+++ b/libblkid/src/superblocks/lsi_raid.c
@@ -29,8 +29,6 @@ static int probe_lsiraid(blkid_probe pr,
 	uint64_t off;
 	struct lsi_metadata *lsi;
 
-	if (pr->size < 0x10000)
-		return 1;
 	if (!S_ISREG(pr->mode) && !blkid_probe_is_wholedisk(pr))
 		return 1;
 
@@ -53,6 +51,7 @@ static int probe_lsiraid(blkid_probe pr,
 const struct blkid_idinfo lsiraid_idinfo = {
 	.name		= "lsi_mega_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x10000,
 	.probefunc	= probe_lsiraid,
 	.magics		= BLKID_NONE_MAGIC
 };

--- a/libblkid/src/superblocks/nvidia_raid.c
+++ b/libblkid/src/superblocks/nvidia_raid.c
@@ -41,8 +41,6 @@ static int probe_nvraid(blkid_probe pr,
 	uint64_t off;
 	struct nv_metadata *nv;
 
-	if (pr->size < 0x10000)
-		return 1;
 	if (!S_ISREG(pr->mode) && !blkid_probe_is_wholedisk(pr))
 		return 1;
 
@@ -71,6 +69,7 @@ static int probe_nvraid(blkid_probe pr,
 const struct blkid_idinfo nvraid_idinfo = {
 	.name		= "nvidia_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x10000,
 	.probefunc	= probe_nvraid,
 	.magics		= BLKID_NONE_MAGIC
 };

--- a/libblkid/src/superblocks/promise_raid.c
+++ b/libblkid/src/superblocks/promise_raid.c
@@ -33,8 +33,6 @@ static int probe_pdcraid(blkid_probe pr,
 	};
 	uint64_t nsectors;
 
-	if (pr->size < 0x40000)
-		return 1;
 	if (!S_ISREG(pr->mode) && !blkid_probe_is_wholedisk(pr))
 		return 1;
 
@@ -70,6 +68,7 @@ static int probe_pdcraid(blkid_probe pr,
 const struct blkid_idinfo pdcraid_idinfo = {
 	.name		= "promise_fasttrack_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x40000,
 	.probefunc	= probe_pdcraid,
 	.magics		= BLKID_NONE_MAGIC
 };

--- a/libblkid/src/superblocks/silicon_raid.c
+++ b/libblkid/src/superblocks/silicon_raid.c
@@ -91,8 +91,6 @@ static int probe_silraid(blkid_probe pr,
 	uint64_t off;
 	struct silicon_metadata *sil;
 
-	if (pr->size < 0x10000)
-		return 1;
 	if (!S_ISREG(pr->mode) && !blkid_probe_is_wholedisk(pr))
 		return 1;
 
@@ -127,6 +125,7 @@ static int probe_silraid(blkid_probe pr,
 const struct blkid_idinfo silraid_idinfo = {
 	.name		= "silicon_medley_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x10000,
 	.probefunc	= probe_silraid,
 	.magics		= BLKID_NONE_MAGIC
 };

--- a/libblkid/src/superblocks/via_raid.c
+++ b/libblkid/src/superblocks/via_raid.c
@@ -51,8 +51,6 @@ static int probe_viaraid(blkid_probe pr,
 	uint64_t off;
 	struct via_metadata *v;
 
-	if (pr->size < 0x10000)
-		return 1;
 	if (!S_ISREG(pr->mode) && !blkid_probe_is_wholedisk(pr))
 		return 1;
 
@@ -84,6 +82,7 @@ static int probe_viaraid(blkid_probe pr,
 const struct blkid_idinfo viaraid_idinfo = {
 	.name		= "via_raid_member",
 	.usage		= BLKID_USAGE_RAID,
+	.minsz		= 0x10000,
 	.probefunc	= probe_viaraid,
 	.magics		= BLKID_NONE_MAGIC
 };


### PR DESCRIPTION
This PR mostly refactors the DRBD prober to avoid potential unaligned access when comparing the superblock magic.
For this it introduces some generic infrastructure that will be also useful for other probers.