### PR TITLE
libblkid: (lvm2) read complete superblock

### DIFF
--- a/libblkid/src/superblocks/lvm.c
+++ b/libblkid/src/superblocks/lvm.c
@@ -80,7 +80,7 @@ static int probe_lvm2(blkid_probe pr, const struct blkid_idmag *mag)
 
 	buf = blkid_probe_get_buffer(pr,
 			mag->kboff << 10,
-			512 + sizeof(struct lvm2_pv_label_header));
+			512 + LVM2_LABEL_SIZE);
 	if (!buf)
 		return errno ? -errno : 1;
 


### PR DESCRIPTION
The lvm2_calc_crc() will create a checksum over LVM2_LABEL_SIZE bytes, which all need to be read.

Currently this works because the superblock is cached by blkid_probe_get_idmag() which always reads 1024 bytes.