### PR TITLE
docs: use HTTPS for GitHub clone URLs

### DIFF
--- a/Documentation/howto-contribute.txt
+++ b/Documentation/howto-contribute.txt
@@ -47,7 +47,7 @@ Repositories & Branches
 	  We use this repository for master and stable branches only.
 
 	* Backup repository at github.com:
-	  git clone git://github.com/util-linux/util-linux.git
+	  git clone https://github.com/util-linux/util-linux.git
 
 	  We use this repository to backup kernel.org and for pull requests,
 	  issues tracking and topic branches. The master and stable branches are

--- a/Documentation/howto-pull-request.txt
+++ b/Documentation/howto-pull-request.txt
@@ -149,7 +149,7 @@ mail-list archive.  Obviously the pull request content does not get
 indexed, and that is why it is worse.
 
 git format-patch --cover-letter master..textual
-git request-pull upstream/master git://github.com/yourlogin/util-linux.git textual > tempfile
+git request-pull upstream/master https://github.com/yourlogin/util-linux.git textual > tempfile
 
 Take from the 'tempfile' the header:
 
@@ -160,7 +160,7 @@ The following changes since commit 17bf9c1c39b4f35163ec5c443b8bbd5857386ddd:
 
 are available in the git repository at:
 
-  git://github.com/yourlogin/util-linux.git textual
+  https://github.com/yourlogin/util-linux.git textual
 ----------------------------------------------------------------
 
 and copy paste it to 0000-cover-letter.patch file somewhere near 'BLURB

--- a/README
+++ b/README
@@ -74,7 +74,7 @@ SOURCE CODE:
 	  git clone git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
 
     Backup repository:
-	  git clone git://github.com/util-linux/util-linux.git
+	  git clone https://github.com/util-linux/util-linux.git
 
     Web interfaces:
 	  https://git.kernel.org/cgit/utils/util-linux/util-linux.git


### PR DESCRIPTION
GitHub has dropped support for the git:// protocol:
https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/