### PR TITLE
libfdisk: reset errno before calling read()

### DIFF
--- a/libfdisk/src/utils.c
+++ b/libfdisk/src/utils.c
@@ -29,6 +29,7 @@ static int read_from_device(struct fdisk_context *cxt,
 		return -errno;
 	}
 
+	errno = 0;
 	r = read(cxt->dev_fd, buf, size);
 	if (r < 0 || (size_t)r != size) {
 		if (!errno)


### PR DESCRIPTION
The else branch will be executed on short reads.
For those errno is not reset so a random left-over errno value may be checked.