### PR TITLE
Revert "libmount: (tab) avoid leaking memory allocated in loop"

### DIFF
--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -1856,7 +1856,6 @@ int __mnt_table_is_fs_mounted(struct libmnt_table *tb, struct libmnt_fs *fstab_f
 				if (!*p)
 					tgt = tgt_prefix;	/* target is '/' */
 				else {
-					free(tgt_buf);
 					if (asprintf(&tgt_buf, "%s/%s", tgt_prefix, p) <= 0) {
 						rc = -ENOMEM;
 						goto done;


### PR DESCRIPTION
coverity claims that this is now a use-after-free. Let's revert the original change and make the code clearer before trying another fix.

This reverts commit d36306a560fd6d747e18ab22fc1279f4a373f43d.