### PR TITLE
 libmount: report all kernel messages for fd-based mount API 

### DIFF
--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -89,6 +89,8 @@ static void set_syscall_status_cxt_log(struct libmnt_context *cxt,
 	}
 }
 
+#define set_syscall_status set_syscall_status_cxt_log
+
 /*
  * This hookset uses 'struct libmnt_sysapi' (mountP.h) as hookset data.
  */

--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -64,6 +64,31 @@ static void close_sysapi_fds(struct libmnt_sysapi *api)
 	api->fd_tree = api->fd_fs = -1;
 }
 
+static void debug_fs_fd_messages(int fd)
+{
+	uint8_t buf[BUFSIZ];
+	int rc;
+
+	while ((rc = read(fd, buf, sizeof(buf))) != -1) {
+		if (rc > 0 && buf[rc - 1] == '\n')
+			buf[rc - 1] = '\0';
+		DBG(CXT, ul_debug("message from kernel: %*s", rc, buf));
+	}
+}
+
+static void set_syscall_status_cxt_log(struct libmnt_context *cxt,
+				       const char *name, int x)
+{
+	struct libmnt_sysapi *api;
+
+	set_syscall_status(cxt, name, x);
+
+	if (!x) {
+		api = get_sysapi(cxt);
+		debug_fs_fd_messages(api->fd_fs);
+	}
+}
+
 /*
  * This hookset uses 'struct libmnt_sysapi' (mountP.h) as hookset data.
  */

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -479,22 +479,24 @@ struct libmnt_context
 /* Flags usable with MS_BIND|MS_REMOUNT */
 #define MNT_BIND_SETTABLE	(MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_NOATIME|MS_NODIRATIME|MS_RELATIME|MS_RDONLY|MS_NOSYMFOLLOW)
 
-#define set_syscall_status(_cxt, _name, _x) __extension__ ({ \
-		if (!(_x)) { \
-			DBG(CXT, ul_debug("syscall '%s' [%m]", _name)); \
-			(_cxt)->syscall_status = -errno; \
-			(_cxt)->syscall_name = (_name); \
-		} else { \
-			DBG(CXT, ul_debug("syscall '%s' [success]", _name)); \
-			(_cxt)->syscall_status = 0; \
-		} \
-	})
+static inline void set_syscall_status(struct libmnt_context *cxt, const char *name, int x)
+{
+	if (!x) {
+		DBG(CXT, ul_debug("syscall '%s' [%m]", name));
+		cxt->syscall_status = -errno;
+		cxt->syscall_name = name;
+	} else {
+		DBG(CXT, ul_debug("syscall '%s' [success]", name));
+		cxt->syscall_status = 0;
+	}
+}
 
-#define reset_syscall_status(_cxt)	__extension__ ({ \
-		DBG(CXT, ul_debug("reset syscall status")); \
-		(_cxt)->syscall_status = 0; \
-		(_cxt)->syscall_name = NULL; \
-	})
+static inline void reset_syscall_status(struct libmnt_context *cxt)
+{
+	DBG(CXT, ul_debug("reset syscall status"));
+	cxt->syscall_status = 0;
+	cxt->syscall_name = NULL;
+}
 
 /* optmap.c */
 extern const struct libmnt_optmap *mnt_optmap_get_entry(


### PR DESCRIPTION
The kernel helpfully provides feedback about failed operations via the
filesystem descriptor. Read that information and expose it via libmounts
debug facilities.

Notes:

For #2528 we get the following message:
`646514: libmount:      CXT: message from kernel:  e overlay: No changes allowed in reconfigure`

The `#define`-based usage is a bit iffy but so convenient.

Related to #2314 