### PR TITLE
libblkid: asymmetric buffers alignment [for testing only]

### DIFF
--- a/libblkid/src/blkidP.h
+++ b/libblkid/src/blkidP.h
@@ -208,6 +208,9 @@ struct blkid_struct_probe
 	uint64_t		size;		/* end of data on the device */
 	uint64_t		io_size;	/* optimal size of IO */
 
+	uint64_t		hot_area_size;	/* from start/end of the device */
+	uint64_t		hot_io_size;	/* io_size for the hot area */
+
 	dev_t			devno;		/* device number (st.st_rdev) */
 	dev_t			disk_devno;	/* devno of the whole-disk or 0 */
 	unsigned int		blkssz;		/* sector size (BLKSSZGET ioctl) */


### PR DESCRIPTION
The usual location of the FS or RAID superblock is at the begging or end of the probing area. This patch introduces "hot area" definition where we can create cache probing buffers in bigger chunks. For testing purpose it's possible to set it by env. variables (in bytes).

 - LIBBLKID_HOT_AREASIZE offset from start/end where to apply LIBBLKID_HOT_IOSIZE
 - LIBBLKID_HOT_IOSIZE align buffers to this size
 - LIBBLKID_IOSIZE default alignment for the buffers

For example:

LIBBLKID_HOT_AREASIZE=32768 LIBBLKID_HOT_IOSIZE=16384 LIBBLKID_IOSIZE=512 LIBBLKID_DEBUG=all \
    ./build/blkid -p /dev/loop1 2>
    >(awk '/summary/ { bytes+=$6; n+=$9 }; /I\/O:/ { print $0 } END { print "bytes: " bytes " syscalls: " n "\n" }')

I/O: size=512, hot=16384, hotarea=32768
bytes: 1095680 syscalls: 34