### PR TITLE
login: simplify code

### DIFF
--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -861,8 +861,7 @@ static void loginpam_err(pam_handle_t *pamh, int retcode)
 static const char *loginpam_get_prompt(struct login_context *cxt)
 {
 	const char *host;
-	char *prompt, *dflt_prompt = _("login: ");
-	size_t sz;
+	char *prompt = NULL, *dflt_prompt = _("login: ");
 
 	if (cxt->nohost)
 		return dflt_prompt;	/* -H on command line */
@@ -873,9 +872,7 @@ static const char *loginpam_get_prompt(struct login_context *cxt)
 	if (!(host = get_thishost(cxt, NULL)))
 		return dflt_prompt;
 
-	sz = strlen(host) + 1 + strlen(dflt_prompt) + 1;
-	prompt = xmalloc(sz);
-	snprintf(prompt, sz, "%s %s", host, dflt_prompt);
+	xasprintf(&prompt, "%s %s", host, dflt_prompt);
 
 	return prompt;
 }


### PR DESCRIPTION
- Use xasprintf instead of manually performing strlen + malloc + snprintf
- Access login.noauth file directly instead of scanning its parent directory for all files