### PR TITLE
meson: avoid int operation with non-int

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -731,7 +731,8 @@ int main(void) {
 have = cc.compiles(code, name : 'using __progname')
 conf.set('HAVE___PROGNAME', have ? 1 : false)
 
-have = conf.get('HAVE_PTY_H') != false and conf.get('HAVE_SYS_SIGNALFD_H') != false
+have = conf.get('HAVE_PTY_H').to_string() == '1' \
+       and conf.get('HAVE_SYS_SIGNALFD_H').to_string() == '1'
 conf.set('HAVE_PTY', have ? 1 : false)
 
 have_opal_get_status= cc.has_header_symbol('linux/sed-opal.h', 'IOC_OPAL_GET_STATUS')
@@ -2918,7 +2919,7 @@ if not is_disabler(exe)
   bashcompletions += ['fadvise']
 endif
 
-if LINUX and conf.get('HAVE_PIDFD_OPEN') != false
+if LINUX and conf.get('HAVE_PIDFD_OPEN').to_string() == '1'
   exe = executable(
     'waitpid',
     waitpid_sources,
@@ -3080,7 +3081,8 @@ exe = executable(
   build_by_default: program_tests)
 exes += exe
 
-if conf.get('HAVE_OPENAT') != false and conf.get('HAVE_DIRFD') != false
+if conf.get('HAVE_OPENAT').to_string() == '1' \
+   and conf.get('HAVE_DIRFD').to_string() == '1'
   exe = executable(
     'test_procfs',
     'lib/procfs.c',
@@ -3102,7 +3104,7 @@ if conf.get('HAVE_OPENAT') != false and conf.get('HAVE_DIRFD') != false
   exes += exe
 endif
 
-if conf.get('HAVE_PTY') != false
+if conf.get('HAVE_PTY').to_string() == '1'
   exe = executable(
     'test_pty',
     pty_session_c,
@@ -3416,7 +3418,7 @@ exes += exe
 
 ############################################################
 
-if conf.get('HAVE_OPENAT') != false
+if conf.get('HAVE_OPENAT').to_string() == '1'
   exe = executable(
     'sample-scols-tree',
     'libsmartcols/samples/tree.c',


### PR DESCRIPTION
`conf` as configuration_data() object can contain any datatype. For `HAVE_FOO` variables this will be a `1` int to generate `#define HAVE_FOO 1` or a `false` bool to generate `#undef HAVE_FOO` in `conf.h`.

When retrieving and testing `HAVE_FOO` from `conf` it can be both types. Newer versions of meson are unhappy about comparisions of int with non-int

    ../meson.build:734: DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.2.0': int operations with non-int. It is not commutative and only worked because of leaky Python abstractions.

    WARNING: Broken features used:
     * 1.2.0: {'int operations with non-int'}

As both `int` and `bool` support a `.to_string()` method, we can use that to convert them into a well-known type and compare that.

Unfortunately meson does not implement a way to determine the type of a value.
A method `int.to_int()` would also have worked but does not exist.

This broken feature was actually first recognized in util-linux. See #2312 and https://github.com/mesonbuild/meson/pull/11879.

Cc @eli-schwartz 