### PR TITLE
[tests] fix chfn/gecos libuser.conf absence

### DIFF
--- a/tests/ts/chfn/gecos
+++ b/tests/ts/chfn/gecos
@@ -22,6 +22,8 @@ TS_DESC="gecos"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
+export LIBUSER_CONF=/dev/null
+
 ts_skip_nonroot
 ts_check_test_command "$TS_CMD_CHFN"
 ts_check_prog "useradd"


### PR DESCRIPTION
Don't fail on `chfn/gecos` test in case of `/etc/libuser.conf` absence

Current behaviour:
```
         chfn: gecos                          ...chfn: libuser initialization failed: could not open configuration file `/etc/libuser.conf': No such file or directory.
 FAILED (chfn/gecos)
 ```

after patch:
```
util-linux/tests# ./run.sh chfn/gecos
...
         chfn: gecos                          ... OK
```