### PR TITLE
lscpu: fix caches separator for --parse=<list>

### DIFF
--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -1459,10 +1459,13 @@ int main(int argc, char *argv[])
 			columns[ncolumns++] = COL_CPU_NODE;
 			columns[ncolumns++] = COL_CPU_CACHE;
 		}
-		if (outarg && string_add_to_idarray(outarg, columns,
+		if (outarg) {
+			if (string_add_to_idarray(outarg, columns,
 					ARRAY_SIZE(columns),
 					&ncolumns, cpu_column_name_to_id) < 0)
-			return EXIT_FAILURE;
+				return EXIT_FAILURE;
+			cxt->show_compatible = 0;
+		}
 
 		print_cpus_parsable(cxt, columns, ncolumns);
 		break;


### PR DESCRIPTION
Fixes: https://github.com/util-linux/util-linux/issues/2544