### PR TITLE
libsmartcols: add support for zero separator 

### DIFF
--- a/include/mbsalign.h
+++ b/include/mbsalign.h
@@ -55,6 +55,7 @@ extern size_t mbs_width(const char *s);
 extern char *mbs_safe_encode(const char *s, size_t *width);
 extern char *mbs_safe_encode_to_buffer(const char *s, size_t *width, char *buf, const char *safechars);
 extern size_t mbs_safe_encode_size(size_t bytes);
+extern size_t mbs_safe_decode_size(const char *s);
 
 extern char *mbs_invalid_encode(const char *s, size_t *width);
 extern char *mbs_invalid_encode_to_buffer(const char *s, size_t *width, char *buf);

--- a/include/strutils.h
+++ b/include/strutils.h
@@ -388,6 +388,23 @@ static inline void strrem(char *s, int rem)
 	*p = '\0';
 }
 
+/* returns next string after \0 if before @end */
+static inline char *ul_next_string(char *p, char *end)
+{
+	char *last;
+
+	if (!p || !end || p >= end)
+		return NULL;
+
+	for (last = p; p < end; p++) {
+		if (*last == '\0' && p != last)
+			return p;
+		last = p;
+	}
+
+	return NULL;
+}
+
 extern char *strnconcat(const char *s, const char *suffix, size_t b);
 extern char *strconcat(const char *s, const char *suffix);
 extern char *strfconcat(const char *s, const char *format, ...)

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -11,7 +11,7 @@
 void ul_buffer_reset_data(struct ul_buffer *buf)
 {
 	if (buf->begin)
-		buf->begin[0] = '\0';
+		memset(buf->begin, 0, buf->sz);
 	buf->end = buf->begin;
 
 	if (buf->ptrs && buf->nptrs)
@@ -134,12 +134,11 @@ int ul_buffer_append_data(struct ul_buffer *buf, const char *data, size_t sz)
 
 	if (!buf)
 		return -EINVAL;
-	if (!data || !*data)
+	if (!data)
 		return 0;
 
 	if (buf->begin && buf->end)
 		maxsz = buf->sz - (buf->end - buf->begin);
-
 	if (maxsz <= sz + 1) {
 		int rc = ul_buffer_alloc_data(buf, buf->sz + sz + 1);
 		if (rc)

--- a/lib/mbsalign.c
+++ b/lib/mbsalign.c
@@ -310,9 +310,30 @@ char *mbs_invalid_encode_to_buffer(const char *s, size_t *width, char *buf)
 	return buf;
 }
 
+/*
+ * Guess size
+ */
 size_t mbs_safe_encode_size(size_t bytes)
 {
 	return (bytes * 4) + 1;
+}
+
+/*
+ * Count size of the original string in bytes (count \x?? as one byte)
+ */
+size_t mbs_safe_decode_size(const char *p)
+{
+	size_t bytes = 0;
+
+	while (p && *p) {
+		if (*p == '\\' && *(p + 1) == 'x' &&
+		    isxdigit(*(p + 2)) && isxdigit(*(p + 3)))
+			p += 4;
+		else
+			p++;
+		bytes++;
+	}
+	return bytes;
 }
 
 /*

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -1414,6 +1414,15 @@ int main(int argc, char *argv[])
 		printf("\"%s\" --> \"%s\"\n", argv[2], ul_strchr_escaped(argv[2], *argv[3]));
 		return EXIT_SUCCESS;
 
+	} else if (argc == 2 && strcmp(argv[1], "--next-string") == 0) {
+		char *buf = "abc\0Y\0\0xyz\0X";
+		char *end = buf + 12;
+		char *p = buf;
+
+		do {
+			printf("str: '%s'\n", p);
+		} while ((p = ul_next_string(p, end)));
+
 	} else {
 		fprintf(stderr, "usage: %1$s --size <number>[suffix]\n"
 				"       %1$s --cmp-paths <path> <path>\n"

--- a/libsmartcols/docs/libsmartcols-sections.txt
+++ b/libsmartcols/docs/libsmartcols-sections.txt
@@ -5,9 +5,11 @@ scols_cell_copy_content
 scols_cell_get_alignment
 scols_cell_get_color
 scols_cell_get_data
+scols_cell_get_datasiz
 scols_cell_get_flags
 scols_cell_get_userdata
 scols_cell_refer_data
+scols_cell_refer_memory
 scols_cell_set_color
 scols_cell_set_data
 scols_cell_set_flags
@@ -29,6 +31,7 @@ scols_column_get_safechars
 scols_column_get_table
 scols_column_get_whint
 scols_column_get_width
+scols_column_get_wrap_data
 scols_column_is_customwrap
 scols_column_is_hidden
 scols_column_is_noextremes
@@ -52,6 +55,7 @@ scols_ref_column
 scols_unref_column
 scols_wrapnl_chunksize
 scols_wrapnl_nextchunk
+scols_wrapzero_nextchunk
 </SECTION>
 
 <SECTION>
@@ -146,6 +150,7 @@ scols_table_enable_shellvar
 scols_table_get_column
 scols_table_get_column_by_name
 scols_table_get_column_separator
+scols_table_get_cursor
 scols_table_get_line
 scols_table_get_line_separator
 scols_table_get_name

--- a/libsmartcols/samples/fromfile.c
+++ b/libsmartcols/samples/fromfile.c
@@ -148,21 +148,22 @@ static int parse_column_data(FILE *f, struct libscols_table *tb, int col)
 			break;
 
 		p = strrchr(str, '\n');
-		if (p) {
+		if (p)
 			*p = '\0';
-			len = p - str;
-		}
 		if (!*str)
 			continue;
 
 		/* convert \x?? to real bytes */
 		if (strstr(str, "\\x")) {
 			struct libscols_cell *ce = scols_line_get_cell(ln, col);
-			char *buf = xcalloc(1, ++len);
+			size_t sz = len + 1;
+			char *buf = xcalloc(1, sz);
 
-			len = unhexmangle_to_buffer(str, buf, len);
-			if (len)
-				rc = scols_cell_refer_memory(ce, buf, len);
+			sz = unhexmangle_to_buffer(str, buf, sz);
+			if (sz)
+				rc = scols_cell_refer_memory(ce, buf, sz);
+			else
+				free(buf);
 		} else
 			rc = scols_line_set_data(ln, col, str);
 		if (rc)

--- a/libsmartcols/samples/fromfile.c
+++ b/libsmartcols/samples/fromfile.c
@@ -141,7 +141,7 @@ static int parse_column_data(FILE *f, struct libscols_table *tb, int col)
 
 	while ((i = getline(&str, &len, f)) != -1) {
 		struct libscols_line *ln;
-		int rc;
+		int rc = 0;
 
 		ln = scols_table_get_line(tb, nlines++);
 		if (!ln)
@@ -162,7 +162,7 @@ static int parse_column_data(FILE *f, struct libscols_table *tb, int col)
 
 			len = unhexmangle_to_buffer(str, buf, len);
 			if (len)
-				scols_cell_refer_memory(ce, buf, len);
+				rc = scols_cell_refer_memory(ce, buf, len);
 		} else
 			rc = scols_line_set_data(ln, col, str);
 		if (rc)

--- a/libsmartcols/samples/fromfile.c
+++ b/libsmartcols/samples/fromfile.c
@@ -36,6 +36,7 @@ static const struct column_flag flags[] = {
 	{ "hidden",	SCOLS_FL_HIDDEN },
 	{ "wrap",	SCOLS_FL_WRAP },
 	{ "wrapnl",	SCOLS_FL_WRAP },
+	{ "wrapzero",	SCOLS_FL_WRAP },
 	{ "none",	0 }
 };
 
@@ -100,11 +101,16 @@ static struct libscols_column *parse_column(FILE *f)
 				goto fail;
 			if (strcmp(line, "wrapnl") == 0) {
 				scols_column_set_wrapfunc(cl,
-						scols_wrapnl_chunksize,
+						NULL,
 						scols_wrapnl_nextchunk,
 						NULL);
 				scols_column_set_safechars(cl, "\n");
 
+			} else if (strcmp(line, "wrapzero") == 0) {
+				scols_column_set_wrapfunc(cl,
+						NULL,
+						scols_wrapzero_nextchunk,
+						NULL);
 			}
 			break;
 		}

--- a/libsmartcols/samples/wrap.c
+++ b/libsmartcols/samples/wrap.c
@@ -92,7 +92,15 @@ int main(int argc, char *argv[])
 	if (!tb)
 		err(EXIT_FAILURE, "failed to create output table");
 
-	scols_table_enable_colors(tb, isatty(STDOUT_FILENO));
+	if (argc > 1 && strcmp(argv[1], "--export") == 0)
+		scols_table_enable_export(tb, 1);
+	else if (argc > 1 && strcmp(argv[1], "--raw") == 0)
+		scols_table_enable_raw(tb, 1);
+	else if (argc > 1 && strcmp(argv[1], "--json") == 0)
+		scols_table_enable_json(tb, 1);
+	else
+		scols_table_enable_colors(tb, isatty(STDOUT_FILENO));
+
 	setup_columns(tb);
 
 	ln = add_line(tb, NULL, "A");

--- a/libsmartcols/src/cell.c
+++ b/libsmartcols/src/cell.c
@@ -108,6 +108,8 @@ int scols_cell_refer_data(struct libscols_cell *ce, char *data)
  * with string!
  *
  * Returns: 0, a negative value in case of an error.
+ *
+ * Since: 2.40
  */
 int scols_cell_refer_memory(struct libscols_cell *ce, char *data, size_t datasiz)
 {
@@ -124,6 +126,8 @@ int scols_cell_refer_memory(struct libscols_cell *ce, char *data, size_t datasiz
  * @ce: a pointer to a struct libscols_cell instance
  *
  * Returns: the current set data size.
+ *
+ * Since: 2.40
  */
 size_t scols_cell_get_datasiz(struct libscols_cell *ce)
 {

--- a/libsmartcols/src/column.c
+++ b/libsmartcols/src/column.c
@@ -802,7 +802,7 @@ int scols_column_set_properties(struct libscols_column *cl, const char *opts)
 	return rc;
 }
 
-static void scols_column_reset_wrap(struct libscols_column *cl)
+void scols_column_reset_wrap(struct libscols_column *cl)
 {
 	if (!cl)
 		return;

--- a/libsmartcols/src/column.c
+++ b/libsmartcols/src/column.c
@@ -539,6 +539,8 @@ int scols_column_set_wrapfunc(struct libscols_column *cl,
  * This function returns the current status of wrapping cell data (for multi-line cells).
  *
  * Returns: 0, a negative value in case of an error.
+ *
+ * Since: 2.40
  */
 int scols_column_get_wrap_data(const struct libscols_column *cl,
 		char **data, size_t *datasiz, char **cur, char **next)

--- a/libsmartcols/src/libsmartcols.h.in
+++ b/libsmartcols/src/libsmartcols.h.in
@@ -216,6 +216,11 @@ extern int scols_column_set_wrapfunc(struct libscols_column *cl,
 extern char *scols_wrapnl_nextchunk(const struct libscols_column *cl, char *data, void *userdata);
 extern size_t scols_wrapnl_chunksize(const struct libscols_column *cl, const char *data, void *userdata);
 
+extern char *scols_wrapzero_nextchunk(const struct libscols_column *cl, char *data, void *userdata);
+
+extern int scols_column_get_wrap_data(const struct libscols_column *cl,
+                char **data, size_t *datasiz, char **cur, char **next);
+
 /* line.c */
 extern struct libscols_line *scols_new_line(void);
 extern void scols_ref_line(struct libscols_line *ln);

--- a/libsmartcols/src/libsmartcols.h.in
+++ b/libsmartcols/src/libsmartcols.h.in
@@ -310,6 +310,12 @@ extern int scols_table_reduce_termwidth(struct libscols_table *tb, size_t reduce
 
 extern int scols_sort_table(struct libscols_table *tb, struct libscols_column *cl);
 extern int scols_sort_table_by_tree(struct libscols_table *tb);
+
+extern int scols_table_get_cursor(struct libscols_table *tb,
+                           struct libscols_line **ln,
+                           struct libscols_column **cl,
+                           struct libscols_cell **ce);
+
 /*
  *
  */

--- a/libsmartcols/src/libsmartcols.h.in
+++ b/libsmartcols/src/libsmartcols.h.in
@@ -146,7 +146,11 @@ extern int scols_cell_copy_content(struct libscols_cell *dest,
 				   const struct libscols_cell *src);
 extern int scols_cell_set_data(struct libscols_cell *ce, const char *data);
 extern int scols_cell_refer_data(struct libscols_cell *ce, char *data);
+extern int scols_cell_refer_memory(struct libscols_cell *ce, char *data, size_t datasiz);
+
 extern const char *scols_cell_get_data(const struct libscols_cell *ce);
+extern size_t scols_cell_get_datasiz(struct libscols_cell *ce);
+
 extern int scols_cell_set_color(struct libscols_cell *ce, const char *color);
 extern const char *scols_cell_get_color(const struct libscols_cell *ce);
 
@@ -159,6 +163,7 @@ extern int scols_cell_set_userdata(struct libscols_cell *ce, void *data);
 
 extern int scols_cmpstr_cells(struct libscols_cell *a,
 			      struct libscols_cell *b, void *data);
+
 /* column.c */
 extern int scols_column_is_tree(const struct libscols_column *cl);
 extern int scols_column_is_trunc(const struct libscols_column *cl);

--- a/libsmartcols/src/libsmartcols.sym
+++ b/libsmartcols/src/libsmartcols.sym
@@ -219,4 +219,6 @@ SMARTCOLS_2.40 {
 	scols_table_get_cursor;
 	scols_cell_refer_memory;
 	scols_cell_get_datasiz;
+	scols_wrapzero_nextchunk;
+	scols_column_get_wrap_data;
 } SMARTCOLS_2.39;

--- a/libsmartcols/src/libsmartcols.sym
+++ b/libsmartcols/src/libsmartcols.sym
@@ -210,8 +210,11 @@ SMARTCOLS_2.38 {
 	scols_table_enable_shellvar;
 } SMARTCOLS_2.35;
 
-
 SMARTCOLS_2.39 {
 	scols_column_set_properties;
 	scols_table_get_column_by_name;
 } SMARTCOLS_2.38;
+
+SMARTCOLS_2.40 {
+	scols_table_get_cursor;
+} SMARTCOLS_2.39;

--- a/libsmartcols/src/libsmartcols.sym
+++ b/libsmartcols/src/libsmartcols.sym
@@ -217,4 +217,6 @@ SMARTCOLS_2.39 {
 
 SMARTCOLS_2.40 {
 	scols_table_get_cursor;
+	scols_cell_refer_memory;
+	scols_cell_get_datasiz;
 } SMARTCOLS_2.39;

--- a/libsmartcols/src/print.c
+++ b/libsmartcols/src/print.c
@@ -232,21 +232,6 @@ static int groups_ascii_art_to_buffer(	struct libscols_table *tb,
 	return 0;
 }
 
-static int has_pending_data(struct libscols_table *tb)
-{
-	struct libscols_column *cl;
-	struct libscols_iter itr;
-
-	scols_reset_iter(&itr, SCOLS_ITER_FORWARD);
-	while (scols_table_next_column(tb, &itr, &cl) == 0) {
-		if (scols_column_is_hidden(cl))
-			continue;
-		if (scols_column_has_pending_wrap(cl))
-			return 1;
-	}
-	return 0;
-}
-
 static void fputs_color_reset(struct libscols_table *tb)
 {
 	if (tb->cur_color) {
@@ -349,7 +334,7 @@ static void print_empty_cell(struct libscols_table *tb,
 
 		tree_ascii_art_to_buffer(tb, ln, &art);
 
-		if (!list_empty(&ln->ln_branch) && has_pending_data(tb))
+		if (!list_empty(&ln->ln_branch))
 			ul_buffer_append_string(&art, vertical_symbol(tb));
 
 		if (scols_table_is_noencoding(tb))

--- a/libsmartcols/src/print.c
+++ b/libsmartcols/src/print.c
@@ -656,6 +656,7 @@ int __cursor_to_buffer(struct libscols_table *tb,
 		     int cal)
 {
 	const char *data = NULL;
+	size_t datasiz = 0;
 	struct libscols_cell *ce;
 	struct libscols_line *ln;
 	struct libscols_column *cl;
@@ -681,9 +682,13 @@ int __cursor_to_buffer(struct libscols_table *tb,
 			if (rc < 0)
 				return rc;
 			data = x;
+			if (data && *data)
+				datasiz = strlen(data);
 			rc = 0;
-		} else
+		} else {
 			data = scols_cell_get_data(ce);
+			datasiz = scols_cell_get_datasiz(ce);
+		}
 	}
 
 	if (!scols_column_is_tree(cl))
@@ -710,8 +715,9 @@ int __cursor_to_buffer(struct libscols_table *tb,
 	if (!rc && (ln->parent || cl->is_groups) && !scols_table_is_json(tb))
 		ul_buffer_save_pointer(buf, SCOLS_BUFPTR_TREEEND);
 notree:
-	if (!rc && data)
-		rc = ul_buffer_append_string(buf, data);
+	if (!rc && data && datasiz)
+		rc = ul_buffer_append_data(buf, data, datasiz);
+
 	return rc;
 }
 

--- a/libsmartcols/src/print.c
+++ b/libsmartcols/src/print.c
@@ -649,7 +649,7 @@ static int print_data(struct libscols_table *tb, struct ul_buffer *buf)
 }
 
 /*
- * Copy curret cell data to buffer. The @cal means "calculation" phase.
+ * Copy current cell data to buffer. The @cal means "calculation" phase.
  */
 int __cursor_to_buffer(struct libscols_table *tb,
 		     struct ul_buffer *buf,
@@ -689,6 +689,7 @@ int __cursor_to_buffer(struct libscols_table *tb,
 			data = scols_cell_get_data(ce);
 			datasiz = scols_cell_get_datasiz(ce);
 		}
+		DBG(CELL, ul_debugobj(cl, "cursor data: '%s' [%zu]", data, datasiz));
 	}
 
 	if (!scols_column_is_tree(cl))
@@ -718,6 +719,9 @@ notree:
 	if (!rc && data && datasiz)
 		rc = ul_buffer_append_data(buf, data, datasiz);
 
+	/* reset wrapping after greatest chunk calculation */
+	if (cal && scols_column_is_wrap(cl))
+		scols_column_reset_wrap(cl);
 	return rc;
 }
 
@@ -777,6 +781,8 @@ static int print_line(struct libscols_table *tb,
 					rc = print_pending_data(tb, buf);
 				if (!rc && scols_column_has_pending_wrap(cl))
 					pending = 1;
+				if (!rc && !pending)
+					scols_column_reset_wrap(cl);
 			} else
 				print_empty_cell(tb, cl, ln, NULL, ul_buffer_get_bufsiz(buf));
 			scols_table_reset_cursor(tb);

--- a/libsmartcols/src/print.c
+++ b/libsmartcols/src/print.c
@@ -689,7 +689,7 @@ int __cursor_to_buffer(struct libscols_table *tb,
 			data = scols_cell_get_data(ce);
 			datasiz = scols_cell_get_datasiz(ce);
 		}
-		DBG(CELL, ul_debugobj(cl, "cursor data: '%s' [%zu]", data, datasiz));
+		/*DBG(CELL, ul_debugobj(ce, "cursor data: '%s' [%zu]", data, datasiz));*/
 	}
 
 	if (!scols_column_is_tree(cl))

--- a/libsmartcols/src/smartcolsP.h
+++ b/libsmartcols/src/smartcolsP.h
@@ -307,6 +307,7 @@ int scols_line_next_group_child(struct libscols_line *ln,
 /*
  * column.c
  */
+void scols_column_reset_wrap(struct libscols_column *cl);
 int scols_column_next_wrap(     struct libscols_column *cl,
                                 struct libscols_cell *ce,
                                 char **data);

--- a/libsmartcols/src/smartcolsP.h
+++ b/libsmartcols/src/smartcolsP.h
@@ -80,6 +80,7 @@ struct libscols_symbols {
  */
 struct libscols_cell {
 	char	*data;
+	size_t	datasiz;
 	char	*color;
 	void    *userdata;
 	int	flags;

--- a/libsmartcols/src/smartcolsP.h
+++ b/libsmartcols/src/smartcolsP.h
@@ -247,6 +247,10 @@ struct libscols_table {
 
 	const char *cur_color;	/* current active color when printing */
 
+	struct libscols_cell *cur_cell;		/* currently used cell */
+	struct libscols_line *cur_line;		/* currently used line */
+	struct libscols_column *cur_column;	/* currently used column */
+
 	/* flags */
 	unsigned int	ascii		:1,	/* don't use unicode */
 			colors_wanted	:1,	/* enable colors */
@@ -306,6 +310,11 @@ int scols_line_next_group_child(struct libscols_line *ln,
 int scols_table_next_group(struct libscols_table *tb,
                           struct libscols_iter *itr,
                           struct libscols_group **gr);
+int scols_table_set_cursor(struct libscols_table *tb,
+                           struct libscols_line *ln,
+                           struct libscols_column *cl,
+                           struct libscols_cell *ce);
+
 
 /*
  * grouping.c

--- a/libsmartcols/src/table.c
+++ b/libsmartcols/src/table.c
@@ -521,6 +521,50 @@ size_t scols_table_get_nlines(const struct libscols_table *tb)
 	return tb->nlines;
 }
 
+
+int scols_table_set_cursor(struct libscols_table *tb,
+			   struct libscols_line *ln,
+			   struct libscols_column *cl,
+			   struct libscols_cell *ce)
+{
+	if (!tb)
+		return -EINVAL;
+
+	tb->cur_line = ln;
+	tb->cur_column = cl;
+	tb->cur_cell = ce;
+
+	return 0;
+}
+
+/**
+ * scols_table_get_cursor:
+ * @tb: table
+ * @ln: returns current line (optional)
+ * @cl: returns current column (optional)
+ * @ce: returns current cell (optional)
+ *
+ * Returns: 0 on success, negative number in case of error.
+ *
+ * Since: 2.40
+ */
+int scols_table_get_cursor(struct libscols_table *tb,
+			   struct libscols_line **ln,
+			   struct libscols_column **cl,
+			   struct libscols_cell **ce)
+{
+	if (!tb)
+		return -EINVAL;
+
+	if (ln)
+		*ln = tb->cur_line;
+	if (cl)
+		*cl = tb->cur_column;
+	if (ce)
+		*ce = tb->cur_cell;
+	return 0;
+}
+
 /**
  * scols_table_set_stream:
  * @tb: table

--- a/misc-utils/findmnt.8.adoc
+++ b/misc-utils/findmnt.8.adoc
@@ -105,6 +105,8 @@ Output almost all available columns. The columns that require *--poll* are not i
 
 *-P*, *--pairs*::
 Produce output in the form of key="value" pairs. All potentially unsafe value characters are hex-escaped (\x<code>). See also option *--shell*.
++
+Note that SOURCES column, use multi-line cells. In these cases, the column use an array-like formatting in the output, for example *name=("aaa" "bbb" "ccc")*.
 
 *-p*, *--poll*[_=list_]::
 Monitor changes in the _/proc/self/mountinfo_ file. Supported actions are: mount, umount, remount and move. More than one action may be specified in a comma-separated list. All actions are monitored by default.
@@ -131,6 +133,8 @@ Print recursively all submounts for the selected filesystems. The restrictions d
 
 *-r*, *--raw*::
 Use raw output format. All potentially unsafe characters are hex-escaped (\x<code>).
++
+Note that column SOURCES, use multi-line cells. In these cases, the column may produce more strings on the same line.
 
 *--real*::
 Print only real filesystems.

--- a/tests/expected/libsmartcols/fromfile-wrapzero
+++ b/tests/expected/libsmartcols/fromfile-wrapzero
@@ -1,0 +1,19 @@
+NAME         NUM WRAPZERO
+aaaa           0 aaa
+bbb          100 bbbbb
+ccccc         21 cccc
+                 CCCC
+dddddd         3 dddddddd
+                 DDDD
+                 DD
+ee           411 hello
+                 baby
+ffff        5111 aaa
+                 bbb
+                 ccc
+                 ddd
+gggggg 678993321 eee
+hhh      7666666 fffff
+iiiiii      8765 g
+                 hhhhh
+jj        987456 ppppppppp

--- a/tests/expected/libsmartcols/fromfile-wrapzero-tree
+++ b/tests/expected/libsmartcols/fromfile-wrapzero-tree
@@ -1,0 +1,19 @@
+TREE           ID PARENT WRAPZERO
+aaaa            1      0 aaa
+|-bbb           2      1 bbbbb
+| |-ee          5      2 hello
+| |                      baby
+| `-ffff        6      2 aaa
+|                        bbb
+|                        ccc
+|                        ddd
+|-ccccc         3      1 cccc
+| |                      CCCC
+| `-gggggg      7      3 eee
+|   |-hhh       8      7 fffff
+|   | `-iiiiii  9      8 g
+|   |                    hhhhh
+|   `-jj       10      7 ppppppppp
+`-dddddd        4      1 dddddddd
+                         DDDD
+                         DD

--- a/tests/ts/libsmartcols/files/col-wrapzero
+++ b/tests/ts/libsmartcols/files/col-wrapzero
@@ -1,0 +1,3 @@
+WRAPZERO
+0
+wrapzero

--- a/tests/ts/libsmartcols/files/data-string-nl
+++ b/tests/ts/libsmartcols/files/data-string-nl
@@ -1,10 +1,10 @@
 aaa
 bbbbb
-cccc\nCCCC
-dddddddd\nDDDD\nDD
-hello\nbaby
-aaa\nbbb\nccc\nddd
+cccc\x0ACCCC
+dddddddd\x0ADDDD\x0ADD
+hello\x0Ababy
+aaa\x0Abbb\x0Accc\x0Addd
 eee
 fffff
-g\nhhhhh
+g\x0Ahhhhh
 ppppppppp

--- a/tests/ts/libsmartcols/files/data-string-zero
+++ b/tests/ts/libsmartcols/files/data-string-zero
@@ -1,0 +1,10 @@
+aaa
+bbbbb
+cccc\x00CCCC
+dddddddd\x00DDDD\x00DD
+hello\x00baby
+aaa\x00bbb\x00ccc\x00ddd
+eee
+fffff
+g\x00hhhhh
+ppppppppp

--- a/tests/ts/libsmartcols/fromfile
+++ b/tests/ts/libsmartcols/fromfile
@@ -249,6 +249,32 @@ ts_run $TESTPROG --nlines 10 \
 	>> $TS_OUTPUT 2>> $TS_ERRLOG
 ts_finalize_subtest
 
+ts_init_subtest "wrapzero"
+ts_run $TESTPROG --nlines 10 \
+	--column $TS_SELF/files/col-name \
+	--column $TS_SELF/files/col-number \
+	--column $TS_SELF/files/col-wrapzero \
+	$TS_SELF/files/data-string \
+	$TS_SELF/files/data-number \
+	$TS_SELF/files/data-string-zero \
+	>> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "wrapzero-tree"
+ts_run $TESTPROG --nlines 10 \
+	--tree-id-column 1 \
+	--tree-parent-column 2 \
+	--column $TS_SELF/files/col-tree \
+	--column $TS_SELF/files/col-id \
+	--column $TS_SELF/files/col-parent \
+	--column $TS_SELF/files/col-wrapzero \
+	$TS_SELF/files/data-string \
+	$TS_SELF/files/data-id \
+	$TS_SELF/files/data-parent \
+	$TS_SELF/files/data-string-zero \
+	>> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
 ts_init_subtest "raw"
 ts_run $TESTPROG --nlines 10 --raw \
 	--column $TS_SELF/files/col-name \


### PR DESCRIPTION
Now, we use line-break to separate data in multi-line cells (for example, MOUNTPOINTS in lsblk). This is pretty fragile as \n is a valid char in many cases (see https://github.com/util-linux/util-linux/issues/2533).

This set of patches adds to libsmartcols support to use \0 to separate data for the custom wrapping function (callback). It also rewrites how libsmartcols prepares data for the cells to make more easier to use (in the library) and avoid spaghetti code ...