### PR TITLE
Make the ways of using output stream consistent in usage()

### DIFF
--- a/Documentation/boilerplate.c
+++ b/Documentation/boilerplate.c
@@ -37,26 +37,26 @@
 static void __attribute__((__noreturn__)) usage(void)
 {
 	fputs(USAGE_HEADER, stdout);
-	printf(_(" %s [options] file...\n"), program_invocation_short_name);
+	fprintf(stdout, _(" %s [options] file...\n"), program_invocation_short_name);
 
 	fputs(USAGE_SEPARATOR, stdout);
-	puts(_("Short program description."));
+	fputs(_("Short program description."), stdout);
 
 	fputs(USAGE_OPTIONS, stdout);
-	puts(_(" -n, --no-argument       option does not use argument"));
-	puts(_("     --optional[=<arg>]  option argument is optional"));
-	puts(_(" -r, --required <arg>    option requires an argument"));
-	puts(_(" -z                      no long option"));
-	puts(_("     --xyzzy             a long option only"));
-	puts(_(" -e, --extremely-long-long-option\n"
-	       "                         use next line for description when needed"));
-	puts(_(" -l, --long-explanation  an example of very verbose, and chatty option\n"
-	       "                           description on two, or multiple lines, where the\n"
-	       "                           consecutive lines are intended by two spaces"));
-	puts(_(" -f, --foobar            next option description resets indent"));
+	fputs(_(" -n, --no-argument       option does not use argument"), stdout);
+	fputs(_("     --optional[=<arg>]  option argument is optional"), stdout);
+	fputs(_(" -r, --required <arg>    option requires an argument"), stdout);
+	fputs(_(" -z                      no long option"), stdout);
+	fputs(_("     --xyzzy             a long option only"), stdout);
+	fputs(_(" -e, --extremely-long-long-option\n"
+		"                         use next line for description when needed"), stdout);
+	fputs(_(" -l, --long-explanation  an example of very verbose, and chatty option\n"
+		"                           description on two, or multiple lines, where the\n"
+		"                           consecutive lines are intended by two spaces"), stdout);
+	fputs(_(" -f, --foobar            next option description resets indent"), stdout);
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(25)); /* char offset to align option descriptions */
-	printf(USAGE_MAN_TAIL("fixme-command-name(1)"));
+	fprintf(stdout, USAGE_HELP_OPTIONS(25)); /* char offset to align option descriptions */
+	fprintf(stdout, USAGE_MAN_TAIL("fixme-command-name(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/addpart.c
+++ b/disk-utils/addpart.c
@@ -19,8 +19,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Tell the kernel about the existence of a specified partition.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("addpart(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("addpart(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/blockdev.c
+++ b/disk-utils/blockdev.c
@@ -201,36 +201,36 @@ static void __attribute__((__noreturn__)) usage(void)
 	size_t i;
 
 	fputs(USAGE_HEADER, stdout);
-	printf(_(
+	fprintf(stdout, _(
 	         " %1$s [-v|-q] commands devices\n"
 	         " %1$s --report [devices]\n"
 	         " %1$s -h|-V\n"
 		), program_invocation_short_name);
 
 	fputs(USAGE_SEPARATOR, stdout);
-	puts(  _("Call block device ioctls from the command line."));
+	fputs(  _("Call block device ioctls from the command line."), stdout);
 
 	fputs(USAGE_OPTIONS, stdout);
-	puts(  _(" -q             quiet mode"));
-	puts(  _(" -v             verbose mode"));
-	puts(  _("     --report   print report for specified (or all) devices"));
+	fputs(  _(" -q             quiet mode"), stdout);
+	fputs(  _(" -v             verbose mode"), stdout);
+	fputs(  _("     --report   print report for specified (or all) devices"), stdout);
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(16));
+	fprintf(stdout, USAGE_HELP_OPTIONS(16));
 
 	fputs(USAGE_SEPARATOR, stdout);
-	puts(  _("Available commands:"));
-	printf(_(" %-25s get size in 512-byte sectors\n"), "--getsz");
+	fputs(_("Available commands:"), stdout);
+	fprintf(stdout, _(" %-25s get size in 512-byte sectors\n"), "--getsz");
 	for (i = 0; i < ARRAY_SIZE(bdcms); i++) {
 		if (bdcms[i].argname)
-			printf(" %s %-*s %s\n", bdcms[i].name,
+			fprintf(stdout, " %s %-*s %s\n", bdcms[i].name,
 				(int)(24 - strlen(bdcms[i].name)),
 				bdcms[i].argname, _(bdcms[i].help));
 		else
-			printf(" %-25s %s\n", bdcms[i].name,
+			fprintf(stdout, " %-25s %s\n", bdcms[i].name,
 				_(bdcms[i].help));
 	}
 
-	printf(USAGE_MAN_TAIL("blockdev(8)"));
+	fprintf(stdout, USAGE_MAN_TAIL("blockdev(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -2737,9 +2737,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -r, --read-only          forced open cfdisk in read-only mode\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
 
-	printf(USAGE_MAN_TAIL("cfdisk(8)"));
+	fprintf(out, USAGE_MAN_TAIL("cfdisk(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/delpart.c
+++ b/disk-utils/delpart.c
@@ -19,8 +19,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Tell the kernel to forget about a specified partition.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("delpart(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("delpart(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/fdformat.c
+++ b/disk-utils/fdformat.c
@@ -157,8 +157,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -n, --no-verify   disable the verification after the format\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(19));
-	printf(USAGE_MAN_TAIL("fdformat(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(19));
+	fprintf(out, USAGE_MAN_TAIL("fdformat(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/disk-utils/fdisk-list.c
+++ b/disk-utils/fdisk-list.c
@@ -439,7 +439,7 @@ void list_available_columns(FILE *out)
 
 	termwidth = get_terminal_width(80);
 
-	fprintf(out, USAGE_COLUMNS);
+	fputs(USAGE_COLUMNS, out);
 
 	while (fdisk_next_label(cxt, &lb) == 0) {
 		size_t width = 6;	/* label name and separators */
@@ -543,4 +543,3 @@ done:
 		*n = fields_nids;
 	return fields_ids;
 }
-

--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -884,11 +884,11 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -S, --sectors <number>        specify the number of sectors per track\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(31));
+	fprintf(out, USAGE_HELP_OPTIONS(31));
 
 	list_available_columns(out);
 
-	printf(USAGE_MAN_TAIL("fdisk(8)"));
+	fprintf(out, USAGE_MAN_TAIL("fdisk(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -1412,11 +1412,11 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -V         explain what is being done\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf( " -?, --help     %s\n", USAGE_OPTSTR_HELP);
-	printf( "     --version  %s\n", USAGE_OPTSTR_VERSION);
+	fprintf(out, " -?, --help     %s\n", USAGE_OPTSTR_HELP);
+	fprintf(out, "     --version  %s\n", USAGE_OPTSTR_VERSION);
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("See the specific fsck.* commands for available fs-options."), out);
-	printf(USAGE_MAN_TAIL("fsck(8)"));
+	fprintf(out, USAGE_MAN_TAIL("fsck(8)"));
 	exit(FSCK_EX_OK);
 }
 

--- a/disk-utils/fsck.cramfs.c
+++ b/disk-utils/fsck.cramfs.c
@@ -126,9 +126,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -b, --blocksize <size>   use this blocksize, defaults to page size\n"), out);
 	fputs(_("     --extract[=<dir>]    test uncompression, optionally extract into <dir>\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
 
-	printf(USAGE_MAN_TAIL("fsck.cramfs(8)"));
+	fprintf(out, USAGE_MAN_TAIL("fsck.cramfs(8)"));
 	exit(FSCK_EX_OK);
 }
 

--- a/disk-utils/fsck.minix.c
+++ b/disk-utils/fsck.minix.c
@@ -192,8 +192,8 @@ usage(void) {
 	fputs(_(" -m, --uncleared  activate mode not cleared warnings\n"), out);
 	fputs(_(" -f, --force      force check\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(18));
-	printf(USAGE_MAN_TAIL("fsck.minix(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(18));
+	fprintf(out, USAGE_MAN_TAIL("fsck.minix(8)"));
 	exit(FSCK_EX_OK);
 }
 

--- a/disk-utils/isosize.c
+++ b/disk-utils/isosize.c
@@ -106,8 +106,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -d, --divisor=<number>  divide the amount of bytes by <number>\n"), stdout);
 	fputs(_(" -x, --sectors           show sector count and size\n"), stdout);
 
-	printf(USAGE_HELP_OPTIONS(25));
-	printf(USAGE_MAN_TAIL("isosize(8)"));
+	fprintf(stdout, USAGE_HELP_OPTIONS(25));
+	fprintf(stdout, USAGE_MAN_TAIL("isosize(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/disk-utils/mkfs.bfs.c
+++ b/disk-utils/mkfs.bfs.c
@@ -87,9 +87,9 @@ static void __attribute__((__noreturn__)) usage(void)
 		       " -l                  this option is silently ignored\n"
 		       " --lock[=<mode>]     use exclusive device lock (yes, no or nonblock)\n"
 		       ));
-	printf(USAGE_HELP_OPTIONS(21));
+	fprintf(out, USAGE_HELP_OPTIONS(21));
 
-	printf(USAGE_MAN_TAIL("mkfs.bfs(8)"));
+	fprintf(out, USAGE_MAN_TAIL("mkfs.bfs(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/mkfs.c
+++ b/disk-utils/mkfs.c
@@ -55,9 +55,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fprintf(out, _("     <size>         number of blocks to be used on the device\n"));
 	fprintf(out, _(" -V, --verbose      explain what is being done;\n"
 		       "                      specifying -V more than once will cause a dry-run\n"));
-	printf(USAGE_HELP_OPTIONS(20));
+	fprintf(out, USAGE_HELP_OPTIONS(20));
 
-	printf(USAGE_MAN_TAIL("mkfs(8)"));
+	fprintf(out, USAGE_MAN_TAIL("mkfs(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -126,27 +126,27 @@ struct entry {
 static void __attribute__((__noreturn__)) usage(void)
 {
 	fputs(USAGE_HEADER, stdout);
-	printf(_(" %s [-h] [-v] [-b blksize] [-e edition] [-N endian] [-i file] [-n name] dirname outfile\n"),
+	fprintf(stdout, _(" %s [-h] [-v] [-b blksize] [-e edition] [-N endian] [-i file] [-n name] dirname outfile\n"),
 		program_invocation_short_name);
 	fputs(USAGE_SEPARATOR, stdout);
-	puts(_("Make compressed ROM file system."));
+	fputs(_("Make compressed ROM file system."), stdout);
 	fputs(USAGE_OPTIONS, stdout);
-	puts(_(  " -v             be verbose"));
-	puts(_(  " -E             make all warnings errors (non-zero exit status)"));
-	puts(_(  " -b blksize     use this blocksize, must equal page size"));
-	puts(_(  " -e edition     set edition number (part of fsid)"));
-	printf(_(" -N endian      set cramfs endianness (%s|%s|%s), default %s\n"), "big", "little", "host", "host");
-	puts(_(  " -i file        insert a file image into the filesystem"));
-	puts(_(  " -n name        set name of cramfs filesystem"));
-	printf(_(" -p             pad by %d bytes for boot code\n"), PAD_SIZE);
-	puts(_(  " -s             sort directory entries (old option, ignored)"));
-	puts(_(  " -z             make explicit holes"));
-	puts(_(  " -l[=<mode>]    use exclusive device lock (yes, no or nonblock)"));
-	puts(_(  " dirname        root of the filesystem to be compressed"));
-	puts(_(  " outfile        output file"));
+	fputs(_(  " -v             be verbose"), stdout);
+	fputs(_(  " -E             make all warnings errors (non-zero exit status)"), stdout);
+	fputs(_(  " -b blksize     use this blocksize, must equal page size"), stdout);
+	fputs(_(  " -e edition     set edition number (part of fsid)"), stdout);
+	fprintf(stdout, _(" -N endian      set cramfs endianness (%s|%s|%s), default %s\n"), "big", "little", "host", "host");
+	fputs(_(  " -i file        insert a file image into the filesystem"), stdout);
+	fputs(_(  " -n name        set name of cramfs filesystem"), stdout);
+	fprintf(stdout, _(" -p             pad by %d bytes for boot code\n"), PAD_SIZE);
+	fputs(_(  " -s             sort directory entries (old option, ignored)"), stdout);
+	fputs(_(  " -z             make explicit holes"), stdout);
+	fputs(_(  " -l[=<mode>]    use exclusive device lock (yes, no or nonblock)"), stdout);
+	fputs(_(  " dirname        root of the filesystem to be compressed"), stdout);
+	fputs(_(  " outfile        output file"), stdout);
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("mkfs.cramfs(8)"));
+	fprintf(stdout, USAGE_HELP_OPTIONS(16));
+	fprintf(stdout, USAGE_MAN_TAIL("mkfs.cramfs(8)"));
 	exit(MKFS_EX_OK);
 }
 

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -148,8 +148,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fprintf(out, _(
 		"     --lock[=<mode>]     use exclusive device lock (%s, %s or %s)\n"), "yes", "no", "nonblock");
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(25));
-	printf(USAGE_MAN_TAIL("mkfs.minix(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_MAN_TAIL("mkfs.minix(8)"));
 	exit(MKFS_EX_OK);
 }
 

--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -201,9 +201,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fprintf(out,
 	      _("     --lock[=<mode>]       use exclusive device lock (%s, %s or %s)\n"), "yes", "no", "nonblock");
 
-	printf(USAGE_HELP_OPTIONS(27));
+	fprintf(out, USAGE_HELP_OPTIONS(27));
 
-	printf(USAGE_MAN_TAIL("mkswap(8)"));
+	fprintf(out, USAGE_MAN_TAIL("mkswap(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/partx.c
+++ b/disk-utils/partx.c
@@ -776,13 +776,13 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -v, --verbose        verbose mode\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(out, USAGE_HELP_OPTIONS(22));
 
 	fputs(USAGE_COLUMNS, out);
 	for (i = 0; i < NCOLS; i++)
 		fprintf(out, " %10s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("partx(8)"));
+	fprintf(out, USAGE_MAN_TAIL("partx(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/disk-utils/raw.c
+++ b/disk-utils/raw.c
@@ -59,8 +59,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_OPTIONS, out);
 	fputs(_(" -q, --query    set query mode\n"), out);
 	fputs(_(" -a, --all      query all raw devices\n"), out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("raw(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("raw(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/resizepart.c
+++ b/disk-utils/resizepart.c
@@ -24,8 +24,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Tell the kernel about the new size of a partition.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("resizepart(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("resizepart(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -2105,12 +2105,12 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -u, --unit S              deprecated, only sector unit is supported\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf( " -h, --help                %s\n", USAGE_OPTSTR_HELP);
-	printf( " -v, --version             %s\n", USAGE_OPTSTR_VERSION);
+	fprintf(out, " -h, --help                %s\n", USAGE_OPTSTR_HELP);
+	fprintf(out, " -v, --version             %s\n", USAGE_OPTSTR_VERSION);
 
 	list_available_columns(out);
 
-	printf(USAGE_MAN_TAIL("sfdisk(8)"));
+	fprintf(out, USAGE_MAN_TAIL("sfdisk(8)"));
 	exit(EXIT_SUCCESS);
 }
 
@@ -2474,4 +2474,3 @@ int main(int argc, char *argv[])
 	DBG(MISC, ul_debug("bye! [rc=%d]", rc));
 	return rc == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
-

--- a/disk-utils/swaplabel.c
+++ b/disk-utils/swaplabel.c
@@ -130,8 +130,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -L, --label <label> specify a new label\n"
 		" -U, --uuid <uuid>   specify a new uuid\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(21));
-	printf(USAGE_MAN_TAIL("swaplabel(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(21));
+	fprintf(out, USAGE_MAN_TAIL("swaplabel(8)"));
 	exit(EXIT_SUCCESS);
 }
 
@@ -191,4 +191,3 @@ int main(int argc, char *argv[])
 	}
 	return rc ? EXIT_FAILURE : EXIT_SUCCESS;
 }
-

--- a/login-utils/chsh.c
+++ b/login-utils/chsh.c
@@ -77,9 +77,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -l, --list-shells    print list of shells and exit\n"), fp);
 
 	fputs(USAGE_SEPARATOR, fp);
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(fp, USAGE_HELP_OPTIONS(22));
 
-	printf(USAGE_MAN_TAIL("chsh(1)"));
+	fprintf(fp, USAGE_MAN_TAIL("chsh(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -593,8 +593,8 @@ static void __attribute__((__noreturn__)) usage(const struct last_control *ctl)
 		"                               notime|short|full|iso\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(22));
-	printf(USAGE_MAN_TAIL("last(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(22));
+	fprintf(out, USAGE_MAN_TAIL("last(1)"));
 
 	exit(out == stderr ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -1470,13 +1470,13 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --btmp-file <path>   set an alternate path for btmp\n"), out);
 	fputs(_("     --lastlog <path>     set an alternate path for lastlog\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
 
 	fputs(USAGE_COLUMNS, out);
 	for (i = 0; i < ARRAY_SIZE(coldescs); i++)
 		fprintf(out, " %14s  %s\n", coldescs[i].name, _(coldescs[i].help));
 
-	printf(USAGE_MAN_TAIL("lslogins(1)"));
+	fprintf(out, USAGE_MAN_TAIL("lslogins(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/login-utils/newgrp.c
+++ b/login-utils/newgrp.c
@@ -178,8 +178,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Log in to a new group.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("newgrp(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("newgrp(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/login-utils/nologin.c
+++ b/login-utils/nologin.c
@@ -32,9 +32,9 @@ static void __attribute__((__noreturn__)) usage(void)
 
 	fputs(USAGE_OPTIONS, out);
 	fputs(_(" -c, --command <command>  does nothing (for compatibility with su -c)\n"), out);
-	printf(USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
 
-	printf(USAGE_MAN_TAIL("nologin(8)"));
+	fprintf(out, USAGE_MAN_TAIL("nologin(8)"));
 	exit(EXIT_FAILURE);
 }
 

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -883,8 +883,8 @@ static void usage(void)
 		out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
-	printf(USAGE_MAN_TAIL("sulogin(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_MAN_TAIL("sulogin(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/login-utils/utmpdump.c
+++ b/login-utils/utmpdump.c
@@ -324,9 +324,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -f, --follow         output appended data as the file grows\n"), out);
 	fputs(_(" -r, --reverse        write back dumped data into utmp file\n"), out);
 	fputs(_(" -o, --output <file>  write to file instead of standard output\n"), out);
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(out, USAGE_HELP_OPTIONS(22));
 
-	printf(USAGE_MAN_TAIL("utmpdump(1)"));
+	fprintf(out, USAGE_MAN_TAIL("utmpdump(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/login-utils/vipw.c
+++ b/login-utils/vipw.c
@@ -304,8 +304,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Edit the password or group file.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("vipw(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("vipw(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/misc-utils/blkid.c
+++ b/misc-utils/blkid.c
@@ -100,14 +100,14 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(	" -D, --no-part-details      don't print info from partition table\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(28));
+	fprintf(out, USAGE_HELP_OPTIONS(28));
 
 	fputs(USAGE_ARGUMENTS, out);
-	printf(USAGE_ARG_SIZE(_("<size> and <offset>")));
+	fprintf(out, USAGE_ARG_SIZE(_("<size> and <offset>")));
 	fputs(USAGE_ARG_SEPARATOR, out);
 	fputs(_(" <dev> specify device(s) to probe (default: all devices)\n"), out);
 
-	printf(USAGE_MAN_TAIL("blkid(8)"));
+	fprintf(out, USAGE_MAN_TAIL("blkid(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -1296,8 +1296,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	        "                         %s\n", USAGE_COLORS_DEFAULT);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(23));
-	printf(USAGE_MAN_TAIL("cal(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(23));
+	fprintf(out, USAGE_MAN_TAIL("cal(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/fadvise.c
+++ b/misc-utils/fadvise.c
@@ -55,7 +55,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -o, --offset <num>    offset for range operations, in bytes\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(23));
+	fprintf(out, USAGE_HELP_OPTIONS(23));
 
 	fputs(_("\nAvailable values for advice:\n"), out);
 	for (i = 0; i < ARRAY_SIZE(advices); i++) {
@@ -63,7 +63,7 @@ static void __attribute__((__noreturn__)) usage(void)
 			advices[i].name);
 	}
 
-	printf(USAGE_MAN_TAIL("fadvise(1)"));
+	fprintf(out, USAGE_MAN_TAIL("fadvise(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -407,7 +407,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_SEPARATOR, out);
 	printf(USAGE_HELP_OPTIONS(23));
 
-	fprintf(out, USAGE_COLUMNS);
+	fputs(USAGE_COLUMNS, out);
 
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %22s  %s\n", infos[i].name, _(infos[i].help));

--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -405,14 +405,14 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -r, --raw             use raw output format\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(23));
+	fprintf(out, USAGE_HELP_OPTIONS(23));
 
 	fputs(USAGE_COLUMNS, out);
 
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %22s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("fincore(1)"));
+	fprintf(out, USAGE_MAN_TAIL("fincore(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/findfs.c
+++ b/misc-utils/findfs.c
@@ -32,8 +32,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Find a filesystem by label or UUID.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("findfs(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("findfs(8)"));
 	exit(FINDFS_SUCCESS);
 }
 
@@ -76,4 +76,3 @@ int main(int argc, char **argv)
 	puts(dev);
 	return FINDFS_SUCCESS;
 }
-

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1379,13 +1379,13 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --vfs-all          print all VFS options\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
 
 	fputs(USAGE_COLUMNS, out);
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %11s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("findmnt(8)"));
+	fprintf(out, USAGE_MAN_TAIL("findmnt(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/getopt.c
+++ b/misc-utils/getopt.c
@@ -359,8 +359,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -T, --test                    test for getopt(1) version\n"), stdout);
 	fputs(_(" -u, --unquoted                do not quote the output\n"), stdout);
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(31));
-	printf(USAGE_MAN_TAIL("getopt(1)"));
+	fprintf(stdout, USAGE_HELP_OPTIONS(31));
+	fprintf(stdout, USAGE_MAN_TAIL("getopt(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -1192,8 +1192,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --skip-reflinks        skip already cloned files (enabled on --reflink)\n"), out);
 #endif
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(28));
-	printf(USAGE_MAN_TAIL("hardlink(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(28));
+	fprintf(out, USAGE_MAN_TAIL("hardlink(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/kill.c
+++ b/misc-utils/kill.c
@@ -217,8 +217,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --verbose          print pids that will be signaled\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
-	printf(USAGE_MAN_TAIL("kill(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_MAN_TAIL("kill(1)"));
 
 	exit(EXIT_SUCCESS);
 }
@@ -557,4 +557,3 @@ int main(int argc, char **argv)
 
 	return KILL_EXIT_SOMEOK;	/* partial success */
 }
-

--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -1091,8 +1091,8 @@ static void __attribute__((__noreturn__)) usage(void)
 #endif
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
-	printf(USAGE_MAN_TAIL("logger(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_MAN_TAIL("logger(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/look.c
+++ b/misc-utils/look.c
@@ -366,8 +366,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -t, --terminate <char>   define the string-termination character\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
-	printf(USAGE_MAN_TAIL("look(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_MAN_TAIL("look(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -2018,7 +2018,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_SEPARATOR, out);
 	printf(USAGE_HELP_OPTIONS(22));
 
-	fprintf(out, USAGE_COLUMNS);
+	fputs(USAGE_COLUMNS, out);
 
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %12s  %s\n", infos[i].name, _(infos[i].help));

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -2016,14 +2016,14 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -z, --zoned          print zone related information\n"), out);
 	fputs(_("     --sysroot <dir>  use specified directory as system root\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(out, USAGE_HELP_OPTIONS(22));
 
 	fputs(USAGE_COLUMNS, out);
 
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %12s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("lsblk(8)"));
+	fprintf(out, USAGE_MAN_TAIL("lsblk(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -195,7 +195,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_SEPARATOR, out);
 	printf(USAGE_HELP_OPTIONS(29));
 
-	fprintf(out, USAGE_COLUMNS);
+	fputs(USAGE_COLUMNS, out);
 
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %16s  %-10s%s\n", infos[i].name,

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -193,7 +193,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -c, --cpu-clock <pid>      also display CPU clock of specified process\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(29));
+	fprintf(out, USAGE_HELP_OPTIONS(29));
 
 	fputs(USAGE_COLUMNS, out);
 
@@ -206,7 +206,7 @@ static void __attribute__((__noreturn__)) usage(void)
 			"<boolean>",
 			_(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("lslocks(1)"));
+	fprintf(out, USAGE_MAN_TAIL("lslocks(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -1764,7 +1764,7 @@ static void collect_processes(struct lsfd_control *ctl, const pid_t pids[], int 
 
 static void __attribute__((__noreturn__)) list_colunms(FILE *out)
 {
-	fprintf(out, USAGE_COLUMNS);
+	fputs(USAGE_COLUMNS, out);
 	for (size_t i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %20s  %-10s%s\n", infos[i].name,
 			infos[i].json_type == SCOLS_JSON_STRING?  "<string>":

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -563,14 +563,14 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -u, --notruncate       don't truncate text in columns\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
 
 	fputs(USAGE_COLUMNS, out);
 
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %11s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("lslocks(8)"));
+	fprintf(out, USAGE_MAN_TAIL("lslocks(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/mcookie.c
+++ b/misc-utils/mcookie.c
@@ -91,12 +91,12 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -v, --verbose         explain what is being done\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(23));
+	fprintf(out, USAGE_HELP_OPTIONS(23));
 
 	fputs(USAGE_ARGUMENTS, out);
-	printf(USAGE_ARG_SIZE(_("<num>")));
+	fprintf(out, USAGE_ARG_SIZE(_("<num>")));
 
-	printf(USAGE_MAN_TAIL("mcookie(1)"));
+	fprintf(out, USAGE_MAN_TAIL("mcookie(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/namei.c
+++ b/misc-utils/namei.c
@@ -373,9 +373,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_( " -Z, --context       print any security context of each file \n"), out);
 #endif
 
-	printf(USAGE_HELP_OPTIONS(21));
+	fprintf(out, USAGE_HELP_OPTIONS(21));
 
-	printf(USAGE_MAN_TAIL("namei(1)"));
+	fprintf(out, USAGE_MAN_TAIL("namei(1)"));
 	exit(EXIT_SUCCESS);
 }
 
@@ -488,4 +488,3 @@ main(int argc, char **argv)
 
 	return rc;
 }
-

--- a/misc-utils/pipesz.c
+++ b/misc-utils/pipesz.c
@@ -62,37 +62,37 @@ static char opt_verbose = 0;	/* --verbose */
 static void __attribute__((__noreturn__)) usage(void)
 {
 	fputs(USAGE_HEADER, stdout);
-	printf(_(" %s [options] [--set <size>] [--] [command]\n"), program_invocation_short_name);
-	printf(_(" %s [options] --get\n"), program_invocation_short_name);
+	fprintf(stdout, _(" %s [options] [--set <size>] [--] [command]\n"), program_invocation_short_name);
+	fprintf(stdout, _(" %s [options] --get\n"), program_invocation_short_name);
 
 	fputs(USAGE_SEPARATOR, stdout);
 	/* TRANSLATORS: 'command' refers to a program argument */
-	puts(_("Set or examine pipe buffer sizes and optionally execute command."));
+	fputs(_("Set or examine pipe buffer sizes and optionally execute command."), stdout);
 
 	fputs(USAGE_OPTIONS, stdout);
-	puts(_(" -g, --get          examine pipe buffers"));
+	fputs(_(" -g, --get          examine pipe buffers"), stdout);
 	/* TRANSLATORS: '%s' refers to a system file */
-	printf(
+	fprintf(stdout,
 	     _(" -s, --set <size>   set pipe buffer sizes\n"
 	       "                      size defaults to %s\n"),
 		PIPESZ_DEFAULT_SIZE_FILE);
 
 	fputs(USAGE_SEPARATOR, stdout);
-	puts(_(" -f, --file <path>  act on a file"));
-	puts(_(" -n, --fd <num>     act on a file descriptor"));
-	puts(_(" -i, --stdin        act on standard input"));
-	puts(_(" -o, --stdout       act on standard output"));
-	puts(_(" -e, --stderr       act on standard error"));
+	fputs(_(" -f, --file <path>  act on a file"), stdout);
+	fputs(_(" -n, --fd <num>     act on a file descriptor"), stdout);
+	fputs(_(" -i, --stdin        act on standard input"), stdout);
+	fputs(_(" -o, --stdout       act on standard output"), stdout);
+	fputs(_(" -e, --stderr       act on standard error"), stdout);
 
 	fputs(USAGE_SEPARATOR, stdout);
-	puts(_(" -c, --check        do not continue after an error"));
-	puts(_(" -q, --quiet        do not warn of non-fatal errors"));
-	puts(_(" -v, --verbose      provide detailed output"));
+	fputs(_(" -c, --check        do not continue after an error"), stdout);
+	fputs(_(" -q, --quiet        do not warn of non-fatal errors"), stdout);
+	fputs(_(" -v, --verbose      provide detailed output"), stdout);
 
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(20));
+	fprintf(stdout, USAGE_HELP_OPTIONS(20));
 
-	printf(USAGE_MAN_TAIL("pipesz(1)"));
+	fprintf(stdout, USAGE_MAN_TAIL("pipesz(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -270,8 +270,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -o, --no-overwrite  don't overwrite existing files\n"), out);
 	fputs(_(" -i, --interactive   prompt before overwrite\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(21));
-	printf(USAGE_MAN_TAIL("rename(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(21));
+	fprintf(out, USAGE_MAN_TAIL("rename(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -113,8 +113,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -d, --debug             run in debugging mode\n"), out);
 	fputs(_(" -q, --quiet             turn on quiet mode\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(25));
-	printf(USAGE_MAN_TAIL("uuidd(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_MAN_TAIL("uuidd(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/misc-utils/uuidgen.c
+++ b/misc-utils/uuidgen.c
@@ -34,15 +34,15 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -r, --random          generate random-based uuid\n"), out);
 	fputs(_(" -t, --time            generate time-based uuid\n"), out);
 	fputs(_(" -n, --namespace <ns>  generate hash-based uuid in this namespace\n"), out);
-	printf(_("                        available namespaces: %s\n"), "@dns @url @oid @x500");
+	fprintf(out, _("                        available namespaces: %s\n"), "@dns @url @oid @x500");
 	fputs(_(" -N, --name <name>     generate hash-based uuid from this name\n"), out);
 	fputs(_(" -m, --md5             generate md5 hash\n"), out);
 	fputs(_(" -C, --count <num>     generate more uuids in loop\n"), out);
 	fputs(_(" -s, --sha1            generate sha1 hash\n"), out);
 	fputs(_(" -x, --hex             interpret name as hex string\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(21));
-	printf(USAGE_MAN_TAIL("uuidgen(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(21));
+	fprintf(out, USAGE_MAN_TAIL("uuidgen(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/misc-utils/uuidparse.c
+++ b/misc-utils/uuidparse.c
@@ -97,17 +97,17 @@ static void __attribute__((__noreturn__)) usage(void)
 	fprintf(stdout, _(" %s [options] <uuid ...>\n"), program_invocation_short_name);
 
 	fputs(USAGE_OPTIONS, stdout);
-	puts(_(" -J, --json             use JSON output format"));
-	puts(_(" -n, --noheadings       don't print headings"));
-	puts(_(" -o, --output <list>    COLUMNS to display (see below)"));
-	puts(_(" -r, --raw              use the raw output format"));
-	printf(USAGE_HELP_OPTIONS(24));
+	fputs(_(" -J, --json             use JSON output format"), stdout);
+	fputs(_(" -n, --noheadings       don't print headings"), stdout);
+	fputs(_(" -o, --output <list>    COLUMNS to display (see below)"), stdout);
+	fputs(_(" -r, --raw              use the raw output format"), stdout);
+	fprintf(stdout, USAGE_HELP_OPTIONS(24));
 
 	fputs(USAGE_COLUMNS, stdout);
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(stdout, " %8s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("uuidparse(1)"));
+	fprintf(stdout, USAGE_MAN_TAIL("uuidparse(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/misc-utils/whereis.c
+++ b/misc-utils/whereis.c
@@ -220,8 +220,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -l         output effective lookup paths\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("whereis(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("whereis(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/misc-utils/wipefs.c
+++ b/misc-utils/wipefs.c
@@ -630,36 +630,36 @@ usage(void)
 	size_t i;
 
 	fputs(USAGE_HEADER, stdout);
-	printf(_(" %s [options] <device>\n"), program_invocation_short_name);
+	fprintf(stdout, _(" %s [options] <device>\n"), program_invocation_short_name);
 
 	fputs(USAGE_SEPARATOR, stdout);
-	puts(_("Wipe signatures from a device."));
+	fputs(_("Wipe signatures from a device."), stdout);
 
 	fputs(USAGE_OPTIONS, stdout);
-	puts(_(" -a, --all           wipe all magic strings (BE CAREFUL!)"));
-	puts(_(" -b, --backup        create a signature backup in $HOME"));
-	puts(_(" -f, --force         force erasure"));
-	puts(_(" -i, --noheadings    don't print headings"));
-	puts(_(" -J, --json          use JSON output format"));
-	puts(_(" -n, --no-act        do everything except the actual write() call"));
-	puts(_(" -o, --offset <num>  offset to erase, in bytes"));
-	puts(_(" -O, --output <list> COLUMNS to display (see below)"));
-	puts(_(" -p, --parsable      print out in parsable instead of printable format"));
-	puts(_(" -q, --quiet         suppress output messages"));
-	puts(_(" -t, --types <list>  limit the set of filesystem, RAIDs or partition tables"));
-	printf(
+	fputs(_(" -a, --all           wipe all magic strings (BE CAREFUL!)"), stdout);
+	fputs(_(" -b, --backup        create a signature backup in $HOME"), stdout);
+	fputs(_(" -f, --force         force erasure"), stdout);
+	fputs(_(" -i, --noheadings    don't print headings"), stdout);
+	fputs(_(" -J, --json          use JSON output format"), stdout);
+	fputs(_(" -n, --no-act        do everything except the actual write() call"), stdout);
+	fputs(_(" -o, --offset <num>  offset to erase, in bytes"), stdout);
+	fputs(_(" -O, --output <list> COLUMNS to display (see below)"), stdout);
+	fputs(_(" -p, --parsable      print out in parsable instead of printable format"), stdout);
+	fputs(_(" -q, --quiet         suppress output messages"), stdout);
+	fputs(_(" -t, --types <list>  limit the set of filesystem, RAIDs or partition tables"), stdout);
+	fprintf(stdout,
 	     _("     --lock[=<mode>] use exclusive device lock (%s, %s or %s)\n"), "yes", "no", "nonblock");
 
-	printf(USAGE_HELP_OPTIONS(21));
+	fprintf(stdout, USAGE_HELP_OPTIONS(21));
 
 	fputs(USAGE_ARGUMENTS, stdout);
-	printf(USAGE_ARG_SIZE(_("<num>")));
+	fprintf(stdout, USAGE_ARG_SIZE(_("<num>")));
 
 	fputs(USAGE_COLUMNS, stdout);
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(stdout, " %8s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("wipefs(8)"));
+	fprintf(stdout, USAGE_MAN_TAIL("wipefs(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -90,9 +90,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -v, --verbose        display status information\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(out, USAGE_HELP_OPTIONS(22));
 
-	printf(USAGE_MAN_TAIL("chrt(1)"));
+	fprintf(out, USAGE_MAN_TAIL("chrt(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/schedutils/ionice.c
+++ b/schedutils/ionice.c
@@ -123,9 +123,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -u, --uid <uid>...     act on already running processes owned by these users\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
 
-	printf(USAGE_MAN_TAIL("ionice(1)"));
+	fprintf(out, USAGE_MAN_TAIL("ionice(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/schedutils/taskset.c
+++ b/schedutils/taskset.c
@@ -66,7 +66,7 @@ static void __attribute__((__noreturn__)) usage(void)
 		" -p, --pid               operate on existing given pid\n"
 		" -c, --cpu-list          display and specify cpus in list format\n"
 		));
-	printf(USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
 
 	fputs(USAGE_SEPARATOR, out);
 	fprintf(out, _(
@@ -82,7 +82,7 @@ static void __attribute__((__noreturn__)) usage(void)
 		"    e.g. 0-31:2 is equivalent to mask 0x55555555\n"),
 		program_invocation_short_name);
 
-	printf(USAGE_MAN_TAIL("taskset(1)"));
+	fprintf(out, USAGE_MAN_TAIL("taskset(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/schedutils/uclampset.c
+++ b/schedutils/uclampset.c
@@ -69,13 +69,13 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -R, --reset-on-fork  set reset-on-fork flag\n"), out);
 	fputs(_(" -v, --verbose        display status information\n"), out);
 
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(out, USAGE_HELP_OPTIONS(22));
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Utilization value range is [0:1024]. Use special -1 value to "
 		"reset to system's default.\n"), out);
 
-	printf(USAGE_MAN_TAIL("uclampset(1)"));
+	fprintf(out, USAGE_MAN_TAIL("uclampset(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/blkdiscard.c
+++ b/sys-utils/blkdiscard.c
@@ -105,12 +105,12 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -z, --zeroout       zero-fill rather than discard\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(21));
+	fprintf(out, USAGE_HELP_OPTIONS(21));
 
 	fputs(USAGE_ARGUMENTS, out);
-	printf(USAGE_ARG_SIZE(_("<num>")));
+	fprintf(out, USAGE_ARG_SIZE(_("<num>")));
 
-	printf(USAGE_MAN_TAIL("blkdiscard(8)"));
+	fprintf(out, USAGE_MAN_TAIL("blkdiscard(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/blkpr.c
+++ b/sys-utils/blkpr.c
@@ -223,7 +223,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -t, --type <type>        command type\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
 
 	fputs(USAGE_ARGUMENTS, out);
 
@@ -236,7 +236,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" <type> is a command type, available types:\n"), out);
 	print_pr_type(out);
 
-	printf(USAGE_MAN_TAIL("blkpr(8)"));
+	fprintf(out, USAGE_MAN_TAIL("blkpr(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/blkzone.c
+++ b/sys-utils/blkzone.c
@@ -402,12 +402,12 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -f, --force            enforce on block devices used by the system\n"), out);
 	fputs(_(" -v, --verbose          display more details\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
 
 	fputs(USAGE_ARGUMENTS, out);
-	printf(USAGE_ARG_SIZE(_("<sector> and <sectors>")));
+	fprintf(out, USAGE_ARG_SIZE(_("<sector> and <sectors>")));
 
-	printf(USAGE_MAN_TAIL("blkzone(8)"));
+	fprintf(out, USAGE_MAN_TAIL("blkzone(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/chcpu.c
+++ b/sys-utils/chcpu.c
@@ -253,9 +253,9 @@ static void __attribute__((__noreturn__)) usage(void)
 		" -p, --dispatch <mode>         set dispatching mode\n"
 		" -r, --rescan                  trigger rescan of cpus\n"
 		), stdout);
-	printf(USAGE_HELP_OPTIONS(31));
+	fprintf(stdout, USAGE_HELP_OPTIONS(31));
 
-	printf(USAGE_MAN_TAIL("chcpu(8)"));
+	fprintf(stdout, USAGE_MAN_TAIL("chcpu(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/chmem.c
+++ b/sys-utils/chmem.c
@@ -348,13 +348,13 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -b, --blocks       use memory blocks\n"), out);
 	fputs(_(" -z, --zone <name>  select memory zone (see below)\n"), out);
 	fputs(_(" -v, --verbose      verbose output\n"), out);
-	printf(USAGE_HELP_OPTIONS(20));
+	fprintf(out, USAGE_HELP_OPTIONS(20));
 
 	fputs(_("\nSupported zones:\n"), out);
 	for (i = 0; i < ARRAY_SIZE(zone_names); i++)
 		fprintf(out, " %s\n", zone_names[i]);
 
-	printf(USAGE_MAN_TAIL("chmem(8)"));
+	fprintf(out, USAGE_MAN_TAIL("chmem(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/choom.c
+++ b/sys-utils/choom.c
@@ -47,8 +47,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -n, --adjust <num>     specify the adjust score value\n"), out);
 	fputs(_(" -p, --pid <num>        process ID\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
-	printf(USAGE_MAN_TAIL("choom(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_MAN_TAIL("choom(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/ctrlaltdel.c
+++ b/sys-utils/ctrlaltdel.c
@@ -31,8 +31,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fprintf(out, _("Set the function of the Ctrl-Alt-Del combination.\n"));
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("ctrlaltdel(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("ctrlaltdel(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -322,7 +322,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --until <time>          display the lines until the specified time\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(29));
+	fprintf(out, USAGE_HELP_OPTIONS(29));
 	fputs(_("\nSupported log facilities:\n"), out);
 	for (i = 0; i < ARRAY_SIZE(level_names); i++)
 		fprintf(out, " %7s - %s\n",
@@ -335,7 +335,7 @@ static void __attribute__((__noreturn__)) usage(void)
 			level_names[i].name,
 			_(level_names[i].help));
 
-	printf(USAGE_MAN_TAIL("dmesg(1)"));
+	fprintf(out, USAGE_MAN_TAIL("dmesg(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -164,10 +164,10 @@ static void __attribute__((__noreturn__)) usage(void)
 		out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(29));
+	fprintf(out, USAGE_HELP_OPTIONS(29));
 
 	fputs(_("\nBy default tries -r, -s, -f, and -q in order until success.\n"), out);
-	printf(USAGE_MAN_TAIL("eject(1)"));
+	fprintf(out, USAGE_MAN_TAIL("eject(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -101,12 +101,12 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -v, --verbose        verbose mode\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(out, USAGE_HELP_OPTIONS(22));
 
 	fputs(USAGE_ARGUMENTS, out);
-	printf(USAGE_ARG_SIZE(_("<num>")));
+	fprintf(out, USAGE_ARG_SIZE(_("<num>")));
 
-	printf(USAGE_MAN_TAIL("fallocate(1)"));
+	fprintf(out, USAGE_MAN_TAIL("fallocate(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/flock.c
+++ b/sys-utils/flock.c
@@ -49,7 +49,7 @@
 static void __attribute__((__noreturn__)) usage(void)
 {
 	fputs(USAGE_HEADER, stdout);
-	printf(
+	fprintf(stdout,
 		_(" %1$s [options] <file>|<directory> <command> [<argument>...]\n"
 		  " %1$s [options] <file>|<directory> -c <command>\n"
 		  " %1$s [options] <file descriptor number>\n"),
@@ -70,8 +70,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(  " -F, --no-fork            execute command without forking\n"), stdout);
 	fputs(_(  "     --verbose            increase verbosity\n"), stdout);
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(26));
-	printf(USAGE_MAN_TAIL("flock(1)"));
+	fprintf(stdout, USAGE_HELP_OPTIONS(26));
+	fprintf(stdout, USAGE_MAN_TAIL("flock(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/fsfreeze.c
+++ b/sys-utils/fsfreeze.c
@@ -47,8 +47,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -f, --freeze      freeze the filesystem\n"), out);
 	fputs(_(" -u, --unfreeze    unfreeze the filesystem\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(19));
-	printf(USAGE_MAN_TAIL("fsfreeze(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(19));
+	fprintf(out, USAGE_MAN_TAIL("fsfreeze(8)"));
 
 	exit(EXIT_SUCCESS);
 }
@@ -147,4 +147,3 @@ done:
 	close(fd);
 	return rc;
 }
-

--- a/sys-utils/fstrim.c
+++ b/sys-utils/fstrim.c
@@ -469,12 +469,12 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -n, --dry-run            does everything, but trim\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(21));
+	fprintf(out, USAGE_HELP_OPTIONS(21));
 
 	fputs(USAGE_ARGUMENTS, out);
-	printf(USAGE_ARG_SIZE(_("<num>")));
+	fprintf(out, USAGE_ARG_SIZE(_("<num>")));
 
-	printf(USAGE_MAN_TAIL("fstrim(8)"));
+	fprintf(out, USAGE_MAN_TAIL("fstrim(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -1256,22 +1256,22 @@ usage(void)
 	puts(_(" -v, --verbose                   display more details"));
 
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(33));
+	fprintf(stdout, USAGE_HELP_OPTIONS(33));
 
 #ifdef __linux__
 	fputs(USAGE_ARGUMENTS, stdout);
-	puts(_(" <param> is either a numeric RTC parameter value or one of these aliases:"));
+	fputs(_(" <param> is either a numeric RTC parameter value or one of these aliases:"), stdout);
 
 	while (param->name) {
-		printf(_("   - %1$s: %2$s (0x%3$x)\n"), param->name, param->help, param->id);
+		fprintf(stdout, _("   - %1$s: %2$s (0x%3$x)\n"), param->name, param->help, param->id);
 		param++;
 	}
 
-	puts(_("   See Kernel's include/uapi/linux/rtc.h for parameters and values."));
+	fputs(_("   See Kernel's include/uapi/linux/rtc.h for parameters and values."), stdout);
 	fputs(USAGE_ARG_SEPARATOR, stdout);
-	puts(_(" <param> and <value> accept hexadecimal values if prefixed with 0x, otherwise decimal."));
+	fputs(_(" <param> and <value> accept hexadecimal values if prefixed with 0x, otherwise decimal."), stdout);
 #endif
-	printf(USAGE_MAN_TAIL("hwclock(8)"));
+	fprintf(stdout, USAGE_MAN_TAIL("hwclock(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/ipcmk.c
+++ b/sys-utils/ipcmk.c
@@ -76,12 +76,12 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -p, --mode <mode>        permission for the resource (default is 0644)\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
 
 	fputs(USAGE_ARGUMENTS, out);
-	printf(USAGE_ARG_SIZE(_("<size>")));
+	fprintf(out, USAGE_ARG_SIZE(_("<size>")));
 
-	printf(USAGE_MAN_TAIL("ipcmk(1)"));
+	fprintf(out, USAGE_MAN_TAIL("ipcmk(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/ipcrm.c
+++ b/sys-utils/ipcrm.c
@@ -65,8 +65,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -v, --verbose              explain what is being done\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(28));
-	printf(USAGE_MAN_TAIL("ipcrm(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(28));
+	fprintf(out, USAGE_MAN_TAIL("ipcrm(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/ipcs.c
+++ b/sys-utils/ipcs.c
@@ -66,7 +66,7 @@ static void __attribute__((__noreturn__)) usage(void)
 
 	fputs(USAGE_OPTIONS, out);
 	fputs(_(" -i, --id <id>  print details on resource identified by <id>\n"), out);
-	printf(USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Resource options:\n"), out);
@@ -84,7 +84,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -u, --summary     show status summary\n"), out);
 	fputs(_("     --human       show sizes in human-readable format\n"), out);
 	fputs(_(" -b, --bytes       show sizes in bytes\n"), out);
-	printf(USAGE_MAN_TAIL("ipcs(1)"));
+	fprintf(out, USAGE_MAN_TAIL("ipcs(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/irqtop.c
+++ b/sys-utils/irqtop.c
@@ -272,7 +272,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -s, --sort <column>  specify sort column\n"), stdout);
 	fputs(_(" -S, --softirq        show softirqs instead of interrupts\n"), stdout);
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(stdout, USAGE_HELP_OPTIONS(22));
 
 	fputs(_("\nThe following interactive key commands are valid:\n"), stdout);
 	fputs(_("  i      sort by IRQ\n"), stdout);
@@ -284,7 +284,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_COLUMNS, stdout);
 	irq_print_columns(stdout, 0);
 
-	printf(USAGE_MAN_TAIL("irqtop(1)"));
+	fprintf(stdout, USAGE_MAN_TAIL("irqtop(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/ldattach.c
+++ b/sys-utils/ldattach.c
@@ -217,7 +217,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -i, --iflag [-]<iflag>  set input mode flag\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
 
 	fputs(_("\nKnown <ldisc> names:\n"), out);
 	print_table(out, ld_discs);
@@ -226,7 +226,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("\nKnown <iflag> names:\n"), out);
 	print_table(out, ld_iflags);
 
-	printf(USAGE_MAN_TAIL("ldattach(8)"));
+	fprintf(out, USAGE_MAN_TAIL("ldattach(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -488,13 +488,13 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --raw                     use raw --list output format\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(31));
+	fprintf(out, USAGE_HELP_OPTIONS(31));
 
 	fputs(USAGE_COLUMNS, out);
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %12s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("losetup(8)"));
+	fprintf(out, USAGE_MAN_TAIL("losetup(8)"));
 
 	exit(EXIT_SUCCESS);
 }
@@ -992,4 +992,3 @@ int main(int argc, char **argv)
 	loopcxt_deinit(&lc);
 	return res ? EXIT_FAILURE : EXIT_SUCCESS;
 }
-

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -1198,7 +1198,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --hierarchic[=when] use subsections in summary (auto, never, always)\n"), out);
 	fputs(_("     --output-all        print all available columns for -e, -p or -C\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
 
 	fputs(_("\nAvailable output columns for -e or -p:\n"), out);
 	for (i = 0; i < ARRAY_SIZE(coldescs_cpu); i++)
@@ -1208,7 +1208,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	for (i = 0; i < ARRAY_SIZE(coldescs_cache); i++)
 		fprintf(out, " %13s  %s\n", coldescs_cache[i].name, _(coldescs_cache[i].help));
 
-	printf(USAGE_MAN_TAIL("lscpu(1)"));
+	fprintf(out, USAGE_MAN_TAIL("lscpu(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -320,7 +320,7 @@ static void __attribute__((__noreturn__)) usage(void)
 
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
 
 	fprintf(out, _("\nGeneric columns:\n"));
 	for (i = COLDESC_IDX_GEN_FIRST; i <= COLDESC_IDX_GEN_LAST; i++)
@@ -342,7 +342,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	for (i = COLDESC_IDX_SUM_FIRST; i <= COLDESC_IDX_SUM_LAST; i++)
 		fprintf(out, " %14s  %s\n", coldescs[i].name, _(coldescs[i].help));
 
-	printf(USAGE_MAN_TAIL("lsipc(1)"));
+	fprintf(out, USAGE_MAN_TAIL("lsipc(1)"));
 	exit(EXIT_SUCCESS);
 }
 
@@ -1354,4 +1354,3 @@ int main(int argc, char *argv[])
 
 	return EXIT_SUCCESS;
 }
-

--- a/sys-utils/lsirq.c
+++ b/sys-utils/lsirq.c
@@ -57,7 +57,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	printf(_(" %s [options]\n"), program_invocation_short_name);
 	fputs(USAGE_SEPARATOR, stdout);
 
-	puts(_("Utility to display kernel interrupt information."));
+	fputs(_("Utility to display kernel interrupt information."), stdout);
 
 	fputs(USAGE_OPTIONS, stdout);
 	fputs(_(" -J, --json           use JSON output format\n"), stdout);
@@ -67,12 +67,12 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -s, --sort <column>  specify sort column\n"), stdout);
 	fputs(_(" -S, --softirq        show softirqs instead of interrupts\n"), stdout);
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(stdout, USAGE_HELP_OPTIONS(22));
 
 	fputs(USAGE_COLUMNS, stdout);
 	irq_print_columns(stdout, 1);
 
-	printf(USAGE_MAN_TAIL("lsirq(1)"));
+	fprintf(stdout, USAGE_MAN_TAIL("lsirq(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/lsmem.c
+++ b/sys-utils/lsmem.c
@@ -535,13 +535,13 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --summary[=when] print summary information (never,always or only)\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(22));
+	fprintf(out, USAGE_HELP_OPTIONS(22));
 
 	fputs(USAGE_COLUMNS, out);
 	for (i = 0; i < ARRAY_SIZE(coldescs); i++)
 		fprintf(out, " %10s  %s\n", coldescs[i].name, _(coldescs[i].help));
 
-	printf(USAGE_MAN_TAIL("lsmem(1)"));
+	fprintf(out, USAGE_MAN_TAIL("lsmem(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -1302,13 +1302,13 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -T, --tree <rel>       use tree format (parent, owner, or process)\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
 
 	fputs(USAGE_COLUMNS, out);
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %11s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("lsns(8)"));
+	fprintf(out, USAGE_MAN_TAIL("lsns(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/mount.c
+++ b/sys-utils/mount.c
@@ -482,7 +482,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	FILE *out = stdout;
 
 	fputs(USAGE_HEADER, out);
-	printf(_(
+	fprintf(out, _(
 		" %1$s [-lhV]\n"
 		" %1$s -a [options]\n"
 		" %1$s [options] [--source] <source> | [--target] <directory>\n"
@@ -529,7 +529,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -N, --namespace <ns>    perform mount in another namespace\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Source:\n"), out);
@@ -558,7 +558,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" --make-rprivate         recursively mark a whole subtree as private\n"), out);
 	fputs(_(" --make-runbindable      recursively mark a whole subtree as unbindable\n"), out);
 
-	printf(USAGE_MAN_TAIL("mount(8)"));
+	fprintf(out, USAGE_MAN_TAIL("mount(8)"));
 
 	exit(MNT_EX_SUCCESS);
 }

--- a/sys-utils/mountpoint.c
+++ b/sys-utils/mountpoint.c
@@ -130,8 +130,8 @@ static void __attribute__((__noreturn__)) usage(void)
 		" -d, --fs-devno     print maj:min device number of the filesystem\n"
 		" -x, --devno        print maj:min device number of the block device\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(20));
-	printf(USAGE_MAN_TAIL("mountpoint(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(20));
+	fprintf(out, USAGE_MAN_TAIL("mountpoint(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -120,8 +120,8 @@ static void __attribute__((__noreturn__)) usage(void)
 #endif
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
-	printf(USAGE_MAN_TAIL("nsenter(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_MAN_TAIL("nsenter(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/pivot_root.c
+++ b/sys-utils/pivot_root.c
@@ -38,8 +38,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Change the root filesystem.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("pivot_root(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("pivot_root(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/prlimit.c
+++ b/sys-utils/prlimit.c
@@ -179,7 +179,7 @@ static void __attribute__((__noreturn__)) usage(void)
 		"     --raw              use the raw output format\n"
 		"     --verbose          verbose output\n"
 		), out);
-	printf(USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
 
 	fputs(_("\nResources:\n"), out);
 	fputs(_(" -c, --core             maximum size of core files created\n"
@@ -209,7 +209,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %11s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("prlimit(1)"));
+	fprintf(out, USAGE_MAN_TAIL("prlimit(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/readprofile.c
+++ b/sys-utils/readprofile.c
@@ -124,8 +124,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -r, --reset               reset all the counters (root only)\n"), out);
 	fputs(_(" -n, --no-auto             disable byte order auto-detection\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(27));
-	printf(USAGE_MAN_TAIL("readprofile(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(27));
+	fprintf(out, USAGE_MAN_TAIL("readprofile(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/renice.c
+++ b/sys-utils/renice.c
@@ -78,8 +78,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -g, --pgrp             interpret arguments as process group ID\n"), out);
 	fputs(_(" -u, --user             interpret arguments as username or user ID\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
-	printf(USAGE_MAN_TAIL("renice(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_MAN_TAIL("renice(1)"));
 	exit(EXIT_SUCCESS);
 }
 
@@ -100,7 +100,7 @@ static int donice(const int which, const int who, const int prio, const int rela
 
 	if (getprio(which, who, &oldprio) != 0)
 		return 1;
-	
+
 	newprio = prio; // if not relative, set absolute priority
 
 	if (relative)

--- a/sys-utils/rfkill.c
+++ b/sys-utils/rfkill.c
@@ -643,7 +643,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -r, --raw              use the raw output format\n"), stdout);
 
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(24));
+	fprintf(stdout, USAGE_HELP_OPTIONS(24));
 
 	fputs(USAGE_COLUMNS, stdout);
 	for (i = 0; i < ARRAY_SIZE(infos); i++)

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -118,8 +118,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -v, --verbose            verbose messages\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
-	printf(USAGE_MAN_TAIL("rtcwake(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_MAN_TAIL("rtcwake(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/setarch.c
+++ b/sys-utils/setarch.c
@@ -139,9 +139,9 @@ static void __attribute__((__noreturn__)) usage(int archwrapper)
 {
 	fputs(USAGE_HEADER, stdout);
 	if (!archwrapper)
-		printf(_(" %s [<arch>] [options] [<program> [<argument>...]]\n"), program_invocation_short_name);
+		fprintf(stdout, _(" %s [<arch>] [options] [<program> [<argument>...]]\n"), program_invocation_short_name);
 	else
-		printf(_(" %s [options] [<program> [<argument>...]]\n"), program_invocation_short_name);
+		fprintf(stdout, _(" %s [options] [<program> [<argument>...]]\n"), program_invocation_short_name);
 
 	fputs(USAGE_SEPARATOR, stdout);
 	fputs(_("Change the reported architecture and set personality flags.\n"), stdout);
@@ -167,8 +167,8 @@ static void __attribute__((__noreturn__)) usage(int archwrapper)
 	}
 
 	fputs(USAGE_SEPARATOR, stdout);
-	printf(USAGE_HELP_OPTIONS(26));
-	printf(USAGE_MAN_TAIL("setarch(8)"));
+	fprintf(stdout, USAGE_HELP_OPTIONS(26));
+	fprintf(stdout, USAGE_MAN_TAIL("setarch(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/setpgid.c
+++ b/sys-utils/setpgid.c
@@ -26,9 +26,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_OPTIONS, out);
 	fputs(_(" -f, --foregound     Make a foreground process group\n"), out);
 
-	printf(USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
 
-	printf(USAGE_MAN_TAIL("setpgid(1)"));
+	fprintf(out, USAGE_MAN_TAIL("setpgid(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/setpriv.c
+++ b/sys-utils/setpriv.c
@@ -147,10 +147,10 @@ static void __attribute__((__noreturn__)) usage(void)
 		"                               HOME, SHELL, USER, LOGNAME and PATH\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(29));
+	fprintf(out, USAGE_HELP_OPTIONS(29));
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_(" This tool can be dangerous.  Read the manpage, and be careful.\n"), out);
-	printf(USAGE_MAN_TAIL("setpriv(1)"));
+	fprintf(out, USAGE_MAN_TAIL("setpriv(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/setsid.c
+++ b/sys-utils/setsid.c
@@ -41,9 +41,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -f, --fork     always fork\n"), out);
 	fputs(_(" -w, --wait     wait program to exit, and use the same return\n"), out);
 
-	printf(USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
 
-	printf(USAGE_MAN_TAIL("setsid(1)"));
+	fprintf(out, USAGE_MAN_TAIL("setsid(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/swapoff.c
+++ b/sys-utils/swapoff.c
@@ -148,7 +148,7 @@ static void __attribute__((__noreturn__)) usage(void)
 		" -v, --verbose          verbose mode\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
 
 	fputs(_("\nThe <spec> parameter:\n" \
 		" -L <label>             LABEL of device to be used\n" \
@@ -158,7 +158,7 @@ static void __attribute__((__noreturn__)) usage(void)
 		" <device>               name of device to be used\n" \
 		" <file>                 name of file to be used\n"), out);
 
-	printf(USAGE_MAN_TAIL("swapoff(8)"));
+	fprintf(out, USAGE_MAN_TAIL("swapoff(8)"));
 	exit(SWAPOFF_EX_OK);
 }
 

--- a/sys-utils/swapon.c
+++ b/sys-utils/swapon.c
@@ -825,7 +825,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -v, --verbose            verbose mode\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(26));
+	fprintf(out, USAGE_HELP_OPTIONS(26));
 
 	fputs(_("\nThe <spec> parameter:\n" \
 		" -L <label>             synonym for LABEL=<label>\n"
@@ -846,7 +846,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %-5s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("swapon(8)"));
+	fprintf(out, USAGE_MAN_TAIL("swapon(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/sys-utils/switch_root.c
+++ b/sys-utils/switch_root.c
@@ -230,8 +230,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Switch to another filesystem as the root of the mount tree.\n"), output);
 
 	fputs(USAGE_OPTIONS, output);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("switch_root(8)"));
+	fprintf(output, USAGE_HELP_OPTIONS(16));
+	fprintf(output, USAGE_MAN_TAIL("switch_root(8)"));
 
 	exit(EXIT_SUCCESS);
 }
@@ -280,4 +280,3 @@ int main(int argc, char *argv[])
 	execv(init, initargs);
 	errexec(init);
 }
-

--- a/sys-utils/tunelp.c
+++ b/sys-utils/tunelp.c
@@ -112,8 +112,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -r, --reset                  reset the port\n"), out);
 	fputs(_(" -q, --print-irq <on|off>     display current irq setting\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(30));
-	printf(USAGE_MAN_TAIL("tunelp(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(30));
+	fprintf(out, USAGE_MAN_TAIL("tunelp(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -107,8 +107,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -N, --namespace <ns>    perform umount in another namespace\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(25));
-	printf(USAGE_MAN_TAIL("umount(8)"));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_MAN_TAIL("umount(8)"));
 
 	exit(MNT_EX_SUCCESS);
 }
@@ -656,4 +656,3 @@ int main(int argc, char **argv)
 
 	return (rc < 256) ? rc : 255;
 }
-

--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -683,8 +683,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" --boottime <offset>       set clock boottime offset (seconds) in time namespaces\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(27));
-	printf(USAGE_MAN_TAIL("unshare(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(27));
+	fprintf(out, USAGE_MAN_TAIL("unshare(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/wdctl.c
+++ b/sys-utils/wdctl.c
@@ -247,7 +247,7 @@ static void __attribute__((__noreturn__)) usage(void)
 		" -x, --flags-only       print only flags table (same as -I -T)\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(24));
+	fprintf(out, USAGE_HELP_OPTIONS(24));
 	fputs(USAGE_SEPARATOR, out);
 
 	if (dflt)
@@ -259,7 +259,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %13s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("wdctl(8)"));
+	fprintf(out, USAGE_MAN_TAIL("wdctl(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/sys-utils/zramctl.c
+++ b/sys-utils/zramctl.c
@@ -559,10 +559,10 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -t, --streams <number>    number of compression streams\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(27));
+	fprintf(out, USAGE_HELP_OPTIONS(27));
 
 	fputs(USAGE_ARGUMENTS, out);
-	printf(USAGE_ARG_SIZE(_("<size>")));
+	fprintf(out, USAGE_ARG_SIZE(_("<size>")));
 
 	fputs(_(" <alg> specify algorithm, supported are:\n"), out);
 	fputs(_("   lzo, lz4, lz4hc, deflate, 842 and zstd\n"), out);
@@ -572,7 +572,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	for (i = 0; i < ARRAY_SIZE(infos); i++)
 		fprintf(out, " %11s  %s\n", infos[i].name, _(infos[i].help));
 
-	printf(USAGE_MAN_TAIL("zramctl(8)"));
+	fprintf(out, USAGE_MAN_TAIL("zramctl(8)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -2488,9 +2488,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --nice <number>        run login with this priority\n"), out);
 	fputs(_("     --reload               reload prompts on running agetty instances\n"), out);
 	fputs(_("     --list-speeds          display supported baud rates\n"), out);
-	printf( "     --help                 %s\n", USAGE_OPTSTR_HELP);
-	printf( "     --version              %s\n", USAGE_OPTSTR_VERSION);
-	printf(USAGE_MAN_TAIL("agetty(8)"));
+	fprintf(out, "     --help                 %s\n", USAGE_OPTSTR_HELP);
+	fprintf(out, "     --version              %s\n", USAGE_OPTSTR_VERSION);
+	fprintf(out, USAGE_MAN_TAIL("agetty(8)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/term-utils/mesg.c
+++ b/term-utils/mesg.c
@@ -82,8 +82,8 @@ static void __attribute__((__noreturn__)) usage(void)
 
 	fputs(USAGE_OPTIONS, out);
 	fputs(_(" -v, --verbose  explain what is being done\n"), out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("mesg(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("mesg(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -216,8 +216,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -q, --quiet                   be quiet\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(31));
-	printf(USAGE_MAN_TAIL("script(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(31));
+	fprintf(out, USAGE_MAN_TAIL("script(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/term-utils/scriptlive.c
+++ b/term-utils/scriptlive.c
@@ -73,9 +73,9 @@ usage(void)
 	fputs(_(" -c, --command <command> run command rather than interactive shell\n"), out);
 	fputs(_(" -d, --divisor <num>     speed up or slow down execution with time divisor\n"), out);
 	fputs(_(" -m, --maxdelay <num>    wait at most this many seconds between updates\n"), out);
-	printf(USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
 
-	printf(USAGE_MAN_TAIL("scriptlive(1)"));
+	fprintf(out, USAGE_MAN_TAIL("scriptlive(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -68,9 +68,9 @@ usage(void)
 	fputs(_(" -m, --maxdelay <num>    wait at most this many seconds between updates\n"), out);
 	fputs(_(" -x, --stream <name>     stream type (out, in, signal or info)\n"), out);
 	fputs(_(" -c, --cr-mode <type>    CR char mode (auto, never, always)\n"), out);
-	printf(USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
 
-	printf(USAGE_MAN_TAIL("scriptreplay(1)"));
+	fprintf(out, USAGE_MAN_TAIL("scriptreplay(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/term-utils/setterm.c
+++ b/term-utils/setterm.c
@@ -438,10 +438,10 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" --bfreq[=<number>]            bell frequency in Hertz\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf( " --help                        %s\n", USAGE_OPTSTR_HELP);
-	printf( " --version                     %s\n", USAGE_OPTSTR_VERSION);
+	fprintf(out, " --help                        %s\n", USAGE_OPTSTR_HELP);
+	fprintf(out, " --version                     %s\n", USAGE_OPTSTR_VERSION);
 
-	printf(USAGE_MAN_TAIL("setterm(1)"));
+	fprintf(out, USAGE_MAN_TAIL("setterm(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/term-utils/wall.c
+++ b/term-utils/wall.c
@@ -101,8 +101,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -n, --nobanner          do not print banner, works only for root\n"), out);
 	fputs(_(" -t, --timeout <timeout> write timeout in seconds\n"), out);
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(25));
-	printf(USAGE_MAN_TAIL("wall(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_MAN_TAIL("wall(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/term-utils/write.c
+++ b/term-utils/write.c
@@ -96,8 +96,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Send a message to another user.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("write(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("write(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/text-utils/col.c
+++ b/text-utils/col.c
@@ -182,10 +182,10 @@ static void __attribute__((__noreturn__)) usage(void)
 		" -x, --spaces           convert tabs to spaces\n"
 		" -l, --lines NUM        buffer at least NUM lines\n"
 		));
-	printf( " -H, --help             %s\n", USAGE_OPTSTR_HELP);
-	printf( " -V, --version          %s\n", USAGE_OPTSTR_VERSION);
+	fprintf(out, " -H, --help             %s\n", USAGE_OPTSTR_HELP);
+	fprintf(out, " -V, --version          %s\n", USAGE_OPTSTR_VERSION);
 
-	printf(USAGE_MAN_TAIL("col(1)"));
+	fprintf(out, USAGE_MAN_TAIL("col(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/text-utils/colcrt.c
+++ b/text-utils/colcrt.c
@@ -89,9 +89,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -2, --half-lines        print all half-lines\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(25));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
 
-	printf(USAGE_MAN_TAIL("colcrt(1)"));
+	fprintf(out, USAGE_MAN_TAIL("colcrt(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/text-utils/colrm.c
+++ b/text-utils/colrm.c
@@ -65,10 +65,10 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Filter out the specified columns.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
 	fprintf(out, _("%s reads from standard input and writes to standard output\n\n"),
 		       program_invocation_short_name);
-	printf(USAGE_MAN_TAIL("colrm(1)"));
+	fprintf(out, USAGE_MAN_TAIL("colrm(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/text-utils/column.c
+++ b/text-utils/column.c
@@ -778,8 +778,8 @@ static void __attribute__((__noreturn__)) usage(void)
 
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(34));
-	printf(USAGE_MAN_TAIL("column(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(34));
+	fprintf(out, USAGE_MAN_TAIL("column(1)"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/text-utils/hexdump.c
+++ b/text-utils/hexdump.c
@@ -187,12 +187,12 @@ void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -v, --no-squeezing        output identical lines\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(27));
+	fprintf(out, USAGE_HELP_OPTIONS(27));
 
 	fputs(USAGE_ARGUMENTS, out);
-	printf(USAGE_ARG_SIZE(_("<length> and <offset>")));
+	fprintf(out, USAGE_ARG_SIZE(_("<length> and <offset>")));
 
-	printf(USAGE_MAN_TAIL("hexdump(1)"));
+	fprintf(out, USAGE_MAN_TAIL("hexdump(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/text-utils/line.c
+++ b/text-utils/line.c
@@ -34,8 +34,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Read one line.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("line(1)"));
+	fprintf(out,USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("line(1)"));
 	exit(EXIT_SUCCESS);
 }
 

--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -247,9 +247,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" +/pattern/   start at the line containing pattern\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	printf(USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
 
-	printf(USAGE_MAN_TAIL("pg(1)"));
+	fprintf(out, USAGE_MAN_TAIL("pg(1)"));
 	exit(0);
 }
 

--- a/text-utils/rev.c
+++ b/text-utils/rev.c
@@ -79,8 +79,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Reverse lines characterwise.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	printf(USAGE_HELP_OPTIONS(16));
-	printf(USAGE_MAN_TAIL("rev(1)"));
+	fprintf(out, USAGE_HELP_OPTIONS(16));
+	fprintf(out, USAGE_MAN_TAIL("rev(1)"));
 
 	exit(EXIT_SUCCESS);
 }
@@ -202,4 +202,3 @@ int main(int argc, char *argv[])
 	free(buf);
 	return rval;
 }
-

--- a/text-utils/ul.c
+++ b/text-utils/ul.c
@@ -128,9 +128,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_OPTIONS, out);
 	fputs(_(" -t, -T, --terminal TERMINAL  override the TERM environment variable\n"), out);
 	fputs(_(" -i, --indicated              underlining is indicated via a separate line\n"), out);
-	printf(USAGE_HELP_OPTIONS(30));
+	fprintf(out, USAGE_HELP_OPTIONS(30));
 
-	printf(USAGE_MAN_TAIL("ul(1)"));
+	fprintf(out, USAGE_MAN_TAIL("ul(1)"));
 
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
I found various combinations were used in usage():

```
puts(...);
fputs(..., stdout);
fpurts(..., out);
printf(...);
fprintf(out, ...);
fprintf(stdout, ...);
```

At least, in one usage() function, they should be consistent.

