### PR TITLE
meson: install write executable with group 'tty'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2466,7 +2466,7 @@ exe = executable(
   link_with : [lib_common],
   dependencies : [lib_systemd],
   install_dir : usrbin_exec_dir,
-  install_mode : 'rwxr-sr-x',
+  install_mode : [ 'rwxr-sr-x', 'root', 'tty' ],
   install : opt,
   build_by_default : opt)
 if opt

--- a/meson.build
+++ b/meson.build
@@ -2446,7 +2446,7 @@ exe = executable(
   link_with : [lib_common],
   dependencies : [lib_systemd],
   install_dir : usrbin_exec_dir,
-  install_mode : 'rwxr-sr-x',
+  install_mode : [ 'rwxr-sr-x', 'root', 'tty' ],
   install : opt,
   build_by_default : opt)
 if opt


### PR DESCRIPTION
... to fix:

write: effective gid does not match group of /dev/pts/3