### PR TITLE
libuuid/src/gen_uuid.c: fix cs_min declaration

### DIFF
--- a/libuuid/src/gen_uuid.c
+++ b/libuuid/src/gen_uuid.c
@@ -518,6 +518,10 @@ int __uuid_generate_time_cont(uuid_t out, int *num, uint32_t cont_offset)
 	return __uuid_generate_time_internal(out, num, cont_offset);
 }
 
+#define CS_MIN		(1<<6)
+#define CS_MAX		(1<<18)
+#define CS_FACTOR	2
+
 /*
  * Generate time-based UUID and store it to @out
  *
@@ -529,11 +533,8 @@ int __uuid_generate_time_cont(uuid_t out, int *num, uint32_t cont_offset)
 static int uuid_generate_time_generic(uuid_t out) {
 #ifdef HAVE_TLS
 	/* thread local cache for uuidd based requests */
-	const int			cs_min = (1<<6);
-	const int			cs_max = (1<<18);
-	const int			cs_factor = 2;
 	THREAD_LOCAL int		num = 0;
-	THREAD_LOCAL int		cache_size = cs_min;
+	THREAD_LOCAL int		cache_size = CS_MIN;
 	THREAD_LOCAL int		last_used = 0;
 	THREAD_LOCAL struct uuid	uu;
 	THREAD_LOCAL time_t		last_time = 0;
@@ -552,10 +553,10 @@ static int uuid_generate_time_generic(uuid_t out) {
 		 * Start with a small cache size to cover short running applications
 		 * and adjust the cache size over the runntime.
 		 */
-		if ((last_used == cache_size) && (cache_size < cs_max))
-			cache_size *= cs_factor;
-		else if ((last_used < (cache_size / cs_factor)) && (cache_size > cs_min))
-			cache_size /= cs_factor;
+		if ((last_used == cache_size) && (cache_size < CS_MAX))
+			cache_size *= CS_FACTOR;
+		else if ((last_used < (cache_size / CS_FACTOR)) && (cache_size > CS_MIN))
+			cache_size /= CS_FACTOR;
 
 		num = cache_size;
 
@@ -568,7 +569,7 @@ static int uuid_generate_time_generic(uuid_t out) {
 		}
 		/* request to daemon failed, reset cache */
 		num = 0;
-		cache_size = cs_min;
+		cache_size = CS_MIN;
 	}
 	if (num > 0) { /* serve uuid from cache */
 		uu.time_low++;


### PR DESCRIPTION
Define cs_min through a `define` and not a `const int` to avoid the following build failure with `-O0` raised since version 2.39 and https://github.com/util-linux/util-linux/commit/2fa4168c8bc9d5438bc1dfadda293c7c21b6fa59:

```
libuuid/src/gen_uuid.c: In function 'uuid_generate_time_generic': libuuid/src/gen_uuid.c:536:33: error: initializer element is not constant
  THREAD_LOCAL int  cache_size = cs_min;
                                 ^~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/2f80a5cdb523cc3c8c0f3693607a1be036b2ae98