### PR TITLE
uuidd: Add timeout to uuidd.service

### DIFF
--- a/misc-utils/uuidd.service.in
+++ b/misc-utils/uuidd.service.in
@@ -4,7 +4,7 @@ Documentation=man:uuidd(8)
 Requires=uuidd.socket
 
 [Service]
-ExecStart=@usrsbin_execdir@/uuidd --socket-activation --cont-clock
+ExecStart=@usrsbin_execdir@/uuidd --socket-activation --cont-clock --timeout 60
 Restart=no
 User=uuidd
 Group=uuidd


### PR DESCRIPTION
The `uuidd` service already works by socket activation as a way to optimize resources and only actually starting the daemon when needed.

However, once started it will stay up indefinitely regardless of whether it's being used or not.

This adds a timeout flag so that it if doesn't receive requests for the following minute after the last usage, it will automatically quit, freeing memory and potential leaks.