### PR TITLE
lslocks: reduce "(unknown)" and "(undefined)" by utilizing "lock:" fields of /proc/$pid/fdinfo/$fd

### DIFF
--- a/misc-utils/lslocks.8.adoc
+++ b/misc-utils/lslocks.8.adoc
@@ -74,7 +74,7 @@ PID::
 The process ID of the process which holds the lock or -1 for OFDLCK.
 
 TYPE::
-The type of lock; can be FLOCK (created with *flock*(2)), POSIX (created with *fcntl*(2) and *lockf*(3)) or OFDLCK (created with *fcntl*(2)).
+The type of lock; can be LEASE (created with *fcntl*(2)), FLOCK (created with *flock*(2)), POSIX (created with *fcntl*(2) and *lockf*(3)) or OFDLCK (created with *fcntl*(2)).
 
 SIZE::
 Size of the locked file.

--- a/misc-utils/lslocks.8.adoc
+++ b/misc-utils/lslocks.8.adoc
@@ -29,8 +29,6 @@ lslocks - list local system locks
 
 *lslocks* lists information about all the currently held file locks in a Linux system.
 
-Note that lslocks also lists OFD (Open File Description) locks, these locks are not associated with any process (PID is -1). OFD locks are associated with the open file description on which they are acquired. This lock type is available since Linux 3.15, see *fcntl*(2) for more details.
-
 == OPTIONS
 
 *-b*, *--bytes*::
@@ -71,7 +69,7 @@ COMMAND::
 The command name of the process holding the lock.
 
 PID::
-The process ID of the process which holds the lock or -1 for OFDLCK.
+The process ID of the process.
 
 TYPE::
 The type of lock; can be LEASE (created with *fcntl*(2)), FLOCK (created with *flock*(2)), POSIX (created with *fcntl*(2) and *lockf*(3)) or OFDLCK (created with *fcntl*(2)).
@@ -106,6 +104,13 @@ The PID of the process which blocks the lock.
 == NOTES
 
 The *lslocks* command is meant to replace the *lslk*(8) command, originally written by mailto:abe@purdue.edu[Victor A. Abell] and unmaintained since 2001.
+
+"The process holding the lock" for leases, FLOCK locks, and
+OFD locks is a fake-concept.  They are associated with the open file
+description on which they are acquired.  With *fork*(2) and/or
+*cmsg*(3), multiple processes can share an open file description. So
+the holder process of a lease (or a lock) is not uniquely determined.
+*lslocks* shows the one of the holder processes in COMMAND and PID columns.
 
 == AUTHORS
 

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -239,7 +239,7 @@ static ino_t get_dev_inode(char *str, dev_t *dev)
 	return inum;
 }
 
-static struct lock *get_local_lock(char *buf)
+static struct lock *get_lock(char *buf)
 {
 	int i;
 	char *tok = NULL;
@@ -326,7 +326,7 @@ static struct lock *get_local_lock(char *buf)
 	return l;
 }
 
-static int get_local_locks(struct list_head *locks)
+static int get_proc_locks(struct list_head *locks)
 {
 	FILE *fp;
 	char buf[PATH_MAX];
@@ -335,7 +335,7 @@ static int get_local_locks(struct list_head *locks)
 		return -1;
 
 	while (fgets(buf, sizeof(buf), fp)) {
-		struct lock *l = get_local_lock(buf);
+		struct lock *l = get_lock(buf);
 		if (l)
 			list_add(&l->locks, locks);
 	}
@@ -582,7 +582,7 @@ static void __attribute__((__noreturn__)) usage(void)
 int main(int argc, char *argv[])
 {
 	int c, rc = 0;
-	struct list_head locks;
+	struct list_head proc_locks;
 	char *outarg = NULL;
 	enum {
 		OPT_OUTPUT_ALL = CHAR_MAX + 1
@@ -658,7 +658,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	INIT_LIST_HEAD(&locks);
+	INIT_LIST_HEAD(&proc_locks);
 
 	if (!ncolumns) {
 		/* default columns */
@@ -679,10 +679,10 @@ int main(int argc, char *argv[])
 
 	scols_init_debug(0);
 
-	rc = get_local_locks(&locks);
+	rc = get_proc_locks(&proc_locks);
 
-	if (!rc && !list_empty(&locks))
-		rc = show_locks(&locks, target_pid);
+	if (!rc && !list_empty(&proc_locks))
+		rc = show_locks(&proc_locks, target_pid);
 
 	mnt_unref_table(tab);
 	return rc;

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <stdbool.h>
 
 #include <libmount.h>
 #include <libsmartcols.h>
@@ -239,13 +240,42 @@ static ino_t get_dev_inode(char *str, dev_t *dev)
 	return inum;
 }
 
-static struct lock *get_lock(char *buf)
+struct override_info {
+	pid_t pid;
+	const char *cmdname;
+};
+
+static void patch_lock(struct lock *l, struct list_head *fallback)
+{
+	struct list_head *p;
+
+	list_for_each(p, fallback) {
+		struct lock *m = list_entry(p, struct lock, locks);
+		if (l->start == m->start &&
+		    l->end == m->end &&
+		    l->inode == m->inode &&
+		    l->dev == m->dev &&
+		    l->mandatory == m->mandatory &&
+		    l->blocked == m->blocked &&
+		    strcmp(l->type, m->type) == 0 &&
+		    strcmp(l->mode, m->mode) == 0) {
+			/* size and id can be ignored. */
+			l->pid = m->pid;
+			l->cmdname = xstrdup(m->cmdname);
+			break;
+		}
+	}
+}
+
+static struct lock *get_lock(char *buf, struct override_info *oinfo, struct list_head *fallback)
 {
 	int i;
 	char *tok = NULL;
 	size_t sz;
 	struct lock *l = xcalloc(1, sizeof(*l));
 	INIT_LIST_HEAD(&l->locks);
+
+	bool cmdname_unknown = false;
 
 	for (tok = strtok(buf, " "), i = 0; tok;
 	     tok = strtok(NULL, " "), i++) {
@@ -256,8 +286,12 @@ static struct lock *get_lock(char *buf)
 		 */
 		switch (i) {
 		case 0: /* ID: */
-			tok[strlen(tok) - 1] = '\0';
-			l->id = strtos32_or_err(tok, _("failed to parse ID"));
+			if (oinfo)
+				l->id = -1;
+			else {
+				tok[strlen(tok) - 1] = '\0';
+				l->id = strtos32_or_err(tok, _("failed to parse ID"));
+			}
 			break;
 		case 1: /* posix, flock, etc */
 			if (strcmp(tok, "->") == 0) {	/* optional field */
@@ -279,13 +313,20 @@ static struct lock *get_lock(char *buf)
 			 * If user passed a pid we filter it later when adding
 			 * to the list, no need to worry now. OFD locks use -1 PID.
 			 */
-			l->pid = strtos32_or_err(tok, _("failed to parse pid"));
-			if (l->pid > 0) {
-				l->cmdname = pid_get_cmdname(l->pid);
-				if (!l->cmdname)
-					l->cmdname = xstrdup(_("(unknown)"));
-			} else
-				l->cmdname = xstrdup(_("(undefined)"));
+			if (oinfo) {
+				l->pid = oinfo->pid;
+				l->cmdname = xstrdup(oinfo->cmdname);
+			} else {
+				l->pid = strtos32_or_err(tok, _("failed to parse pid"));
+				if (l->pid > 0) {
+					l->cmdname = pid_get_cmdname(l->pid);
+					if (!l->cmdname) {
+						l->cmdname = NULL;
+						cmdname_unknown = true;
+					}
+				} else
+					l->cmdname = NULL;
+			}
 			break;
 
 		case 5: /* device major:minor and inode number */
@@ -308,6 +349,14 @@ static struct lock *get_lock(char *buf)
 		}
 	}
 
+	if ((!l->blocked) && fallback && !l->cmdname)
+		patch_lock(l, fallback);
+	if (!l->cmdname) {
+		if (cmdname_unknown)
+			l->cmdname = xstrdup(_("(unknown)"));
+		else
+			l->cmdname = xstrdup(_("(undefined)"));
+	}
 	l->path = get_filename_sz(l->inode, l->pid, &sz);
 
 	/* no permissions -- ignore */
@@ -326,7 +375,96 @@ static struct lock *get_lock(char *buf)
 	return l;
 }
 
-static int get_proc_locks(struct list_head *locks)
+static int get_pid_lock(struct list_head *locks, FILE *fp,
+			pid_t pid, const char *cmdname)
+{
+	char buf[PATH_MAX];
+	struct override_info oinfo = {
+		.pid = pid,
+		.cmdname = cmdname,
+	};
+
+	while (fgets(buf, sizeof(buf), fp)) {
+		struct lock *l;
+		if (strncmp(buf, "lock:\t", 6))
+			continue;
+		l = get_lock(buf + 6, &oinfo, NULL);
+		if (l)
+			list_add(&l->locks, locks);
+		/* no break here.
+		   Multiple recode locks can be taken via one fd. */
+	}
+
+	return 0;
+}
+
+static int get_pid_locks(struct list_head *locks, struct path_cxt *pc,
+			 pid_t pid, const char *cmdname)
+{
+	DIR *sub = NULL;
+	struct dirent *d = NULL;
+	int rc = 0;
+
+	while (ul_path_next_dirent(pc, &sub, "fdinfo", &d) == 0) {
+		uint64_t num;
+		FILE *fdinfo;
+
+		if (ul_strtou64(d->d_name, &num, 10) != 0)	/* only numbers */
+			continue;
+
+		fdinfo = ul_path_fopenf(pc, "r", "fdinfo/%ju", num);
+		if (fdinfo == NULL)
+			continue;
+
+		get_pid_lock(locks, fdinfo, pid, cmdname);
+		fclose(fdinfo);
+	}
+
+	return rc;
+}
+
+static int get_pids_locks(struct list_head *locks)
+{
+	DIR *dir;
+	struct dirent *d;
+	struct path_cxt *pc = NULL;
+	int rc = 0;
+
+	pc = ul_new_path(NULL);
+	if (!pc)
+		err(EXIT_FAILURE, _("failed to alloc procfs handler"));
+
+	dir = opendir(_PATH_PROC);
+	if (!dir)
+		err(EXIT_FAILURE, _("failed to open /proc"));
+
+	while ((d = readdir(dir))) {
+		pid_t pid;
+		char buf[BUFSIZ];
+		const char *cmdname = NULL;
+
+		if (procfs_dirent_get_pid(d, &pid) != 0)
+			continue;
+
+		if (procfs_process_init_path(pc, pid) != 0) {
+			rc = -1;
+			break;
+		}
+
+		if (procfs_process_get_cmdname(pc, buf, sizeof(buf)) <= 0)
+			continue;
+		cmdname = buf;
+
+		get_pid_locks(locks, pc, pid, cmdname);
+	}
+
+	closedir(dir);
+	ul_unref_path(pc);
+
+	return rc;
+}
+
+static int get_proc_locks(struct list_head *locks, struct list_head *fallback)
 {
 	FILE *fp;
 	char buf[PATH_MAX];
@@ -335,7 +473,7 @@ static int get_proc_locks(struct list_head *locks)
 		return -1;
 
 	while (fgets(buf, sizeof(buf), fp)) {
-		struct lock *l = get_lock(buf);
+		struct lock *l = get_lock(buf, NULL, fallback);
 		if (l)
 			list_add(&l->locks, locks);
 	}
@@ -587,7 +725,7 @@ static void __attribute__((__noreturn__)) usage(void)
 int main(int argc, char *argv[])
 {
 	int c, rc = 0;
-	struct list_head proc_locks;
+	struct list_head proc_locks, pid_locks;
 	char *outarg = NULL;
 	enum {
 		OPT_OUTPUT_ALL = CHAR_MAX + 1
@@ -664,6 +802,7 @@ int main(int argc, char *argv[])
 	}
 
 	INIT_LIST_HEAD(&proc_locks);
+	INIT_LIST_HEAD(&pid_locks);
 
 	if (!ncolumns) {
 		/* default columns */
@@ -684,11 +823,17 @@ int main(int argc, char *argv[])
 
 	scols_init_debug(0);
 
-	rc = get_proc_locks(&proc_locks);
+	/* get_pids_locks() get locks related information from "lock:" fields
+	 * of /proc/$pid/fdinfo/$fd as fallback information.
+	 * get_proc_locks() used the fallback information if /proc/locks
+	 * doesn't provides enough information or provides staled information. */
+	get_pids_locks(&pid_locks);
+	rc = get_proc_locks(&proc_locks, &pid_locks);
 
 	if (!rc && !list_empty(&proc_locks))
 		rc = show_locks(&proc_locks, target_pid);
 
+	rem_locks(&pid_locks);
 	rem_locks(&proc_locks);
 
 	mnt_unref_table(tab);

--- a/tests/commands.sh
+++ b/tests/commands.sh
@@ -91,6 +91,7 @@ TS_CMD_LSBLK=${TS_CMD_LSBLK-"${ts_commandsdir}lsblk"}
 TS_CMD_LSCLOCKS=${TS_CMD_LSCPU-"${ts_commandsdir}lsclocks"}
 TS_CMD_LSCPU=${TS_CMD_LSCPU-"${ts_commandsdir}lscpu"}
 TS_CMD_LSFD=${TS_CMD_LSFD-"${ts_commandsdir}lsfd"}
+TS_CMD_LSLOCKS=${TS_CMD_LSLOCKS-"${ts_commandsdir}lslocks"}
 TS_CMD_LSMEM=${TS_CMD_LSMEM-"${ts_commandsdir}lsmem"}
 TS_CMD_LSNS=${TS_CMD_LSNS-"${ts_commandsdir}lsns"}
 TS_CMD_MCOOKIE=${TS_CMD_MCOOKIE-"${ts_commandsdir}mcookie"}

--- a/tests/expected/lslocks/lslocks-flock-ex
+++ b/tests/expected/lslocks/lslocks-flock-ex
@@ -1,0 +1,4 @@
+test_mkfds FLOCK  WRITE 0 0
+# flock-ex + COMMAND,TYPE,SIZE,MODE,START,END + --raw --noheadings: 0
+util-linux-lslocks-target-file
+# flock-ex + PATH + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-flock-sh
+++ b/tests/expected/lslocks/lslocks-flock-sh
@@ -1,0 +1,4 @@
+test_mkfds FLOCK  READ 0 0
+# flock-sh + COMMAND,TYPE,SIZE,MODE,START,END + --raw --noheadings: 0
+util-linux-lslocks-target-file
+# flock-sh + PATH + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-lease-w
+++ b/tests/expected/lslocks/lslocks-lease-w
@@ -1,0 +1,4 @@
+test_mkfds LEASE  WRITE 0 0
+# lease-w + COMMAND,TYPE,SIZE,MODE,START,END + --raw --noheadings: 0
+util-linux-lslocks-target-file
+# lease-w + PATH + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-ofd--w
+++ b/tests/expected/lslocks/lslocks-ofd--w
@@ -1,0 +1,4 @@
+test_mkfds OFDLCK 1B WRITE 0 0
+# ofd--w + COMMAND,TYPE,SIZE,MODE,START,END + --raw --noheadings: 0
+util-linux-lslocks-target-file
+# ofd--w + PATH + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-ofd-r-
+++ b/tests/expected/lslocks/lslocks-ofd-r-
@@ -1,0 +1,4 @@
+test_mkfds OFDLCK 1B READ 0 0
+# ofd-r- + COMMAND,TYPE,SIZE,MODE,START,END + --raw --noheadings: 0
+util-linux-lslocks-target-file
+# ofd-r- + PATH + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-ofd-rw
+++ b/tests/expected/lslocks/lslocks-ofd-rw
@@ -1,0 +1,6 @@
+test_mkfds OFDLCK 3B READ 0 0
+test_mkfds OFDLCK 3B WRITE 2 2
+# ofd-rw + COMMAND,TYPE,SIZE,MODE,START,END + --raw --noheadings: 0
+util-linux-lslocks-target-file
+util-linux-lslocks-target-file
+# ofd-rw + PATH + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-posix--w
+++ b/tests/expected/lslocks/lslocks-posix--w
@@ -1,0 +1,4 @@
+test_mkfds POSIX 1B WRITE 0 0
+# posix--w + COMMAND,TYPE,SIZE,MODE,START,END + --raw --noheadings: 0
+util-linux-lslocks-target-file
+# posix--w + PATH + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-posix-r-
+++ b/tests/expected/lslocks/lslocks-posix-r-
@@ -1,0 +1,4 @@
+test_mkfds POSIX 1B READ 0 0
+# posix-r- + COMMAND,TYPE,SIZE,MODE,START,END + --raw --noheadings: 0
+util-linux-lslocks-target-file
+# posix-r- + PATH + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-posix-rw
+++ b/tests/expected/lslocks/lslocks-posix-rw
@@ -1,0 +1,6 @@
+test_mkfds POSIX 3B READ 0 0
+test_mkfds POSIX 3B WRITE 2 2
+# posix-rw + COMMAND,TYPE,SIZE,MODE,START,END + --raw --noheadings: 0
+util-linux-lslocks-target-file
+util-linux-lslocks-target-file
+# posix-rw + PATH + --raw --noheadings: 0

--- a/tests/ts/lslocks/lslocks
+++ b/tests/ts/lslocks/lslocks
@@ -37,9 +37,9 @@ METHODS=(
     posix-r-
     posix--w
     posix-rw
-#   ofd-r-
-#   ofd--w
-#   ofd-rw    
+    ofd-r-
+    ofd--w
+    ofd-rw
     lease-w
 )
 

--- a/tests/ts/lslocks/lslocks
+++ b/tests/ts/lslocks/lslocks
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="flock"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_LSLOCKS"
+ts_check_test_command "$TS_HELPER_MKFDS"
+ts_check_prog "sed"
+
+ts_cd "$TS_OUTDIR"
+
+FILE0=util-linux-lslocks-target-file
+FILE=${FILE0}--$$
+FD=17
+COLS=COMMAND,TYPE,SIZE,MODE,START,END
+OPTS="--raw --noheadings"
+METHODS=(
+    flock-sh
+    flock-ex    
+    posix-r-
+    posix--w
+    posix-rw
+#   ofd-r-
+#   ofd--w
+#   ofd-rw    
+    lease-w
+)
+
+run_lslocks()
+{
+    local m=$1
+
+    {
+	rm -f "${FILE}"
+	coproc MKFDS { "$TS_HELPER_MKFDS" make-regular-file $FD file="$FILE" lock=$m; }
+	if read -r -u "${MKFDS[0]}" PID; then
+	    "$TS_CMD_LSLOCKS" ${OPTS} --pid "${PID}" -o "${COLS}"
+	    echo "# $m + ${COLS} + ${OPTS}": $?
+	    "$TS_CMD_LSLOCKS" ${OPTS} --pid "${PID}" -o PATH | sed -e 's#.*\('"$FILE0"'\)--[0-9]\+ *$#\1#'
+	    echo "# $m + PATH + ${OPTS}": ${PIPESTATUS[0]}
+	    echo DONE >&"${MKFDS[1]}"
+	fi
+    } > "$TS_OUTPUT" 2>&1
+
+    wait "${MKFDS_PID}"
+}
+
+for m in "${METHODS[@]}"; do
+    ts_init_subtest "$m"
+    run_lslocks "$m"  
+    ts_finalize_subtest
+done


### PR DESCRIPTION
With this change, lslocks can show fill the COMMAND and PID columns of OFDLCK locks if the process of lslocks can access /proc/$pid/fdinfo/$fd.


```
# ./lslocks  | grep OFD
qemu-system-x86 3003408 OFDLCK   10G READ  0        100        101 /var/lib/libvirt/images/client8-0.qcow2
qemu-system-x86 3003408 OFDLCK   10G READ  0        103        103 /var/lib/libvirt/images/client8-0.qcow2
qemu-system-x86 3003408 OFDLCK   10G READ  0        201        201 /var/lib/libvirt/images/client8-0.qcow2
qemu-system-x86 3003408 OFDLCK   10G READ  0        203        203 /var/lib/libvirt/images/client8-0.qcow2
...
```
