### PR TITLE
lsfd: avoid undefined behavior

### DIFF
--- a/misc-utils/lsfd-sock-xinfo.c
+++ b/misc-utils/lsfd-sock-xinfo.c
@@ -128,7 +128,8 @@ static void load_ifaces_from_getifaddrs(struct netns *nsobj)
 
 static const char *get_iface_name(ino_t netns, unsigned int iface_index)
 {
-	struct netns **nsobj = tfind(&netns, &netns_tree, netns_compare);
+	struct netns key = { .inode = netns };
+	struct netns **nsobj = tfind(&key, &netns_tree, netns_compare);
 	if (!nsobj)
 		return NULL;
 
@@ -142,7 +143,8 @@ static const char *get_iface_name(ino_t netns, unsigned int iface_index)
 
 static bool is_sock_xinfo_loaded(ino_t netns)
 {
-	return tfind(&netns, &netns_tree, netns_compare)? true: false;
+	struct netns key = { .inode = netns };
+	return tfind(&key, &netns_tree, netns_compare)? true: false;
 }
 
 static struct netns *mark_sock_xinfo_loaded(ino_t ino)
@@ -297,7 +299,8 @@ static void add_sock_info(struct sock_xinfo *xinfo)
 
 struct sock_xinfo *get_sock_xinfo(ino_t inode)
 {
-	struct sock_xinfo **xinfo = tfind(&inode, &xinfo_tree, xinfo_compare);
+	struct sock_xinfo key = { .inode = inode };
+	struct sock_xinfo **xinfo = tfind(&key, &xinfo_tree, xinfo_compare);
 
 	if (xinfo)
 		return *xinfo;

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -515,7 +515,8 @@ static int proc_tree_compare(const void *a, const void *b)
 
 struct proc *get_proc(pid_t pid)
 {
-	struct proc **node = tfind(&pid, &proc_tree, proc_tree_compare);
+	struct proc key = { .pid = pid };
+	struct proc **node = tfind(&key, &proc_tree, proc_tree_compare);
 	if (node)
 		return *node;
 	return NULL;


### PR DESCRIPTION
Passing a pointer to a pid_t to tfind() which expects it to be backed by a 'struct proc' evokes undefined behavior.
This triggers UBSAN as shown below.

Instead pass a proper 'struct proc'.

```
../misc-utils/lsfd.c:513:27: runtime error: member access within misaligned address 0x7ffe9ee6495c for type 'struct proc', which requires 8 byte alignment 0x7ffe9ee6495c: note: pointer points here
  1a 1a 1a 1a 01 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  d0 49 e6 9e fe 7f 00 00
              ^
    #0 0x56159cfa4a3b in proc_tree_compare ../misc-utils/lsfd.c:513
    #1 0x7f9dd4d2d743 in __tfind (/usr/lib/libc.so.6+0x10f743) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)
    #2 0x56159cfa4ac3 in get_proc ../misc-utils/lsfd.c:518
    #3 0x56159cfe217b in anon_pidfd_get_name ../misc-utils/lsfd-unkn.c:203
    #4 0x56159cfe1040 in unkn_fill_column ../misc-utils/lsfd-unkn.c:93
    #5 0x56159cfaaa37 in fill_column ../misc-utils/lsfd.c:1178
    #6 0x56159cfaaac5 in convert_file ../misc-utils/lsfd.c:1193
    #7 0x56159cfaac4f in convert ../misc-utils/lsfd.c:1212
    #8 0x56159cfb2b54 in main ../misc-utils/lsfd.c:2317
    #9 0x7f9dd4c45ccf  (/usr/lib/libc.so.6+0x27ccf) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)
    #10 0x7f9dd4c45d89 in __libc_start_main (/usr/lib/libc.so.6+0x27d89) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)
    #11 0x56159cfa3c34 in _start (util-linux/build-meson/lsfd+0x41c34) (BuildId: 35fece1a205f96a2dbfe7a0e93b658530de675c4)
```

Cc @masatake 
