### PR TITLE
treewide: explicitly mark unused arguments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,9 +178,6 @@ AC_SUBST([BSD_WARN_CFLAGS])
 UL_WARN_ADD([-Wno-cast-function-type], [PYTHON_WARN_CFLAGS])
 AC_SUBST([PYTHON_WARN_CFLAGS])
 
-UL_WARN_ADD([-Wno-unused-parameter], [NO_UNUSED_WARN_CFLAGS])
-AC_SUBST([NO_UNUSED_WARN_CFLAGS])
-
 
 AC_ARG_ENABLE([asan],
   AS_HELP_STRING([--enable-asan], [compile with Address Sanitizer]),

--- a/libfdisk/samples/Makemodule.am
+++ b/libfdisk/samples/Makemodule.am
@@ -3,8 +3,7 @@ check_PROGRAMS += \
 	sample-fdisk-mkpart \
 	sample-fdisk-mkpart-fullspec
 
-sample_fdisk_cflags = $(AM_CFLAGS) $(NO_UNUSED_WARN_CFLAGS) \
-                      -I$(ul_libfdisk_incdir)
+sample_fdisk_cflags = $(AM_CFLAGS) -I$(ul_libfdisk_incdir)
 sample_fdisk_ldadd = $(LDADD) libfdisk.la
 
 sample_fdisk_mkpart_SOURCES = libfdisk/samples/mkpart.c

--- a/libfdisk/samples/mkpart-fullspec.c
+++ b/libfdisk/samples/mkpart-fullspec.c
@@ -27,7 +27,7 @@
 
 static int ask_callback(struct fdisk_context *cxt __attribute__((__unused__)),
 			struct fdisk_ask *ask,
-			void *data)
+			void *data __attribute__((unused)))
 {
 	switch(fdisk_ask_get_type(ask)) {
 	case FDISK_ASKTYPE_INFO:

--- a/libfdisk/samples/mkpart.c
+++ b/libfdisk/samples/mkpart.c
@@ -39,7 +39,7 @@
 
 static int ask_callback(struct fdisk_context *cxt __attribute__((__unused__)),
 			struct fdisk_ask *ask,
-			void *data)
+			void *data __attribute__((unused)))
 {
 	switch(fdisk_ask_get_type(ask)) {
 	case FDISK_ASKTYPE_INFO:

--- a/libfdisk/src/Makemodule.am
+++ b/libfdisk/src/Makemodule.am
@@ -67,7 +67,7 @@ check_PROGRAMS += \
 	test_fdisk_version \
 	test_fdisk_item
 
-libfdisk_tests_cflags  = -DTEST_PROGRAM $(libfdisk_la_CFLAGS) $(NO_UNUSED_WARN_CFLAGS)
+libfdisk_tests_cflags  = -DTEST_PROGRAM $(libfdisk_la_CFLAGS)
 libfdisk_tests_ldflags = libuuid.la -static
 libfdisk_tests_ldadd   = libfdisk.la $(LDADD)
 
@@ -102,7 +102,7 @@ check_PROGRAMS += test_fdisk_script_fuzz
 nodist_EXTRA_test_fdisk_script_fuzz_SOURCES = dummy.cxx
 
 test_fdisk_script_fuzz_SOURCES = libfdisk/src/script.c
-test_fdisk_script_fuzz_CFLAGS = -DFUZZ_TARGET $(libfdisk_la_CFLAGS) $(NO_UNUSED_WARN_CFLAGS)
+test_fdisk_script_fuzz_CFLAGS = -DFUZZ_TARGET $(libfdisk_la_CFLAGS)
 test_fdisk_script_fuzz_LDFLAGS = $(libfdisk_tests_ldflags) -lpthread
 test_fdisk_script_fuzz_LDADD = $(libfdisk_tests_ldadd) $(LIB_FUZZING_ENGINE)
 endif

--- a/libfdisk/src/ask.c
+++ b/libfdisk/src/ask.c
@@ -1035,7 +1035,9 @@ int fdisk_info_new_partition(
 }
 
 #ifdef TEST_PROGRAM
-static int test_ranges(struct fdisk_test *ts, int argc, char *argv[])
+static int test_ranges(struct fdisk_test *ts __attribute__((unused)),
+		       int argc __attribute__((unused)),
+		       char *argv[] __attribute__((unused)))
 {
 	/*                1  -  3,       6,    8, 9,   11    13 */
 	size_t nums[] = { 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1 };

--- a/libfdisk/src/gpt.c
+++ b/libfdisk/src/gpt.c
@@ -3322,8 +3322,12 @@ void fdisk_gpt_enable_minimize(struct fdisk_label *lb, int enable)
 }
 
 #ifdef TEST_PROGRAM
-static int test_getattr(struct fdisk_test *ts, int argc, char *argv[])
+static int test_getattr(struct fdisk_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
+	if (argc != 3)
+		return -1;
+
 	const char *disk = argv[1];
 	size_t part = strtoul(argv[2], NULL, 0) - 1;
 	struct fdisk_context *cxt;
@@ -3344,8 +3348,12 @@ static int test_getattr(struct fdisk_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_setattr(struct fdisk_test *ts, int argc, char *argv[])
+static int test_setattr(struct fdisk_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
+	if (argc != 4)
+		return -1;
+
 	const char *disk = argv[1];
 	size_t part = strtoul(argv[2], NULL, 0) - 1;
 	uint64_t atters = strtoull(argv[3], NULL, 0);

--- a/libfdisk/src/item.c
+++ b/libfdisk/src/item.c
@@ -199,8 +199,12 @@ int fdisk_labelitem_is_number(struct fdisk_labelitem *li)
 }
 
 #ifdef TEST_PROGRAM
-static int test_listitems(struct fdisk_test *ts, int argc, char *argv[])
+static int test_listitems(struct fdisk_test *ts __attribute__((unused)),
+			  int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	const char *disk = argv[1];
 	struct fdisk_context *cxt;
 	struct fdisk_labelitem *item;

--- a/libfdisk/src/script.c
+++ b/libfdisk/src/script.c
@@ -1669,8 +1669,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 #endif
 
 #ifdef TEST_PROGRAM
-static int test_dump(struct fdisk_test *ts, int argc, char *argv[])
+static int test_dump(struct fdisk_test *ts __attribute__((unused)),
+		     int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	char *devname = argv[1];
 	struct fdisk_context *cxt;
 	struct fdisk_script *dp;
@@ -1688,8 +1692,12 @@ static int test_dump(struct fdisk_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_read(struct fdisk_test *ts, int argc, char *argv[])
+static int test_read(struct fdisk_test *ts __attribute__((unused)),
+		     int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	char *filename = argv[1];
 	struct fdisk_script *dp;
 	struct fdisk_context *cxt;
@@ -1711,8 +1719,12 @@ static int test_read(struct fdisk_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_stdin(struct fdisk_test *ts, int argc, char *argv[])
+static int test_stdin(struct fdisk_test *ts __attribute__((unused)),
+		      int argc, char *argv[] __attribute__((unused)))
 {
+	if (argc != 1)
+		return -1;
+
 	char buf[BUFSIZ] = { '\0' };
 	struct fdisk_script *dp;
 	struct fdisk_context *cxt;
@@ -1746,8 +1758,12 @@ static int test_stdin(struct fdisk_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_apply(struct fdisk_test *ts, int argc, char *argv[])
+static int test_apply(struct fdisk_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
+	if (argc != 3)
+		return -1;
+
 	char *devname = argv[1], *scriptname = argv[2];
 	struct fdisk_context *cxt;
 	struct fdisk_script *dp;
@@ -1788,8 +1804,12 @@ done:
 	return 0;
 }
 
-static int test_tokens(struct fdisk_test *ts, int argc, char *argv[])
+static int test_tokens(struct fdisk_test *ts __attribute__((unused)),
+		       int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	char *p, *str = argc == 2 ? strdup(argv[1]) : NULL;
 	int i;
 

--- a/libfdisk/src/utils.c
+++ b/libfdisk/src/utils.c
@@ -183,11 +183,15 @@ done:
 }
 
 #ifdef TEST_PROGRAM
-struct fdisk_label *fdisk_new_dos_label(struct fdisk_context *cxt) { return NULL; }
-struct fdisk_label *fdisk_new_bsd_label(struct fdisk_context *cxt) { return NULL; }
+struct fdisk_label *fdisk_new_dos_label(struct fdisk_context *cxt __attribute__((unused))) { return NULL; }
+struct fdisk_label *fdisk_new_bsd_label(struct fdisk_context *cxt __attribute__((unused))) { return NULL; }
 
-static int test_partnames(struct fdisk_test *ts, int argc, char *argv[])
+static int test_partnames(struct fdisk_test *ts __attribute__((unused)),
+			  int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	size_t i;
 	const char *disk = argv[1];
 

--- a/libfdisk/src/version.c
+++ b/libfdisk/src/version.c
@@ -91,7 +91,9 @@ int fdisk_get_library_features(const char ***features)
 }
 
 #ifdef TEST_PROGRAM
-static int test_version(struct fdisk_test *ts, int argc, char *argv[])
+static int test_version(struct fdisk_test *ts __attribute__((unused)),
+			int argc __attribute__((unused)),
+			char *argv[] __attribute__((unused)))
 {
 	const char *ver;
 	const char **features;

--- a/libmount/samples/Makemodule.am
+++ b/libmount/samples/Makemodule.am
@@ -2,8 +2,7 @@
 check_PROGRAMS += \
 	sample-mount-overwrite
 
-sample_mount_cflags = $(AM_CFLAGS) $(NO_UNUSED_WARN_CFLAGS) \
-                      -I$(ul_libmount_incdir)
+sample_mount_cflags = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 sample_mount_ldadd = libmount.la $(LDADD)
 
 

--- a/libmount/src/Makemodule.am
+++ b/libmount/src/Makemodule.am
@@ -101,7 +101,7 @@ check_PROGRAMS += test_mount_context test_mount_context_mount
 check_PROGRAMS += test_mount_monitor
 endif
 
-libmount_tests_cflags  = -DTEST_PROGRAM $(libmount_la_CFLAGS) $(NO_UNUSED_WARN_CFLAGS)
+libmount_tests_cflags  = -DTEST_PROGRAM $(libmount_la_CFLAGS)
 libmount_tests_ldflags = -static
 libmount_tests_ldadd   = libmount.la libblkid.la $(LDADD) $(REALTIME_LIBS)
 

--- a/libmount/src/cache.c
+++ b/libmount/src/cache.c
@@ -748,7 +748,9 @@ char *mnt_resolve_spec(const char *spec, struct libmnt_cache *cache)
 
 #ifdef TEST_PROGRAM
 
-static int test_resolve_path(struct libmnt_test *ts, int argc, char *argv[])
+static int test_resolve_path(struct libmnt_test *ts __attribute__((unused)),
+			     int argc __attribute__((unused)),
+			     char *argv[] __attribute__((unused)))
 {
 	char line[BUFSIZ];
 	struct libmnt_cache *cache;
@@ -771,7 +773,9 @@ static int test_resolve_path(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_resolve_spec(struct libmnt_test *ts, int argc, char *argv[])
+static int test_resolve_spec(struct libmnt_test *ts __attribute__((unused)),
+			     int argc __attribute__((unused)),
+			     char *argv[] __attribute__((unused)))
 {
 	char line[BUFSIZ];
 	struct libmnt_cache *cache;
@@ -794,7 +798,9 @@ static int test_resolve_spec(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_read_tags(struct libmnt_test *ts, int argc, char *argv[])
+static int test_read_tags(struct libmnt_test *ts __attribute__((unused)),
+			  int argc __attribute__((unused)),
+			  char *argv[] __attribute__((unused)))
 {
 	char line[BUFSIZ];
 	struct libmnt_cache *cache;

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -3166,7 +3166,8 @@ struct libmnt_ns *mnt_context_switch_target_ns(struct libmnt_context *cxt)
 
 #ifdef TEST_PROGRAM
 
-static int test_search_helper(struct libmnt_test *ts, int argc, char *argv[])
+static int test_search_helper(struct libmnt_test *ts __attribute__((unused)),
+			      int argc, char *argv[])
 {
 	struct libmnt_context *cxt;
 	const char *type;
@@ -3200,7 +3201,8 @@ static void lock_fallback(void)
 		mnt_unlock_file(lock);
 }
 
-static int test_mount(struct libmnt_test *ts, int argc, char *argv[])
+static int test_mount(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	int idx = 1, rc = 0;
 	struct libmnt_context *cxt;
@@ -3250,7 +3252,8 @@ static int test_mount(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_umount(struct libmnt_test *ts, int argc, char *argv[])
+static int test_umount(struct libmnt_test *ts __attribute__((unused)),
+		       int argc, char *argv[])
 {
 	int idx = 1, rc = 0;
 	struct libmnt_context *cxt;
@@ -3305,7 +3308,8 @@ err:
 	return rc;
 }
 
-static int test_flags(struct libmnt_test *ts, int argc, char *argv[])
+static int test_flags(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	int idx = 1, rc = 0;
 	struct libmnt_context *cxt;
@@ -3343,7 +3347,8 @@ static int test_flags(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_cxtsync(struct libmnt_test *ts, int argc, char *argv[])
+static int test_cxtsync(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	struct libmnt_context *cxt;
 	struct libmnt_fs *fs;
@@ -3387,7 +3392,8 @@ static int test_cxtsync(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_mountall(struct libmnt_test *ts, int argc, char *argv[])
+static int test_mountall(struct libmnt_test *ts __attribute__((unused)),
+			 int argc, char *argv[])
 {
 	struct libmnt_context *cxt;
 	struct libmnt_iter *itr;

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1751,7 +1751,8 @@ int mnt_context_get_mount_excode(
 
 #ifdef TEST_PROGRAM
 
-static int test_perms(struct libmnt_test *ts, int argc, char *argv[])
+static int test_perms(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	struct libmnt_context *cxt;
 	struct libmnt_optlist *ls;
@@ -1794,7 +1795,8 @@ static int test_perms(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_fixopts(struct libmnt_test *ts, int argc, char *argv[])
+static int test_fixopts(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	struct libmnt_context *cxt;
 	struct libmnt_optlist *ls;

--- a/libmount/src/lock.c
+++ b/libmount/src/lock.c
@@ -295,7 +295,8 @@ static void __attribute__((__noreturn__)) sig_handler(int sig)
 	errx(EXIT_FAILURE, "\n%d: catch signal: %s\n", getpid(), strsignal(sig));
 }
 
-static int test_lock(struct libmnt_test *ts, int argc, char *argv[])
+static int test_lock(struct libmnt_test *ts __attribute__((unused)),
+		     int argc, char *argv[])
 {
 	time_t synctime = 0;
 	unsigned int usecs;

--- a/libmount/src/monitor.c
+++ b/libmount/src/monitor.c
@@ -870,7 +870,8 @@ err:
 /*
  * create a monitor and add the monitor fd to epoll
  */
-static int __test_epoll(struct libmnt_test *ts, int argc, char *argv[], int cleanup)
+static int __test_epoll(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[], int cleanup)
 {
 	int fd, efd = -1, rc = -1;
 	struct epoll_event ev;
@@ -947,7 +948,8 @@ static int test_epoll_cleanup(struct libmnt_test *ts, int argc, char *argv[])
 /*
  * create a monitor and wait for a change
  */
-static int test_wait(struct libmnt_test *ts, int argc, char *argv[])
+static int test_wait(struct libmnt_test *ts __attribute__((unused)),
+		     int argc, char *argv[])
 {
 	const char *filename;
 	struct libmnt_monitor *mn = create_test_monitor(argc, argv);

--- a/libmount/src/optlist.c
+++ b/libmount/src/optlist.c
@@ -1241,7 +1241,8 @@ static inline unsigned long str2flg(const char *str)
 	return (unsigned long) strtox64_or_err(str, "connt convert string to flags");
 }
 
-static int test_append_str(struct libmnt_test *ts, int argc, char *argv[])
+static int test_append_str(struct libmnt_test *ts __attribute__((unused)),
+			   int argc, char *argv[])
 {
 	struct libmnt_optlist *ol;
 	int rc;
@@ -1257,7 +1258,8 @@ static int test_append_str(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_prepend_str(struct libmnt_test *ts, int argc, char *argv[])
+static int test_prepend_str(struct libmnt_test *ts __attribute__((unused)),
+			    int argc, char *argv[])
 {
 	struct libmnt_optlist *ol;
 	int rc;
@@ -1273,7 +1275,8 @@ static int test_prepend_str(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_set_str(struct libmnt_test *ts, int argc, char *argv[])
+static int test_set_str(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	struct libmnt_optlist *ol;
 	int rc;
@@ -1289,7 +1292,8 @@ static int test_set_str(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_append_flg(struct libmnt_test *ts, int argc, char *argv[])
+static int test_append_flg(struct libmnt_test *ts __attribute__((unused)),
+			   int argc, char *argv[])
 {
 	struct libmnt_optlist *ol;
 	int rc;
@@ -1305,7 +1309,8 @@ static int test_append_flg(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_set_flg(struct libmnt_test *ts, int argc, char *argv[])
+static int test_set_flg(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	struct libmnt_optlist *ol;
 	int rc;
@@ -1321,7 +1326,8 @@ static int test_set_flg(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_get_str(struct libmnt_test *ts, int argc, char *argv[])
+static int test_get_str(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	struct libmnt_optlist *ol;
 	const struct libmnt_optmap *map;
@@ -1380,7 +1386,8 @@ done:
 	return rc;
 }
 
-static int test_get_flg(struct libmnt_test *ts, int argc, char *argv[])
+static int test_get_flg(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	struct libmnt_optlist *ol;
 	unsigned long flags = 0;
@@ -1397,7 +1404,8 @@ static int test_get_flg(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_split(struct libmnt_test *ts, int argc, char *argv[])
+static int test_split(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	struct libmnt_optlist *ol;
 	int rc;

--- a/libmount/src/optstr.c
+++ b/libmount/src/optstr.c
@@ -910,7 +910,8 @@ int mnt_match_options(const char *optstr, const char *pattern)
 }
 
 #ifdef TEST_PROGRAM
-static int test_append(struct libmnt_test *ts, int argc, char *argv[])
+static int test_append(struct libmnt_test *ts __attribute__((unused)),
+		       int argc, char *argv[])
 {
 	const char *value = NULL, *name;
 	char *optstr;
@@ -933,7 +934,8 @@ static int test_append(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_prepend(struct libmnt_test *ts, int argc, char *argv[])
+static int test_prepend(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	const char *value = NULL, *name;
 	char *optstr;
@@ -956,7 +958,8 @@ static int test_prepend(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_split(struct libmnt_test *ts, int argc, char *argv[])
+static int test_split(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	char *optstr, *user = NULL, *fs = NULL, *vfs = NULL;
 	int rc;
@@ -982,7 +985,8 @@ static int test_split(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_flags(struct libmnt_test *ts, int argc, char *argv[])
+static int test_flags(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	char *optstr;
 	int rc;
@@ -1010,7 +1014,8 @@ static int test_flags(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_apply(struct libmnt_test *ts, int argc, char *argv[])
+static int test_apply(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	char *optstr;
 	int rc, map;
@@ -1042,7 +1047,8 @@ static int test_apply(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_set(struct libmnt_test *ts, int argc, char *argv[])
+static int test_set(struct libmnt_test *ts __attribute__((unused)),
+		    int argc, char *argv[])
 {
 	const char *value = NULL, *name;
 	char *optstr;
@@ -1065,7 +1071,8 @@ static int test_set(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_get(struct libmnt_test *ts, int argc, char *argv[])
+static int test_get(struct libmnt_test *ts __attribute__((unused)),
+		    int argc, char *argv[])
 {
 	char *optstr;
 	const char *name;
@@ -1094,7 +1101,8 @@ static int test_get(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_remove(struct libmnt_test *ts, int argc, char *argv[])
+static int test_remove(struct libmnt_test *ts __attribute__((unused)),
+		       int argc, char *argv[])
 {
 	const char *name;
 	char *optstr;
@@ -1114,7 +1122,8 @@ static int test_remove(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_dedup(struct libmnt_test *ts, int argc, char *argv[])
+static int test_dedup(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	const char *name;
 	char *optstr;
@@ -1134,7 +1143,8 @@ static int test_dedup(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_match(struct libmnt_test *ts, int argc, char *argv[])
+static int test_match(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	char *optstr, *pattern;
 

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -1925,7 +1925,8 @@ int mnt_table_is_fs_mounted(struct libmnt_table *tb, struct libmnt_fs *fstab_fs)
 #ifdef TEST_PROGRAM
 #include "pathnames.h"
 
-static int parser_errcb(struct libmnt_table *tb, const char *filename, int line)
+static int parser_errcb(struct libmnt_table *tb __attribute__((unused)),
+			const char *filename, int line)
 {
 	fprintf(stderr, "%s:%d: parse error\n", filename, line);
 
@@ -1954,11 +1955,15 @@ err:
 	return NULL;
 }
 
-static int test_copy_fs(struct libmnt_test *ts, int argc, char *argv[])
+static int test_copy_fs(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	struct libmnt_table *tb;
 	struct libmnt_fs *fs;
 	int rc = -1;
+
+	if (argc != 2)
+		return -1;
 
 	tb = create_table(argv[1], FALSE);
 	if (!tb)
@@ -1984,7 +1989,8 @@ done:
 	return rc;
 }
 
-static int test_parse(struct libmnt_test *ts, int argc, char *argv[])
+static int test_parse(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
 	struct libmnt_table *tb = NULL;
 	struct libmnt_iter *itr = NULL;
@@ -2020,7 +2026,8 @@ done:
 	return rc;
 }
 
-static int test_find_idx(struct libmnt_test *ts, int argc, char *argv[])
+static int test_find_idx(struct libmnt_test *ts __attribute__((unused)),
+			 int argc, char *argv[])
 {
 	struct libmnt_table *tb;
 	struct libmnt_fs *fs = NULL;
@@ -2065,7 +2072,8 @@ done:
 	return rc;
 }
 
-static int test_find(struct libmnt_test *ts, int argc, char *argv[], int dr)
+static int test_find(struct libmnt_test *ts __attribute__((unused)),
+		     int argc, char *argv[], int dr)
 {
 	struct libmnt_table *tb;
 	struct libmnt_fs *fs = NULL;
@@ -2107,22 +2115,28 @@ done:
 	return rc;
 }
 
-static int test_find_bw(struct libmnt_test *ts, int argc, char *argv[])
+static int test_find_bw(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	return test_find(ts, argc, argv, MNT_ITER_BACKWARD);
 }
 
-static int test_find_fw(struct libmnt_test *ts, int argc, char *argv[])
+static int test_find_fw(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	return test_find(ts, argc, argv, MNT_ITER_FORWARD);
 }
 
-static int test_find_pair(struct libmnt_test *ts, int argc, char *argv[])
+static int test_find_pair(struct libmnt_test *ts __attribute__((unused)),
+			  int argc, char *argv[])
 {
 	struct libmnt_table *tb;
 	struct libmnt_fs *fs;
 	struct libmnt_cache *mpc = NULL;
 	int rc = -1;
+
+	if (argc != 4)
+		return -1;
 
 	tb = create_table(argv[1], FALSE);
 	if (!tb)
@@ -2144,12 +2158,16 @@ done:
 	return rc;
 }
 
-static int test_find_mountpoint(struct libmnt_test *ts, int argc, char *argv[])
+static int test_find_mountpoint(struct libmnt_test *ts __attribute__((unused)),
+				int argc, char *argv[])
 {
 	struct libmnt_table *tb;
 	struct libmnt_fs *fs;
 	struct libmnt_cache *mpc = NULL;
 	int rc = -1;
+
+	if (argc != 2)
+		return -1;
 
 	tb = mnt_new_table_from_file(_PATH_PROC_MOUNTINFO);
 	if (!tb)
@@ -2171,12 +2189,16 @@ done:
 	return rc;
 }
 
-static int test_is_mounted(struct libmnt_test *ts, int argc, char *argv[])
+static int test_is_mounted(struct libmnt_test *ts __attribute__((unused)),
+			   int argc, char *argv[])
 {
 	struct libmnt_table *tb = NULL, *fstab = NULL;
 	struct libmnt_fs *fs;
 	struct libmnt_iter *itr = NULL;
 	struct libmnt_cache *mpc = NULL;
+
+	if (argc != 2)
+		return -1;
 
 	tb = mnt_new_table_from_file("/proc/self/mountinfo");
 	if (!tb) {
@@ -2227,7 +2249,8 @@ static int test_uniq_cmp(struct libmnt_table *tb __attribute__((__unused__)),
 	return mnt_fs_streq_target(a, mnt_fs_get_target(b)) ? 0 : 1;
 }
 
-static int test_uniq(struct libmnt_test *ts, int argc, char *argv[])
+static int test_uniq(struct libmnt_test *ts __attribute__((unused)),
+		     int argc, char *argv[])
 {
 	struct libmnt_table *tb;
 	int rc = -1;

--- a/libmount/src/tab_diff.c
+++ b/libmount/src/tab_diff.c
@@ -309,13 +309,17 @@ done:
 
 #ifdef TEST_PROGRAM
 
-static int test_diff(struct libmnt_test *ts, int argc, char *argv[])
+static int test_diff(struct libmnt_test *ts __attribute__((unused)),
+		     int argc, char *argv[])
 {
 	struct libmnt_table *tb_old, *tb_new;
 	struct libmnt_tabdiff *diff;
 	struct libmnt_iter *itr;
 	struct libmnt_fs *old, *new;
 	int rc = -1, change;
+
+	if (argc != 3)
+		return -1;
 
 	tb_old = mnt_new_table_from_file(argv[1]);
 	tb_new = mnt_new_table_from_file(argv[2]);

--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -970,7 +970,8 @@ done:
 	return rc;
 }
 
-static int test_add(struct libmnt_test *ts, int argc, char *argv[])
+static int test_add(struct libmnt_test *ts __attribute__((unused)),
+		    int argc, char *argv[])
 {
 	struct libmnt_fs *fs = mnt_new_fs();
 	int rc;
@@ -987,14 +988,16 @@ static int test_add(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_remove(struct libmnt_test *ts, int argc, char *argv[])
+static int test_remove(struct libmnt_test *ts __attribute__((unused)),
+		       int argc, char *argv[])
 {
 	if (argc < 2)
 		return -1;
 	return update(argv[1], NULL, 0);
 }
 
-static int test_move(struct libmnt_test *ts, int argc, char *argv[])
+static int test_move(struct libmnt_test *ts __attribute__((unused)),
+		     int argc, char *argv[])
 {
 	struct libmnt_fs *fs = mnt_new_fs();
 	int rc;
@@ -1010,7 +1013,8 @@ static int test_move(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_remount(struct libmnt_test *ts, int argc, char *argv[])
+static int test_remount(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	struct libmnt_fs *fs = mnt_new_fs();
 	int rc;
@@ -1025,7 +1029,8 @@ static int test_remount(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_replace(struct libmnt_test *ts, int argc, char *argv[])
+static int test_replace(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	struct libmnt_fs *fs = mnt_new_fs();
 	struct libmnt_table *tb = mnt_new_table();

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -1287,8 +1287,12 @@ done:
 }
 
 #ifdef TEST_PROGRAM
-static int test_match_fstype(struct libmnt_test *ts, int argc, char *argv[])
+static int test_match_fstype(struct libmnt_test *ts __attribute__((unused)),
+			     int argc, char *argv[])
 {
+	if (argc != 3)
+		return -1;
+
 	char *type = argv[1];
 	char *pattern = argv[2];
 
@@ -1296,8 +1300,12 @@ static int test_match_fstype(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_match_options(struct libmnt_test *ts, int argc, char *argv[])
+static int test_match_options(struct libmnt_test *ts __attribute__((unused)),
+			      int argc, char *argv[])
 {
+	if (argc != 3)
+		return -1;
+
 	char *optstr = argv[1];
 	char *pattern = argv[2];
 
@@ -1305,8 +1313,12 @@ static int test_match_options(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_startswith(struct libmnt_test *ts, int argc, char *argv[])
+static int test_startswith(struct libmnt_test *ts __attribute__((unused)),
+			   int argc, char *argv[])
 {
+	if (argc != 3)
+		return -1;
+
 	char *optstr = argv[1];
 	char *pattern = argv[2];
 
@@ -1314,8 +1326,12 @@ static int test_startswith(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_endswith(struct libmnt_test *ts, int argc, char *argv[])
+static int test_endswith(struct libmnt_test *ts __attribute__((unused)),
+			 int argc, char *argv[])
 {
+	if (argc != 3)
+		return -1;
+
 	char *optstr = argv[1];
 	char *pattern = argv[2];
 
@@ -1323,8 +1339,12 @@ static int test_endswith(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_mountpoint(struct libmnt_test *ts, int argc, char *argv[])
+static int test_mountpoint(struct libmnt_test *ts __attribute__((unused)),
+			   int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	char *path = canonicalize_path(argv[1]),
 	     *mnt = path ? mnt_get_mountpoint(path) :  NULL;
 
@@ -1334,10 +1354,15 @@ static int test_mountpoint(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_filesystems(struct libmnt_test *ts, int argc, char *argv[])
+static int test_filesystems(struct libmnt_test *ts __attribute__((unused)),
+			    int argc, char *argv[])
 {
 	char **filesystems = NULL;
 	int rc;
+
+	if (argc != 2)
+		return -1;
+
 
 	rc = mnt_get_filesystems(&filesystems, argc ? argv[1] : NULL);
 	if (!rc) {
@@ -1349,8 +1374,12 @@ static int test_filesystems(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_chdir(struct libmnt_test *ts, int argc, char *argv[])
+static int test_chdir(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	int rc;
 	char *path = canonicalize_path(argv[1]),
 	     *last = NULL;
@@ -1368,8 +1397,12 @@ static int test_chdir(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_kernel_cmdline(struct libmnt_test *ts, int argc, char *argv[])
+static int test_kernel_cmdline(struct libmnt_test *ts __attribute__((unused)),
+			       int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	char *name = argv[1];
 	char *res;
 
@@ -1387,7 +1420,8 @@ static int test_kernel_cmdline(struct libmnt_test *ts, int argc, char *argv[])
 }
 
 
-static int test_guess_root(struct libmnt_test *ts, int argc, char *argv[])
+static int test_guess_root(struct libmnt_test *ts __attribute__((unused)),
+			   int argc, char *argv[])
 {
 	int rc;
 	char *real;
@@ -1413,9 +1447,13 @@ static int test_guess_root(struct libmnt_test *ts, int argc, char *argv[])
 	return 0;
 }
 
-static int test_mkdir(struct libmnt_test *ts, int argc, char *argv[])
+static int test_mkdir(struct libmnt_test *ts __attribute__((unused)),
+	 	      int argc, char *argv[])
 {
 	int rc;
+
+	if (argc != 2)
+		return -1;
 
 	rc = ul_mkdir_p(argv[1], S_IRWXU |
 			 S_IRGRP | S_IXGRP |
@@ -1425,10 +1463,14 @@ static int test_mkdir(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int test_statfs_type(struct libmnt_test *ts, int argc, char *argv[])
+static int test_statfs_type(struct libmnt_test *ts __attribute__((unused)),
+			    int argc, char *argv[])
 {
 	struct statfs vfs;
 	int rc;
+
+	if (argc != 2)
+		return -1;
 
 	rc = statfs(argv[1], &vfs);
 	if (rc)
@@ -1440,8 +1482,12 @@ static int test_statfs_type(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int tests_parse_uid(struct libmnt_test *ts, int argc, char *argv[])
+static int tests_parse_uid(struct libmnt_test *ts __attribute__((unused)),
+			   int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	char *str = argv[1];
 	uid_t uid = (uid_t) -1;
 	int rc;
@@ -1455,8 +1501,12 @@ static int tests_parse_uid(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int tests_parse_gid(struct libmnt_test *ts, int argc, char *argv[])
+static int tests_parse_gid(struct libmnt_test *ts __attribute__((unused)),
+			   int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	char *str = argv[1];
 	gid_t gid = (gid_t) -1;
 	int rc;
@@ -1470,8 +1520,12 @@ static int tests_parse_gid(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int tests_parse_mode(struct libmnt_test *ts, int argc, char *argv[])
+static int tests_parse_mode(struct libmnt_test *ts __attribute__((unused)),
+			    int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	char *str = argv[1];
 	mode_t mod = (mode_t) -1;
 	int rc;
@@ -1488,8 +1542,12 @@ static int tests_parse_mode(struct libmnt_test *ts, int argc, char *argv[])
 	return rc;
 }
 
-static int tests_stat(struct libmnt_test *ts, int argc, char *argv[])
+static int tests_stat(struct libmnt_test *ts __attribute__((unused)),
+		      int argc, char *argv[])
 {
+	if (argc != 2)
+		return -1;
+
 	char *path = argv[1];
 	struct stat st;
 	int rc;

--- a/libmount/src/version.c
+++ b/libmount/src/version.c
@@ -121,7 +121,8 @@ int mnt_get_library_features(const char ***features)
 }
 
 #ifdef TEST_PROGRAM
-static int test_version(struct libmnt_test *ts, int argc, char *argv[])
+static int test_version(struct libmnt_test *ts __attribute__((unused)),
+			int argc, char *argv[])
 {
 	const char *ver;
 	const char **features;

--- a/libsmartcols/samples/Makemodule.am
+++ b/libsmartcols/samples/Makemodule.am
@@ -9,8 +9,7 @@ check_PROGRAMS += \
 	sample-scols-grouping-overlay \
 	sample-scols-maxout
 
-sample_scols_cflags = $(AM_CFLAGS) $(NO_UNUSED_WARN_CFLAGS) \
-                      -I$(ul_libsmartcols_incdir)
+sample_scols_cflags = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
 sample_scols_ldadd = libsmartcols.la $(LDADD)
 
 if HAVE_OPENAT

--- a/libsmartcols/samples/continuous.c
+++ b/libsmartcols/samples/continuous.c
@@ -65,7 +65,7 @@ fail:
 	err(EXIT_FAILURE, "failed to create output line");
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	struct libscols_table *tb;
 	size_t i;

--- a/libsmartcols/samples/maxout.c
+++ b/libsmartcols/samples/maxout.c
@@ -19,7 +19,7 @@
 
 enum { COL_LEFT, COL_FOO, COL_RIGHT };
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	struct libscols_table *tb;
 	int rc = -1, nlines = 3;

--- a/meson.build
+++ b/meson.build
@@ -3220,8 +3220,7 @@ endif
 
 ############################################################
 
-libfdisk_tests_cflags = ['-DTEST_PROGRAM',
-                         '-Wno-unused']
+libfdisk_tests_cflags = ['-DTEST_PROGRAM']
 libfdisk_tests_ldadd = [lib_fdisk_static, lib_uuid, lib_blkid]
 
 exe = executable(
@@ -3290,13 +3289,11 @@ if not is_disabler(exe)
   exes += exe
 endif
 
-sample_fdisk_cflags = ['-Wno-unused']
 sample_fdisk_ldadd = [lib_common, lib_fdisk]
 
 exe = executable(
   'sample-fdisk-mkpart',
   'libfdisk/samples/mkpart.c',
-  c_args : sample_fdisk_cflags,
   include_directories : lib_fdisk_includes,
   link_with : sample_fdisk_ldadd)
 if not is_disabler(exe)
@@ -3306,7 +3303,6 @@ endif
 exe = executable(
   'sample-fdisk-mkpart-fullspec',
   'libfdisk/samples/mkpart-fullspec.c',
-  c_args : sample_fdisk_cflags,
   include_directories : lib_fdisk_includes,
   link_with : sample_fdisk_ldadd)
 if not is_disabler(exe)


### PR DESCRIPTION
The autotools build used -Wno-unused-parameter to silence these warnings for a few files. On meson however this configuration was not duplicated leading to persistent warnings, preventing the usage of -Werror.

Instead of having to maintain the exceptions in two buildsystems, mark the exceptions directly in the source code.

Afterward clean up autotools to not use -Wno-unused-parameter anymore.