### PR TITLE
lslocks: add HOLDERS column

### DIFF
--- a/include/xalloc.h
+++ b/include/xalloc.h
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include "c.h"
+#include "strutils.h"
 
 #ifndef XALLOC_EXIT_CODE
 # define XALLOC_EXIT_CODE EXIT_FAILURE
@@ -125,6 +126,43 @@ int xvasprintf(char **strp, const char *fmt, va_list ap)
 	return ret;
 }
 
+static inline void xstrappend(char **a, const char *b)
+{
+	if (strappend(a, b) < 0)
+		err(XALLOC_EXIT_CODE, "cannot allocate string");
+}
+
+static inline void xstrputc(char **a, char c)
+{
+	char b[] = {c, '\0'};
+	xstrappend(a, b);
+}
+
+static inline
+__attribute__((__format__(printf, 2, 0)))
+int xstrvfappend(char **a, const char *format, va_list ap)
+{
+	int ret = strvfappend(a, format, ap);
+
+	if (ret < 0)
+		err(XALLOC_EXIT_CODE, "cannot allocate string");
+	return ret;
+
+}
+
+static inline
+__attribute__ ((__format__ (__printf__, 2, 3)))
+int xstrfappend(char **a, const char *format, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, format);
+	ret = xstrvfappend(a, format, ap);
+	va_end(ap);
+
+	return ret;
+}
 
 static inline
 __attribute__((warn_unused_result))

--- a/misc-utils/lsfd.h
+++ b/misc-utils/lsfd.h
@@ -275,44 +275,6 @@ const char *get_miscdev(unsigned long minor);
 const char *get_nodev_filesystem(unsigned long minor);
 void add_nodev(unsigned long minor, const char *filesystem);
 
-static inline void xstrappend(char **a, const char *b)
-{
-	if (strappend(a, b) < 0)
-		err(XALLOC_EXIT_CODE, _("failed to allocate memory for string"));
-}
-
-static inline void xstrputc(char **a, char c)
-{
-	char b[] = {c, '\0'};
-	xstrappend(a, b);
-}
-
-static inline
-__attribute__((__format__(printf, 2, 0)))
-int xstrvfappend(char **a, const char *format, va_list ap)
-{
-	int ret = strvfappend(a, format, ap);
-
-	if (ret < 0)
-		err(XALLOC_EXIT_CODE, "cannot allocate string");
-	return ret;
-
-}
-
-static inline
-__attribute__ ((__format__ (__printf__, 2, 3)))
-int xstrfappend(char **a, const char *format, ...)
-{
-	va_list ap;
-	int ret;
-
-	va_start(ap, format);
-	ret = xstrvfappend(a, format, ap);
-	va_end(ap);
-
-	return ret;
-}
-
 /*
  * Net namespace
  */

--- a/misc-utils/lslocks.8.adoc
+++ b/misc-utils/lslocks.8.adoc
@@ -101,6 +101,11 @@ Full path of the lock. If none is found, or there are no permissions to read the
 BLOCKER::
 The PID of the process which blocks the lock.
 
+HOLDERS::
+The holder(s) of the lock.  The format of the holder is _PID_,_COMMAND_,_FD_.
+If a lock is an open file description-oriented lock, there can be more than one holder for the lock.
+See the NOTES below.
+
 == NOTES
 
 The *lslocks* command is meant to replace the *lslk*(8) command, originally written by mailto:abe@purdue.edu[Victor A. Abell] and unmaintained since 2001.

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -293,6 +293,18 @@ struct override_info {
 	const char *cmdname;
 };
 
+static bool is_co_holder(struct lock *l, struct lock *m)
+{
+	return (l->start == m->start &&
+		l->end == m->end &&
+		l->inode == m->inode &&
+		l->dev == m->dev &&
+		l->mandatory == m->mandatory &&
+		l->blocked == m->blocked &&
+		strcmp(l->type, m->type) == 0 &&
+		strcmp(l->mode, m->mode) == 0);
+}
+
 static void patch_lock(struct lock *l, void *fallback)
 {
 	struct lock_tnode tmp = { .dev = l->dev, .inode = l->inode, };
@@ -304,14 +316,7 @@ static void patch_lock(struct lock *l, void *fallback)
 
 	list_for_each(p, &(*head)->chain) {
 		struct lock *m = list_entry(p, struct lock, locks);
-		if (l->start == m->start &&
-		    l->end == m->end &&
-		    l->inode == m->inode &&
-		    l->dev == m->dev &&
-		    l->mandatory == m->mandatory &&
-		    l->blocked == m->blocked &&
-		    strcmp(l->type, m->type) == 0 &&
-		    strcmp(l->mode, m->mode) == 0) {
+		if (is_co_holder(l, m)) {
 			/* size and id can be ignored. */
 			l->pid = m->pid;
 			l->cmdname = xstrdup(m->cmdname);

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -151,7 +151,7 @@ static void add_to_tree(void *troot, struct lock *l)
 	struct lock_tnode *new_head;
 
 	if (head) {
-		list_add(&l->locks, &(*head)->chain);
+		list_add_tail(&l->locks, &(*head)->chain);
 		return;
 	}
 
@@ -162,7 +162,7 @@ static void add_to_tree(void *troot, struct lock *l)
 	if (tsearch(new_head, troot, lock_tnode_compare) == NULL)
 		errx(EXIT_FAILURE, _("failed to allocate memory"));
 
-	list_add(&l->locks, &new_head->chain);
+	list_add_tail(&l->locks, &new_head->chain);
 }
 
 static void rem_lock(struct lock *lock)

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -657,6 +657,7 @@ static void add_scols_line(struct libscols_table *table, struct lock *l, struct 
 						get_blocker(l->id, locks) : 0;
 			if (bl)
 				xasprintf(&str, "%d", (int) bl);
+			break;
 		}
 		default:
 			break;

--- a/tests/expected/lslocks/lslocks-flock-ex+HOLDERS
+++ b/tests/expected/lslocks/lslocks-flock-ex+HOLDERS
@@ -1,0 +1,2 @@
+test_mkfds FLOCK  WRITE 0 0 1,test_mkfds,17\x0a1,test_mkfds,18
+# flock-ex + COMMAND,TYPE,SIZE,MODE,START,END,HOLDERS + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-flock-sh+HOLDERS
+++ b/tests/expected/lslocks/lslocks-flock-sh+HOLDERS
@@ -1,0 +1,2 @@
+test_mkfds FLOCK  READ 0 0 1,test_mkfds,17\x0a1,test_mkfds,18
+# flock-sh + COMMAND,TYPE,SIZE,MODE,START,END,HOLDERS + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-lease-w+HOLDERS
+++ b/tests/expected/lslocks/lslocks-lease-w+HOLDERS
@@ -1,0 +1,2 @@
+test_mkfds LEASE  WRITE 0 0 1,test_mkfds,17\x0a1,test_mkfds,18
+# lease-w + COMMAND,TYPE,SIZE,MODE,START,END,HOLDERS + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-ofd--w+HOLDERS
+++ b/tests/expected/lslocks/lslocks-ofd--w+HOLDERS
@@ -1,0 +1,2 @@
+test_mkfds OFDLCK 1B WRITE 0 0 1,test_mkfds,17\x0a1,test_mkfds,18
+# ofd--w + COMMAND,TYPE,SIZE,MODE,START,END,HOLDERS + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-ofd-r-+HOLDERS
+++ b/tests/expected/lslocks/lslocks-ofd-r-+HOLDERS
@@ -1,0 +1,2 @@
+test_mkfds OFDLCK 1B READ 0 0 1,test_mkfds,17\x0a1,test_mkfds,18
+# ofd-r- + COMMAND,TYPE,SIZE,MODE,START,END,HOLDERS + --raw --noheadings: 0

--- a/tests/expected/lslocks/lslocks-ofd-rw+HOLDERS
+++ b/tests/expected/lslocks/lslocks-ofd-rw+HOLDERS
@@ -1,0 +1,3 @@
+test_mkfds OFDLCK 3B READ 0 0 1,test_mkfds,17\x0a1,test_mkfds,18
+test_mkfds OFDLCK 3B WRITE 2 2 1,test_mkfds,17\x0a1,test_mkfds,18
+# ofd-rw + COMMAND,TYPE,SIZE,MODE,START,END,HOLDERS + --raw --noheadings: 0

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -3139,7 +3139,7 @@ static const struct factory factories[] = {
 				.name = "read-lease",
 				.type = PTYPE_BOOLEAN,
 				.desc = "taking out read lease for the file",
-				.defv.integer = false,
+				.defv.boolean = false,
 			},
 			PARAM_END
 		},

--- a/tests/ts/lslocks/lslocks
+++ b/tests/ts/lslocks/lslocks
@@ -29,6 +29,7 @@ ts_cd "$TS_OUTDIR"
 FILE0=util-linux-lslocks-target-file
 FILE=${FILE0}--$$
 FD=17
+DFD=18
 COLS=COMMAND,TYPE,SIZE,MODE,START,END
 OPTS="--raw --noheadings"
 METHODS=(
@@ -43,6 +44,17 @@ METHODS=(
     lease-w
 )
 
+OFD_METHODS=(
+    flock-sh
+    flock-ex
+    ofd-r-
+    ofd--w
+    ofd-rw
+    lease-w
+)
+
+DFD=18
+COLS_WITH_HOLDERS=COMMAND,TYPE,SIZE,MODE,START,END,HOLDERS
 run_lslocks()
 {
     local m=$1
@@ -62,8 +74,31 @@ run_lslocks()
     wait "${MKFDS_PID}"
 }
 
+run_lslocks_with_co_holders()
+{
+    local m=$1
+
+    {
+	rm -f "${FILE}"
+	coproc MKFDS { "$TS_HELPER_MKFDS" make-regular-file $FD file="$FILE" lock=$m dupfd=$DFD; }
+	if read -r -u "${MKFDS[0]}" PID; then
+	    "$TS_CMD_LSLOCKS" ${OPTS} --pid "${PID}" -o "${COLS_WITH_HOLDERS}" | sed -e "s/${PID},/1,/g"
+	    echo "# $m + ${COLS_WITH_HOLDERS} + ${OPTS}": ${PIPESTATUS[0]}
+	    echo DONE >&"${MKFDS[1]}"
+	fi
+    } > "$TS_OUTPUT" 2>&1
+
+    wait "${MKFDS_PID}"
+}
+
 for m in "${METHODS[@]}"; do
     ts_init_subtest "$m"
-    run_lslocks "$m"  
+    run_lslocks "$m"
+    ts_finalize_subtest
+done
+
+for m in "${OFD_METHODS[@]}"; do
+    ts_init_subtest "$m+HOLDERS"
+    run_lslocks_with_co_holders "$m"
     ts_finalize_subtest
 done

--- a/tests/ts/lslocks/lslocks
+++ b/tests/ts/lslocks/lslocks
@@ -33,7 +33,7 @@ COLS=COMMAND,TYPE,SIZE,MODE,START,END
 OPTS="--raw --noheadings"
 METHODS=(
     flock-sh
-    flock-ex    
+    flock-ex
     posix-r-
     posix--w
     posix-rw


### PR DESCRIPTION
In open file description-oriented locks like flock, there can be more than one holder for a lock. This pull request adds a new column "CO-HOLDERS" to lslocks. The column is for printing the holders for a lock.


An example output:

```
$  ./test_mkfds make-regular-file 5 file=/tmp/xxx lock=lease-w dupfd=9
3113841
```

This command line makes a write lease for /tmp/xxx opened as fd 5, then duplicates the fd. The process gets 9 as the duplicated fd.

```
$ ./lslocks -p 3113841 -o+CO-HOLDERS
COMMAND             PID  TYPE SIZE MODE  M START END PATH   CO-HOLDERS
test_mkfds      3113841 LEASE      WRITE 0     0   0 /tmp/x 3113841,test_mkfds,5
                                                            3113841,test_mkfds,9
```

lslocks can print both 5 and 9 in the CO-HOLDERS column.
