### PR TITLE
irqtop: fix numeric sorting

### DIFF
--- a/sys-utils/irq-common.c
+++ b/sys-utils/irq-common.c
@@ -369,18 +369,29 @@ static inline int cmp_name(const struct irq_info *a,
 	return strcoll(a->name, b->name);
 }
 
+static inline int cmp_ulong_descending(unsigned long a,
+		      unsigned long b)
+{
+	if (a == b)
+		return 0;
+	if (a < b)
+		return 1;
+	else
+		return -1;
+}
+
 static inline int cmp_total(const struct irq_info *a,
 		      const struct irq_info *b)
 {
-	return a->total < b->total;
+	int cmp = cmp_ulong_descending(a->total, b->total);
+	return cmp ? cmp : cmp_name(a, b);
 }
 
 static inline int cmp_delta(const struct irq_info *a,
 		      const struct irq_info *b)
 {
-	if (a->delta != b->delta)
-		return a->delta < b->delta;
-	return cmp_name(a, b);
+	int cmp = cmp_ulong_descending(a->delta, b->delta);
+	return cmp ? cmp : cmp_name(a, b);
 }
 
 static inline int cmp_interrupts(const struct irq_info *a,


### PR DESCRIPTION
`qsort`(3) requires three-way result like that from `strcmp`(3), not an `std::less`-like boolean.

The wrong result is very obvious on Alpine where musl version of `qsort`(3) probably have different properties than one in glibc.

The suggested fix seems to work on both musl and glibc.
