### PR TITLE
ci: enable -Werror for meson

### DIFF
--- a/.github/workflows/cibuild.sh
+++ b/.github/workflows/cibuild.sh
@@ -125,7 +125,7 @@ for phase in "${PHASES[@]}"; do
         make install DESTDIR=/tmp/dest
         ;;
     MESONCONF)
-        meson build
+        meson -Dwerror=true build
         ;;
     MESONBUILD)
         ninja -C build


### PR DESCRIPTION
Now that all warnings have been eliminated from the meson build, make sure no new ones are introduced.