### PR TITLE
Refactor the implementation of -H option in lsfd

### DIFF
--- a/include/Makemodule.am
+++ b/include/Makemodule.am
@@ -13,6 +13,7 @@ dist_noinst_HEADERS += \
 	include/closestream.h \
 	include/colors.h \
 	include/color-names.h \
+	include/column-list-table.h \
 	include/coverage.h \
 	include/cpuset.h \
 	include/crc32.h \

--- a/include/column-list-table.h
+++ b/include/column-list-table.h
@@ -1,0 +1,88 @@
+/*
+ * column-list-table.h - helper functions for implementing -H/--list-columns option
+ *
+ * Copyright (C) 2023 Red Hat, Inc. All rights reserved.
+ * Written by Masatake YAMATO <yamato@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef UTIL_LINUX_COLUMN_LIST_TABLE_H
+#define UTIL_LINUX_COLUMN_LIST_TABLE_H
+
+#include "libsmartcols.h"
+#include <stdio.h>
+
+enum { CLT_COL_HOLDER, CLT_COL_TYPE, CLT_COL_DESC };
+
+static inline struct libscols_table *xcolumn_list_table_new(const char *table_name,
+							    FILE *out,
+							    int raw,
+							    int json)
+{
+	struct clt_colinfo {
+		const char *name;
+		int flags;
+	};
+	struct libscols_table *tb;
+
+	scols_init_debug(0);
+
+	tb = scols_new_table();
+	if (!tb)
+		err(EXIT_FAILURE, _("failed to allocate output table"));
+
+	scols_table_set_name(tb, table_name);
+	scols_table_set_stream(tb, out);
+	scols_table_enable_noheadings(tb, 1);
+	scols_table_enable_raw(tb, raw);
+	scols_table_enable_json(tb, json);
+
+	if (!scols_table_new_column(tb, "HOLDER", 0, SCOLS_FL_RIGHT))
+		goto failed;
+	if (!scols_table_new_column(tb, "TYPE", 0, 0))
+		goto failed;
+	if (!scols_table_new_column(tb, "DESCRIPTION", 0, 0))
+		goto failed;
+	return tb;
+
+ failed:
+	err(EXIT_FAILURE, _("failed to allocate output column"));
+}
+
+static inline void xcolumn_list_table_append_line(struct libscols_table *tb,
+						  const char *name,
+						  int json_type, const char *fallback_typename,
+						  const char *desc)
+{
+	struct libscols_line *ln = scols_table_new_line(tb, NULL);
+	if (!ln)
+		err(EXIT_FAILURE, _("failed to allocate output line"));
+
+	if (scols_line_set_data(ln, CLT_COL_HOLDER, name))
+		err(EXIT_FAILURE, _("failed to add output data"));
+	if (scols_line_set_data(ln, CLT_COL_TYPE, (json_type == SCOLS_JSON_STRING ?        "<string>":
+						   json_type == SCOLS_JSON_ARRAY_STRING ?  "<string>":
+						   json_type == SCOLS_JSON_ARRAY_NUMBER ?  "<string>":
+						   json_type == SCOLS_JSON_NUMBER ?        "<integer>":
+						   json_type == SCOLS_JSON_FLOAT ?         "<float>":
+						   json_type == SCOLS_JSON_BOOLEAN ?       "<boolean>":
+						   fallback_typename ?: "<string>")))
+		err(EXIT_FAILURE, _("failed to add output data"));
+	if (scols_line_set_data(ln, CLT_COL_DESC, desc))
+		err(EXIT_FAILURE, _("failed to add output data"));
+}
+
+#endif

--- a/misc-utils/lslocks.8.adoc
+++ b/misc-utils/lslocks.8.adoc
@@ -34,6 +34,9 @@ lslocks - list local system locks
 *-b*, *--bytes*::
 include::man-common/in-bytes.adoc[]
 
+*-H*, *--list-columns*::
+List the available columns.
+
 *-i*, *--noinaccessible*::
 Ignore lock files which are inaccessible for the current user.
 

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -760,8 +760,10 @@ static int show_locks(struct list_head *locks, pid_t target_pid, void *pid_locks
 
 			switch (id) {
 			case COL_SIZE:
-				if (!bytes)
+				if (!bytes) {
+					scols_column_set_json_type(cl, SCOLS_JSON_STRING);
 					break;
+				}
 				/* fallthrough */
 			case COL_PID:
 			case COL_START:


### PR DESCRIPTION
Before implementing -H options to the other ls* commands, I revised that in lsfd.

The original code does the following:

```
		fprintf(out, " %20s  %-10s%s\n", infos[i].name,
```

I wanted to remove "20" and "10".
Do you think using libscols as the replacement is overkiling?