### PR TITLE
libuuid: Add uuid_time64 for 64bit time_t on 32bit

### DIFF
--- a/libuuid/src/libuuid.sym
+++ b/libuuid/src/libuuid.sym
@@ -52,6 +52,15 @@ global:
 	uuid_parse_range;
 } UUID_2.31;
 
+/*
+ * version(s) since util-linux.2.40
+ */
+UUID_2.40 {
+global:
+        uuid_time64; /* only on 32bit architectures with 64bit time_t */
+} UUID_2.36;
+
+
 
 /*
  * __uuid_* this is not part of the official API, this is

--- a/libuuid/src/uuid.h
+++ b/libuuid/src/uuid.h
@@ -109,6 +109,9 @@ extern void uuid_unparse_lower(const uuid_t uu, char *out);
 extern void uuid_unparse_upper(const uuid_t uu, char *out);
 
 /* uuid_time.c */
+#if defined(__USE_TIME_BITS64) && defined(__GLIBC__)
+# define uuid_time uuid_time64
+#endif
 extern time_t uuid_time(const uuid_t uu, struct timeval *ret_tv);
 extern int uuid_type(const uuid_t uu);
 extern int uuid_variant(const uuid_t uu);


### PR DESCRIPTION
There is one big problem where I don't know how to solve best: it is not expected that uuid_time() can fail. But with an uuid created e.g. 2040, it has to fail. The current "error handling" by does not really work, any ideas how this could be done better?
My current proposal would be, set ret_val to NULL, set errno and return -1.

Else the behavior depends on with which flags which parts where compiled:

Old 32bit binary using libuuid with time64_t: identical output as with libuuid.so.1.3.0 for UUIDs created before 2038. With UUIDs created after 2038, error handling is missing.

New 32bit binary with time64_t linked against time64_t compiled libuuid: everything works correct.

New 32bit binary with time64_t linked against time64_t compiled libuuid, but running with a new libuuid compiled without time64_t:
/lib/libuuid.so.1: version `UUID_2.40' not found (required by ./uuid_time-time64_t)

