### PR TITLE
login-utils: include libgen.h for basename API

### DIFF
--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <pwd.h>
 #include <grp.h>
+#include <libgen.h>
 #include <security/pam_appl.h>
 #ifdef HAVE_SECURITY_PAM_MISC_H
 # include <security/pam_misc.h>
@@ -840,17 +841,20 @@ static void run_shell(
 				su->simulate_login ? " login" : "",
 				su->fast_startup ? " fast-start" : ""));
 
+  char* tmp = xstrdup(shell);
 	if (su->simulate_login) {
 		char *arg0;
 		char *shell_basename;
 
-		shell_basename = basename(shell);
+		shell_basename = basename(tmp);
 		arg0 = xmalloc(strlen(shell_basename) + 2);
 		arg0[0] = '-';
 		strcpy(arg0 + 1, shell_basename);
 		args[0] = arg0;
-	} else
-		args[0] = basename(shell);
+	} else {
+    args[0] = basename(tmp);
+  }
+  free(tmp);
 
 	if (su->fast_startup)
 		args[argno++] = "-f";


### PR DESCRIPTION
musl has removed the non-prototype declaration of basename from string.h [1] which now results in build errors with clang-17+ compiler

include libgen.h for using the posix declaration of the funciton.

Fixes

../util-linux-2.39.2/login-utils/su-common.c:847:20: error: call to undeclared function 'basename'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  847 |                 shell_basename = basename(shell);
      |                                  ^

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7
Signed-off-by: Khem Raj <raj.khem@gmail.com>