### PR TITLE
unshare: don't try to reset the disposition of SIGKILL

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -994,8 +994,10 @@ int main(int argc, char *argv[])
 
 			int termsig = WTERMSIG(status);
 
-			if (signal(termsig, SIG_DFL) == SIG_ERR ||
-				sigemptyset(&sigset) != 0 ||
+			if (termsig != SIGKILL && signal(termsig, SIG_DFL) == SIG_ERR)
+				err(EXIT_FAILURE,
+					_("signal handler reset failed"));
+			if (sigemptyset(&sigset) != 0 ||
 				sigaddset(&sigset, termsig) != 0 ||
 				sigprocmask(SIG_UNBLOCK, &sigset, NULL) != 0)
 				err(EXIT_FAILURE,


### PR DESCRIPTION
If the child process is killed with `SIGKILL`, don't attempt to reset the disposition of `SIGKILL` (which can't be caught or ignored anyway) before self-signalling, which caused a misleading `sigprocmask unblock failed` error instead of dying with the same `SIGKILL` status as the child. This fixes https://github.com/util-linux/util-linux/issues/2614.