### PR TITLE
rename: properly handle directories with trailing slash

### DIFF
--- a/misc-utils/rename.c
+++ b/misc-utils/rename.c
@@ -28,6 +28,7 @@ for i in $@; do N=`echo "$i" | sed "s/$FROM/$TO/g"`; mv "$i" "$N"; done
 #include <errno.h>
 #include <getopt.h>
 #include <fcntl.h>
+#include <libgen.h>
 #include <unistd.h>
 #include <termios.h>
 #include <sys/types.h>
@@ -58,12 +59,7 @@ static char *find_initial_replace(char *from, char *to, char *orig)
 		/* We only want to search in the final path component. Don't
 		   include the final '/' in that component; if `from` is empty,
 		   we want it to first match after the '/', not before. */
-		search_start = strrchr(orig, '/');
-
-		if (search_start == NULL)
-			search_start = orig;
-		else
-			search_start++;
+		search_start = basename(orig);
 	}
 
 	return strstr(search_start, from);

--- a/tests/expected/rename/basic
+++ b/tests/expected/rename/basic
@@ -17,3 +17,4 @@ what is rename_all* *.? doing here?
 `rename_zz_last_zzz.z' -> `rename_zz_last_zAAzzBB.z'
 what is rename*last* doing here?
 `rename_all_empty' -> `_r_e_n_a_m_e___a_l_l___e_m_p_t_y_'
+`rename_dir' -> `rename_new_dir'

--- a/tests/ts/rename/basic
+++ b/tests/ts/rename/basic
@@ -72,4 +72,8 @@ touch rename_all_empty
 $TS_CMD_RENAME -v -a '' _ rename_all_empty >> $TS_OUTPUT 2>> $TS_ERRLOG
 rm -f _r_e_n_a_m_e___a_l_l___e_m_p_t_y_
 
+mkdir rename_dir
+$TS_CMD_RENAME -v dir new_dir rename_dir/ >> $TS_OUTPUT 2>> $TS_ERRLOG
+rmdir rename_new_dir
+
 ts_finalize


### PR DESCRIPTION
Instead of hand-rolling a basename() function use the standard one which provides the functionality that we want to use.

Also add a testcase.

Fixes #2569