### PR TITLE
lscpu-cputype.c: assign value directly to bit32 and bit64

### DIFF
--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -643,11 +643,11 @@ struct lscpu_arch *lscpu_read_architecture(struct lscpu_cxt *cxt)
 
 		snprintf(buf, sizeof(buf), " %s ", ct->flags);
 		if (strstr(buf, " lm "))
-			ar->bit32 = 1, ar->bit64 = 1;			/* x86_64 */
+			ar->bit32 = ar->bit64 = 1;			/* x86_64 */
 		if (strstr(buf, " zarch "))
-			ar->bit32 = 1, ar->bit64 = 1;			/* s390x */
+			ar->bit32 = ar->bit64 = 1;			/* s390x */
 		if (strstr(buf, " sun4v ") || strstr(buf, " sun4u "))
-			ar->bit32 = 1, ar->bit64 = 1;			/* sparc64 */
+			ar->bit32 = ar->bit64 = 1;			/* sparc64 */
 	}
 
 	if (ct && ct->isa) {


### PR DESCRIPTION
Hello,
clang with -Wcomma will emit an warning of "misuse of comma operator". Since the value that will be assigned, is the same for both (bit32 and bit64), just assigning directly to both variables seems reasonable.