### PR TITLE
more: exit if POLLERR and POLLHUP on stdin is received

### DIFF
--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -1392,6 +1392,11 @@ static int more_poll(struct more_control *ctl, int timeout)
 			abort();
 		}
 	}
+
+	/* Check for POLLERR and POLLHUP in stdin revents */
+	if ((pfd[1].revents & POLLERR) && (pfd[1].revents & POLLHUP))
+		more_exit(ctl);
+
 	if (pfd[1].revents == 0)
 		return 1;
 	return 0;


### PR DESCRIPTION
more command continues to run in case stdin have closed the file and it takes 100% of CPU. This is because revents on stdin send POLLIN | POLLHUP | POLLERR once stdin is closed. more receives it even though it is not requested in events. This is common Linux behaviour to never mask out POLLHUP or POLLERR. The loop in more_key_command() runs infinitely because more_poll() returns 0 and read_command() reads 0 bytes.

Check for POLLERR and POLLHUP, and exit more in case of an error.

Steps to reproduce:
1. Setup /etc/systemd/logind.conf with KillUserProcesses=no
2. Add config "Defaults use_pty" in /etc/sudoers
3. Start an ssh session to the machine
4. # sudo su -
5. # more <big enough file>
6. kill the parent ssh process, say close the tab

At this time "more" runs with 100% CPU utilization.