### PR TITLE
fdisk: guard posix variable

### DIFF
--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -290,7 +290,9 @@ int main(int argc, char **argv)
 	int	fd;
 	int	mode = 0;
 	int	dig = 0;
-	int posix = 0;
+#ifdef HAVE_POSIX_FALLOCATE
+	int	posix = 0;
+#endif
 	loff_t	length = -2LL;
 	loff_t	offset = 0;
 


### PR DESCRIPTION
Otherwise it can generate a unused variable warning.