### PR TITLE
exch: Add man page to po4a.cfg to make it translatable

### DIFF
--- a/po-man/po4a.cfg
+++ b/po-man/po4a.cfg
@@ -14,7 +14,6 @@
 [type:asciidoc] ../disk-utils/blockdev.8.adoc     $lang:$lang/blockdev.8.adoc
 [type:asciidoc] ../disk-utils/cfdisk.8.adoc       $lang:$lang/cfdisk.8.adoc
 [type:asciidoc] ../disk-utils/delpart.8.adoc      $lang:$lang/delpart.8.adoc
-[type:asciidoc] ../disk-utils/exch.1.adoc         $lang:$lang/exch.1.adoc
 [type:asciidoc] ../disk-utils/fdformat.8.adoc     $lang:$lang/fdformat.8.adoc
 [type:asciidoc] ../disk-utils/fdisk.8.adoc        $lang:$lang/fdisk.8.adoc
 [type:asciidoc] ../disk-utils/fsck.8.adoc         $lang:$lang/fsck.8.adoc
@@ -61,6 +60,7 @@
 
 [type:asciidoc] ../misc-utils/blkid.8.adoc        $lang:$lang/blkid.8.adoc
 [type:asciidoc] ../misc-utils/cal.1.adoc          $lang:$lang/cal.1.adoc
+[type:asciidoc] ../misc-utils/exch.1.adoc         $lang:$lang/exch.1.adoc
 [type:asciidoc] ../misc-utils/fadvise.1.adoc      $lang:$lang/fadvise.1.adoc
 [type:asciidoc] ../misc-utils/fincore.1.adoc      $lang:$lang/fincore.1.adoc
 [type:asciidoc] ../misc-utils/findfs.8.adoc       $lang:$lang/findfs.8.adoc

--- a/po-man/po4a.cfg
+++ b/po-man/po4a.cfg
@@ -14,6 +14,7 @@
 [type:asciidoc] ../disk-utils/blockdev.8.adoc     $lang:$lang/blockdev.8.adoc
 [type:asciidoc] ../disk-utils/cfdisk.8.adoc       $lang:$lang/cfdisk.8.adoc
 [type:asciidoc] ../disk-utils/delpart.8.adoc      $lang:$lang/delpart.8.adoc
+[type:asciidoc] ../disk-utils/exch.1.adoc         $lang:$lang/exch.1.adoc
 [type:asciidoc] ../disk-utils/fdformat.8.adoc     $lang:$lang/fdformat.8.adoc
 [type:asciidoc] ../disk-utils/fdisk.8.adoc        $lang:$lang/fdisk.8.adoc
 [type:asciidoc] ../disk-utils/fsck.8.adoc         $lang:$lang/fsck.8.adoc


### PR DESCRIPTION
As usual: Once a new man page arises, it needs to be added to po-man/po4a.cfg to make it translatable. Maybe an extension of the script tools/checkadoc-missing.sh would be helpful…?