### PR TITLE
login: allow login shells with blank in path

### DIFF
--- a/login-utils/login.1.adoc
+++ b/login-utils/login.1.adoc
@@ -32,7 +32,7 @@ The environment variable *$TERM* will be preserved, if it exists, else it will b
 
 The environment variables defined by PAM are always preserved.
 
-Then the user's shell is started. If no shell is specified for the user in _/etc/passwd_, then _/bin/sh_ is used. If there is no home directory specified in _/etc/passwd_, then _/_ is used, followed by _.hushlogin_ check as described below.
+Then the user's shell is started. If no shell is specified for the user in _/etc/passwd_, then _/bin/sh_ is used. If the specified shell contains a space, it is treated as a shell script. If there is no home directory specified in _/etc/passwd_, then _/_ is used, followed by _.hushlogin_ check as described below.
 
 If the file _.hushlogin_ exists, then a "quiet" login is performed. This disables the checking of mail and the printing of the last login time and message of the day. Otherwise, if _/var/log/lastlog_ exists, the last login time is printed, and the current login is recorded.
 

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1420,6 +1420,7 @@ int main(int argc, char **argv)
 		.conv = { openpam_ttyconv, NULL } /* OpenPAM conversation function */
 #endif
 	};
+	bool script;
 
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
@@ -1544,7 +1545,9 @@ int main(int argc, char **argv)
 	}
 
 	/* if the shell field has a space: treat it like a shell script */
-	if (strchr(pwd->pw_shell, ' ')) {
+	script = strchr(pwd->pw_shell, ' ') != NULL;
+
+	if (script) {
 		char *buff;
 
 		xasprintf(&buff, "exec %s", pwd->pw_shell);
@@ -1569,7 +1572,7 @@ int main(int argc, char **argv)
 
 	execvp(child_argv[0], child_argv + 1);
 
-	if (!strcmp(child_argv[0], "/bin/sh"))
+	if (script)
 		warn(_("couldn't exec shell script"));
 	else
 		warn(_("no shell"));

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1553,14 +1553,13 @@ int main(int argc, char **argv)
 		child_argv[child_argc++] = "-c";
 		child_argv[child_argc++] = buff;
 	} else {
-		char tbuf[PATH_MAX + 2], *p;
+		char *buff, *p;
 
-		tbuf[0] = '-';
-		xstrncpy(tbuf + 1, ((p = strrchr(pwd->pw_shell, '/')) ?
-				    p + 1 : pwd->pw_shell), sizeof(tbuf) - 1);
-
+		xasprintf(&buff, "-%.*s", PATH_MAX,
+			  ((p = strrchr(pwd->pw_shell, '/')) ?
+			  p + 1 : pwd->pw_shell));
 		child_argv[child_argc++] = pwd->pw_shell;
-		child_argv[child_argc++] = xstrdup(tbuf);
+		child_argv[child_argc++] = buff;
 	}
 
 	child_argv[child_argc++] = NULL;


### PR DESCRIPTION
The login program would run every shell with a blank in its name (as defined in pw_shell) as a shell script. Check if it is an executable binary first to support such login shells as well.

While at it, improve error message and simplify name creation.

Proof of Concept (error message):
1. Set login shell of a user to `/bin/sh`
2. Remove executable permission for this user from `/bin/sh`
3. Try to log in

You will see that the error message states that shell script could not be executed

Proof of Concept (blank shell)
1. Create symbolic link from e.g. `/bin/sh with blank` to `/bin/sh`
2. Set login shell of a user to `/bin/sh with blank`
3. Depending on your PAM setup, you have to add `/bin/sh with blank` to `/etc/shells`
5. Try to log in

The login will fail due to illegal call of the shell `/bin/sh`