### PR TITLE
enosys and lsclocks: Add man pages to po4a.cfg

### DIFF
--- a/misc-utils/lsclocks.1.adoc
+++ b/misc-utils/lsclocks.1.adoc
@@ -39,24 +39,24 @@ Output all columns.
 *-r*, *--raw*::
 Use raw output format.
 
-*-r*, *--time* _clock_
+*-r*, *--time* _clock_::
 Show current time of one specific clocks.
 
-*--no-discover-dynamic*
+*--no-discover-dynamic*::
 Do not try to discover dynamic clocks.
 
-*-d*, *--dynamic-clock* _path_
+*-d*, *--dynamic-clock* _path_::
 Also display specified dynamic clock.
 Can be specified multiple times.
 
-*--no-discover-rtc*
+*--no-discover-rtc*::
 Do not try to discover RTCs.
 
-*-x*, *--rtc* _path_
+*-x*, *--rtc* _path_::
 Also display specified RTC.
 Can be specified multiple times.
 
-*-c*, *--cpu-clock* _pid_
+*-c*, *--cpu-clock* _pid_::
 Also display CPU clock of specified process.
 Can be specified multiple times.
 


### PR DESCRIPTION
This patch adds the man pages of enosys and lsclocks to po4a.cfg to make them translatable. Besides that, it fixes the Asciidoctor markup in lsclocks.1.adoc to add line breaks for better readability.