### PR TITLE
libmount: utab event

### DIFF
--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -2209,7 +2209,7 @@ int mnt_context_update_tabs(struct libmnt_context *cxt)
 
 		if (mnt_update_already_done(cxt->update, cxt->lock)) {
 			DBG(CXT, ul_debugobj(cxt, "don't update: error evaluate or already updated"));
-			goto end;
+			goto emit;
 		}
 	} else if (cxt->helper) {
 		DBG(CXT, ul_debugobj(cxt, "don't update: external helper"));
@@ -2225,7 +2225,9 @@ int mnt_context_update_tabs(struct libmnt_context *cxt)
 	}
 
 	rc = mnt_update_table(cxt->update, cxt->lock);
-
+emit:
+	if (rc == 0 && !mnt_context_within_helper(cxt))
+		mnt_update_emit_event(cxt->update);
 end:
 	if (!mnt_context_switch_ns(cxt, ns_old))
 		return -MNT_ERR_NAMESPACE;

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -2737,7 +2737,6 @@ int mnt_context_get_excode(
 	return rc;
 }
 
-
 /**
  * mnt_context_init_helper
  * @cxt: mount context
@@ -2771,6 +2770,14 @@ int mnt_context_init_helper(struct libmnt_context *cxt, int action,
 
 	DBG(CXT, ul_debugobj(cxt, "initialized for [u]mount.<type> helper [rc=%d]", rc));
 	return rc;
+}
+
+/*
+ * libmount used in /sbin/[u]mount.<type> helper
+ */
+int mnt_context_within_helper(struct libmnt_context *cxt)
+{
+	return cxt && (cxt->flags & MNT_FL_HELPER);
 }
 
 /**

--- a/libmount/src/context_umount.c
+++ b/libmount/src/context_umount.c
@@ -270,7 +270,7 @@ static int lookup_umount_fs_by_statfs(struct libmnt_context *cxt, const char *tg
 	 */
 	if (mnt_context_is_restricted(cxt)
 	    || *tgt != '/'
-	    || (cxt->flags & MNT_FL_HELPER)
+	    || mnt_context_within_helper(cxt)
 	    || mnt_context_is_force(cxt)
 	    || mnt_context_is_lazy(cxt)
 	    || mnt_context_is_nocanonicalize(cxt)

--- a/libmount/src/lock.c
+++ b/libmount/src/lock.c
@@ -146,7 +146,7 @@ static int lock_simplelock(struct libmnt_lock *ml)
 	const char *lfile;
 	int rc;
 	struct stat sb;
-	const mode_t lock_mask = S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH;
+	const mode_t lock_mask = S_IRUSR|S_IWUSR;
 
 	assert(ml);
 
@@ -161,8 +161,7 @@ static int lock_simplelock(struct libmnt_lock *ml)
 		sigprocmask(SIG_BLOCK, &sigs, &ml->oldsigmask);
 	}
 
-	ml->lockfile_fd = open(lfile, O_RDONLY|O_CREAT|O_CLOEXEC,
-				      S_IWUSR|S_IRUSR|S_IRGRP|S_IROTH);
+	ml->lockfile_fd = open(lfile, O_RDONLY|O_CREAT|O_CLOEXEC, lock_mask);
 	if (ml->lockfile_fd < 0) {
 		rc = -errno;
 		goto err;

--- a/libmount/src/monitor.c
+++ b/libmount/src/monitor.c
@@ -229,7 +229,7 @@ static int userspace_add_watch(struct monitor_entry *me, int *final, int *fd)
 	 * libmount uses utab.event file to monitor and control utab updates
 	 */
 	if (asprintf(&filename, "%s.event", me->path) <= 0) {
-		rc = -errno;
+		rc = -ENOMEM;
 		goto done;
 	}
 

--- a/libmount/src/monitor.c
+++ b/libmount/src/monitor.c
@@ -226,18 +226,16 @@ static int userspace_add_watch(struct monitor_entry *me, int *final, int *fd)
 	assert(me->path);
 
 	/*
-	 * libmount uses rename(2) to atomically update utab, monitor
-	 * rename changes is too tricky. It seems better to monitor utab
-	 * lockfile close.
+	 * libmount uses utab.event file to monitor and control utab updates
 	 */
-	if (asprintf(&filename, "%s.lock", me->path) <= 0) {
+	if (asprintf(&filename, "%s.event", me->path) <= 0) {
 		rc = -errno;
 		goto done;
 	}
 
-	/* try lock file if already exists */
+	/* try event file if already exists */
 	errno = 0;
-	wd = inotify_add_watch(me->fd, filename, IN_CLOSE_NOWRITE);
+	wd = inotify_add_watch(me->fd, filename, IN_CLOSE_WRITE);
 	if (wd >= 0) {
 		DBG(MONITOR, ul_debug(" added inotify watch for %s [fd=%d]", filename, wd));
 		rc = 0;
@@ -256,7 +254,7 @@ static int userspace_add_watch(struct monitor_entry *me, int *final, int *fd)
 		if (!*filename)
 			break;
 
-		/* try directory where is the lock file */
+		/* try directory where is the event file */
 		errno = 0;
 		wd = inotify_add_watch(me->fd, filename, IN_CREATE|IN_ISDIR);
 		if (wd >= 0) {
@@ -339,10 +337,10 @@ static int userspace_event_verify(struct libmnt_monitor *mn,
 			e = (const struct inotify_event *) p;
 			DBG(MONITOR, ul_debugobj(mn, " inotify event 0x%x [%s]\n", e->mask, e->len ? e->name : ""));
 
-			if (e->mask & IN_CLOSE_NOWRITE)
+			if (e->mask & IN_CLOSE_WRITE)
 				status = 1;
 			else {
-				/* event on lock file */
+				/* add watch for the event file */
 				userspace_add_watch(me, &status, &fd);
 
 				if (fd != e->wd) {

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -620,6 +620,8 @@ extern struct libmnt_context *mnt_copy_context(struct libmnt_context *o);
 extern int mnt_context_utab_writable(struct libmnt_context *cxt);
 extern const char *mnt_context_get_writable_tabpath(struct libmnt_context *cxt);
 
+extern int mnt_context_within_helper(struct libmnt_context *cxt);
+
 extern int mnt_context_get_mountinfo(struct libmnt_context *cxt, struct libmnt_table **tb);
 extern int mnt_context_get_mountinfo_for_target(struct libmnt_context *cxt,
 				    struct libmnt_table **mountinfo, const char *tgt);

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -663,6 +663,7 @@ extern int mnt_context_apply_fs(struct libmnt_context *cxt, struct libmnt_fs *fs
 extern struct libmnt_optlist *mnt_context_get_optlist(struct libmnt_context *cxt);
 
 /* tab_update.c */
+extern int mnt_update_emit_event(struct libmnt_update *upd);
 extern int mnt_update_set_filename(struct libmnt_update *upd, const char *filename);
 extern int mnt_update_already_done(struct libmnt_update *upd,
 				   struct libmnt_lock *lc);

--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -1013,7 +1013,7 @@ int mnt_update_emit_event(struct libmnt_update *upd)
 		return -EINVAL;
 
 	if (asprintf(&filename, "%s.event", upd->filename) <= 0)
-		return -errno;
+		return -ENOMEM;
 
 	fd = open(filename, O_WRONLY|O_CREAT|O_CLOEXEC,
 			    S_IWUSR|S_IRUSR|S_IRGRP|S_IROTH);

--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -1004,6 +1004,25 @@ done:
 	return rc;
 }
 
+int mnt_update_emit_event(struct libmnt_update *upd)
+{
+	char *filename;
+	int fd;
+
+	if (!upd || !upd->filename)
+		return -EINVAL;
+
+	if (asprintf(&filename, "%s.event", upd->filename) <= 0)
+		return -errno;
+
+	fd = open(filename, O_WRONLY|O_CREAT|O_CLOEXEC,
+			    S_IWUSR|S_IRUSR|S_IRGRP|S_IROTH);
+	free(filename);
+	if (fd < 0)
+		return -errno;
+	close(fd);
+	return 0;
+}
 
 #ifdef TEST_PROGRAM
 

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -1032,7 +1032,7 @@ int mnt_open_uniq_filename(const char *filename, char **name)
 
 	rc = asprintf(&n, "%s.XXXXXX", filename);
 	if (rc <= 0)
-		return -errno;
+		return -ENOMEM;
 
 	/* This is for very old glibc and for compatibility with Posix, which says
 	 * nothing about mkstemp() mode. All sane glibc use secure mode (0600).

--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -248,7 +248,7 @@ static int unix_socket(struct logger_ctl *ctl, const char *path, int *socket_typ
 		errx(EXIT_FAILURE, _("openlog %s: pathname too long"), path);
 
 	s_addr.sun_family = AF_UNIX;
-	strncpy(s_addr.sun_path, path, sizeof(s_addr.sun_path));
+	xstrncpy(s_addr.sun_path, path, sizeof(s_addr.sun_path));
 
 	for (i = 2; i; i--) {
 		int st = -1;


### PR DESCRIPTION
This PR splits utab locking and utab changes reporting. The issue is that the lock can be used more than once during one mount(8) call when /sbin/mount.type helper used. The multiple events for one mount can make some applications that depend on x-* options in utab confused (e.g. gnome).

After this, libmount will use utab.lock for locking and utab.event to inform applications about a change. The built-in libmount monitor was also modified to use utab.event now. The change is backward compatible, applications that monitor utab.lock will still work without a change.