### PR TITLE
libfdisk: constify builtin fdisk_parttype

### DIFF
--- a/libfdisk/src/bsd.c
+++ b/libfdisk/src/bsd.c
@@ -46,7 +46,7 @@ static const char * const bsd_dktypenames[] = {
 };
 #define BSD_DKMAXTYPES	(ARRAY_SIZE(bsd_dktypenames) - 1)
 
-static struct fdisk_parttype bsd_fstypes[] = {
+static const struct fdisk_parttype bsd_fstypes[] = {
         {BSD_FS_UNUSED, "unused"},
 	{BSD_FS_SWAP,   "swap"},
 	{BSD_FS_V6,     "Version 6"},

--- a/libfdisk/src/dos.c
+++ b/libfdisk/src/dos.c
@@ -67,7 +67,7 @@ struct fdisk_dos_label {
 /*
  * Partition types
  */
-static struct fdisk_parttype dos_parttypes[] = {
+static const struct fdisk_parttype dos_parttypes[] = {
 	#include "pt-mbr-partnames.h"
 };
 

--- a/libfdisk/src/fdiskP.h
+++ b/libfdisk/src/fdiskP.h
@@ -286,7 +286,7 @@ enum {
 struct fdisk_label {
 	const char		*name;		/* label name */
 	enum fdisk_labeltype	id;		/* FDISK_DISKLABEL_* */
-	struct fdisk_parttype	*parttypes;	/* supported partitions types */
+	const struct fdisk_parttype *parttypes;	/* supported partitions types */
 	size_t			nparttypes;	/* number of items in parttypes[] */
 
 	const struct fdisk_shortcut *parttype_cuts;	/* partition type shortcuts */

--- a/libfdisk/src/gpt.c
+++ b/libfdisk/src/gpt.c
@@ -152,7 +152,7 @@ struct gpt_legacy_mbr {
 		.name = (_n),    \
 	}
 
-static struct fdisk_parttype gpt_parttypes[] =
+static const struct fdisk_parttype gpt_parttypes[] =
 {
 	#include "pt-gpt-partnames.h"
 };

--- a/libfdisk/src/parttype.c
+++ b/libfdisk/src/parttype.c
@@ -145,7 +145,7 @@ struct fdisk_parttype *fdisk_label_get_parttype(const struct fdisk_label *lb, si
 {
 	if (!lb || n >= lb->nparttypes)
 		return NULL;
-	return &lb->parttypes[n];
+	return (struct fdisk_parttype *)&lb->parttypes[n];
 }
 
 /**
@@ -237,7 +237,7 @@ struct fdisk_parttype *fdisk_label_get_parttype_from_code(
 
 	for (i = 0; i < lb->nparttypes; i++)
 		if (lb->parttypes[i].code == code)
-			return &lb->parttypes[i];
+			return (struct fdisk_parttype *)&lb->parttypes[i];
 	return NULL;
 }
 
@@ -265,7 +265,7 @@ struct fdisk_parttype *fdisk_label_get_parttype_from_string(
 	for (i = 0; i < lb->nparttypes; i++)
 		if (lb->parttypes[i].typestr
 		    && strcasecmp(lb->parttypes[i].typestr, str) == 0)
-			return &lb->parttypes[i];
+			return (struct fdisk_parttype *)&lb->parttypes[i];
 
 	return NULL;
 }
@@ -324,7 +324,8 @@ static struct fdisk_parttype *parttype_from_data(
 				unsigned int *xcode,
 				int use_seqnum)
 {
-	struct fdisk_parttype *types, *ret = NULL;
+	const struct fdisk_parttype *types;
+	struct fdisk_parttype *ret = NULL;
 	char *end = NULL;
 
 	assert(lb);
@@ -369,7 +370,7 @@ static struct fdisk_parttype *parttype_from_data(
 			if (use_seqnum && errno == 0
 			    && *end == '\0' && i > 0
 			    && i - 1 < (int) lb->nparttypes)
-				ret = &types[i - 1];
+				ret = (struct fdisk_parttype *)&types[i - 1];
 		}
 	}
 
@@ -428,7 +429,7 @@ static struct fdisk_parttype *parttype_from_name(
 		const char *name = lb->parttypes[i].name;
 
 		if (name && *name && ul_stralnumcmp(name, str) == 0)
-			return &lb->parttypes[i];
+			return (struct fdisk_parttype *)&lb->parttypes[i];
 	}
 
 	return NULL;

--- a/libfdisk/src/sgi.c
+++ b/libfdisk/src/sgi.c
@@ -41,7 +41,7 @@ struct fdisk_sgi_label {
 	} freelist[SGI_MAXPARTITIONS + 1];
 };
 
-static struct fdisk_parttype sgi_parttypes[] =
+static const struct fdisk_parttype sgi_parttypes[] =
 {
 	{SGI_TYPE_VOLHDR,	N_("SGI volhdr")},
 	{SGI_TYPE_TRKREPL,	N_("SGI trkrepl")},

--- a/libfdisk/src/sun.c
+++ b/libfdisk/src/sun.c
@@ -35,7 +35,7 @@ struct fdisk_sun_label {
 	struct sun_disklabel   *header;		/* on-disk data (pointer to cxt->firstsector) */
 };
 
-static struct fdisk_parttype sun_parttypes[] = {
+static const struct fdisk_parttype sun_parttypes[] = {
 	{SUN_TAG_UNASSIGNED, N_("Unassigned")},
 	{SUN_TAG_BOOT, N_("Boot")},
 	{SUN_TAG_ROOT, N_("SunOS root")},


### PR DESCRIPTION
The builtin struct fdisk_parttypes are not supposed to be modified. This is enforced in the mutation functions.

While the API could be cleaned up to distinguish between const and non-const versions of fdisk_parttype this could break user code.

Instead preserve the API and add some internal casts.