### PR TITLE
libfdisk: (tests) fix tests for removal of non-blockdev sync()

### DIFF
--- a/tests/expected/fdisk/mbr-nondos-mode-first-sector-at-end
+++ b/tests/expected/fdisk/mbr-nondos-mode-first-sector-at-end
@@ -27,7 +27,6 @@ Select (default p): Partition number (2-4, default 2): First sector (2048-19999,
 Created a new partition <removed>.
 
 Command (m for help): The partition table has been altered.
-Syncing disks.
 
 
 ---layout----------

--- a/tests/expected/fdisk/sunlabel-create-second-partition
+++ b/tests/expected/fdisk/sunlabel-create-second-partition
@@ -8,7 +8,6 @@ Command (m for help): Partition number (2-8, default 2): First cylinder (128-325
 Created a new partition <removed>.
 
 Command (m for help): The partition table has been altered.
-Syncing disks.
 
 a87e80830aa13d2d68b766962f052750 sunlabel.img
 Disk <removed>: 10 MiB, 10485760 bytes, 20480 sectors

--- a/tests/expected/libfdisk/gpt-all-defaults
+++ b/tests/expected/libfdisk/gpt-all-defaults
@@ -21,4 +21,3 @@ Device             Start   End Sectors Size Type
 <removed>2 12288 18431    6144   3M Linux filesystem
 
 The partition table has been altered.
-Syncing disks.

--- a/tests/expected/libfdisk/gpt-all-defaults-with-typo
+++ b/tests/expected/libfdisk/gpt-all-defaults-with-typo
@@ -21,4 +21,3 @@ Device             Start   End Sectors Size Type
 <removed>2 12288 18431    6144   3M Linux filesystem
 
 The partition table has been altered.
-Syncing disks.


### PR DESCRIPTION
Fixes: 101dca2f18eb ("libfdisk: fdisk_deassign_device: only sync(2) blockdevs")