### PR TITLE
lscpu: cure empty output of lscpu -b/-p

### DIFF
--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -224,9 +224,13 @@ static const struct cpuinfo_pattern type_patterns[] =
 	DEF_PAT_CPUTYPE( "max thread id",	PAT_MAX_THREAD_ID, mtid),	/* s390 */
 	DEF_PAT_CPUTYPE( "model",		PAT_MODEL,	model),
 	DEF_PAT_CPUTYPE( "model name",		PAT_MODEL_NAME,	modelname),
+	DEF_PAT_CPUTYPE( "mvendorid",		PAT_VENDOR,	vendor),	/* riscv */
+	DEF_PAT_CPUTYPE( "marchid",		PAT_FAMILY,	family),	/* riscv */
+	DEF_PAT_CPUTYPE( "mimpid",		PAT_MODEL,	model),		/* riscv */
 	DEF_PAT_CPUTYPE( "revision",		PAT_REVISION,	revision),
 	DEF_PAT_CPUTYPE( "stepping",		PAT_STEPPING,	stepping),
 	DEF_PAT_CPUTYPE( "type",		PAT_TYPE,	flags),		/* sparc64 */
+	DEF_PAT_CPUTYPE( "uarch",		PAT_MODEL_NAME,	modelname),	/* riscv */
 	DEF_PAT_CPUTYPE( "vendor",		PAT_VENDOR,	vendor),
 	DEF_PAT_CPUTYPE( "vendor_id",		PAT_VENDOR,	vendor),	/* s390 */
 };


### PR DESCRIPTION
On riscv, /proc/cpuinfo looks like:

	processor       : 3
	hart            : 4
	isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zba_zbb
	mmu             : sv39
	uarch           : sifive,u74-mc
	mvendorid       : 0x489
	marchid         : 0x8000000000000007
	mimpid          : 0x4210427
	hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zba_zbb

As none of the cputype_patterns match any of the fields in that file, `cpu->type` is never set, which causes `get_cell_data` to always return nullptr. The output of `lscpu -b --extended=CPU` and `lscpu -p` is then empty.

Resolve that.

---

Before:
```
jengelh@starfive:~> lscpu -b -e=CPU
CPU
  -
  -
  -
  -
jengelh@starfive:~> lscpu -p
# The following is the parsable format, which can be fed to other
# programs. Each different item in every column has an unique ID
# starting usually from zero.
# CPU,Core,Socket,Node
,,,
,,,
,,,
,,,
jengelh@starfive:~/util-linux> lscpu
Architecture:          riscv64
  Byte Order:          Little Endian
CPU(s):                4
  On-line CPU(s) list: 0-3
NUMA:                  
  NUMA node(s):        1
  NUMA node0 CPU(s):   0-3
```

After:

```
jengelh@starfive:~/util-linux> ./lscpu -b -e=CPU
CPU
  0
  1
  2
  3
jengelh@starfive:~/util-linux> ./lscpu -p
# The following is the parsable format, which can be fed to other
# programs. Each different item in every column has an unique ID
# starting usually from zero.
# CPU,Core,Socket,Node,,L1d,L1i,L2
0,0,0,0,,0,0,0
1,1,0,0,,1,1,0
2,2,0,0,,2,2,0
3,3,0,0,,3,3,0
jengelh@starfive:~/util-linux> ./lscpu
Architecture:          riscv64
  Byte Order:          Little Endian
CPU(s):                4
  On-line CPU(s) list: 0-3
Model name:            sifive,u74-mc
  CPU family:          0x8000000000000007
  Model:               0x4210427
  Thread(s) per core:  1
  Core(s) per socket:  4
  Socket(s):           1
Caches (sum of all):   
  L1d:                 128 KiB (4 instances)
  L1i:                 128 KiB (4 instances)
  L2:                  2 MiB (1 instance)
NUMA:                  
  NUMA node(s):        1
  NUMA node0 CPU(s):   0-3
```