### PR TITLE
ctrlaltdel: remove unnecessary uid check

### DIFF
--- a/sys-utils/ctrlaltdel.c
+++ b/sys-utils/ctrlaltdel.c
@@ -68,10 +68,6 @@ static int set_cad(const char *arg)
 {
 	unsigned int cmd;
 
-	if (geteuid()) {
-		warnx(_("You must be root to set the Ctrl-Alt-Del behavior"));
-		return EXIT_FAILURE;
-	}
 	if (!strcmp("hard", arg))
 		cmd = LINUX_REBOOT_CMD_CAD_ON;
 	else if (!strcmp("soft", arg))


### PR DESCRIPTION
The ctrlaltdel performs an extra permission check with `geteuid()` , preventing the non-root processes from executing the reboot system call, even with the CAP_SYS_BOOT capability which should be enough. Sees #2709 