### PR TITLE
fallocate: fix the way to evaluate values returned from posix_fallocate

### DIFF
--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -144,8 +144,8 @@ static void xfallocate(int fd, int mode, off_t offset, off_t length)
 #ifdef HAVE_POSIX_FALLOCATE
 static void xposix_fallocate(int fd, off_t offset, off_t length)
 {
-	int error = posix_fallocate(fd, offset, length);
-	if (error < 0) {
+	errno = posix_fallocate(fd, offset, length);
+	if (errno != 0) {
 		err(EXIT_FAILURE, _("fallocate failed"));
 	}
 }


### PR DESCRIPTION
Unlike Linux native system calls, posix_fallocate doesn't return -1 whe an error occurs; it returns a errno value directly.

The bug of the original code was reported by @Yugend on #2714.