### PR TITLE
libmount: veil kernel events in monitor

### DIFF
--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -302,6 +302,8 @@ libmnt_lock
 mnt_free_lock
 mnt_lock_file
 mnt_new_lock
+mnt_ref_lock
+mnt_unref_lock
 mnt_unlock_file
 mnt_lock_block_signals
 </SECTION>

--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -456,5 +456,6 @@ mnt_monitor_get_fd
 mnt_monitor_close_fd
 mnt_monitor_next_change
 mnt_monitor_event_cleanup
+mnt_monitor_veil_kernel
 mnt_monitor_wait
 </SECTION>

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -107,7 +107,7 @@ void mnt_free_context(struct libmnt_context *cxt)
 	mnt_unref_optlist(cxt->optlist_saved);
 	mnt_unref_optlist(cxt->optlist);
 
-	mnt_free_lock(cxt->lock);
+	mnt_unref_lock(cxt->lock);
 	mnt_free_update(cxt->update);
 
 	mnt_context_set_target_ns(cxt, NULL);

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -2207,7 +2207,7 @@ int mnt_context_update_tabs(struct libmnt_context *cxt)
 	    && mnt_context_get_helper_status(cxt) == 0
 	    && mnt_context_utab_writable(cxt)) {
 
-		if (mnt_update_already_done(cxt->update, cxt->lock)) {
+		if (mnt_update_already_done(cxt->update)) {
 			DBG(CXT, ul_debugobj(cxt, "don't update: error evaluate or already updated"));
 			goto emit;
 		}

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -2179,6 +2179,10 @@ int mnt_context_prepare_update(struct libmnt_context *cxt)
 		rc = mnt_update_set_fs(cxt->update, flags,
 					NULL, cxt->fs);
 
+	if (mnt_update_is_ready(cxt->update)) {
+		DBG(CXT, ul_debugobj(cxt, "update is ready"));
+		mnt_update_start(cxt->update);
+	}
 	return rc < 0 ? rc : 0;
 }
 
@@ -2228,7 +2232,10 @@ int mnt_context_update_tabs(struct libmnt_context *cxt)
 emit:
 	if (rc == 0 && !mnt_context_within_helper(cxt))
 		mnt_update_emit_event(cxt->update);
+
 end:
+	mnt_update_end(cxt->update);
+
 	if (!mnt_context_switch_ns(cxt, ns_old))
 		return -MNT_ERR_NAMESPACE;
 	return rc;

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -444,6 +444,8 @@ extern const struct libmnt_optmap *mnt_get_builtin_optmap(int id);
 /* lock.c */
 extern struct libmnt_lock *mnt_new_lock(const char *datafile, pid_t id)
 			__ul_attribute__((warn_unused_result));
+extern void mnt_ref_lock(struct libmnt_lock *ml);
+extern void mnt_unref_lock(struct libmnt_lock *ml);
 extern void mnt_free_lock(struct libmnt_lock *ml);
 
 extern void mnt_unlock_file(struct libmnt_lock *ml);

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -699,6 +699,8 @@ extern int mnt_monitor_enable_kernel(struct libmnt_monitor *mn, int enable);
 extern int mnt_monitor_enable_userspace(struct libmnt_monitor *mn,
 				int enable, const char *filename);
 
+extern int mnt_monitor_veil_kernel(struct libmnt_monitor *mn, int enable);
+
 extern int mnt_monitor_get_fd(struct libmnt_monitor *mn);
 extern int mnt_monitor_close_fd(struct libmnt_monitor *mn);
 extern int mnt_monitor_wait(struct libmnt_monitor *mn, int timeout);

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -375,3 +375,8 @@ MOUNT_2_39 {
 	mnt_table_enable_noautofs;
 	mnt_table_is_noautofs;
 } MOUNT_2_38;
+
+MOUNT_2_40 {
+	mnt_ref_lock;
+	mnt_unref_lock;
+} MOUNT_2_39;

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -379,4 +379,5 @@ MOUNT_2_39 {
 MOUNT_2_40 {
 	mnt_ref_lock;
 	mnt_unref_lock;
+	mnt_monitor_veil_kernel;
 } MOUNT_2_39;

--- a/libmount/src/monitor.c
+++ b/libmount/src/monitor.c
@@ -64,6 +64,8 @@ struct libmnt_monitor {
 	int			fd;		/* public monitor file descriptor */
 
 	struct list_head	ents;
+
+	unsigned int		kernel_veiled: 1;
 };
 
 struct monitor_opers {
@@ -471,12 +473,28 @@ err:
 	return rc;
 }
 
+static int kernel_event_verify(struct libmnt_monitor *mn,
+			       struct monitor_entry *me)
+{
+	int status = 1;
+
+	if (!mn || !me || me->fd < 0)
+		return 0;
+
+	if (mn->kernel_veiled && access(MNT_PATH_UTAB ".act", F_OK) == 0) {
+		status = 0;
+		DBG(MONITOR, ul_debugobj(mn, "kernel event veiled"));
+	}
+	return status;
+}
+
 /*
  * kernel monitor operations
  */
 static const struct monitor_opers kernel_opers = {
 	.op_get_fd		= kernel_monitor_get_fd,
 	.op_close_fd		= kernel_monitor_close_fd,
+	.op_event_verify	= kernel_event_verify
 };
 
 /**
@@ -543,6 +561,28 @@ err:
 	free_monitor_entry(me);
 	DBG(MONITOR, ul_debugobj(mn, "failed to allocate kernel monitor [rc=%d]", rc));
 	return rc;
+}
+
+/**
+ * mnt_monitor_veil_kernel:
+ * @mn: monitor instance
+ * @enable: 1 or 0
+ *
+ * Force monitor to ignore kernel events if the same mount/umount operation
+ * will generate an userspace event later. The kernel-only mount operation will
+ * be not affected.
+ *
+ * Return: 0 on success and <0 on error.
+ *
+ * Since: 2.40
+ */
+int mnt_monitor_veil_kernel(struct libmnt_monitor *mn, int enable)
+{
+	if (!mn)
+		return -EINVAL;
+
+	mn->kernel_veiled = enable ? 1 : 0;
+	return 0;
 }
 
 /*
@@ -852,6 +892,8 @@ static struct libmnt_monitor *create_test_monitor(int argc, char *argv[])
 				warn("failed to initialize kernel monitor");
 				goto err;
 			}
+		} else if (strcmp(argv[i], "veil") == 0) {
+			mnt_monitor_veil_kernel(mn, 1);
 		}
 	}
 	if (i == 1) {
@@ -899,12 +941,14 @@ static int __test_epoll(struct libmnt_test *ts __attribute__((unused)),
 		goto done;
 	}
 
-	printf("waiting for changes...\n");
 	do {
 		const char *filename = NULL;
 		struct epoll_event events[1];
-		int n = epoll_wait(efd, events, 1, -1);
+		int n;
 
+		printf("waiting for changes...\n");
+
+		n = epoll_wait(efd, events, 1, -1);
 		if (n < 0) {
 			rc = -errno;
 			warn("polling error");
@@ -962,6 +1006,7 @@ static int test_wait(struct libmnt_test *ts __attribute__((unused)),
 		while (mnt_monitor_next_change(mn, &filename, NULL) == 0)
 			printf(" %s: change detected\n", filename);
 
+		printf("waiting for changes...\n");
 	}
 	mnt_unref_monitor(mn);
 	return 0;
@@ -970,9 +1015,9 @@ static int test_wait(struct libmnt_test *ts __attribute__((unused)),
 int main(int argc, char *argv[])
 {
 	struct libmnt_test tss[] = {
-		{ "--epoll", test_epoll, "<userspace kernel ...>  monitor in epoll" },
-		{ "--epoll-clean", test_epoll_cleanup, "<userspace kernel ...>  monitor in epoll and clean events" },
-		{ "--wait",  test_wait,  "<userspace kernel ...>  monitor wait function" },
+		{ "--epoll", test_epoll, "<userspace kernel veil ...>  monitor in epoll" },
+		{ "--epoll-clean", test_epoll_cleanup, "<userspace kernel veil ...>  monitor in epoll and clean events" },
+		{ "--wait",  test_wait,  "<userspace kernel veil ...>  monitor wait function" },
 		{ NULL }
 	};
 

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -665,8 +665,7 @@ extern struct libmnt_optlist *mnt_context_get_optlist(struct libmnt_context *cxt
 /* tab_update.c */
 extern int mnt_update_emit_event(struct libmnt_update *upd);
 extern int mnt_update_set_filename(struct libmnt_update *upd, const char *filename);
-extern int mnt_update_already_done(struct libmnt_update *upd,
-				   struct libmnt_lock *lc);
+extern int mnt_update_already_done(struct libmnt_update *upd);
 
 #if __linux__
 /* btrfs.c */

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -666,6 +666,8 @@ extern struct libmnt_optlist *mnt_context_get_optlist(struct libmnt_context *cxt
 extern int mnt_update_emit_event(struct libmnt_update *upd);
 extern int mnt_update_set_filename(struct libmnt_update *upd, const char *filename);
 extern int mnt_update_already_done(struct libmnt_update *upd);
+extern int mnt_update_start(struct libmnt_update *upd);
+extern int mnt_update_end(struct libmnt_update *upd);
 
 #if __linux__
 /* btrfs.c */

--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -40,6 +40,7 @@ struct libmnt_update {
 			missing_options : 1;
 
 	struct libmnt_table *mountinfo;
+	struct libmnt_lock  *lock;
 };
 
 static int set_fs_root(struct libmnt_update *upd, struct libmnt_fs *fs, unsigned long mountflags);
@@ -75,6 +76,7 @@ void mnt_free_update(struct libmnt_update *upd)
 
 	DBG(UPDATE, ul_debugobj(upd, "free"));
 
+	mnt_unref_lock(upd->lock);
 	mnt_unref_fs(upd->fs);
 	mnt_unref_table(upd->mountinfo);
 	free(upd->target);
@@ -668,43 +670,42 @@ static int add_file_entry(struct libmnt_table *tb, struct libmnt_update *upd)
 	return update_table(upd, tb);
 }
 
-static int update_add_entry(struct libmnt_update *upd, struct libmnt_lock *lc)
+static int update_add_entry(struct libmnt_update *upd)
 {
 	struct libmnt_table *tb;
 	int rc = 0;
 
 	assert(upd);
 	assert(upd->fs);
+	assert(upd->lock);
 
 	DBG(UPDATE, ul_debugobj(upd, "%s: add entry", upd->filename));
 
-	if (lc)
-		rc = mnt_lock_file(lc);
+	rc = mnt_lock_file(upd->lock);
 	if (rc)
 		return -MNT_ERR_LOCK;
 
 	tb = __mnt_new_table_from_file(upd->filename, MNT_FMT_UTAB, 1);
 	if (tb)
 		rc = add_file_entry(tb, upd);
-	if (lc)
-		mnt_unlock_file(lc);
 
+	mnt_unlock_file(upd->lock);
 	mnt_unref_table(tb);
 	return rc;
 }
 
-static int update_remove_entry(struct libmnt_update *upd, struct libmnt_lock *lc)
+static int update_remove_entry(struct libmnt_update *upd)
 {
 	struct libmnt_table *tb;
 	int rc = 0;
 
 	assert(upd);
 	assert(upd->target);
+	assert(upd->lock);
 
 	DBG(UPDATE, ul_debugobj(upd, "%s: remove entry", upd->filename));
 
-	if (lc)
-		rc = mnt_lock_file(lc);
+	rc = mnt_lock_file(upd->lock);
 	if (rc)
 		return -MNT_ERR_LOCK;
 
@@ -716,23 +717,22 @@ static int update_remove_entry(struct libmnt_update *upd, struct libmnt_lock *lc
 			rc = update_table(upd, tb);
 		}
 	}
-	if (lc)
-		mnt_unlock_file(lc);
 
+	mnt_unlock_file(upd->lock);
 	mnt_unref_table(tb);
 	return rc;
 }
 
-static int update_modify_target(struct libmnt_update *upd, struct libmnt_lock *lc)
+static int update_modify_target(struct libmnt_update *upd)
 {
 	struct libmnt_table *tb = NULL;
 	int rc = 0;
 
 	assert(upd);
+	assert(upd->lock);
 	DBG(UPDATE, ul_debugobj(upd, "%s: modify target", upd->filename));
 
-	if (lc)
-		rc = mnt_lock_file(lc);
+	rc = mnt_lock_file(upd->lock);
 	if (rc)
 		return -MNT_ERR_LOCK;
 
@@ -781,15 +781,13 @@ static int update_modify_target(struct libmnt_update *upd, struct libmnt_lock *l
 	}
 
 done:
-	if (lc)
-		mnt_unlock_file(lc);
-
+	mnt_unlock_file(upd->lock);
 	mnt_unref_table(tb);
 	return rc;
 }
 
 /* replaces option in the table entry by new options from @udp */
-static int update_modify_options(struct libmnt_update *upd, struct libmnt_lock *lc)
+static int update_modify_options(struct libmnt_update *upd)
 {
 	struct libmnt_table *tb = NULL;
 	int rc = 0;
@@ -797,13 +795,13 @@ static int update_modify_options(struct libmnt_update *upd, struct libmnt_lock *
 
 	assert(upd);
 	assert(upd->fs);
+	assert(upd->lock);
 
 	DBG(UPDATE, ul_debugobj(upd, "%s: modify options", upd->filename));
 
 	fs = upd->fs;
 
-	if (lc)
-		rc = mnt_lock_file(lc);
+	rc = mnt_lock_file(upd->lock);
 	if (rc)
 		return -MNT_ERR_LOCK;
 
@@ -822,15 +820,13 @@ static int update_modify_options(struct libmnt_update *upd, struct libmnt_lock *
 			rc = add_file_entry(tb, upd);	/* not found, add new */
 	}
 
-	if (lc)
-		mnt_unlock_file(lc);
-
+	mnt_unlock_file(upd->lock);
 	mnt_unref_table(tb);
 	return rc;
 }
 
 /* add user options missing in the table entry by new options from @udp */
-static int update_add_options(struct libmnt_update *upd, struct libmnt_lock *lc)
+static int update_add_options(struct libmnt_update *upd)
 {
 	struct libmnt_table *tb = NULL;
 	int rc = 0;
@@ -838,6 +834,7 @@ static int update_add_options(struct libmnt_update *upd, struct libmnt_lock *lc)
 
 	assert(upd);
 	assert(upd->fs);
+	assert(upd->lock);
 
 	if (!upd->fs->user_optstr)
 		return 0;
@@ -846,8 +843,7 @@ static int update_add_options(struct libmnt_update *upd, struct libmnt_lock *lc)
 
 	fs = upd->fs;
 
-	if (lc)
-		rc = mnt_lock_file(lc);
+	rc = mnt_lock_file(upd->lock);
 	if (rc)
 		return -MNT_ERR_LOCK;
 
@@ -873,12 +869,28 @@ static int update_add_options(struct libmnt_update *upd, struct libmnt_lock *lc)
 			rc = add_file_entry(tb, upd);	/* not found, add new */
 	}
 
-	if (lc)
-		mnt_unlock_file(lc);
-
+	mnt_unlock_file(upd->lock);
 	mnt_unref_table(tb);
 	return rc;
 
+}
+
+static int update_init_lock(struct libmnt_update *upd, struct libmnt_lock *lc)
+{
+	assert(upd);
+
+	if (lc) {
+		mnt_unref_lock(upd->lock);
+		mnt_ref_lock(lc);
+		upd->lock = lc;
+	} else if (!upd->lock) {
+		upd->lock = mnt_new_lock(upd->filename, 0);
+		if (!upd->lock)
+			return -ENOMEM;
+		mnt_lock_block_signals(lc, TRUE);
+	}
+
+	return 0;
 }
 
 /**
@@ -897,7 +909,6 @@ static int update_add_options(struct libmnt_update *upd, struct libmnt_lock *lc)
  */
 int mnt_update_table(struct libmnt_update *upd, struct libmnt_lock *lc)
 {
-	struct libmnt_lock *lc0 = lc;
 	int rc = -EINVAL;
 
 	if (!upd || !upd->filename)
@@ -909,35 +920,32 @@ int mnt_update_table(struct libmnt_update *upd, struct libmnt_lock *lc)
 	if (upd->fs) {
 		DBG(UPDATE, mnt_fs_print_debug(upd->fs, stderr));
 	}
-	if (!lc) {
-		lc = mnt_new_lock(upd->filename, 0);
-		if (lc)
-			mnt_lock_block_signals(lc, TRUE);
-	}
+
+	rc = update_init_lock(upd, lc);
+	if (rc)
+		goto done;
 
 	if (!upd->fs && upd->target)
-		rc = update_remove_entry(upd, lc);	/* umount */
+		rc = update_remove_entry(upd);		/* umount */
 	else if (upd->mountflags & MS_MOVE)
-		rc = update_modify_target(upd, lc);	/* move */
+		rc = update_modify_target(upd);		/* move */
 	else if (upd->mountflags & MS_REMOUNT)
-		rc = update_modify_options(upd, lc);	/* remount */
+		rc = update_modify_options(upd);	/* remount */
 	else if (upd->fs && upd->missing_options)
-		rc = update_add_options(upd, lc);	/* mount by externel helper */
+		rc = update_add_options(upd);		/* mount by externel helper */
 	else if (upd->fs)
-		rc = update_add_entry(upd, lc);		/* mount */
+		rc = update_add_entry(upd);		/* mount */
 
 	upd->ready = 1;
+done:
 	DBG(UPDATE, ul_debugobj(upd, "%s: update tab: done [rc=%d]",
 				upd->filename, rc));
-	if (lc != lc0)
-		 mnt_free_lock(lc);
 	return rc;
 }
 
-int mnt_update_already_done(struct libmnt_update *upd, struct libmnt_lock *lc)
+int mnt_update_already_done(struct libmnt_update *upd)
 {
 	struct libmnt_table *tb = NULL;
-	struct libmnt_lock *lc0 = lc;
 	int rc = 0;
 
 	if (!upd || !upd->filename || (!upd->fs && !upd->target))
@@ -945,22 +953,7 @@ int mnt_update_already_done(struct libmnt_update *upd, struct libmnt_lock *lc)
 
 	DBG(UPDATE, ul_debugobj(upd, "%s: checking for previous update", upd->filename));
 
-	if (!lc) {
-		lc = mnt_new_lock(upd->filename, 0);
-		if (lc)
-			mnt_lock_block_signals(lc, TRUE);
-	}
-	if (lc) {
-		rc = mnt_lock_file(lc);
-		if (rc) {
-			rc = -MNT_ERR_LOCK;
-			goto done;
-		}
-	}
-
 	tb = __mnt_new_table_from_file(upd->filename, MNT_FMT_UTAB, 1);
-	if (lc)
-		mnt_unlock_file(lc);
 	if (!tb)
 		goto done;
 
@@ -997,8 +990,6 @@ int mnt_update_already_done(struct libmnt_update *upd, struct libmnt_lock *lc)
 
 	mnt_unref_table(tb);
 done:
-	if (lc && lc != lc0)
-		mnt_free_lock(lc);
 	DBG(UPDATE, ul_debugobj(upd, "%s: previous update check done [rc=%d]",
 				upd->filename, rc));
 	return rc;

--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -36,6 +36,9 @@ struct libmnt_update {
 	char		*filename;
 	unsigned long	mountflags;
 
+	int		act_fd;
+	char		*act_filename;
+
 	unsigned int	ready : 1,
 			missing_options : 1;
 
@@ -59,6 +62,7 @@ struct libmnt_update *mnt_new_update(void)
 	if (!upd)
 		return NULL;
 
+	upd->act_fd = -1;
 	DBG(UPDATE, ul_debugobj(upd, "allocate"));
 	return upd;
 }
@@ -79,8 +83,11 @@ void mnt_free_update(struct libmnt_update *upd)
 	mnt_unref_lock(upd->lock);
 	mnt_unref_fs(upd->fs);
 	mnt_unref_table(upd->mountinfo);
+	if (upd->act_fd >= 0)
+		close(upd->act_fd);
 	free(upd->target);
 	free(upd->filename);
+	free(upd->act_filename);
 	free(upd);
 }
 
@@ -1006,12 +1013,114 @@ int mnt_update_emit_event(struct libmnt_update *upd)
 	if (asprintf(&filename, "%s.event", upd->filename) <= 0)
 		return -ENOMEM;
 
+	DBG(UPDATE, ul_debugobj(upd, "emitting utab event"));
+
 	fd = open(filename, O_WRONLY|O_CREAT|O_CLOEXEC,
 			    S_IWUSR|S_IRUSR|S_IRGRP|S_IROTH);
 	free(filename);
 	if (fd < 0)
 		return -errno;
 	close(fd);
+	return 0;
+}
+
+/*
+ * Let's use /run/mount/utab.act file to report to libmount monitor that
+ * libmount is working with utab. In this case, the monitor can ignore all
+ * events from kernel until entire mount (with all steps) is done.
+ *
+ * For example mount NFS with x-* options, means
+ * - create utab.act and mark it as used (by LOCK_SH)
+ * - exec /sbin/mount.nfs
+ *   - call mount(2) (kernel event on /proc/self/mounts)
+ *   - utab update (NFS stuff)
+ * - utab update (add x-* userspace options)
+ * - unlink utab.act (if not use anyone else)
+ * - release event by /run/mount/utab.event
+ *
+ * Note, this is used only when utab is in the game (x-* options).
+ */
+int mnt_update_start(struct libmnt_update *upd)
+{
+	int rc = 0;
+	mode_t oldmask;
+
+	if (!upd || !upd->filename)
+		return -EINVAL;
+
+	if (!upd->act_filename &&
+	    asprintf(&upd->act_filename, "%s.act", upd->filename) <= 0)
+		return -ENOMEM;
+
+	/* Use exclusive lock to avoid some other proces will remove the the
+	 * file before it's marked as used by LOCK_SH (below) */
+	rc = update_init_lock(upd, NULL);
+	if (rc)
+		return rc;
+
+	rc = mnt_lock_file(upd->lock);
+	if (rc)
+		return -MNT_ERR_LOCK;
+
+	DBG(UPDATE, ul_debugobj(upd, "creating act file"));
+
+	oldmask = umask(S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH);
+	upd->act_fd = open(upd->act_filename, O_WRONLY|O_CREAT|O_CLOEXEC, S_IRUSR|S_IWUSR);
+	umask(oldmask);
+
+	if (upd->act_fd < 0) {
+		rc = -errno;
+		goto fail;
+	}
+
+	/* mark the file as used */
+	rc = flock(upd->act_fd, LOCK_SH);
+	if (rc) {
+		rc = -errno;
+		goto fail;
+	}
+
+	mnt_unlock_file(upd->lock);
+	return 0;
+fail:
+	DBG(UPDATE, ul_debugobj(upd, "act file failed [rc=%d]", rc));
+	mnt_unlock_file(upd->lock);
+	unlink(upd->act_filename);
+	close(upd->act_fd);
+	upd->act_fd = -1;
+	return rc;
+}
+
+int mnt_update_end(struct libmnt_update *upd)
+{
+	int rc;
+
+	if (!upd || upd->act_fd < 0)
+		return -EINVAL;
+
+	DBG(UPDATE, ul_debugobj(upd, "removing act file"));
+
+	/* make sure nobody else will use the file */
+	rc = mnt_lock_file(upd->lock);
+	if (rc)
+		return -MNT_ERR_LOCK;
+
+	/* mark the file as unused */
+	flock(upd->act_fd, LOCK_UN);
+	errno = 0;
+
+	/* check if nobody else need the file (if yes, then the file is under LOCK_SH) )*/
+	if (flock(upd->act_fd, LOCK_EX | LOCK_NB) != 0) {
+		if (errno == EWOULDBLOCK)
+			DBG(UPDATE, ul_debugobj(upd, "act file used, no unlink"));
+	} else {
+		DBG(UPDATE, ul_debugobj(upd, "unlinking act file"));
+		unlink(upd->act_filename);
+	}
+
+	mnt_unlock_file(upd->lock);
+	close(upd->act_fd);
+	upd->act_fd = -1;
 	return 0;
 }
 


### PR DESCRIPTION
This is the last set of patches to improve x-* options used in gnome and other userspace applications that monitor mount events. We must avoid reloading the mount table in the applications if the mount process is incomplete and generates multiple events. This all is done only for mounts with x-* options. For performance reasons, kernel-only mounts have no userspace synchronization with the monitor.