### PR TITLE
findmnt: add -I, --dfi options for imitating the output of df -i

### DIFF
--- a/bash-completion/findmnt
+++ b/bash-completion/findmnt
@@ -106,6 +106,7 @@ _findmnt_module()
 				--ascii
 				--canonicalize
 				--df
+				--dfi
 				--direction
 				--evaluate
 				--tab-file

--- a/misc-utils/findmnt.8.adoc
+++ b/misc-utils/findmnt.8.adoc
@@ -52,7 +52,7 @@ Canonicalize all printed paths.
 Print filesystems where target (mountpoint) is marked as deleted by kernel.
 
 *-D*, *--df*::
-Imitate the output of *df*(1). This option is equivalent to *-o SOURCE,FSTYPE,SIZE,USED,AVAIL,USE%,TARGET* but excludes all pseudo filesystems. Use *--all* to print all filesystems.
+Imitate the output of *df*(1). This option is equivalent to *-o SOURCE,FSTYPE,SIZE,USED,AVAIL,USE%,TARGET* but excludes all pseudo filesystems. Use *--all* to print all filesystems. See also *-I*, *--dfi* options.
 
 *-d*, *--direction* _word_::
 The search direction, either *forward* or *backward*.
@@ -68,6 +68,9 @@ Print the first matching filesystem only.
 
 *-H*, *--list-columns*::
 List the available columns, use with *--json* or *--raw* to get output in machine-readable format.
+
+*-I*, *--dfi*::
+Imitate the output of *df*(1) with its *-i* option. This option is equivalent to *-o SOURCE,FSTYPE,INO.TOTAL,INO.USED,INO.AVAIL,INO.USE%,TARGET* but excludes all pseudo filesystems. Use *--all* to print all filesystems.
 
 *-i*, *--invert*::
 Invert the sense of matching.

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1436,6 +1436,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	        "                          to device names\n"), out);
 	fputs(_(" -F, --tab-file <path>  alternative file for -s, -m or -k options\n"), out);
 	fputs(_(" -f, --first-only       print the first found filesystem only\n"), out);
+	fputs(_(" -I, --dfi              imitate the output of df(1) with -i option\n"), out);
 	fputs(_(" -i, --invert           invert the sense of matching\n"), out);
 	fputs(_(" -J, --json             use JSON output format\n"), out);
 	fputs(_(" -l, --list             use list format output\n"), out);
@@ -1531,6 +1532,7 @@ int main(int argc, char *argv[])
 		{ "canonicalize",   no_argument,       NULL, 'c'		 },
 		{ "direction",	    required_argument, NULL, 'd'		 },
 		{ "df",		    no_argument,       NULL, 'D'		 },
+		{ "dfi",	    no_argument,       NULL, 'I'		 },
 		{ "evaluate",	    no_argument,       NULL, 'e'		 },
 		{ "first-only",	    no_argument,       NULL, 'f'		 },
 		{ "fstab",	    no_argument,       NULL, 's'		 },
@@ -1595,7 +1597,7 @@ int main(int argc, char *argv[])
 	flags |= FL_TREE;
 
 	while ((c = getopt_long(argc, argv,
-				"AabCcDd:ehiJfF:o:O:p::PklmM:nN:rst:uvRS:T:Uw:VxyH",
+				"AabCcDd:ehIiJfF:o:O:p::PklmM:nN:rst:uvRS:T:Uw:VxyH",
 				longopts, NULL)) != -1) {
 
 		err_exclusive_options(c, longopts, excl, excl_st);
@@ -1631,6 +1633,10 @@ int main(int argc, char *argv[])
 			break;
 		case 'e':
 			flags |= FL_EVALUATE;
+			break;
+		case 'I':
+			flags &= ~FL_TREE;
+			flags |= FL_DF_INODES;
 			break;
 		case 'i':
 			flags |= FL_INVERT;
@@ -1769,7 +1775,16 @@ int main(int argc, char *argv[])
 	if (collist)
 		list_colunms();		/* print end exit */
 
-	if (!ncolumns && (flags & FL_DF)) {
+	if (!ncolumns && (flags & FL_DF_INODES)) {
+		add_column(columns, ncolumns++, COL_SOURCE);
+		add_column(columns, ncolumns++, COL_FSTYPE);
+		add_column(columns, ncolumns++, COL_INO_TOTAL);
+		add_column(columns, ncolumns++, COL_INO_USED);
+		add_column(columns, ncolumns++, COL_INO_AVAIL);
+		add_column(columns, ncolumns++, COL_INO_USEPERC);
+		add_column(columns, ncolumns++, COL_TARGET);
+	}
+	else if (!ncolumns && (flags & FL_DF)) {
 		add_column(columns, ncolumns++, COL_SOURCE);
 		add_column(columns, ncolumns++, COL_FSTYPE);
 		add_column(columns, ncolumns++, COL_SIZE);

--- a/misc-utils/findmnt.h
+++ b/misc-utils/findmnt.h
@@ -24,6 +24,7 @@ enum {
 	FL_SHADOWED	= (1 << 20),
 	FL_DELETED      = (1 << 21),
 	FL_SHELLVAR     = (1 << 22),
+	FL_DF_INODES	= (1 << 23) | FL_DF,
 
 	/* basic table settings */
 	FL_ASCII	= (1 << 25),


### PR DESCRIPTION
    An example output:
    
      $ ./findmnt -I
      SOURCE                            FSTYPE      INO.TOTAL  INO.USED INO.AVAIL INO.USE% TARGET
      /dev/mapper/fedora_dev64-root     ext4          5341184   1135307   4205877      21% /
      devtmpfs                          devtmpfs     32930640      1209  32929431       0% /dev
      tmpfs                             tmpfs        32938620        86  32938534       0% /dev/shm
      ...
 