### PR TITLE
lsfd: list file descriptors with incomplete information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ config/test-driver
 configure
 cscope.out
 depcomp
+errnos.h
 GPATH
 GRTAGS
 GTAGS

--- a/meson.build
+++ b/meson.build
@@ -2680,12 +2680,18 @@ if not is_disabler(exe)
   bashcompletions += ['lsblk']
 endif
 
+errnos_h = custom_target('errnos.h',
+  input : 'tools/all_errnos',
+  output : 'errnos.h',
+  command : ['tools/all_errnos', cc.cmd_array()]
+)
+
 mq_libs = []
 mq_libs += cc.find_library('rt', required : true)
 
 exe = executable(
   'lsfd',
-  lsfd_sources,
+  lsfd_sources, errnos_h,
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols],

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -272,6 +272,16 @@ hardlink_CFLAGS = $(AM_CFLAGS)
 endif
 
 if BUILD_LSFD
+
+misc-utils/lsfd-file.c: errnos.h
+
+errnos.h: $(top_srcdir)/tools/all_errnos
+	@echo '  GEN      $@'
+	@$(top_srcdir)/tools/all_errnos $(CC) $(CFLAGS)
+
+-include errnos.h.deps
+CLEANFILES += errnos.h errnos.h.deps
+
 bin_PROGRAMS += lsfd
 MANPAGES += misc-utils/lsfd.1
 dist_noinst_DATA += misc-utils/lsfd.1.adoc

--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -300,8 +300,8 @@ static bool file_fill_column(struct proc *proc,
 	case COL_XMODE: {
 		char r, w, x;
 		char D = file->stat.st_nlink == 0? 'D': '-';
-		char L = file->locked.write? 'L'
-			:file->locked.read?  'l'
+		char L = file->locked_write? 'L'
+			:file->locked_read?  'l'
 			:                    '-';
 		char m = file->multiplexed? 'm': '-';
 
@@ -400,10 +400,10 @@ static int file_handle_fdinfo(struct file *file, const char *key, const char* va
 	} else if (strcmp(key, "lock") == 0) {
 		switch (parse_lock_line(value)) {
 		case READ_LOCK:
-			file->locked.read = 1;
+			file->locked_read = 1;
 			break;
 		case WRITE_LOCK:
-			file->locked.write = 1;
+			file->locked_write = 1;
 			break;
 		}
 		rc = 1;

--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -46,9 +46,21 @@
 
 #include "lsfd.h"
 
-static struct idcache *username_cache;
-
 static size_t pagesize;
+
+
+/*
+ * Abstract file class
+ *
+ * This class is for filling columns that don't need "sb" member, the
+ * result of stat(2).
+ */
+#define does_file_has_fdinfo_alike(file)	\
+	((file)->association >= 0		\
+	 || (file)->association == -ASSOC_SHM	\
+	 || (file)->association == -ASSOC_MEM)
+
+static struct idcache *username_cache;
 
 static const char *assocstr[N_ASSOCS] = {
 	[ASSOC_CWD]       = "cwd",
@@ -70,6 +82,152 @@ static const char *assocstr[N_ASSOCS] = {
 	[ASSOC_SHM]       = "shm",
 };
 
+extern void lsfd_decode_file_flags(struct ul_buffer *buf, int flags);
+static void file_fill_flags_buf(struct ul_buffer *buf, int flags)
+{
+	lsfd_decode_file_flags(buf, flags);
+}
+
+static uint64_t get_map_length(struct file *file)
+{
+	uint64_t res = 0;
+
+	if (is_association(file, SHM) || is_association(file, MEM))
+		res = (file->map_end - file->map_start) / pagesize;
+
+	return res;
+}
+
+static void abst_class_initialize(void)
+{
+	username_cache = new_idcache();
+	if (!username_cache)
+		err(EXIT_FAILURE, _("failed to allocate UID cache"));
+}
+
+static void abst_class_finalize(void)
+{
+	free_idcache(username_cache);
+}
+
+static bool abst_fill_column(struct proc *proc,
+			     struct file *file,
+			     struct libscols_line *ln,
+			     int column_id,
+			     size_t column_index)
+{
+	char *str = NULL;
+
+	switch(column_id) {
+	case COL_COMMAND:
+		if (proc->command
+		    && scols_line_set_data(ln, column_index, proc->command))
+			err(EXIT_FAILURE, _("failed to add output data"));
+		return true;
+	case COL_NAME:
+	case COL_KNAME:
+		if (file->name
+		    && scols_line_set_data(ln, column_index, file->name))
+			err(EXIT_FAILURE, _("failed to add output data"));
+		return true;
+	case COL_USER:
+		add_uid(username_cache, (int)proc->uid);
+		if (scols_line_set_data(ln, column_index,
+					get_id(username_cache,
+					       (int)proc->uid)->name))
+			err(EXIT_FAILURE, _("failed to add output data"));
+		return true;
+	case COL_DEVTYPE:
+		if (scols_line_set_data(ln, column_index,
+					"nodev"))
+			err(EXIT_FAILURE, _("failed to add output data"));
+		return true;
+	case COL_FD:
+		if (!is_opened_file(file))
+			return false;
+		/* FALL THROUGH */
+	case COL_ASSOC:
+		if (is_opened_file(file))
+			xasprintf(&str, "%d", file->association);
+		else {
+			int assoc = file->association * -1;
+			if (assoc >= N_ASSOCS)
+				return false; /* INTERNAL ERROR */
+			str = xstrdup(assocstr[assoc]);
+		}
+		break;
+	case COL_PID:
+		xasprintf(&str, "%d", (int)proc->leader->pid);
+		break;
+	case COL_TID:
+		xasprintf(&str, "%d", (int)proc->pid);
+		break;
+	case COL_UID:
+		xasprintf(&str, "%d", (int)proc->uid);
+		break;
+	case COL_KTHREAD:
+		xasprintf(&str, "%u", proc->kthread);
+		break;
+	case COL_MODE:
+		xasprintf(&str, "???");
+		break;
+	case COL_XMODE: {
+		char r, w, x;
+		char D = '?';
+		char L = file->locked_write? 'L'
+			:file->locked_read?  'l'
+			:                    '-';
+		char m = file->multiplexed? 'm': '-';
+		r = w = x = '?';
+		xasprintf(&str, "%c%c%c%c%c%c", r, w, x, D, L, m);
+		break;
+	}
+	case COL_POS:
+		xasprintf(&str, "%" PRIu64,
+			  (does_file_has_fdinfo_alike(file))? file->pos: 0);
+		break;
+	case COL_FLAGS: {
+		struct ul_buffer buf = UL_INIT_BUFFER;
+
+		if (!is_opened_file(file))
+			return true;
+
+		if (file->sys_flags == 0)
+			return true;
+
+		file_fill_flags_buf(&buf, file->sys_flags);
+		if (ul_buffer_is_empty(&buf))
+			return true;
+		str = ul_buffer_get_data(&buf, NULL, NULL);
+		break;
+	}
+	case COL_MAPLEN:
+		if (!is_mapped_file(file))
+			return true;
+		xasprintf(&str, "%ju", (uintmax_t)get_map_length(file));
+		break;
+	default:
+		return false;
+	}
+
+	if (!str)
+		err(EXIT_FAILURE, _("failed to add output data"));
+	if (scols_line_refer_data(ln, column_index, str))
+		err(EXIT_FAILURE, _("failed to add output data"));
+	return true;
+}
+
+const struct file_class abst_class = {
+	.super = NULL,
+	.size = sizeof(struct file),
+	.initialize_class = abst_class_initialize,
+	.finalize_class = abst_class_finalize,
+	.fill_column = abst_fill_column,
+};
+
+/*
+ * Concrete file class
+ */
 static const char *strftype(mode_t ftype)
 {
 	switch (ftype) {
@@ -90,27 +248,6 @@ static const char *strftype(mode_t ftype)
 	default:
 		return "UNKN";
 	}
-}
-
-extern void lsfd_decode_file_flags(struct ul_buffer *buf, int flags);
-static void file_fill_flags_buf(struct ul_buffer *buf, int flags)
-{
-	lsfd_decode_file_flags(buf, flags);
-}
-
-#define does_file_has_fdinfo_alike(file)	\
-	((file)->association >= 0		\
-	 || (file)->association == -ASSOC_SHM	\
-	 || (file)->association == -ASSOC_MEM)
-
-static uint64_t get_map_length(struct file *file)
-{
-	uint64_t res = 0;
-
-	if (is_association(file, SHM) || is_association(file, MEM))
-		res = (file->map_end - file->map_start) / pagesize;
-
-	return res;
 }
 
 void decode_source(char *buf, size_t bufsize,
@@ -161,7 +298,7 @@ static char *strnrstr(const char *haystack, const char *needle, size_t needle_le
 	} while (1);
 }
 
-static bool file_fill_column(struct proc *proc,
+static bool file_fill_column(struct proc *proc __attribute__((__unused__)),
 			     struct file *file,
 			     struct libscols_line *ln,
 			     int column_id,
@@ -172,11 +309,6 @@ static bool file_fill_column(struct proc *proc,
 	char buf[BUFSIZ];
 
 	switch(column_id) {
-	case COL_COMMAND:
-		if (proc->command
-		    && scols_line_set_data(ln, column_index, proc->command))
-			err(EXIT_FAILURE, _("failed to add output data"));
-		return true;
 	case COL_NAME:
 		if (file->name && file->stat.st_nlink == 0) {
 			char *d = strnrstr(file->name, "(deleted)",
@@ -203,39 +335,6 @@ static bool file_fill_column(struct proc *proc,
 		if (scols_line_set_data(ln, column_index, strftype(ftype)))
 			err(EXIT_FAILURE, _("failed to add output data"));
 		return true;
-	case COL_USER:
-		add_uid(username_cache, (int)proc->uid);
-		if (scols_line_set_data(ln, column_index,
-					get_id(username_cache,
-					       (int)proc->uid)->name))
-			err(EXIT_FAILURE, _("failed to add output data"));
-		return true;
-	case COL_OWNER:
-		add_uid(username_cache, (int)file->stat.st_uid);
-		if (scols_line_set_data(ln, column_index,
-					get_id(username_cache,
-					       (int)file->stat.st_uid)->name))
-			err(EXIT_FAILURE, _("failed to add output data"));
-		return true;
-	case COL_DEVTYPE:
-		if (scols_line_set_data(ln, column_index,
-					"nodev"))
-			err(EXIT_FAILURE, _("failed to add output data"));
-		return true;
-	case COL_FD:
-		if (!is_opened_file(file))
-			return false;
-		/* FALL THROUGH */
-	case COL_ASSOC:
-		if (is_opened_file(file))
-			xasprintf(&str, "%d", file->association);
-		else {
-			int assoc = file->association * -1;
-			if (assoc >= N_ASSOCS)
-				return false; /* INTERNAL ERROR */
-			str = xstrdup(assocstr[assoc]);
-		}
-		break;
 	case COL_INODE:
 		xasprintf(&str, "%llu", (unsigned long long)file->stat.st_ino);
 		break;
@@ -260,15 +359,6 @@ static bool file_fill_column(struct proc *proc,
 			  major(file->stat.st_rdev),
 			  minor(file->stat.st_rdev));
 		break;
-	case COL_PID:
-		xasprintf(&str, "%d", (int)proc->leader->pid);
-		break;
-	case COL_TID:
-		xasprintf(&str, "%d", (int)proc->pid);
-		break;
-	case COL_UID:
-		xasprintf(&str, "%d", (int)proc->uid);
-		break;
 	case COL_FUID:
 		xasprintf(&str, "%d", (int)file->stat.st_uid);
 		break;
@@ -280,9 +370,6 @@ static bool file_fill_column(struct proc *proc,
 		break;
 	case COL_DELETED:
 		xasprintf(&str, "%d", file->stat.st_nlink == 0);
-		break;
-	case COL_KTHREAD:
-		xasprintf(&str, "%u", proc->kthread);
 		break;
 	case COL_MNT_ID:
 		xasprintf(&str, "%d", is_opened_file(file)? file->mnt_id: 0);
@@ -315,30 +402,6 @@ static bool file_fill_column(struct proc *proc,
 		xasprintf(&str, "%c%c%c%c%c%c", r, w, x, D, L, m);
 		break;
 	}
-	case COL_POS:
-		xasprintf(&str, "%" PRIu64,
-			  (does_file_has_fdinfo_alike(file))? file->pos: 0);
-		break;
-	case COL_FLAGS: {
-		struct ul_buffer buf = UL_INIT_BUFFER;
-
-		if (!is_opened_file(file))
-			return true;
-
-		if (file->sys_flags == 0)
-			return true;
-
-		file_fill_flags_buf(&buf, file->sys_flags);
-		if (ul_buffer_is_empty(&buf))
-			return true;
-		str = ul_buffer_get_data(&buf, NULL, NULL);
-		break;
-	}
-	case COL_MAPLEN:
-		if (!is_mapped_file(file))
-			return true;
-		xasprintf(&str, "%ju", (uintmax_t)get_map_length(file));
-		break;
 	default:
 		return false;
 	}
@@ -499,10 +562,6 @@ static void file_class_initialize(void)
 	if (!pagesize)
 		pagesize = getpagesize();
 
-	username_cache = new_idcache();
-	if (!username_cache)
-		err(EXIT_FAILURE, _("failed to allocate UID cache"));
-
 	m = get_minor_for_sysvipc();
 	if (m)
 		add_nodev(m, "tmpfs");
@@ -512,16 +571,11 @@ static void file_class_initialize(void)
 		add_nodev(m, "mqueue");
 }
 
-static void file_class_finalize(void)
-{
-	free_idcache(username_cache);
-}
-
 const struct file_class file_class = {
-	.super = NULL,
+	.super = &abst_class,
 	.size = sizeof(struct file),
 	.initialize_class = file_class_initialize,
-	.finalize_class = file_class_finalize,
+	.finalize_class = NULL,
 	.fill_column = file_fill_column,
 	.handle_fdinfo = file_handle_fdinfo,
 	.free_content = file_free_content,

--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -226,6 +226,104 @@ const struct file_class abst_class = {
 };
 
 /*
+ * Error classes
+ */
+
+/* get_errno_name() --- the private replacement of strerrorname_np(3).
+ * Some platforms don't have strerrorname_np.
+ *
+ * Mainly copied from misc-utils/enosys.c.
+ */
+struct errno_s {
+	const char *const name;
+	long number;
+};
+
+static const struct errno_s errnos[] = {
+#define UL_ERRNO(name, nr) { name, nr },
+#include "errnos.h"
+#undef UL_ERRNO
+};
+
+static const char *get_errno_name(int ern)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(errnos); i ++) {
+		if (errnos[i].number == ern)
+			return errnos[i].name;
+	}
+	return NULL;
+}
+
+static bool error_fill_column(struct proc *proc __attribute__((__unused__)),
+			      struct file *file __attribute__((__unused__)),
+			      struct libscols_line *ln,
+			      int column_id,
+			      size_t column_index)
+{
+	char *str = NULL;
+	const char *ename;
+
+	switch(column_id) {
+	case COL_TYPE:
+		if (scols_line_set_data(ln, column_index, "ERROR"))
+			err(EXIT_FAILURE, _("failed to add output data"));
+		return true;
+	case COL_SOURCE:
+		ename = get_errno_name(file->error.number);
+		if (ename)
+			xasprintf(&str, "%s:%s",
+				  file->error.syscall, ename);
+		else
+			xasprintf(&str, "%s:unknown(%d)",
+				  file->error.syscall, file->error.number);
+		if (scols_line_refer_data(ln, column_index, str))
+			err(EXIT_FAILURE, _("failed to add output data"));
+		return true;
+	default:
+		return false;
+	}
+}
+
+static const struct file_class error_class = {
+	.super = &abst_class,
+	.size = sizeof(struct file),
+	.fill_column = error_fill_column,
+};
+
+static void init_error_content(struct file *file)
+{
+	file->is_error = 1;
+}
+
+static bool readlink_error_fill_column(struct proc *proc __attribute__((__unused__)),
+				       struct file *file __attribute__((__unused__)),
+				       struct libscols_line *ln __attribute__((__unused__)),
+				       int column_id,
+				       size_t column_index __attribute__((__unused__)))
+{
+	switch(column_id) {
+	case COL_NAME:
+	case COL_KNAME:
+		return true;
+	default:
+		return false;
+	}
+}
+
+const struct file_class readlink_error_class = {
+	.super = &error_class,
+	.size = sizeof(struct file),
+	.initialize_content = init_error_content,
+	.fill_column = readlink_error_fill_column,
+};
+
+const struct file_class stat_error_class = {
+	.super = &error_class,
+	.size = sizeof(struct file),
+	.initialize_content = init_error_content,
+};
+
+/*
  * Concrete file class
  */
 static const char *strftype(mode_t ftype)

--- a/misc-utils/lsfd-sock-xinfo.c
+++ b/misc-utils/lsfd-sock-xinfo.c
@@ -502,10 +502,10 @@ static bool unix_is_suitable_ipc(struct ipc *ipc, struct file *file)
  *
  * However, there is a case that we have no sock strcuct for the inode;
  * in the context we know only the sock inode.
- * For the case, unix_make_dumy_sock() provides the way to make a
+ * For the case, unix_make_dummy_sock() provides the way to make a
  * dummy sock struct for the inode.
  */
-static void unix_make_dumy_sock(struct sock *original, ino_t ino, struct sock *dummy)
+static void unix_make_dummy_sock(struct sock *original, ino_t ino, struct sock *dummy)
 {
 	*dummy = *original;
 	dummy->file.stat.st_ino = ino;
@@ -563,7 +563,7 @@ static struct ipc *unix_get_peer_ipc(struct unix_xinfo *ux,
 	if (!unix_ipc)
 		return NULL;
 
-	unix_make_dumy_sock(sock, unix_ipc->ipeer, &dummy_peer_sock);
+	unix_make_dummy_sock(sock, unix_ipc->ipeer, &dummy_peer_sock);
 	return get_ipc(&dummy_peer_sock.file);
 }
 

--- a/misc-utils/lsfd.1.adoc
+++ b/misc-utils/lsfd.1.adoc
@@ -463,6 +463,8 @@ socket system call:
 
 SOURCE <``string``>::
 File system, partition, or device containing the file.
+For the association having ERROR as the value for _TYPE_ coulumn, *lsfd*
+fills this column with _syscall_:_errno_.
 
 STTYPE <``string``>::
 Raw file types returned from *stat*(2): BLK, CHR, DIR, FIFO, LINK, REG, SOCK, or UNKN.
@@ -501,6 +503,9 @@ TYPE <``string``>::
 Cooked version of _STTYPE_. It is same as _STTYPE_ with exceptions.
 For _SOCK_, print the value for _SOCK.PROTONAME_.
 For _UNKN_, print the value for _AINODECLASS_ if _SOURCE_ is `anon_inodefs`.
++
+If *lsfd* gets an error when calling a syscall to know about a target
+file descriptor, *lsfd* fills this column for it with ERROR.
 
 UDP.LADDR <``string``>::
 Local IP address and local UDP port.

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -1909,6 +1909,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -C, --counter <name>:<expr>  define custom counter for --summary output\n"), out);
 	fputs(_("     --dump-counters          dump counter definitions\n"), out);
 	fputs(_("     --summary[=<when>]       print summary information (only, append, or never)\n"), out);
+	fputs(_("     --_drop-privilege        (testing purpose) do setuid(1) just after starting\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_(" -H, --list-columns           list the available columns\n"), out);
@@ -2253,6 +2254,7 @@ int main(int argc, char *argv[])
 		OPT_DEBUG_FILTER = CHAR_MAX + 1,
 		OPT_SUMMARY,
 		OPT_DUMP_COUNTERS,
+		OPT_DROP_PRIVILEGE,
 	};
 	static const struct option longopts[] = {
 		{ "noheadings", no_argument, NULL, 'n' },
@@ -2271,6 +2273,7 @@ int main(int argc, char *argv[])
 		{ "counter",    required_argument, NULL, 'C' },
 		{ "dump-counters",no_argument, NULL, OPT_DUMP_COUNTERS },
 		{ "list-columns",no_argument, NULL, 'H' },
+		{ "_drop-privilege",no_argument,NULL,OPT_DROP_PRIVILEGE },
 		{ NULL, 0, NULL, 0 },
 	};
 
@@ -2346,6 +2349,10 @@ int main(int argc, char *argv[])
 			break;
 		case OPT_DUMP_COUNTERS:
 			dump_counters = true;
+			break;
+		case OPT_DROP_PRIVILEGE:
+			if (setuid(1) == -1)
+				err(EXIT_FAILURE, _("failed to drop privilege"));
 			break;
 		case 'V':
 			print_version(EXIT_SUCCESS);

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -1304,6 +1304,7 @@ static void initialize_class(const struct file_class *class)
 
 static void initialize_classes(void)
 {
+	initialize_class(&abst_class);
 	initialize_class(&file_class);
 	initialize_class(&cdev_class);
 	initialize_class(&bdev_class);

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -926,9 +926,9 @@ static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
 
 	try_map_files:
 		snprintf(map_file, sizeof(map_file), "map_files/%"PRIx64"-%"PRIx64, start, end);
-		if (ul_path_stat(pc, &sb, 0, map_file) < 0)
-			return;
 		if (ul_path_readlink(pc, sym, sizeof(sym), map_file) < 0)
+			return;
+		if (ul_path_stat(pc, &sb, 0, map_file) < 0)
 			return;
 		f = new_file(proc, stat2class(&sb), &sb, sym, -assoc);
 	}

--- a/misc-utils/lsfd.h
+++ b/misc-utils/lsfd.h
@@ -185,10 +185,9 @@ struct file {
 	unsigned int sys_flags;
 	unsigned int mnt_id;
 
-	struct {
-		uint8_t read:1, write:1;
-	} locked;
-	uint8_t multiplexed;
+	uint8_t locked_read:1,
+		locked_write:1,
+		multiplexed:1;
 };
 
 #define is_opened_file(_f) ((_f)->association >= 0)

--- a/misc-utils/lsfd.h
+++ b/misc-utils/lsfd.h
@@ -211,7 +211,7 @@ struct file_class {
 	const struct ipc_class *(*get_ipc_class)(struct file *file);
 };
 
-extern const struct file_class file_class, cdev_class, bdev_class, sock_class, unkn_class, fifo_class,
+extern const struct file_class abst_class, file_class, cdev_class, bdev_class, sock_class, unkn_class, fifo_class,
 	nsfs_file_class, mqueue_file_class;
 
 /*

--- a/misc-utils/lsfd.h
+++ b/misc-utils/lsfd.h
@@ -174,7 +174,13 @@ struct file {
 	const struct file_class *class;
 	int association;
 	char *name;
-	struct stat stat;
+	union {
+		struct stat stat;
+		struct {
+			int number;
+			const char *syscall;
+		} error;
+	};
 	mode_t mode;
 	struct proc *proc;
 
@@ -187,7 +193,8 @@ struct file {
 
 	uint8_t locked_read:1,
 		locked_write:1,
-		multiplexed:1;
+		multiplexed:1,
+		is_error:1;
 };
 
 #define is_opened_file(_f) ((_f)->association >= 0)
@@ -211,7 +218,8 @@ struct file_class {
 	const struct ipc_class *(*get_ipc_class)(struct file *file);
 };
 
-extern const struct file_class abst_class, file_class, cdev_class, bdev_class, sock_class, unkn_class, fifo_class,
+extern const struct file_class abst_class, readlink_error_class, stat_error_class,
+	file_class, cdev_class, bdev_class, sock_class, unkn_class, fifo_class,
 	nsfs_file_class, mqueue_file_class;
 
 /*

--- a/tests/expected/lsfd/error-eaccess
+++ b/tests/expected/lsfd/error-eaccess
@@ -1,0 +1,2 @@
+0 exe ERROR readlink:EACCES
+UID,ASSOC,TYPE,SOURCE:  0

--- a/tests/expected/lsfd/error-eperm
+++ b/tests/expected/lsfd/error-eperm
@@ -1,0 +1,2 @@
+mem ERROR stat:EPERM
+ASSOC,TYPE,SOURCE:  0

--- a/tests/ts/lsfd/error-eaccess
+++ b/tests/ts/lsfd/error-eaccess
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="fd opening a file cannot be readlink(2)'ed"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+ts_skip_nonroot
+
+ts_check_test_command "$TS_CMD_LSFD"
+ts_check_test_command "$TS_HELPER_MKFDS"
+
+ts_cd "$TS_OUTDIR"
+
+PID=
+FD=3
+EXPR=
+
+{
+    coproc MKFDS { "$TS_HELPER_MKFDS" ro-regular-file "$FD"; }
+    if read -u ${MKFDS[0]} PID; then
+	EXPR='(ASSOC == "exe")'
+	${TS_CMD_LSFD} --_drop-privilege -p "$PID" -n -o UID,ASSOC,TYPE,SOURCE -Q "$EXPR"
+	echo "UID,ASSOC,TYPE,SOURCE: " $?
+	echo DONE >&"${MKFDS[1]}"
+    fi
+} > "$TS_OUTPUT" 2>&1
+wait "${MKFDS_PID}"
+
+ts_finalize

--- a/tests/ts/lsfd/error-eperm
+++ b/tests/ts/lsfd/error-eperm
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="fd opening a file cannot be stat(2)'ed"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_LSFD"
+ts_check_test_command "$TS_HELPER_MKFDS"
+ts_check_test_command "$TS_CMD_SETPRIV"
+
+ts_check_prog "chmod"
+ts_check_prog "dd"
+ts_check_prog "id"
+ts_check_prog "mkdir"
+ts_check_prog "rm"
+ts_check_prog "rmdir"
+
+ts_cd "$TS_OUTDIR"
+
+pid=$$
+DIR=d"$pid"
+FILE=${DIR}/f"$pid"
+
+if ! mkdir -p "$DIR"; then
+    ts_die "error in mkdir"
+fi
+
+if ! dd if=/dev/zero of="$FILE" bs=4096 count=1 status=none; then
+    rmdir "$DIR"
+    ts_die "error in dd"
+fi
+
+LAUNCHER=
+if [ "$(id -u)" = 0 ]; then
+    chown -R 1 $DIR
+    LAUNCHER="$TS_CMD_SETPRIV --reuid=1"
+    LSFD_XOPT="--_drop-privilege"
+fi
+
+PID=
+EXPR=
+
+{
+    coproc MKFDS { $LAUNCHER "$TS_HELPER_MKFDS" mmap file="$FILE"; }
+    if read -u ${MKFDS[0]} PID; then
+	chmod u-rwx "$DIR"
+
+	EXPR='(ASSOC == "mem") and (NAME =~ ".*/'"$FILE"'$")'
+	${TS_CMD_LSFD} ${LSFD_XOPT} -p "$PID" -n -o ASSOC,TYPE,SOURCE -Q "$EXPR"
+	echo "ASSOC,TYPE,SOURCE: " $?
+
+	chmod u+rwx "$DIR"
+	rm "$FILE"
+	rmdir "$DIR"
+
+	echo DONE >&"${MKFDS[1]}"
+    fi
+} > "$TS_OUTPUT" 2>&1
+wait "${MKFDS_PID}"
+
+ts_finalize

--- a/tools/Makemodule.am
+++ b/tools/Makemodule.am
@@ -58,4 +58,5 @@ EXTRA_DIST += \
 	tools/asciidoctor-includetracker.rb \
 	tools/asciidoctor-unicodeconverter.rb \
 	\
+	tools/all_errnos \
 	tools/all_syscalls

--- a/tools/all_errnos
+++ b/tools/all_errnos
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Derrived from all_syscalls.
+
+set -e
+
+OUTPUT=errnos.h
+ERRNO_INCLUDES="
+#include <sys/errno.h>
+"
+
+trap 'rm $OUTPUT $OUTPUT.deps' ERR
+
+"$@" -MD -MF "$OUTPUT.deps" <<< "$ERRNO_INCLUDES" -dM -E - \
+	| gawk 'match($0, /^#[ \t]*define[ \t]*E([^ ]+)/, res) { print "UL_ERRNO(\"E" res[1] "\", E" res[1] ")" }' \
+	| sort \
+	> "$OUTPUT"


### PR DESCRIPTION
This change may go to v2.41.


lsfd ignored file descriptors with that readlink(2) or
stat(2) returned errors.
    
With ERORR type, lsfd can print these file descriptors with incomplete
    information.
    
An example output:
    
       COMMAND        PID   USER ASSOC  XMODE  TYPE          SOURCE MNTID INODE NAME
       systemd      10677 yamato    31 ????-- ERROR readlink:EACCES
       slirp4netns 901147 yamato     7 ????-- ERROR     stat:EACCES             /home/yamato/.local/share/.../merged
    
The format of SOURCE column is SYSCALL:ERRNO.
