### PR TITLE
autotools: cleanup lastlog2 stuff

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -353,6 +353,7 @@ AC_CHECK_HEADERS([ \
 	paths.h \
 	pty.h \
 	security/pam_appl.h \
+	security/pam_modules.h \
 	shadow.h \
 	stdint.h \
 	stdio_ext.h \
@@ -390,7 +391,6 @@ AC_CHECK_HEADERS([ \
 	unistd.h \
 	utmp.h \
 	utmpx.h \
-	sqlite3.h \
 ])
 
 # There is a collision in old kernel-headers. The both files mount.h and fs.h
@@ -509,11 +509,11 @@ have_pty_h=$ac_cv_header_pty_h
 have_security_openpam_h=$ac_cv_header_security_openpam_h
 have_security_pam_appl_h=$ac_cv_header_security_pam_appl_h
 have_security_pam_misc_h=$ac_cv_header_security_pam_misc_h
+have_security_pam_modules_h=$ac_cv_header_security_pam_modules_h
 have_shadow_h=$ac_cv_header_shadow_h
 have_sys_signalfd_h=$ac_cv_header_sys_signalfd_h
 have_utmpx_h=$ac_cv_header_utmpx_h
 have_mntent_h=$ac_cv_header_mntent_h
-have_sqlite3_h=$ac_cv_header_sqlite3_h
 
 AS_CASE([$linux_os:$have_linux_version_h],
   [yes:no],
@@ -1225,26 +1225,33 @@ dnl liblastlog2
 dnl
 AC_ARG_ENABLE([liblastlog2],
   AS_HELP_STRING([--disable-liblastlog2], [do not build liblastlog2 and lastlog2 utilities]),
-  [enable_liblastlog2=no], [enable_liblastlog2=check]
+  [], [UL_DEFAULT_ENABLE([liblastlog2], [yes])]
 )
+UL_BUILD_INIT([liblastlog2])
+
+have_sqlite3=no
+AS_IF([test "x$build_liblastlog2" = xyes], [
+  PKG_CHECK_MODULES([SQLITE3], [sqlite3], [have_sqlite3=yes], [have_sqlite3=no])
+])
+UL_REQUIRES_HAVE([liblastlog2], [sqlite3], [sqlite3 library])
+AC_SUBST([SQLITE3_LIBS])
+
 AC_SUBST([LIBLASTLOG2_VERSION])
 AC_SUBST([LIBLASTLOG2_VERSION_INFO])
 AC_DEFINE_UNQUOTED([LIBLASTLOG2_VERSION], ["$LIBLASTLOG2_VERSION"], [liblastlog2 version string])
+AM_CONDITIONAL([BUILD_LIBLASTLOG2], [test "x$build_liblastlog2" = xyes])
+AM_CONDITIONAL([BUILD_LIBLASTLOG2_TESTS], [test "x$build_liblastlog2" = xyes && test "x$enable_static" = xyes])
 
-have_lastlog2=no
-AS_IF([test "x$enable_liblastlog2" != xno], [
-  AS_CASE([$enable_liblastlog2:$have_sqlite3_h],
-    [yes:no],
-       [AC_MSG_ERROR([lastlog2 selected but sqlite3.h not found])],
-    [check:no],
-       [AC_MSG_WARN([sqlite3.h not found, do not build with lastlog2 support])],
-    [*:yes],
-       [have_lastlog2=yes
-        AC_DEFINE(HAVE_LIBLASTLOG2, 1, [Define to 1 if you have the -llastlog2.])]
-  )
-])
-AM_CONDITIONAL([BUILD_LIBLASTLOG2], [test "x$have_lastlog2" = xyes])
-AM_CONDITIONAL([BUILD_LIBLASTLOG2_TESTS], [test "x$have_lastlog2" = xyes && test "x$enable_static" = xyes])
+
+AC_ARG_ENABLE([pam_lastlog2],
+  AS_HELP_STRING([--disable-pam-lastlog2], [do not build PAM lastlog2 module]),
+  [], [UL_DEFAULT_ENABLE([pam_lastlog2], [check])]
+)
+UL_BUILD_INIT([pam_lastlog2])
+UL_REQUIRES_BUILD([pam_lastlog2], [liblastlog2])
+UL_REQUIRES_HAVE([pam_lastlog2], [security_pam_modules_h], [pam_modules.h header file])
+AM_CONDITIONAL([BUILD_PAM_LASTLOG2], [test "x$build_pam_lastlog2" = xyes])
+
 
 dnl
 dnl libblkid
@@ -2986,7 +2993,7 @@ AC_MSG_RESULT([
         tmpfilesdir:               ${with_tmpfilesdir}
         libeconf support:          ${have_econf}
         Btrfs support:             ${have_btrfs}
-        lastlog2 support:          ${have_lastlog2}
+        lastlog2 support:          ${build_liblastlog2}
         Wide-char support:         ${build_widechar}
         libcryptsetup support:     ${have_cryptsetup}
 

--- a/liblastlog2/lastlog2.pc.in
+++ b/liblastlog2/lastlog2.pc.in
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@usrlib_execdir@
@@ -6,6 +8,6 @@ includedir=@includedir@
 Name: lastlog2
 Description: Y2038 safe version of lastlog
 Version: @LIBLASTLOG2_VERSION@
-Requires:
+Requires.private: sqlite3
 Cflags: -I${includedir}/lastlog2
 Libs: -L${libdir} -llastlog2

--- a/liblastlog2/src/Makemodule.am
+++ b/liblastlog2/src/Makemodule.am
@@ -1,5 +1,5 @@
 # includes
-lastlog2incdir = $(includedir)
+lastlog2incdir = $(includedir)/liblastlog2
 lastlog2inc_HEADERS = liblastlog2/src/lastlog2.h
 
 usrlib_exec_LTLIBRARIES += liblastlog2.la
@@ -11,18 +11,22 @@ liblastlog2_la_SOURCES = \
 EXTRA_liblastlog2_la_DEPENDENCIES = \
 	liblastlog2/src/liblastlog2.sym
 
+liblastlog2_la_LIBADD = $(SQLITE3_LIBS)
+
 liblastlog2_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	 $(SOLIB_CFLAGS) \
 	 -I$(ul_liblastlog2_incdir) \
-	 -Iliblastlog2/src
+	 -I$(top_srcdir)/liblastlog2/src
 
 liblastlog2_la_LDFLAGS = $(SOLIB_LDFLAGS)
 if HAVE_VSCRIPT
-liblastlog2_la_LDFLAGS += liblastlog2_la_LDFLAGS += $(VSCRIPT_LDFLAGS),$(top_srcdir)/liblastlog2/src/liblastlog2.sym
+liblastlog2_la_LDFLAGS += $(VSCRIPT_LDFLAGS),$(top_srcdir)/liblastlog2/src/liblastlog2.sym
 endif
-liblastlog2_la_LDFLAGS += -lsqlite3
 liblastlog2_la_LDFLAGS += -version-info $(LIBLASTLOG2_VERSION_INFO)
+
+EXTRA_DIST += liblastlog2/src/liblastlog2.sym
+
 
 if BUILD_LIBLASTLOG2_TESTS
 check_PROGRAMS += \
@@ -35,9 +39,8 @@ check_PROGRAMS += \
 	test_lastlog2_y2038_sqlite3_time
 
 lastlog2_tests_cflags  = -DTEST_PROGRAM $(liblastlog2_la_CFLAGS)
-lastlog2_tests_ldflags =
-lastlog2_tests_ldadd   = $(LDADD) liblastlog2.la
-lastlog2_tests_ldflags += -static -lsqlite3
+lastlog2_tests_ldflags = -static
+lastlog2_tests_ldadd   = $(LDADD) liblastlog2.la $(SOLIB_LDFLAGS) $(SQLITE3_LIBS)
 
 test_lastlog2_dlopen_SOURCES = liblastlog2/src/tests/tst_dlopen.c
 test_lastlog2_dlopen_CFLAGS = $(lastlog2_tests_cflags)
@@ -76,9 +79,6 @@ test_lastlog2_y2038_sqlite3_time_LDADD = $(lastlog2_tests_ldadd)
 
 endif #BUILD_LIBLIBLASTLOG2_TESTS
 
-
-
-EXTRA_DIST += liblastlog2/src/liblastlog2.sym
 
 # move lib from $(usrlib_execdir) to $(libdir) if needed
 install-exec-hook-liblastlog2:

--- a/pam_lastlog2/Makemodule.am
+++ b/pam_lastlog2/Makemodule.am
@@ -1,8 +1,8 @@
-if BUILD_LIBLASTLOG2
+if BUILD_PAM_LASTLOG2
 
 include pam_lastlog2/man/Makemodule.am
 include pam_lastlog2/src/Makemodule.am
 
 EXTRA_DIST     += pam_lastlog2/COPYING
 
-endif # BUILD_LIBLASTLOG2
+endif # BUILD_PAM_LASTLOG2


### PR DESCRIPTION
* use pkg-config (PKG_CHECK_MODULES) rather than check for sqlite3.h only
* define $SQLITE3_LIBS

* use UL_ macros in configure.ac for liblastlog2 and pam_lastlog2

* add --disable-pam-lastlog2

* check for PAM to define BUILD_PAM_LASTLOG2

* install lastlog2.h to $(includedir)/liblastlog2/lastlog2.h

* fix liblastlog2_la_LDFLAG

* add Requires.private to lastlog2.pc.in

* use $(SQLITE3_LIBS) rather than hardcoded -lsqlite3

Fixes: https://github.com/util-linux/util-linux/issues/2734

I'm not sure if something will also be necessary for meson. Probably possibility disable pam_lastlog2, this PR is autotools only ;-)