### PR TITLE
ci: use clang-18-rc1

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -30,8 +30,8 @@ jobs:
           # gcc-13 has false-positives with ubsan
           - { COMPILER: "gcc",   COMPILER_VERSION: "13", SANITIZE: "yes"  }
           - { COMPILER: "gcc",   COMPILER_VERSION: "13", SANITIZE: "no"   }
-          - { COMPILER: "clang", COMPILER_VERSION: "17", SANITIZE: "yes"  }
-          - { COMPILER: "clang", COMPILER_VERSION: "17", SANITIZE: "no"   }
+          - { COMPILER: "clang", COMPILER_VERSION: "18", SANITIZE: "yes"  }
+          - { COMPILER: "clang", COMPILER_VERSION: "18", SANITIZE: "no"   }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout


### PR DESCRIPTION
Before the 2.40 release we can futureproof the codebase.