### PR TITLE
meson: define _GNU_SOURCE when checking for SO_PASSCRED

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -783,6 +783,7 @@ have_sock_nonblock = cc.has_header_symbol(
   required : build_plymouth_support.enabled())
 have_so_passcred = cc.has_header_symbol(
   'sys/socket.h', 'SO_PASSCRED',
+  args : ['-D_GNU_SOURCE'],
   prefix : '#include <sys/types.h>',
   required : build_plymouth_support.enabled())
 


### PR DESCRIPTION
SO_PASSCRED is not exposed in standards mode that was enabled in commit 6240e4458cdf ("build: use -std=c99 and -std=c++11 by default").

Fixes: #2750