### PR TITLE
fstrim: add random delay to systemd timer

### DIFF
--- a/sys-utils/fstrim.timer
+++ b/sys-utils/fstrim.timer
@@ -7,6 +7,7 @@ ConditionPathExists=!/etc/initrd-release
 [Timer]
 OnCalendar=weekly
 AccuracySec=1h
+RandomizedDelaySec=1h
 Persistent=true
 RandomizedDelaySec=100min
 


### PR DESCRIPTION
The fstrim timer tends to fire simultaneously with other timers like updatedb. As fstrim is not time criticaly let's add a random delay of up to an hour.