### PR TITLE
lib/c_strtod: fix uselocale() fallback if strtod_l() is not available

### DIFF
--- a/lib/c_strtod.c
+++ b/lib/c_strtod.c
@@ -50,10 +50,10 @@ double c_strtod(char const *str, char **end)
 		return strtod_l(str, end, cl);
 #elif defined(HAVE_USELOCALE)
 	/*
-	 * B) classic strtod(), but switch to "C" locale by uselocal()
+	 * B) classic strtod(), but switch to "C" locale by uselocale()
 	 */
 	if (cl) {
-		locale_t org_cl = uselocale(locale);
+		locale_t org_cl = uselocale(cl);
 		if (!org_cl)
 			return 0;
 


### PR DESCRIPTION
Without this fix, compilation fails with:
```
../lib/c_strtod.c: In function ‘c_strtod’:
../lib/c_strtod.c:56:45: error: ‘locale’ undeclared (first use in this function); did you mean ‘c_locale’?
   56 |                 locale_t org_cl = uselocale(locale);
      |                                             ^~~~~~
      |                                             c_locale
../lib/c_strtod.c:56:45: note: each undeclared identifier is reported only once for each function it appears in
gmake[2]: *** [Makefile:11631: lib/libcommon_la-c_strtod.lo] Error 1
```