### PR TITLE
lsclocks: use correct clockid for cpu time

### DIFF
--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -506,6 +506,7 @@ static void add_cpu_clock(struct libscols_table *tb,
 		.type = CT_CPU,
 		.name = name,
 		.no_id = true,
+		.id = clockid,
 	};
 	add_posix_clock_line(tb, columns, ncolumns, &clockinfo);
 }


### PR DESCRIPTION
Fixes #2761