### PR TITLE
lsclocks: use clock id from clock_getcpuclockid in add_cpu_clock

### DIFF
--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -504,6 +504,7 @@ static void add_cpu_clock(struct libscols_table *tb,
 
 	struct clockinfo clockinfo = {
 		.type = CT_CPU,
+		.id = clockid,
 		.name = name,
 		.no_id = true,
 	};


### PR DESCRIPTION
Fixes #2761