### PR TITLE
[RFC] use unsigned chars

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ AM_CPPFLAGS += \
 	-include $(top_srcdir)/include/coverage.h
 endif
 
-AM_CFLAGS = -fsigned-char $(WARN_CFLAGS)
+AM_CFLAGS = -funsigned-char $(WARN_CFLAGS)
 AM_CXXFLAGS = $(AM_CFLAGS)
 AM_LDFLAGS = $(ASAN_LDFLAGS) $(UBSAN_LDFLAGS) $(FUZZING_ENGINE_LDFLAGS) $(COVERAGE_LDFLAGS)
 

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ bash_completion = dependency('bash-completion', required : get_option('build-bas
 
 vendordir = get_option('vendordir')
 
-add_project_arguments('-D_GNU_SOURCE', language : 'c')
+add_project_arguments('-D_GNU_SOURCE', '-funsigned-char', language : 'c')
 
 cc = meson.get_compiler('c')
 


### PR DESCRIPTION
This matches was the kernel does.
It also aligns meson with autotools.