### PR TITLE
meson: Only build libmount python module if python was found

### DIFF
--- a/libmount/python/meson.build
+++ b/libmount/python/meson.build
@@ -17,23 +17,23 @@ if LINUX
   pylibmount_sources += 'context.c'
 endif
 
-python.extension_module(
-  'pylibmount',
-  pylibmount_sources,
-  include_directories : [dir_include, dir_libmount],
-  subdir : 'libmount',
-  link_with : lib_mount,
-  dependencies : python.dependency(),
-  c_args : [
-    '-Wno-cast-function-type',
-
-    # https://github.com/util-linux/util-linux/issues/2366
-    python.language_version().version_compare('>=3.12') ?
-      [ '-Wno-error=redundant-decls' ] : [],
-  ],
-  install : true)
-
 if build_python
+  python.extension_module(
+    'pylibmount',
+    pylibmount_sources,
+    include_directories : [dir_include, dir_libmount],
+    subdir : 'libmount',
+    link_with : lib_mount,
+    dependencies : python.dependency(),
+    c_args : [
+      '-Wno-cast-function-type',
+
+      # https://github.com/util-linux/util-linux/issues/2366
+      python.language_version().version_compare('>=3.12') ?
+        [ '-Wno-error=redundant-decls' ] : [],
+    ],
+    install : true)
+
   python.install_sources(
     '__init__.py',
     subdir : 'libmount',


### PR DESCRIPTION
The extension_module call was in the wrong place.