### PR TITLE
lscpu: make sure scaling MHz% make sense

### DIFF
--- a/sys-utils/lscpu-topology.c
+++ b/sys-utils/lscpu-topology.c
@@ -574,6 +574,9 @@ static int read_mhz(struct lscpu_cxt *cxt, struct lscpu_cpu *cpu)
 	if (ul_path_readf_s32(sys, &mhz, "cpu%d/cpufreq/scaling_cur_freq", num) == 0)
 		cpu->mhz_cur_freq = (float) mhz / 1000;
 
+	if (cpu->mhz_cur_freq > cpu->mhz_max_freq)
+		cpu->mhz_cur_freq = cpu->mhz_max_freq;
+
 	if (cpu->type && (cpu->mhz_min_freq || cpu->mhz_max_freq))
 		cpu->type->has_freq = 1;
 

--- a/tests/expected/lscpu/lscpu-x86_64-epyc_7451
+++ b/tests/expected/lscpu/lscpu-x86_64-epyc_7451
@@ -11,7 +11,7 @@ Core(s) per socket:              24
 Socket(s):                       2
 Stepping:                        2
 Frequency boost:                 enabled
-CPU(s) scaling MHz:              126%
+CPU(s) scaling MHz:              100%
 CPU max MHz:                     2300.0000
 CPU min MHz:                     1200.0000
 BogoMIPS:                        4590.83


### PR DESCRIPTION
The dump from x86_64-epyc_7451 contains values where scaling_cur_freq is greater than cpuinfo_max_freq. The result is 126% use of the CPU in lscpu output. It seems like a kernel bug (the dump is pretty old).

$ cd tests/output/lscpu/dumps/x86_64-epyc_7451
$ cat /sys/devices/system/cpu/cpu0/cpufreq/{cpuinfo_max_freq,scaling_cur_freq,scaling_max_freq} 
2300000
2893313
2300000

We should not count on such values.