### PR TITLE
Save and restore errno on signal handlers

### DIFF
--- a/include/c.h
+++ b/include/c.h
@@ -595,4 +595,13 @@ static inline void *reallocarray(void *ptr, size_t nmemb, size_t size)
 }
 #endif
 
+static inline void ul_reset_errno(int *saved_errno) {
+        if (*saved_errno < 0)
+                return;
+
+        errno = *saved_errno;
+}
+
+#define UL_PROTECT_ERRNO __attribute__((__cleanup__(ul_reset_errno))) \
+                         __attribute__((__unused__)) int __ul_saved_errno = errno
 #endif /* UTIL_LINUX_C_H */

--- a/lib/pager.c
+++ b/lib/pager.c
@@ -173,6 +173,7 @@ static void wait_for_pager(void)
 
 static void wait_for_pager_signal(int signo)
 {
+	UL_PROTECT_ERRNO;
 	wait_for_pager();
 	raise(signo);
 }

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -1378,6 +1378,7 @@ static void to_be_called_atexit(void)
 */
 static void sighandler(int i)
 {
+	UL_PROTECT_ERRNO;
 	if (last_signal != SIGINT)
 		last_signal = i;
 	if (i == SIGINT)

--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -371,6 +371,7 @@ static void skip(int direction)
 /* Signal handler while reading from input file. */
 static void sighandler(int signum)
 {
+	UL_PROTECT_ERRNO;
 	if (canjump && (signum == SIGINT || signum == SIGQUIT))
 		longjmp(jmpenv, signum);
 	tcsetattr(STDOUT_FILENO, TCSADRAIN, &otio);


### PR DESCRIPTION
"Fetching and setting the value of errno is async-signal-safe provided that the signal handler saves errno on entry and
       restores its value before returning."

save and restore errno on cases where it is needed.