### PR TITLE
docs: remove duplicated author name in namei.1.adoc

### DIFF
--- a/misc-utils/namei.1.adoc
+++ b/misc-utils/namei.1.adoc
@@ -70,7 +70,7 @@ To be discovered.
 
 The original *namei* program was written by mailto:rogers@amadeus.wr.tek.com[Roger Southwick].
 
-The program was rewritten by Karel Zak mailto:kzak@redhat.com[Karel Zak].
+The program was rewritten by mailto:kzak@redhat.com[Karel Zak].
 
 == SEE ALSO
 


### PR DESCRIPTION
This was being rendered in the man page as:

    The program was rewritten by Karel Zak Karel Zak <kzak@redhat.com>.

Instead of as:

    The program was rewritten by Karel Zak <kzak@redhat.com>.