### PR TITLE
lastlog2: Don't print space if Service column is not printed

### DIFF
--- a/misc-utils/lastlog2.c
+++ b/misc-utils/lastlog2.c
@@ -90,7 +90,8 @@ print_entry(const char *user, int64_t ll_time,
 	}
 	printf("%-16s %-8.8s %*s %s%*s%s\n", user, tty ? tty : "",
 	       -maxIPv6Addrlen, rhost ? rhost : "", datep,
-	       sflg?31-(int)strlen(datep):0, " ", sflg?(pam_service?pam_service:""):"");
+	       sflg?31-(int)strlen(datep):0, (sflg&&pam_service)?" ":"",
+	       sflg?(pam_service?pam_service:""):"");
 
 	if (error)
 		printf("\nError: %s\n", error);


### PR DESCRIPTION
This replicates the behavior of lastlog. Having extra space at the end of the line can trip up some parsers.