### PR TITLE
Adding Neoverse-V3/-N3 ARM cores

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -93,6 +93,8 @@ static const struct id_part arm_part[] = {
     { 0xd80, "Cortex-A520" },
     { 0xd81, "Cortex-A720" },
     { 0xd82, "Cortex-X4" },
+    { 0xd84, "Neoverse-V3" },
+    { 0xd8e, "Neoverse-N3" },
     { -1, "unknown" },
 };
 


### PR DESCRIPTION
References: 

  * [Neoverse-V3](https://developer.arm.com/documentation/107734/0001/AArch64-registers/AArch64-Identification-registers-summary/MIDR-EL1--Main-ID-Register)
  * [Neoverse-N3](https://developer.arm.com/documentation/107997/0000/AArch64-registers/AArch64-Identification-registers-summary/MIDR-EL1--Main-ID-Register)