### PR TITLE
libmount: report kernel message from new API

### DIFF
--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -314,6 +314,8 @@ int mnt_context_reset_status(struct libmnt_context *cxt)
 	if (!cxt)
 		return -EINVAL;
 
+	reset_syscall_status(cxt);
+
 	cxt->syscall_status = 1;		/* means not called yet */
 	cxt->helper_exec_status = 1;
 	cxt->helper_status = 0;

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1571,6 +1571,13 @@ int mnt_context_get_mount_excode(
 	 */
 	syserr = mnt_context_get_syscall_errno(cxt);
 
+	if (buf && cxt->syscall_errmsg) {
+		snprintf(buf, bufsz, _("%s system call failed: %s"),
+					cxt->syscall_name ? : "mount",
+					cxt->syscall_errmsg);
+		return MNT_EX_FAIL;
+	}
+
 	switch(syserr) {
 	case EPERM:
 		if (!buf)

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -432,6 +432,7 @@ struct libmnt_context
 
 	int	syscall_status;	/* 1: not called yet, 0: success, <0: -errno */
 	const char *syscall_name;	/* failed syscall name */
+	char	*syscall_errmsg;	/* message from kernel */
 
 	struct libmnt_ns	ns_orig;	/* original namespace */
 	struct libmnt_ns	ns_tgt;		/* target namespace */
@@ -496,6 +497,9 @@ static inline void reset_syscall_status(struct libmnt_context *cxt)
 	DBG(CXT, ul_debug("reset syscall status"));
 	cxt->syscall_status = 0;
 	cxt->syscall_name = NULL;
+
+	free(cxt->syscall_errmsg);
+	cxt->syscall_errmsg = NULL;
 }
 
 /* optmap.c */


### PR DESCRIPTION
This is a very minimalistic implementation for v2.40 designed to print error messages from the kernel. It exclusively displays errors, and the patch does not introduce any new library interface for this purpose. Instead, it simply replaces hardcoded messages within libmount with kernel messages.

It's worth noting that the final implementation will necessitate per-hook error handling in libmount and likely a new library API to access other types of messages (warnings, notices, etc.).
