### PR TITLE
meson: avoid future-deprecated feature

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -222,8 +222,8 @@ option('vendordir',
 option('pamlibdir', type : 'string',
        description : 'directory for PAM modules')
 option('lastlog-compat-symlink', type : 'boolean',
-       value : 'false',
+       value : false,
        description : 'create lastlog compat symlink')
 option('login-lastlogin', type : 'boolean',
-       value : 'false',
+       value : false,
        description : 'program login writes lastlog entries')


### PR DESCRIPTION
Avoid the following message from meson:

  NOTICE: Future-deprecated features used:
   * 1.1.0: {'"boolean option" keyword argument "value" of type str'}