### PR TITLE
tmpfiles: add and install for uuidd, generate /run/uuidd & /var/lib/l…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,7 @@ bin_PROGRAMS =
 sbin_PROGRAMS =
 dist_usrbin_exec_SCRIPTS =
 systemdsystemunit_DATA =
+tmpfiles_DATA =
 dist_bashcompletion_DATA =
 check_PROGRAMS =
 dist_check_SCRIPTS =

--- a/misc-utils/.gitignore
+++ b/misc-utils/.gitignore
@@ -3,3 +3,4 @@ uuidd.8
 uuidd.rc
 uuidd.service
 uuidd.socket
+uuidd-tmpfiles.conf

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -128,6 +128,7 @@ uuidd_SOURCES = misc-utils/uuidd.c lib/monotonic.c lib/timer.c
 if HAVE_SYSTEMD
 uuidd_LDADD += $(SYSTEMD_LIBS) $(SYSTEMD_DAEMON_LIBS)
 uuidd_CFLAGS += $(SYSTEMD_CFLAGS) $(SYSTEMD_DAEMON_CFLAGS)
+tmpfiles_DATA += misc-utils/uuidd-tmpfiles.conf
 systemdsystemunit_DATA += \
 	misc-utils/uuidd.service \
 	misc-utils/uuidd.socket
@@ -142,7 +143,8 @@ endif # BUILD_UUIDD
 PATHFILES += \
 	misc-utils/uuidd.rc \
 	misc-utils/uuidd.service \
-	misc-utils/uuidd.socket
+	misc-utils/uuidd.socket \
+	misc-utils/uuidd-tmpfiles.conf
 
 if BUILD_BLKID
 sbin_PROGRAMS += blkid

--- a/misc-utils/meson.build
+++ b/misc-utils/meson.build
@@ -76,6 +76,14 @@ test_uuidd_sources = files(
 )
 
 if build_uuidd and systemd.found()
+  uuidd_tmpfiles = configure_file(
+    input : 'uuidd-tmpfiles.conf.in',
+    output : 'uuidd-tmpfiles.conf',
+    configuration : conf)
+  install_data(
+    uuidd_tmpfiles,
+    install_dir : '/usr/lib/tmpfiles.d')
+
   uuidd_service = configure_file(
     input : 'uuidd.service.in',
     output : 'uuidd.service',

--- a/misc-utils/uuidd-tmpfiles.conf.in
+++ b/misc-utils/uuidd-tmpfiles.conf.in
@@ -1,0 +1,6 @@
+# This file is part of uuidd.
+#
+# See tmpfiles.d(5) for details
+#
+d @runstatedir@/uuidd 2775 uuidd uuidd -
+d /var/lib/libuuid 0755 uuidd uuidd -


### PR DESCRIPTION
…ibuuid

These directories are requird for uuidd, so let systemd-tmpfiles create them.

Signed-off-by: Christian Hesse <mail@eworm.de>
(cherry picked from commit 2b7410544c90f56fbb9abca999ed48feffbe31ef)