### PR TITLE
Fixed report return code in blockdev.

### DIFF
--- a/disk-utils/blockdev.8.adoc
+++ b/disk-utils/blockdev.8.adoc
@@ -97,7 +97,7 @@ Print logical sector size in bytes - usually 512.
 Get size in 512-byte sectors.
 
 *--rereadpt*::
-Reread partition table
+Reread partition table.
 
 *--setbsz* _bytes_::
 Set blocksize. Note that the block size is specific to the current file descriptor opening the block device, so the change of block size only persists for as long as *blockdev* has the device open, and is lost once *blockdev* exits.


### PR DESCRIPTION
If you execute the command
blockdev --report /dev/noexist
we get an error "blockdev: cannot open /dev/noexist: No such file or directory".
But the return code (echo $?) is 0.
I suggest to return 1 if we get an error in the report.