### PR TITLE
lib/pty-session: Don't ignore SIGHUP.

### DIFF
--- a/lib/pty-session.c
+++ b/lib/pty-session.c
@@ -241,6 +241,7 @@ int ul_pty_signals_setup(struct ul_pty *pty)
 	sigaddset(&ourset, SIGCHLD);
 	sigaddset(&ourset, SIGWINCH);
 	sigaddset(&ourset, SIGALRM);
+	sigaddset(&ourset, SIGHUP);
 	sigaddset(&ourset, SIGTERM);
 	sigaddset(&ourset, SIGINT);
 	sigaddset(&ourset, SIGQUIT);
@@ -584,6 +585,8 @@ static int handle_signal(struct ul_pty *pty, int fd)
 							&info, (void *) &pty->win);
 		}
 		break;
+	case SIGHUP:
+		/* fallthrough */
 	case SIGTERM:
 		/* fallthrough */
 	case SIGINT:


### PR DESCRIPTION
The blamed commit converted script to use the generic pty code that was added by commit 6954895cae34 ("lib/pty-session: add generic PTY container code").

Commit ec10634e7ec4 says the new pty stuff is based on script. However, there is difference in signal handling.

Before the commit, only the signals that the script was interested in were blocked and handled by signalfd.

After the commit, all signals are blocked and only the interested signals are handled.

This causes regression in the following scenario:

  1. run `script` via /etc/profile.d for ssh session
  2. login to a ssh session using bash
  3. run `sudo -i`
  4. wait until ssh session timeout

After 3., the process tree will be like this.
```
  $ pstree -p | grep script
  |-sshd(2652)-sshd(637993)---sshd(637996)---bash(637997)---script(638028)---bash(638029)---sudo(638057)---sudo(638059)-+
```

The notable thing here is that script is in the parent's process group (637997).
```
  $ ps -eo pid,pgid,ppid,stat,sig,comm | grep script
  638028  637997  637997 S+   0000000000000000 script
```

Thus, the parent bash will send SIGHUP to script, when the timeout occurs at 4.
```
  $ sudo /usr/share/bcc/tools/killsnoop
  TIME      PID      COMM             SIG  TPID     RESULT
  18:46:57  637997   bash             1    637997   0

  $ ps -eo pid,pgid,ppid,stat,sig,comm | grep script
  638028  637997       1 S    0000000000020001 script
```

However, this is not handled, so the script is reaped but remains forever.
```
  $ pstree -p | grep script
  |-script(638028)---bash(638029)
```

To avoid such a situation, we need to handle SIGHUP in script.

With this patch, script will receive SIGHUP from the parrent and kill its child processes.

```
  $ pstree -p | grep script
  |-sshd(2652)-sshd(638400)---sshd(638404)---bash(638405)---script(638436)---bash(638437)---sudo(638465)---sudo(638467)-+

  $ sudo /usr/share/bcc/tools/killsnoop
  TIME      PID      COMM             SIG  TPID     RESULT
  18:50:11  638405   bash             1    638405   0
  18:50:11  638436   script           15   638437   0
  18:50:11  638436   script           15   638437   0
  18:50:13  638436   script           9    638437   0
```

Fixes: ec10634e7ec4 ("script: use lib/pty-session")
Reported-by: Ayame Suzuki <ayameszk@amazon.co.jp>