### PR TITLE
Draft: Add coreset utility to manage core scheduling cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ ylwrap
 /colcrt
 /colrm
 /column
+/coreset
 /ctrlaltdel
 /delpart
 /dmesg

--- a/configure.ac
+++ b/configure.ac
@@ -2500,9 +2500,9 @@ UL_REQUIRES_HAVE([setterm], [ncursesw, ncurses], [ncursesw or ncurses library])
 AM_CONDITIONAL([BUILD_SETTERM], [test "x$build_setterm" = xyes])
 
 # build_schedutils= is just configure-only variable to control
-# ionice, taskset and chrt
+# ionice, taskset, coreset, uclampset and chrt
 AC_ARG_ENABLE([schedutils],
-  AS_HELP_STRING([--disable-schedutils], [do not build chrt, ionice, taskset]),
+  AS_HELP_STRING([--disable-schedutils], [do not build chrt, ionice, taskset, uclampset, coreset]),
   [], [UL_DEFAULT_ENABLE([schedutils], [check])]
 )
 
@@ -2564,6 +2564,11 @@ UL_REQUIRES_SYSCALL_CHECK([uclampset],
 	[UL_CHECK_SYSCALL([sched_setattr])], [sched_setattr])
 AM_CONDITIONAL([BUILD_UCLAMPSET], [test "x$build_uclampset" = xyes])
 
+UL_ENABLE_ALIAS([coreset], [schedutils])
+UL_BUILD_INIT([coreset])
+UL_REQUIRES_SYSCALL_CHECK([coreset],
+	[UL_CHECK_SYSCALL([prctl])], [prct])
+AM_CONDITIONAL([BUILD_CORESET], [test "x$build_coreset" = xyes])
 
 AC_ARG_ENABLE([wall],
   AS_HELP_STRING([--disable-wall], [do not build wall]),

--- a/meson.build
+++ b/meson.build
@@ -3107,8 +3107,17 @@ exe4 = executable(
   install : opt,
   build_by_default : opt)
 
+exe5 = executable(
+  'coreset',
+  'schedutils/coreset.c',
+  include_directories : includes,
+  link_with : lib_common,
+  install_dir : usrbin_exec_dir,
+  install : opt,
+  build_by_default : opt)
+
 if opt and not is_disabler(exe)
-  exes += [exe, exe2, exe3, exe4]
+  exes += [exe, exe2, exe3, exe4, exe5]
   manadocs += ['schedutils/chrt.1.adoc',
                'schedutils/ionice.1.adoc',
                'schedutils/taskset.1.adoc',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -162,7 +162,7 @@ option('build-pipesz', type : 'feature',
 option('build-setterm', type : 'feature',
        description : 'build setterm')
 option('build-schedutils', type : 'feature',
-       description : 'build chrt, ionice, taskset')
+       description : 'build chrt, ionice, taskset, uclampset, coreset')
 option('build-wall', type : 'feature',
        description : 'build wall')
 option('build-write', type : 'feature',

--- a/schedutils/Makemodule.am
+++ b/schedutils/Makemodule.am
@@ -32,8 +32,8 @@ endif
 
 if BUILD_CORESET
 usrbin_exec_PROGRAMS += coreset
-MANPAGES += schedutils/coreset.1
-dist_noinst_DATA += schedutils/coreset.1.adoc
+#MANPAGES += schedutils/coreset.1
+#dist_noinst_DATA += schedutils/coreset.1.adoc
 coreset_SOURCES = schedutils/coreset.c
 coreset_LDADD = $(LDADD) libcommon.la
 endif

--- a/schedutils/Makemodule.am
+++ b/schedutils/Makemodule.am
@@ -29,3 +29,11 @@ dist_noinst_DATA += schedutils/uclampset.1.adoc
 uclampset_SOURCES = schedutils/uclampset.c schedutils/sched_attr.h
 uclampset_LDADD = $(LDADD) libcommon.la
 endif
+
+if BUILD_CORESET
+usrbin_exec_PROGRAMS += coreset
+MANPAGES += schedutils/coreset.1
+dist_noinst_DATA += schedutils/coreset.1.adoc
+coreset_SOURCES = schedutils/coreset.c
+coreset_LDADD = $(LDADD) libcommon.la
+endif

--- a/schedutils/coreset.c
+++ b/schedutils/coreset.c
@@ -58,12 +58,14 @@ enum cmd_type {
 	CORE_CREATE,  /* PR_SCHED_CORE_CREATE */
 	CORE_PUSH,    /* PR_SCHED_CORE_SHARE_TO */
 	CORE_COPY,    /* PR_SCHED_CORE_SHARE_FROM */
+	CORE_COPYPUSH, /* SHARE_FROM and then SHARE_TO */
 };
 
 struct coreset {
 	pid_t		pid;		/* task PID (or tid) */
 	unsigned long   cookie;         /* storage for current cookie */
 	int             cmd;            /* what to do: one of cmd_type */
+	pid_t           dest;           /* only valid for COPYPUSH */
 	int             scope;          /* one of PR_SCHED_CORE_SCOPE_THREAD(0), PR_SCHED_CORE_SCOPE_THREAD_GROUP(1)
                                          * or PR_SCHED_CORE_SCOPE_PROCESS_GROUP  (2)
                                          */
@@ -82,11 +84,12 @@ static void __attribute__((__noreturn__)) usage(void)
 
 	fprintf(out, _(
 		"Options:\n"
-		" -c, --copy              coply the cookie from give pid to this cmd\n"
+		" -c, --copy              copy the cookie from give pid to this cmd (or dest pid)\n"
 		" -n, --new               create new cookie on pid or cmd\n"
 		" -t, --to                copy current task's cookie to existing pid or cmd\n"
 		" Absence of one of the mutually exclusive above options just reports current cookie on given pid (or cmd)\n"
 		" -p, --pid               operate on existing given pid/tid\n"
+		" -d, --dest              Use with -c, copy cookie from pid to dest_pid\n"
 		" -s, --scope             0, 1 or 2: apply change to task (0), thread group (1) or process group (2) of given pid/tid\n"
                 " Default scope is 0. Scope is ignored in some cases where it does not have an effect\n"
 		));
@@ -103,6 +106,8 @@ static void __attribute__((__noreturn__)) usage(void)
                 "    %1$s -s 1 -n -p 700\n"
 		"Copy cookie from existing task to new task:\n"
 		"    %1$s -c -p 700  sshd -b 1024\n"
+		"Copy cookie from existing task to a different existing task:\n"
+		"    %1$s -c -p 700 -d 12345\n"
 		"Clear cookie for all processes for given task (assuming current shell has no cookie):\n"
 		"    %1$s -s 2 -t -p 700\n"
 		"Note: pid can also be a tid as retrieved with the gettid(2) syscall.\n"),
@@ -118,11 +123,18 @@ static void __attribute__((__noreturn__)) usage(void)
 static void print_cookie(struct coreset *cs, int isnew)
 {
 	char *msg;
+	pid_t pid;
+	if (cs->cmd == CORE_COPY || !cs->pid)
+                pid = getpid(); /* with copy we want to report current's cookie */
+        else if (cs->cmd == CORE_COPYPUSH)
+                pid = cs->dest; /* with copypush we are changing dest's cookie */
+        else
+                pid = cs->pid;
 
 	msg = isnew ? _("pid %d's new cookie: 0x%0x\n") :
 		_("pid %d's current cookie: 0x%0x\n");
 
-	printf(msg, cs->pid ? cs->pid : getpid(), cs->cookie);
+	printf(msg, pid, cs->cookie);
 }
 
 static void __attribute__((__noreturn__)) err_cookie(pid_t pid, int set)
@@ -141,7 +153,13 @@ static void __attribute__((__noreturn__)) err_cookie(pid_t pid, int set)
 static unsigned long get_cookie(struct coreset *cs)
 {
 	unsigned long cookie;
-	pid_t pid = (cs->cmd == CORE_COPY ? 0: cs->pid); /* with copy we want to report current's cookie */
+	pid_t pid;
+	if (cs->cmd == CORE_COPY)
+		pid = 0; /* with copy we want to report current's cookie */
+	else if (cs->cmd == CORE_COPYPUSH)
+		pid = cs->dest; /* with copypush we are changing dest's cookie */
+	else 
+		pid = cs->pid; 
 
 	if (prctl(PR_SCHED_CORE, PR_SCHED_CORE_GET, pid, PR_SCHED_CORE_SCOPE_THREAD, &cookie) < 0 )
 		err_cookie(pid ? pid : getpid(), FALSE);
@@ -173,6 +191,13 @@ static void do_coreset(struct coreset *cs)
 		if (prctl(PR_SCHED_CORE, PR_SCHED_CORE_SHARE_TO, cs->pid, cs->scope, NULL) < 0)
 			err_cookie(cs->pid, cs->cmd);
 		break;
+	case CORE_COPYPUSH:
+		/* copy pid's cookie here then push it to dest */
+		if (prctl(PR_SCHED_CORE, PR_SCHED_CORE_SHARE_FROM, cs->pid, PR_SCHED_CORE_SCOPE_THREAD, NULL) < 0)
+                        err_cookie(cs->pid, cs->cmd);
+		if (prctl(PR_SCHED_CORE, PR_SCHED_CORE_SHARE_TO, cs->dest, cs->scope, NULL) < 0)
+                        err_cookie(cs->pid, cs->cmd);
+
 	}
 
 	/* re-read the cookie */
@@ -182,19 +207,20 @@ static void do_coreset(struct coreset *cs)
 
 int main(int argc, char **argv)
 {
-	pid_t pid = 0;
+	pid_t pid = 0, dest_pid = 0;
 	int c, copy = 0, create = 0, push = 0;
 	int do_exec = 0;
 	struct coreset cs;
 
 	static const struct option longopts[] = {
-		{ "copy",	0, NULL, 'c' },
-		{ "new",	0, NULL, 'n' },
-		{ "pid",	1, NULL, 'p' },
-		{ "scope",	1, NULL, 's' },
-		{ "to",	        0, NULL, 't' },
-		{ "help",	0, NULL, 'h' },
-		{ "version",	0, NULL, 'V' },
+		{ "copy",	no_argument, NULL, 'c' },
+		{ "dest",	required_argument, NULL, 'd' },
+		{ "new",	no_argument, NULL, 'n' },
+		{ "pid",	required_argument, NULL, 'p' },
+		{ "scope",	required_argument, NULL, 's' },
+		{ "to",	        no_argument, NULL, 't' },
+		{ "help",	no_argument, NULL, 'h' },
+		{ "version",	no_argument, NULL, 'V' },
 		{ NULL,		0, NULL,  0  }
 	};
 	static const ul_excl_t excl[] = {       /* rows and cols in ASCII order */
@@ -210,11 +236,14 @@ int main(int argc, char **argv)
 
 	memset(&cs, 0, sizeof(cs));
 
-	while ((c = getopt_long(argc, argv, "+cnp:s:thV", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "cd:np:s:thV", longopts, NULL)) != -1) {
                 err_exclusive_options(c, longopts, excl, excl_st);
 		switch (c) {
 		case 'c':
 			copy = 1;
+			break;
+		case 'd':
+			dest_pid = strtopid_or_err(optarg, _("invalid copy dest PID argument"));
 			break;
 		case 'n':
 		        create = 1;
@@ -237,14 +266,20 @@ int main(int argc, char **argv)
 		}
 	}
 
-	// pid and no command is okay. No pid and no command is not.  Copy and no command is not okay.
+	// pid and no command is okay. No pid and no command is not.  Copy and no command is okay if dest_pid.
 	// push and no command is okay. copy and push require pid
-	if (((!pid || copy) && argc - optind < 1) || ((copy || push) && !pid)) {
+	if (((!pid || (copy && !dest_pid)) && argc - optind < 1) || ((copy || push) && !pid)) {
 		warnx(_("bad usage"));
 		errtryhelp(EXIT_FAILURE);
 	}
 
-        /* scope must be one of PR_SCHED_CORE_SCOPE_*  */
+	/* ensure we have dest pid only with copy operation */
+	if (dest_pid && !copy) {
+		warnx(_("Dest pid can only be used with copy"));
+		errtryhelp(EXIT_FAILURE);
+	}
+        
+	/* scope must be one of PR_SCHED_CORE_SCOPE_*  */
 	if (cs.scope < PR_SCHED_CORE_SCOPE_THREAD || cs.scope > PR_SCHED_CORE_SCOPE_PROCESS_GROUP) {
 		warnx(_("invalid scope"));
 		errtryhelp(EXIT_FAILURE);
@@ -255,15 +290,19 @@ int main(int argc, char **argv)
 
 	if (create)
 		cs.cmd = CORE_CREATE;
-	else if (copy)
+	else if (dest_pid) {
+		cs.cmd = CORE_COPYPUSH;
+		cs.dest = dest_pid;
+	} else if (copy)
 		cs.cmd = CORE_COPY;
 	else if (push)
 		cs.cmd = CORE_PUSH;
-	else cs.cmd = CORE_SHOW;
+	else
+		cs.cmd = CORE_SHOW;
 
 	/* create and show with a pid don't use the command */
-	if (pid && do_exec && (cs.cmd == CORE_SHOW || cs.cmd == CORE_CREATE)) {
-		warnx(_("Ingoring extraneous input"));
+	if ((pid  || dest_pid) && do_exec && (cs.cmd == CORE_SHOW || cs.cmd == CORE_CREATE)) {
+		warnx(_("Ignoring extraneous input"));
 		do_exec = 0;
 	}
 

--- a/schedutils/coreset.c
+++ b/schedutils/coreset.c
@@ -1,0 +1,287 @@
+/*
+ * coreset.c - set or retrieve a task's core scheduling cookie
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Copyright (C) 2024 Phil Auld <pauld@redhat.com>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <errno.h>
+#include <sched.h>
+#include <stddef.h>
+#include <sys/prctl.h>
+
+#include "strutils.h"
+#include "c.h"
+#include "closestream.h"
+
+// These are in prctl.h on systems new enough. My dev system isn't
+// should check for this in .configure step and not build
+// this?
+
+#ifndef PR_SCHED_CORE
+/* Request the scheduler to share a core */
+# define PR_SCHED_CORE                   62
+#  define PR_SCHED_CORE_GET              0
+#  define PR_SCHED_CORE_CREATE           1 /* create unique core_sched cookie */
+#  define PR_SCHED_CORE_SHARE_TO         2 /* push core_sched cookie to pid */
+#  define PR_SCHED_CORE_SHARE_FROM       3 /* pull core_sched cookie to pid */
+#  define PR_SCHED_CORE_MAX              4
+#endif
+
+/* some prctl.h have the above but not these */
+#ifndef PR_SCHED_CORE_SCOPE_THREAD
+# define PR_SCHED_CORE_SCOPE_THREAD             0  /* PIDTYPE_PID  */
+# define PR_SCHED_CORE_SCOPE_THREAD_GROUP       1  /* PIDTYPE_TGID */
+# define PR_SCHED_CORE_SCOPE_PROCESS_GROUP      2  /* PIDTYPE_PGID */
+#endif
+
+/* basic operation to perform */
+enum cmd_type {
+	CORE_SHOW,    /* this just does PR_SCHED_CORE_GET */
+	CORE_CREATE,  /* PR_SCHED_CORE_CREATE */
+	CORE_PUSH,    /* PR_SCHED_CORE_SHARE_TO */
+	CORE_COPY,    /* PR_SCHED_CORE_SHARE_FROM */
+};
+
+struct coreset {
+	pid_t		pid;		/* task PID (or tid) */
+	unsigned long   cookie;         /* storage for current cookie */
+	int             cmd;            /* what to do: one of cmd_type */
+	int             scope;          /* one of PR_SCHED_CORE_SCOPE_THREAD(0), PR_SCHED_CORE_SCOPE_THREAD_GROUP(1)
+                                         * or PR_SCHED_CORE_SCOPE_PROCESS_GROUP  (2)
+                                         */
+};
+
+static void __attribute__((__noreturn__)) usage(void)
+{
+	FILE *out = stdout;
+	fprintf(out,
+		_("Usage: %s [options] [-p pid] [cmd [args...]]\n\n"),
+		program_invocation_short_name);
+
+	fputs(USAGE_SEPARATOR, out);
+	fputs(_("Show or change the core scheduling cookie for a process or thread.\n"), out);
+	fputs(USAGE_SEPARATOR, out);
+
+	fprintf(out, _(
+		"Options:\n"
+		" -c, --copy              coply the cookie from give pid to this cmd\n"
+		" -n, --new               create new cookie on pid or cmd\n"
+		" -t, --to                copy current task's cookie to existing pid or cmd\n"
+		" Absence of one of the mutually exclusive above options just reports current cookie on given pid (or cmd)\n"
+		" -p, --pid               operate on existing given pid/tid\n"
+		" -s, --scope             0, 1 or 2: apply change to task (0), thread group (1) or process group (2) of given pid/tid\n"
+                " Default scope is 0. Scope is ignored in some cases where it does not have an effect\n"
+		));
+	fprintf(out, USAGE_HELP_OPTIONS(25));
+
+	fputs(USAGE_SEPARATOR, out);
+	fprintf(out, _(
+		"The default behavior is to show existing cookie (which is of limited value):\n"
+		"    %1$s sshd -b 1024\n"
+		"    %1$s -p 700\n"
+		"Create a new cookie for existing task:\n"
+		"    %1$s -n -p 700\n"
+		"or task and all its sibling threads:\n"
+                "    %1$s -s 1 -n -p 700\n"
+		"Copy cookie from existing task to new task:\n"
+		"    %1$s -c -p 700  sshd -b 1024\n"
+		"Clear cookie for all processes for given task (assuming current shell has no cookie):\n"
+		"    %1$s -s 2 -t -p 700\n"
+		"Note: pid can also be a tid as retrieved with the gettid(2) syscall.\n"),
+		program_invocation_short_name);
+
+	fputs(USAGE_SEPARATOR, out);
+	fprintf(out, _("Core scheduling is available in kernels starting with v5.14.\n"));
+
+	fprintf(out, USAGE_MAN_TAIL("coreset(1)"));
+	exit(EXIT_SUCCESS);
+}
+
+static void print_cookie(struct coreset *cs, int isnew)
+{
+	char *msg;
+
+	msg = isnew ? _("pid %d's new cookie: 0x%0x\n") :
+		_("pid %d's current cookie: 0x%0x\n");
+
+	printf(msg, cs->pid ? cs->pid : getpid(), cs->cookie);
+}
+
+static void __attribute__((__noreturn__)) err_cookie(pid_t pid, int set)
+{
+	char *msg;
+
+	if(set == CORE_COPY)
+		msg = _("failed to copy pid %d's core scheduling cookie");
+	else
+		msg = set ? _("failed to set pid %d's core scheduling cookie") :
+			    _("failed to get pid %d's core scheduling cookie");
+
+	err(EXIT_FAILURE, msg, pid ? pid : getpid());
+}
+
+static unsigned long get_cookie(struct coreset *cs)
+{
+	unsigned long cookie;
+	pid_t pid = (cs->cmd == CORE_COPY ? 0: cs->pid); /* with copy we want to report current's cookie */
+
+	if (prctl(PR_SCHED_CORE, PR_SCHED_CORE_GET, pid, PR_SCHED_CORE_SCOPE_THREAD, &cookie) < 0 ) {
+		err_cookie(pid ? pid : getpid(), FALSE);
+	}
+	return cookie;
+}
+
+static void do_coreset(struct coreset *cs)
+{
+	/* read the current cookie */
+	cs->cookie = get_cookie(cs);
+	print_cookie(cs, FALSE);
+
+	switch (cs->cmd) {
+	case CORE_SHOW:
+		return;
+	case CORE_CREATE:
+                /* create a new cookie for given task (may be 0). Scope only applies with existing pid */
+		if (prctl(PR_SCHED_CORE, PR_SCHED_CORE_CREATE, cs->pid, cs->scope, NULL) < 0)
+			err_cookie(cs->pid, cs->cmd);
+	        break;
+	case CORE_COPY:
+		/* copy cookie, which could be none, from source pid to current task.  Scope must be 0 so we force it*/
+		if (prctl(PR_SCHED_CORE, PR_SCHED_CORE_SHARE_FROM, cs->pid, PR_SCHED_CORE_SCOPE_THREAD, NULL) < 0)
+			err_cookie(cs->pid, cs->cmd);
+		break;
+	case CORE_PUSH:
+                /* push current task's cookie, which could be none, to given pid. Scope is meaningful */
+		if (prctl(PR_SCHED_CORE, PR_SCHED_CORE_SHARE_TO, cs->pid, cs->scope, NULL) < 0)
+			err_cookie(cs->pid, cs->cmd);
+		break;
+	}
+
+	/* re-read the cookie */
+	cs->cookie = get_cookie(cs);
+	print_cookie(cs, TRUE);
+}
+
+int main(int argc, char **argv)
+{
+	pid_t pid = 0;
+	int c, copy = 0, create = 0, push = 0;
+	int do_exec = 0;
+	struct coreset cs;
+
+	static const struct option longopts[] = {
+		{ "copy",	0, NULL, 'c' },
+		{ "new",	0, NULL, 'n' },
+		{ "pid",	0, NULL, 'p' },
+		{ "scope",	0, NULL, 's' },
+		{ "to",	        0, NULL, 't' },
+		{ "help",	0, NULL, 'h' },
+		{ "version",	0, NULL, 'V' },
+		{ NULL,		0, NULL,  0  }
+	};
+
+	setlocale(LC_ALL, "");
+	bindtextdomain(PACKAGE, LOCALEDIR);
+	textdomain(PACKAGE);
+	close_stdout_atexit();
+
+	memset(&cs, 0, sizeof(cs));
+
+	while ((c = getopt_long(argc, argv, "+cnp:s:thV", longopts, NULL)) != -1) {
+		switch (c) {
+		case 'c':
+			copy = 1;
+			break;
+		case 'n':
+		        create = 1;
+			break;
+		case 'p':
+			pid = strtos32_or_err(optarg, _("invalid PID argument"));
+			break;
+		case 's':
+			cs.scope = strtos32_or_err(optarg, _("invalid scope argument"));
+			break;
+		case 't':
+		        push = 1;
+			break;
+		case 'V':
+			print_version(EXIT_SUCCESS);
+		case 'h':
+			usage();
+		default:
+			errtryhelp(EXIT_FAILURE);
+		}
+	}
+
+	// pid and no command is okay. No pid and no command is not.  Copy and no command is not okay.
+	// push and no command is okay. copy and push require pid
+	if (((!pid || copy) && argc - optind < 1) || ((copy || push) && !pid)) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
+
+	/* these are mutually exclusive */
+	if (copy + create + push > 1) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
+
+	/* negative PID is never valid */
+	if (pid < 0) {
+		warnx(_("invalid pid"));
+		errtryhelp(EXIT_FAILURE);
+	}
+
+        /* scope must be one of PR_SCHED_CORE_SCOPE_*  */
+	if (cs.scope < PR_SCHED_CORE_SCOPE_THREAD || cs.scope > PR_SCHED_CORE_SCOPE_PROCESS_GROUP) {
+		warnx(_("invalid scope"));
+		errtryhelp(EXIT_FAILURE);
+	}
+
+	if (argc - optind > 0)
+		do_exec = 1;
+
+	if (create)
+		cs.cmd = CORE_CREATE;
+	else if (copy)
+		cs.cmd = CORE_COPY;
+	else if (push)
+		cs.cmd = CORE_PUSH;
+	else cs.cmd = CORE_SHOW;
+
+	/* create and show with a pid don't use the command */
+	if (pid && do_exec && (cs.cmd == CORE_SHOW || cs.cmd == CORE_CREATE)) {
+		warnx(_("Ingoring extraneous input"));
+		do_exec = 0;
+	}
+
+	if (pid)
+		cs.pid = pid;
+
+	do_coreset(&cs);
+
+	if (do_exec) {
+		argv += optind;
+		execvp(argv[0], argv);
+		errexec(argv[0]);
+	}
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The core scheduling feature went in to the kernel in 5.14.  It's based on a prctl() interface so in order to use it more easily there needs to be a userspace utility to manage the cookies.  This will allow it to be used without rewriting applications. 

See https://lwn.net/Articles/861251 for more details.  There is also documentation in the kernel tree which can be see easily here: https://docs.kernel.org/admin-guide/hw-vuln/core-scheduling.html

This is an initial pass at adding such a utiltiy to util-linux.  Coreset was chosen to be in line with taskset and uclampset in the schedutils section.  The code is loosely modeled on taskset.  There are probably better ways to hook into the configure setup for dependencies. 

A man page is still needed.  Karel suggested getting the initial draft PR in to get feedback before worrying about that. Hopefully the draft part works. 

Currently it works like this:
./coreset --help
Usage: coreset [options] [-p pid] [cmd [args...]]


Show or change the core scheduling cookie for a process or thread.

Options:
 -c, --copy              copy the cookie from give pid to this cmd
 -n, --new               create new cookie on pid or cmd
 -t, --to                copy current task's cookie to existing pid or cmd
 Absence of one of the mutually exclusive above options just reports current cookie on given pid (or cmd)
 -p, --pid               operate on existing given pid/tid
 -d, --dest              Use with -c, copy cookie from pid to dest_pid
 -s, --scope             0, 1 or 2: apply change to task (0), thread group (1) or process group (2) of given pid/tid
 Default scope is 0. Scope is ignored in some cases where it does not have an effect
 -h, --help              display this help
 -V, --version           display version

The default behavior is to show existing cookie (which is of limited value):
    coreset sshd -b 1024
    coreset -p 700
Create a new cookie for existing task:
    coreset -n -p 700
or task and all its sibling threads:
    coreset -s 1 -n -p 700
Copy cookie from existing task to new task:
    coreset -c -p 700  sshd -b 1024
Copy cookie from existing task to a different existing task:
      coreset -c -p 700 -d 12345
Clear cookie for all processes for given task (assuming current shell has no cookie):
    coreset -s 2 -t -p 700
Note: pid can also be a tid as retrieved with the gettid(2) syscall.

Core scheduling is available in kernels starting with v5.14.

For more details see coreset(1).  (TBD)
