### PR TITLE
last: avoid out of bounds array access

### DIFF
--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -351,7 +351,10 @@ static int time_formatter(int fmt, char *dst, size_t dlen, time_t *when)
 	{
 		char buf[CTIME_BUFSIZ];
 
-		ctime_r(when, buf);
+		if (!ctime_r(when, buf)) {
+			ret = -1;
+			break;
+		}
 		snprintf(dst, dlen, "%s", buf);
 		ret = rtrim_whitespace((unsigned char *) dst);
 		break;


### PR DESCRIPTION
In the fuzz test, the value of when variable may be very large(e.g 88123456123456123456),which can not generate a correct time string, may be cause array out-of-bounds access.
```
#include <stdio.h>
#include <time.h>

int main() {
        time_t big_time = 88123456123456123456;
        char buf[26];
        int ret = ctime_r(&big_time, buf);
        printf("ret: %d\nbuf:", ret);
        for(int i = 0; i < 26; i++)
        {
                printf("0x%02x ",buf[i]);
        }

        printf("\n");
}
```
```
ret: 0
buf:0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x60 0x58

```