### PR TITLE
Fix export of mnt_context_is_lazy and mnt_context_is_onlyonce

### DIFF
--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -551,7 +551,7 @@ int mnt_context_enable_onlyonce(struct libmnt_context *cxt, int enable)
 }
 
 /**
- * mnt_context_is_lazy:
+ * mnt_context_is_onlyonce:
  * @cxt: mount context
  *
  * Returns: 1 if lazy umount is enabled or 0

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -370,7 +370,7 @@ MOUNT_2_38 {
 MOUNT_2_39 {
 	mnt_cache_set_sbprobe;
 	mnt_context_enable_onlyonce;
-	mnt_context_is_lazy;
+	mnt_context_is_onlyonce;
 	mnt_context_enable_noautofs;
 	mnt_table_enable_noautofs;
 	mnt_table_is_noautofs;


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/927258
Closes: https://github.com/util-linux/util-linux/issues/2844
Fixes: 3d1c41c8c ("libmount: add --onlyonce")