### PR TITLE
libmount: make sure "option=" is used as string

### DIFF
--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -224,6 +224,9 @@ static int configure_superblock(struct libmnt_context *cxt,
 			/* Ignore VFS flags, userspace and external options */
 			continue;
 
+		if (!value && mnt_opt_is_sepnodata(opt))
+			value = "";	/* force use the value as string */
+
 		rc = fsconfig_set_value(cxt, hs, fd, name, value);
 		if (rc != 0)
 			goto done;

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -608,6 +608,7 @@ extern int mnt_opt_set_value(struct libmnt_opt *opt, const char *str);
 extern int mnt_opt_set_u64value(struct libmnt_opt *opt, uint64_t num);
 extern int mnt_opt_set_quoted_value(struct libmnt_opt *opt, const char *str);
 extern int mnt_opt_is_external(struct libmnt_opt *opt);
+extern int mnt_opt_is_sepnodata(struct libmnt_opt *opt);
 
 /* fs.c */
 extern int mnt_fs_follow_optlist(struct libmnt_fs *fs, struct libmnt_optlist *ol);


### PR DESCRIPTION
mount(8) cares about case when option specified as "name=" (it means without data). See for example 727c689908c5e68c92aa1dd65e0d3bdb6d91c1e5.

We need this also for new mount API and use FSCONFIG_SET_STRING rather than FSCONFIG_SET_FLAG.

strace -e fsconfig ./mount -o usrjquota= /dev/sdc1 /mnt/test

Old:
fsconfig(3, FSCONFIG_SET_STRING, "source", "/dev/sdc1", 0) = 0 fsconfig(3, FSCONFIG_SET_FLAG, "usrjquota", NULL, 0) = -1 EINVAL (Invalid argument)

Fixed:
fsconfig(3, FSCONFIG_SET_STRING, "source", "/dev/sdc1", 0) = 0 fsconfig(3, FSCONFIG_SET_STRING, "usrjquota", "", 0) = 0

Fixes: https://github.com/util-linux/util-linux/issues/2837