### PR TITLE
<for the master branch> tests: (lsfs) skip some test cases if making a NETLINK_SOCK_DIAG socket and/or sending a message via the socket are not allowed

### DIFF
--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -84,6 +84,14 @@ static int kcmp(pid_t pid1 __attribute__((__unused__)),
 
 #include "lsfd.h"
 
+UL_DEBUG_DEFINE_MASK(lsfd);
+UL_DEBUG_DEFINE_MASKNAMES(lsfd) = UL_DEBUG_EMPTY_MASKNAMES;
+
+static void lsfd_init_debug(void)
+{
+	__UL_INIT_DEBUG_FROM_ENV(lsfd, LSFD_DEBUG_, 0, LSFD_DEBUG);
+}
+
 /*
  * /proc/$pid/mountinfo entries
  */
@@ -2505,6 +2513,8 @@ int main(int argc, char *argv[])
 		{ "_drop-privilege",no_argument,NULL,OPT_DROP_PRIVILEGE },
 		{ NULL, 0, NULL, 0 },
 	};
+
+	lsfd_init_debug();
 
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);

--- a/misc-utils/lsfd.h
+++ b/misc-utils/lsfd.h
@@ -28,13 +28,28 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
+#include "debug.h"
 #include "libsmartcols.h"
 #include "list.h"
 #include "nls.h"
 #include "path.h"
 #include "strutils.h"
 #include "xalloc.h"
+
+/*
+ * debug
+ */
+UL_DEBUG_DECLARE_MASK(lsfd);
+
+#define LSFD_DEBUG_INIT	     (1 << 1)
+#define LSFD_DEBUG_ENDPOINTS (1 << 2)
+#define LSFD_DEBUG_ALL       0xFFFF
+
+#define DBG(m, x)       __UL_DBG(lsfd, LSFD_DEBUG_, m, x)
 
 /*
  * column IDs

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -3340,6 +3340,25 @@ static int send_diag_request(int diagsd, void *req, size_t req_size)
 	return 0;
 }
 
+static int recv_diag_request(int diagsd)
+{
+	__attribute__((aligned(sizeof(void *)))) uint8_t buf[8192];
+	const struct nlmsghdr *h;
+	int r = recvfrom(diagsd, buf, sizeof(buf), 0, NULL, NULL);;
+	if (r < 0)
+		return errno;
+
+	h = (void *)buf;
+	if (!NLMSG_OK(h, (size_t)r))
+		return -1;
+
+	if (h->nlmsg_type == NLMSG_ERROR) {
+		struct nlmsgerr *e = (struct nlmsgerr *)NLMSG_DATA(h);
+		return - e->error;
+	}
+	return 0;
+}
+
 static void *make_sockdiag(const struct factory *factory, struct fdesc fdescs[],
 			   int argc, char ** argv)
 {
@@ -3384,6 +3403,16 @@ static void *make_sockdiag(const struct factory *factory, struct fdesc fdescs[],
 		err(EXIT_FAILURE, "failed in sendmsg()");
 	}
 
+	e = recv_diag_request(diagsd);
+	if (e != 0) {
+		close (diagsd);
+		if (e == ENOENT)
+			err(EXIT_ENOENT, "failed in recvfrom()");
+		if (e > 0)
+			err(EXIT_FAILURE, "failed in recvfrom()");
+		if (e < 0)
+			errx(EXIT_FAILURE, "failed in recvfrom() => -1");
+	}
 
 	if (diagsd != fdescs[0].fd) {
 		if (dup2(diagsd, fdescs[0].fd) < 0) {

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -69,7 +69,7 @@
 #define EXIT_EPERM  18
 #define EXIT_ENOPROTOOPT 19
 #define EXIT_EPROTONOSUPPORT 20
-#define EXIT_EACCESS 21
+#define EXIT_EACCES 21
 
 #define _U_ __attribute__((__unused__))
 
@@ -2097,7 +2097,7 @@ static void *make_ping_common(const struct factory *factory, struct fdesc fdescs
 
 	sd = socket(family, SOCK_DGRAM, protocol);
 	if (sd < 0)
-		err((errno == EACCES? EXIT_EACCESS: EXIT_FAILURE),
+		err((errno == EACCES? EXIT_EACCES: EXIT_FAILURE),
 		    "failed to make an icmp socket");
 
 	if (sd != fdescs[0].fd) {
@@ -2117,7 +2117,7 @@ static void *make_ping_common(const struct factory *factory, struct fdesc fdescs
 			int e = errno;
 			close(sd);
 			errno = e;
-			err((errno == EACCES? EXIT_EACCESS: EXIT_FAILURE),
+			err((errno == EACCES? EXIT_EACCES: EXIT_FAILURE),
 			    "failed in bind(2)");
 		}
 	}

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -34,6 +34,8 @@
 #include <linux/if_packet.h>
 #include <linux/if_tun.h>
 #include <linux/netlink.h>
+#include <linux/sock_diag.h>
+# include <linux/unix_diag.h> /* for UNIX domain sockets */
 #include <linux/sockios.h>  /* SIOCGSKNS */
 #include <mqueue.h>
 #include <net/if.h>
@@ -70,6 +72,7 @@
 #define EXIT_ENOPROTOOPT 19
 #define EXIT_EPROTONOSUPPORT 20
 #define EXIT_EACCES 21
+#define EXIT_ENOENT 22
 
 #define _U_ __attribute__((__unused__))
 
@@ -3307,6 +3310,100 @@ static void free_mmap(const struct factory * factory _U_, void *data)
 	       ((struct mmap_data *)data)->len);
 }
 
+static int send_diag_request(int diagsd, void *req, size_t req_size)
+{
+	struct sockaddr_nl nladdr = {
+		.nl_family = AF_NETLINK,
+	};
+
+	struct nlmsghdr nlh = {
+		.nlmsg_len = sizeof(nlh) + req_size,
+		.nlmsg_type = SOCK_DIAG_BY_FAMILY,
+		.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP,
+	};
+
+	struct iovec iovecs[] = {
+		{ &nlh, sizeof(nlh) },
+		{ req, req_size },
+	};
+
+	const struct msghdr mhd = {
+		.msg_namelen = sizeof(nladdr),
+		.msg_name = &nladdr,
+		.msg_iovlen = ARRAY_SIZE(iovecs),
+		.msg_iov = iovecs,
+	};
+
+	if (sendmsg(diagsd, &mhd, 0) < 0)
+		return errno;
+
+	return 0;
+}
+
+static void *make_sockdiag(const struct factory *factory, struct fdesc fdescs[],
+			   int argc, char ** argv)
+{
+	struct arg family = decode_arg("family", factory->params, argc, argv);
+	const char *sfamily = ARG_STRING(family);
+	int ifamily;
+	int diagsd;
+	void *req = NULL;
+	size_t reqlen = 0;
+	int e;
+	struct unix_diag_req udr;
+
+	if (strcmp(sfamily, "unix") == 0)
+		ifamily = AF_UNIX;
+	else
+		errx(EXIT_FAILURE, "unknown/unsupported family: %s", sfamily);
+	free_arg(&family);
+
+	diagsd = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_SOCK_DIAG);
+	if (diagsd < 0)
+		err(errno == EPROTONOSUPPORT? EXIT_EPROTONOSUPPORT: EXIT_FAILURE,
+		    "failed in sendmsg()");
+
+	if (ifamily == AF_UNIX) {
+		udr = (struct unix_diag_req) {
+			.sdiag_family = AF_UNIX,
+			.udiag_states = -1, /* set the all bits. */
+			.udiag_show = UDIAG_SHOW_NAME | UDIAG_SHOW_PEER | UNIX_DIAG_SHUTDOWN,
+		};
+		req = &udr;
+		reqlen = sizeof(udr);
+	}
+
+	e = send_diag_request(diagsd, req, reqlen);
+	if (e) {
+		close (diagsd);
+		errno = e;
+		if (errno == EACCES)
+			err(EXIT_EACCES, "failed in sendmsg()");
+		if (errno == ENOENT)
+			err(EXIT_ENOENT, "failed in sendmsg()");
+		err(EXIT_FAILURE, "failed in sendmsg()");
+	}
+
+
+	if (diagsd != fdescs[0].fd) {
+		if (dup2(diagsd, fdescs[0].fd) < 0) {
+			e = errno;
+			close(diagsd);
+			errno = e;
+			err(EXIT_FAILURE, "failed to dup %d -> %d", diagsd, fdescs[0].fd);
+		}
+		close(diagsd);
+	}
+
+	fdescs[0] = (struct fdesc){
+		.fd    = fdescs[0].fd,
+		.close = close_fdesc,
+		.data  = NULL
+	};
+
+	return NULL;
+}
+
 #define PARAM_END { .name = NULL, }
 static const struct factory factories[] = {
 	{
@@ -4165,6 +4262,24 @@ static const struct factory factories[] = {
 		.EX_N = 0,
 		.make = make_userns,
 		.params = (struct parameter []) {
+			PARAM_END
+		}
+	},
+	{
+		.name = "sockdiag",
+		.desc = "make a sockdiag netlink socket",
+		.priv = false,
+		.N = 1,
+		.EX_N = 0,
+		.make = make_sockdiag,
+		.params = (struct parameter []) {
+			{
+				.name = "family",
+				.type = PTYPE_STRING,
+				/* TODO: inet, inet6 */
+				.desc = "name of a protocol family ([unix])",
+				.defv.string = "unix",
+			},
 			PARAM_END
 		}
 	},

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -58,7 +58,7 @@ function lsfd_compare_dev {
     fi
 }
 
-lsfd_strip_type_stream()
+function lsfd_strip_type_stream
 {
     # lsfd changes the output of NAME column for a unix stream socket
     # whether the kernel reports it is a "UNIX-STREAM" socket or a
@@ -67,7 +67,7 @@ lsfd_strip_type_stream()
     sed -e 's/ type=stream//'
 }
 
-lsfd_make_state_connected()
+function lsfd_make_state_connected
 {
     # Newer kernels report the states of unix dgram sockets created by
     # sockerpair(2) are "connected" via /proc/net/unix though Older

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -19,7 +19,7 @@
 readonly EPERM=18
 readonly ENOPROTOOPT=19
 readonly EPROTONOSUPPORT=20
-readonly EACCESS=21
+readonly EACCES=21
 
 function lsfd_wait_for_pausing {
 	ts_check_prog "sleep"

--- a/tests/ts/lsfd/mkfds-ping
+++ b/tests/ts/lsfd/mkfds-ping
@@ -90,7 +90,7 @@ ERRMSG=
 for i in 0 1; do
     ERRMSG=$("$TS_HELPER_MKFDS"  -c -q "${FACTORY[$i]}" 3 id=$ID 2>&1)
     ERR="$?"
-    if [[ "$ERR" == "$EACCESS" ]]; then
+    if [[ "$ERR" == "$EACCES" ]]; then
 	case "$ERRMSG" in
 	    *bind*)
 		MSG="making ${TYPE[$i]} socket with specifying id is not allowed (blocked by SELinux?)"

--- a/tests/ts/lsfd/mkfds-socketpair
+++ b/tests/ts/lsfd/mkfds-socketpair
@@ -20,6 +20,7 @@ TS_DESC="AF_UNIX socket pair created with socketpair(2)"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
+. "$TS_SELF/lsfd-functions.bash"
 ts_check_test_command "$TS_CMD_LSFD"
 
 ts_check_test_command "$TS_HELPER_MKFDS"
@@ -27,6 +28,8 @@ ts_check_test_command "$TS_HELPER_MKFDS"
 ts_check_prog "sed"
 
 ts_cd "$TS_OUTDIR"
+
+lsfd_check_sockdiag "unix"
 
 PID=
 FD0=3

--- a/tests/ts/lsfd/mkfds-unix-stream-requiring-sockdiag
+++ b/tests/ts/lsfd/mkfds-unix-stream-requiring-sockdiag
@@ -28,6 +28,8 @@ ts_check_test_command "$TS_HELPER_MKFDS"
 
 ts_cd "$TS_OUTDIR"
 
+lsfd_check_sockdiag "unix"
+
 PID=
 FDS=3
 FDC=4


### PR DESCRIPTION
Do the same as #2841 but for the master branch.

---

Close https://github.com/util-linux/util-linux/issues/2822

As reported on https://github.com/util-linux/util-linux/issues/2822, some test cases that require a NETLINK_SOCK_DIAG socket for the AF_UNIX family failed. The platform where the test ran might disallow the test cases from making a NETLINK_SOCK_DIAG socket and/or sending a message via it.

This pull request enhances test_mkfds to make a NETLINK_SOCK_DIAG socket for the AF_UNIX family and send a message via the socket. If running test_mkfds fails, the test cases are skipped.

