### PR TITLE
lscpu: initialize all variables (#2714)

### DIFF
--- a/sys-utils/lscpu-cpu.c
+++ b/sys-utils/lscpu-cpu.c
@@ -20,7 +20,7 @@ struct lscpu_cpu *lscpu_new_cpu(int id)
 	cpu->coreid = -1;
 	cpu->socketid = -1;
 	cpu->bookid = -1;
-	cpu->bookid = -1;
+	cpu->drawerid = -1;
 	cpu->address = -1;
 	cpu->configured = -1;
 


### PR DESCRIPTION
cpu->bookid got initialized twice instead of drawerid