### PR TITLE
Enable dependency manager for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
This should update your existing GitHub Actions to the latest latest version. 

By updating your GitHub Actions, you will get rid of the following [warnings](https://github.com/util-linux/util-linux/actions/runs/8433258299):

```
build (openwrt, ath79)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

```