### PR TITLE
[RFC] libsmartcols: (filter) accept prefix like k, M, G as a parts of a number

### DIFF
--- a/libsmartcols/src/filter-scanner.l
+++ b/libsmartcols/src/filter-scanner.l
@@ -1,6 +1,8 @@
 %{
 #include "smartcolsP.h"
 #include "filter-parser.h"	/* define tokens (T_*) */
+#include <string.h>
+static unsigned long long exapnd_prefix(char c, unsigned int x);
 %}
 
 %option reentrant bison-bridge noyywrap noinput nounput
@@ -44,6 +46,24 @@ true|TRUE	return T_TRUE;
 	return T_FLOAT;
 }
 
+{int}+[KMGT]i {
+	size_t len = strlen(yytext);
+	char c = yytext[len - 1 - 1];
+	yytext[len - 1 - 1] = '\0';
+	yylval->param_number = (int64_t) strtoumax(yytext, NULL, 10);
+	yylval->param_number *= exapnd_prefix(c, 1024);
+	return T_NUMBER;
+}
+
+{int}+[kMGT] {
+	size_t len = strlen(yytext);
+	char c = yytext[len - 1];
+	yytext[len - 1] = '\0';
+	yylval->param_number = (int64_t) strtoumax(yytext, NULL, 10);
+	yylval->param_number *= exapnd_prefix(c, 1000);
+	return T_NUMBER;
+}
+
 {int}+ {
 	yylval->param_number = (int64_t) strtoumax(yytext, NULL, 10);
 	return T_NUMBER;
@@ -59,4 +79,21 @@ true|TRUE	return T_TRUE;
 	return T_STRING;
 }
 
+%%
 
+static unsigned long long exapnd_prefix(char c, unsigned int x)
+{
+    unsigned long long r = 1;
+    switch (c) {
+    case 'T':
+	r *= x; /* fall through */
+    case 'G':
+	r *= x; /* fall through */
+    case 'M':
+	r *= x; /* fall through */
+    case 'K':
+    case 'k':
+	r *= x; /* fall through */
+    }
+    return r;
+}


### PR DESCRIPTION
Wit the change, lsblk accepts k, Ki, M, Mi, G, Gi, T, Ti:

```
$ ./lsblk -Q '(SIZE < 1G) && (SIZE > 0)'
NAME MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda1   8:1    0    1M  0 part 
sdb1   8:17   0   50M  0 part 
sdb3   8:19   0  541M  0 part 
%  ./lsblk -Q '(SIZE >= 1Ti)'
NAME              MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda                 8:0    0  3.6T  0 disk 
sda3                8:3    0  3.6T  0 part 
backup-main       253:1    0  1.8T  0 lvm  /var/lib/libvirt/images
                                           /home/yamato/backup
fedora_dev64-home 253:2    0  3.6T  0 lvm  /home
nvme1n1           259:0    0  1.9T  0 disk 
nvme0n1           259:1    0  1.8T  0 disk 
nvme3n1           259:2    0  1.9T  0 disk 
nvme4n1           259:3    0  1.9T  0 disk 
nvme2n1           259:4    0  1.8T  0 disk 
```

It works fine, but... The questionable behavior is:

```
$ ./lsblk -Q '(SIZE >= 1T)'
NAME              MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
sda                 8:0    0   3.6T  0 disk 
sda3                8:3    0   3.6T  0 part 
sdb                 8:16   0 953.9G  0 disk 
...
```

