### PR TITLE
lsfd: Support pidfs

### DIFF
--- a/include/pidfd-utils.h
+++ b/include/pidfd-utils.h
@@ -7,6 +7,7 @@
 
 #ifdef HAVE_SYS_SYSCALL_H
 # include <sys/syscall.h>
+# include <unistd.h>
 
 /*
  * If the kernel headers are too old to provide the syscall numbers, let's

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -298,7 +298,9 @@ lsfd_SOURCES = \
 	misc-utils/lsfd-sock.h \
 	misc-utils/lsfd-sock-xinfo.c \
 	misc-utils/lsfd-unkn.c \
-	misc-utils/lsfd-fifo.c
+	misc-utils/lsfd-fifo.c \
+	misc-utils/lsfd-pidfd.h \
+	misc-utils/lsfd-pidfd.c
 lsfd_LDADD = $(LDADD) $(MQ_LIBS) libsmartcols.la libcommon.la
 lsfd_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
 endif

--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -45,6 +45,8 @@
 #include "procfs.h"
 
 #include "lsfd.h"
+#include "lsfd-pidfd.h"
+#include "pidfd-utils.h"
 
 static size_t pagesize;
 
@@ -653,6 +655,22 @@ static unsigned long get_minor_for_mqueue(void)
 	return minor(sb.st_dev);
 }
 
+static unsigned long get_minor_for_pidfs(void)
+{
+	int fd = pidfd_open(getpid(), 0);
+	struct stat sb;
+	unsigned long ret = 0;
+
+	if (fd < 0)
+		return 0;
+
+	if (fstat(fd, &sb) == 0 && (sb.st_mode & S_IFMT) == S_IFREG)
+		ret = minor(sb.st_dev);
+
+	close(fd);
+	return ret;
+}
+
 static void file_class_initialize(void)
 {
 	unsigned long m;
@@ -667,6 +685,10 @@ static void file_class_initialize(void)
 	m = get_minor_for_mqueue();
 	if (m)
 		add_nodev(m, "mqueue");
+
+	m = get_minor_for_pidfs();
+	if (m)
+		add_nodev(m, "pidfs");
 }
 
 const struct file_class file_class = {
@@ -935,3 +957,77 @@ const struct file_class mqueue_file_class = {
 	.fill_column = mqueue_file_fill_column,
 	.get_ipc_class = mqueue_file_get_ipc_class,
 };
+
+struct pidfs_file {
+	struct file file;
+	struct pidfd_data data;
+};
+
+static void init_pidfs_file_content(struct file *file)
+{
+	struct pidfs_file *pidfs_file = (struct pidfs_file *)file;
+
+	memset(&pidfs_file->data, 0, sizeof(pidfs_file->data));
+}
+
+static int pidfs_file_handle_fdinfo(struct file *file, const char *key, const char *value)
+{
+	struct pidfs_file *pidfs_file = (struct pidfs_file *)file;
+
+	return pidfd_handle_fdinfo(&pidfs_file->data, key, value);
+}
+
+static void pidfs_file_free_content(struct file *file)
+{
+	struct pidfs_file *pidfs_file = (struct pidfs_file *)file;
+
+	pidfd_free(&pidfs_file->data);
+}
+
+static bool pidfs_file_fill_column(struct proc *proc __attribute__((__unused__)),
+				   struct file *file,
+				   struct libscols_line *ln,
+				   int column_id,
+				   size_t column_index)
+{
+	struct pidfs_file *pidfs_file = (struct pidfs_file *)file;
+	char *buf = NULL;
+
+	switch(column_id) {
+	case COL_TYPE:
+		if (scols_line_set_data(ln, column_index, "pidfd"))
+			err(EXIT_FAILURE, _("failed to add output data"));
+		return true;
+	case COL_NAME:
+		buf = pidfd_get_name(&pidfs_file->data);
+		break;
+	default:
+		if (!pidfd_fill_column(&pidfs_file->data, column_id, &buf))
+			return false;
+	}
+
+	if (buf &&
+	    scols_line_refer_data(ln, column_index, buf))
+		err(EXIT_FAILURE, _("failed to add output data"));
+
+	return true;
+}
+
+const struct file_class pidfs_file_class = {
+	.super = &file_class,
+	.size = sizeof(struct pidfs_file),
+	.initialize_content = init_pidfs_file_content,
+	.handle_fdinfo = pidfs_file_handle_fdinfo,
+	.fill_column = pidfs_file_fill_column,
+	.free_content = pidfs_file_free_content,
+};
+
+bool is_pidfs_dev(dev_t dev)
+{
+	const char *fs = get_nodev_filesystem(minor(dev));
+
+	if (fs && (strcmp (fs, "pidfs") == 0))
+		return true;
+
+	return false;
+}

--- a/misc-utils/lsfd-pidfd.c
+++ b/misc-utils/lsfd-pidfd.c
@@ -1,0 +1,95 @@
+/*
+ * lsfd-pidfd.c - handle pidfd (from anon_inode or pidfs)
+ *
+ * Copyright (C) 2024 Xi Ruoyao <xry111@xry111.site>
+ *
+ * Refactored and moved out from lsfd-unkn.c (originally authored by
+ * Masatake YAMATO <yamato@redhat.com>).
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <string.h>
+
+#include "strutils.h"
+#include "xalloc.h"
+
+#include "lsfd.h"
+#include "lsfd-pidfd.h"
+
+int pidfd_handle_fdinfo(struct pidfd_data *data, const char *key,
+			const char *value)
+{
+	if (strcmp(key, "Pid") == 0) {
+		uint64_t pid;
+		int rc = ul_strtou64(value, &pid, 10);
+
+		if (rc < 0)
+			return 0; /* ignore -- parse failed */
+
+		data->pid = (pid_t)pid;
+		return 1;
+	} else if (strcmp(key, "NSpid") == 0) {
+		data->nspid = xstrdup(value);
+		return 1;
+	}
+
+	return 0;
+}
+
+char *pidfd_get_name(struct pidfd_data *data)
+{
+	char *str = NULL;
+	char *comm = NULL;
+	struct proc *proc = get_proc(data->pid);
+
+	if (proc)
+		comm = proc->command;
+
+	xasprintf(&str, "pid=%d comm=%s nspid=%s",
+			  data->pid,
+			  comm ? comm : "",
+			  data->nspid ? data->nspid : "");
+	return str;
+}
+
+bool pidfd_fill_column(struct pidfd_data *data, int column_id, char **str)
+{
+	switch(column_id) {
+	case COL_PIDFD_COMM: {
+		struct proc *pidfd_proc = get_proc(data->pid);
+		char *pidfd_comm = NULL;
+
+		if (pidfd_proc)
+			pidfd_comm = pidfd_proc->command;
+		if (pidfd_comm) {
+			*str = xstrdup(pidfd_comm);
+			return true;
+		}
+		break;
+	}
+	case COL_PIDFD_NSPID:
+		if (data->nspid) {
+			*str = xstrdup(data->nspid);
+			return true;
+		}
+		break;
+	case COL_PIDFD_PID:
+		xasprintf(str, "%d", (int)data->pid);
+		return true;
+	}
+
+	return false;
+}

--- a/misc-utils/lsfd-pidfd.h
+++ b/misc-utils/lsfd-pidfd.h
@@ -1,0 +1,37 @@
+/*
+ * lsfd-pidfd.h - handle pidfd (from anon_inode or pidfs)
+ *
+ * Copyright (C) 2024 Xi Ruoyao <xry111@xry111.site>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+struct pidfd_data {
+	pid_t pid;
+	char *nspid;
+};
+
+int pidfd_handle_fdinfo(struct pidfd_data *, const char *, const char *);
+char *pidfd_get_name(struct pidfd_data *);
+bool pidfd_fill_column(struct pidfd_data *, int, char **);
+
+static inline void __attribute__((nonnull(1)))
+pidfd_free(struct pidfd_data *data)
+{
+	free(data->nspid);
+}

--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -667,6 +667,9 @@ static const struct file_class *stat2class(struct stat *sb)
 		if (is_mqueue_dev(dev))
 			return &mqueue_file_class;
 
+		if (is_pidfs_dev(dev))
+			return &pidfs_file_class;
+
 		return &file_class;
 	default:
 		break;

--- a/misc-utils/lsfd.h
+++ b/misc-utils/lsfd.h
@@ -220,7 +220,7 @@ struct file_class {
 
 extern const struct file_class abst_class, readlink_error_class, stat_error_class,
 	file_class, cdev_class, bdev_class, sock_class, unkn_class, fifo_class,
-	nsfs_file_class, mqueue_file_class;
+	nsfs_file_class, mqueue_file_class, pidfs_file_class;
 
 /*
  * IPC
@@ -298,5 +298,10 @@ bool is_mqueue_dev(dev_t dev);
  * Eventpoll
  */
 bool is_multiplexed_by_eventpoll(int fd, struct list_head *eventpolls);
+
+/*
+ * Pidfs
+ */
+bool is_pidfs_dev(dev_t dev);
 
 #endif /* UTIL_LINUX_LSFD_H */

--- a/misc-utils/meson.build
+++ b/misc-utils/meson.build
@@ -56,6 +56,7 @@ lsfd_sources = files (
   'lsfd-sock-xinfo.c',
   'lsfd-unkn.c',
   'lsfd-fifo.c',
+  'lsfd-pidfd.c',
 )
 
 uuidgen_sources = files(

--- a/tests/expected/lsfd/column-name-pidfd
+++ b/tests/expected/lsfd/column-name-pidfd
@@ -1,2 +1,2 @@
-3 anon_inode:[pidfd] pid=1 comm= nspid=1
+3 [KNAME] pid=1 comm= nspid=1
 pidfd:ASSOC,KNAME,NAME: 0

--- a/tests/expected/lsfd/column-type-pidfd
+++ b/tests/expected/lsfd/column-type-pidfd
@@ -1,2 +1,2 @@
-3 UNKN pidfd
+3 [STTYPE] pidfd
 pidfd:ASSOC,STTYPE,TYPE: 0

--- a/tests/expected/lsfd/mkfds-pidfd
+++ b/tests/expected/lsfd/mkfds-pidfd
@@ -1,2 +1,2 @@
-3 UNKN anon_inodefs pid=1 comm=systemd nspid=1 systemd     1
+3 [STTYPE] [SOURCE] pid=1 comm=systemd nspid=1 systemd     1
 ASSOC,STTYPE,SOURCE,NAME,PIDFD.COMM,PIDFD.PID: 0

--- a/tests/ts/lsfd/column-ainodeclass
+++ b/tests/ts/lsfd/column-ainodeclass
@@ -42,10 +42,18 @@ for C in pidfd inotify; do
 	fi
 	wait "${MKFDS_PID}"
     } > "$TS_OUTPUT" 2>&1
+
     if [ "$C-$?" == "pidfd-$TS_EXIT_NOTSUPP" ]; then
 	ts_skip_subtest "pidfd_open(2) is not available"
 	continue
     fi
+
+    STTYPE="$(head -n1 "$TS_OUTPUT" | awk '{print $2}')"
+    if [ "$C-$STTYPE" == "pidfd-REG" ]; then
+	ts_skip_subtest "pidfd is from pidfs instead of anon inode"
+	continue
+    fi
+
     ts_finalize_subtest
 done
 

--- a/tests/ts/lsfd/column-name
+++ b/tests/ts/lsfd/column-name
@@ -64,10 +64,17 @@ for C in ro-regular-file pidfd socketpair; do
 	fi
     } > "$TS_OUTPUT" 2>&1
     wait "${MKFDS_PID}"
+
     if [ "$C-$?" == "pidfd-$TS_EXIT_NOTSUPP" ]; then
 	ts_skip_subtest "pidfd_open(2) is not available"
 	continue
     fi
+
+    case $C in
+    pidfd)
+	sed -i -E 's/(pidfd|anon_inode):\[[a-zA-Z]+\]/[KNAME]/' "$TS_OUTPUT"
+    esac
+
     ts_finalize_subtest
 done
 

--- a/tests/ts/lsfd/column-type
+++ b/tests/ts/lsfd/column-type
@@ -50,10 +50,17 @@ for C in ro-regular-file pidfd inotify socketpair; do
 	fi
 	wait "${MKFDS_PID}"
     } > "$TS_OUTPUT" 2>&1
+
     if [ "$C-$?" == "pidfd-$TS_EXIT_NOTSUPP" ]; then
 	ts_skip_subtest "pidfd_open(2) is not available"
 	continue
     fi
+
+    case $C in
+    pidfd)
+	sed -i -E 's/UNKN|REG/[STTYPE]/' "$TS_OUTPUT"
+    esac
+
     ts_finalize_subtest
 done
 

--- a/tests/ts/lsfd/mkfds-pidfd
+++ b/tests/ts/lsfd/mkfds-pidfd
@@ -44,8 +44,12 @@ EXPR="(PID != ${TARGET}) and (FD == 3) and (PIDFD.PID == ${TARGET})"
     fi
     wait ${MKFDS_PID}
 } > $TS_OUTPUT 2>&1
+
 if [ "$?" == "$TS_EXIT_NOTSUPP" ]; then
     ts_skip "pidfd_open(2) is not available"
 fi
+
+sed -i -E -e 's/UNKN|REG/[STTYPE]/' -e 's/pidfs|anon_inodefs/[SOURCE]/' \
+    $TS_OUTPUT
 
 ts_finalize


### PR DESCRIPTION
In Linux 6.9 pidfds are moved from the anonymous inode infrastructure to a tiny pseudo filesystem named pidfs.  Recognize it properly.

Fixes #2865.