### PR TITLE
README.licensing/flock: Add MIT license mention

### DIFF
--- a/README.licensing
+++ b/README.licensing
@@ -12,6 +12,8 @@ There is code under:
 
    * LGPL-2.1-or-later  - GNU Lesser General Public License 2.1 or any later version
 
+   * MIT                - MIT License
+
    * BSD-2-Clause       - Simplified BSD License
 
    * BSD-3-Clause       - BSD 3-Clause "New" or "Revised" License

--- a/sys-utils/flock.c
+++ b/sys-utils/flock.c
@@ -1,4 +1,6 @@
-/*   Copyright 2003-2005 H. Peter Anvin - All Rights Reserved
+/*   SPDX-License-Identifier: MIT
+ *
+ *   Copyright 2003-2005 H. Peter Anvin - All Rights Reserved
  *
  *   Permission is hereby granted, free of charge, to any person
  *   obtaining a copy of this software and associated documentation


### PR DESCRIPTION
Looking at the license text, flock.c is under the MIT license (see https://spdx.org/licenses/MIT).

Add an SPDX license identifier header and add to the list of licenses the source so everything is correctly listed/identified.