### PR TITLE
libuuid: (man) fix function declarations

### DIFF
--- a/libuuid/man/uuid_compare.3.adoc
+++ b/libuuid/man/uuid_compare.3.adoc
@@ -46,7 +46,7 @@ uuid_compare - compare whether two UUIDs are the same
 
 *#include <uuid.h>*
 
-*int uuid_compare(uuid_t __uu1__, uuid_t __uu2__)*
+*int uuid_compare(const uuid_t __uu1__, const uuid_t __uu2__)*
 
 == DESCRIPTION
 

--- a/libuuid/man/uuid_copy.3.adoc
+++ b/libuuid/man/uuid_copy.3.adoc
@@ -46,7 +46,7 @@ uuid_copy - copy a UUID value
 
 *#include <uuid.h>*
 
-*void uuid_copy(uuid_t __dst__, uuid_t __src__);*
+*void uuid_copy(uuid_t __dst__, const uuid_t __src__);*
 
 == DESCRIPTION
 

--- a/libuuid/man/uuid_is_null.3.adoc
+++ b/libuuid/man/uuid_is_null.3.adoc
@@ -46,7 +46,7 @@ uuid_is_null - compare the value of the UUID to the NULL value
 
 *#include <uuid.h>*
 
-*int uuid_is_null(uuid_t __uu__);*
+*int uuid_is_null(const uuid_t __uu__);*
 
 == DESCRIPTION
 

--- a/libuuid/man/uuid_parse.3.adoc
+++ b/libuuid/man/uuid_parse.3.adoc
@@ -46,8 +46,8 @@ uuid_parse - convert an input UUID string into binary representation
 
 *#include <uuid.h>*
 
-*int uuid_parse(char *__in__, uuid_t __uu__);* +
-*int uuid_parse_range(char *__in_start__, char *__in_end__, uuid_t __uu__);*
+*int uuid_parse(const char *__in__, uuid_t __uu__);* +
+*int uuid_parse_range(const char *__in_start__, const char *__in_end__, uuid_t __uu__);*
 
 == DESCRIPTION
 

--- a/libuuid/man/uuid_time.3.adoc
+++ b/libuuid/man/uuid_time.3.adoc
@@ -46,7 +46,7 @@ uuid_time - extract the time at which the UUID was created
 
 *#include <uuid.h>*
 
-*time_t uuid_time(uuid_t __uu__, struct timeval *__ret_tv__)*
+*time_t uuid_time(const uuid_t __uu__, struct timeval *__ret_tv__)*
 
 == DESCRIPTION
 

--- a/libuuid/man/uuid_unparse.3.adoc
+++ b/libuuid/man/uuid_unparse.3.adoc
@@ -46,9 +46,9 @@ uuid_unparse - convert a UUID from binary representation to a string
 
 *#include <uuid.h>*
 
-*void uuid_unparse(uuid_t __uu__, char *__out__);* +
-*void uuid_unparse_upper(uuid_t __uu__, char *__out__);* +
-*void uuid_unparse_lower(uuid_t __uu__, char *__out__);*
+*void uuid_unparse(const uuid_t __uu__, char *__out__);* +
+*void uuid_unparse_upper(const uuid_t __uu__, char *__out__);* +
+*void uuid_unparse_lower(const uuid_t __uu__, char *__out__);*
 
 == DESCRIPTION
 


### PR DESCRIPTION
Several function declarations in the libuuid man pages contradicts with those in [the header](https://github.com/util-linux/util-linux/blob/master/libuuid/src/uuid.h).