### PR TITLE
meson: Add build-lsfd option and make rt dependency optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -728,10 +728,10 @@ if not cc.has_function('socket')
   endif
 endif
 
+lib_rt = cc.find_library('rt', required : false)
 realtime_libs = []
 have = cc.has_function('clock_gettime')
 if not have
-  lib_rt = cc.find_library('rt', required : false)
   if lib_rt.found()
     realtime_libs += lib_rt
     have = cc.has_function('clock_gettime',
@@ -744,7 +744,6 @@ thread_libs = dependency('threads')
 
 have = cc.has_function('timer_create')
 if not have
-  lib_rt = cc.find_library('rt', required : false)
   if lib_rt.found()
     realtime_libs = [lib_rt]
     have = cc.has_function('timer_create',
@@ -2717,9 +2716,7 @@ errnos_h = custom_target('errnos.h',
   command : ['tools/all_errnos', cc.cmd_array(), get_option('c_args')],
 )
 
-lib_rt = cc.find_library('rt', required : get_option('build-lsfd'))
-
-opt = not get_option('build-lsfd').disabled()
+opt = not get_option('build-lsfd').require(lib_rt.found()).disabled()
 exe = executable(
   'lsfd',
   lsfd_sources, errnos_h,

--- a/meson.build
+++ b/meson.build
@@ -731,9 +731,12 @@ endif
 realtime_libs = []
 have = cc.has_function('clock_gettime')
 if not have
-  realtime_libs += cc.find_library('rt', required : true)
-  have = cc.has_function('clock_gettime',
-                         dependencies : realtime_libs)
+  lib_rt = cc.find_library('rt', required : false)
+  if lib_rt.found()
+    realtime_libs += lib_rt
+    have = cc.has_function('clock_gettime',
+                          dependencies : realtime_libs)
+  endif
 endif
 conf.set('HAVE_CLOCK_GETTIME', have ? 1 : false)
 
@@ -741,9 +744,12 @@ thread_libs = dependency('threads')
 
 have = cc.has_function('timer_create')
 if not have
-  realtime_libs = [cc.find_library('rt', required : true)]
-  have = cc.has_function('timer_create',
-                         dependencies : realtime_libs)
+  lib_rt = cc.find_library('rt', required : false)
+  if lib_rt.found()
+    realtime_libs = [lib_rt]
+    have = cc.has_function('timer_create',
+                           dependencies : realtime_libs)
+  endif
   if not have
     realtime_libs += thread_libs
     have = cc.has_function('timer_create',
@@ -2711,19 +2717,20 @@ errnos_h = custom_target('errnos.h',
   command : ['tools/all_errnos', cc.cmd_array(), get_option('c_args')],
 )
 
-mq_libs = []
-mq_libs += cc.find_library('rt', required : true)
+lib_rt = cc.find_library('rt', required : get_option('build-lsfd'))
 
+opt = not get_option('build-lsfd').disabled()
 exe = executable(
   'lsfd',
   lsfd_sources, errnos_h,
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols],
-  dependencies : mq_libs,
+  dependencies : [lib_rt],
   install_dir : usrbin_exec_dir,
-  install : true)
-if not is_disabler(exe)
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
   exes += exe
   manadocs += ['misc-utils/lsfd.1.adoc']
 endif
@@ -3499,14 +3506,14 @@ exe = executable(
   build_by_default: program_tests)
 exes += exe
 
-if LINUX
+if LINUX and lib_rt.found()
   exe = executable(
     'test_mkfds',
     'tests/helpers/test_mkfds.c',
     'tests/helpers/test_mkfds.h',
     'tests/helpers/test_mkfds_ppoll.c',
     include_directories : includes,
-    dependencies : mq_libs,
+    dependencies : [lib_rt],
     build_by_default: program_tests)
   exes += exe
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -101,6 +101,8 @@ option('build-cal', type : 'feature',
        description : 'build cal')
 option('build-logger', type : 'feature',
        description : 'build logger')
+option('build-lsfd', type : 'feature',
+       description : 'build lsfd')
 option('build-switch_root', type : 'feature',
        description : 'switch_root')
 option('build-pivot_root', type : 'feature',


### PR DESCRIPTION
A dependency on the rt library is unnecessarily required when checking for the `clock_gettime` and `timer_create` functions.
This causes the build to fail if the rt library is not found. This should not fail the build as rt is only required for the checks. Additionally, the `lsfd` executable and some tests require rt. There is currently no option to toggle building lsfd.

This PR makes it possible to build without the rt library. Function checks no longer require rt for the build. The function checks for the rt library only run when rt is available. This PR adds an option to allow building without lsfd. This makes it possible to build without the executable that requires rt. To not require rt for the test, an additional check has been added. The effected tests won't be built unless rt has been found.

Fixes #2878 and possibly #2874