### PR TITLE
libblkid: Check LUKS OPAL before RAID

### DIFF
--- a/libblkid/src/blkidP.h
+++ b/libblkid/src/blkidP.h
@@ -241,6 +241,7 @@ struct blkid_struct_probe
 #define BLKID_FL_NOSCAN_DEV	(1 << 4)	/* do not scan this device */
 #define BLKID_FL_MODIF_BUFF	(1 << 5)	/* cached buffers has been modified */
 #define BLKID_FL_OPAL_LOCKED	(1 << 6)	/* OPAL device is locked (I/O errors) */
+#define BLKID_FL_OPAL_CHECKED	(1 << 7)	/* OPAL lock checked */
 
 /* private per-probing flags */
 #define BLKID_PROBE_FL_IGNORE_PT (1 << 1)	/* ignore partition table */

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -603,20 +603,6 @@ static struct blkid_bufinfo *read_buffer(blkid_probe pr, uint64_t real_off, uint
 		 * audio+data disks */
 		if (ret >= 0 || blkid_probe_is_cdrom(pr) || blkdid_probe_is_opal_locked(pr))
 			errno = 0;
-#ifdef HAVE_OPAL_GET_STATUS
-		else {
-			struct opal_status st = { };
-
-			/* If the device is locked with OPAL, we'll fail to read with I/O
-			 * errors when probing deep into the block device. Do not return
-			 * an error, so that we can move on to different types of checks.*/
-			ret = ioctl(pr->fd, IOC_OPAL_GET_STATUS, &st);
-			if (ret == 0 && (st.flags & OPAL_FL_LOCKED)) {
-				pr->flags |= BLKID_FL_OPAL_LOCKED;
-				errno = 0;
-			}
-		}
-#endif
 
 		return NULL;
 	}
@@ -911,6 +897,25 @@ int blkid_probe_is_cdrom(blkid_probe pr)
 
 int blkdid_probe_is_opal_locked(blkid_probe pr)
 {
+	if (!(pr->flags & BLKID_FL_OPAL_CHECKED)) {
+		pr->flags |= BLKID_FL_OPAL_CHECKED;
+
+#ifdef HAVE_OPAL_GET_STATUS
+		ssize_t ret;
+		struct opal_status st = { };
+		int errsv = errno;
+
+		/* If the device is locked with OPAL, we'll fail to read with I/O
+		 * errors when probing deep into the block device. */
+		ret = ioctl(pr->fd, IOC_OPAL_GET_STATUS, &st);
+		if (ret == 0 && (st.flags & OPAL_FL_LOCKED)) {
+			pr->flags |= BLKID_FL_OPAL_LOCKED;
+		}
+
+		errno = errsv;
+#endif
+	}
+
 	return (pr->flags & BLKID_FL_OPAL_LOCKED);
 }
 

--- a/libblkid/src/superblocks/luks.c
+++ b/libblkid/src/superblocks/luks.c
@@ -139,10 +139,26 @@ static int probe_luks(blkid_probe pr, const struct blkid_idmag *mag __attribute_
 	return BLKID_PROBE_NONE;
 }
 
+static int probe_luks_opal(blkid_probe pr, const struct blkid_idmag *mag)
+{
+	if (!blkdid_probe_is_opal_locked(pr))
+		return BLKID_PROBE_NONE;
+
+	return probe_luks(pr, mag);
+}
+
 const struct blkid_idinfo luks_idinfo =
 {
 	.name		= "crypto_LUKS",
 	.usage		= BLKID_USAGE_CRYPTO,
 	.probefunc	= probe_luks,
 	.magics		= BLKID_NONE_MAGIC
+};
+
+const struct blkid_idinfo luks_opal_idinfo =
+{
+	.name		= "crypto_LUKS",
+	.usage		= BLKID_USAGE_CRYPTO,
+	.probefunc	= probe_luks_opal,
+	.magics		= BLKID_NONE_MAGIC,
 };

--- a/libblkid/src/superblocks/luks.c
+++ b/libblkid/src/superblocks/luks.c
@@ -34,6 +34,8 @@
 #define LUKS_MAGIC	"LUKS\xba\xbe"
 #define LUKS_MAGIC_2	"SKUL\xba\xbe"
 
+#define LUKS2_HW_OPAL_SUBSYSTEM	"HW-OPAL"
+
 /* Offsets for secondary header (for scan if primary header is corrupted). */
 #define LUKS2_HDR2_OFFSETS { 0x04000, 0x008000, 0x010000, 0x020000, \
                              0x40000, 0x080000, 0x100000, 0x200000, 0x400000 }
@@ -139,12 +141,31 @@ static int probe_luks(blkid_probe pr, const struct blkid_idmag *mag __attribute_
 	return BLKID_PROBE_NONE;
 }
 
-static int probe_luks_opal(blkid_probe pr, const struct blkid_idmag *mag)
+static int probe_luks_opal(blkid_probe pr, const struct blkid_idmag *mag __attribute__((__unused__)))
 {
+	struct luks2_phdr *header;
+	int version;
+
+	header = (struct luks2_phdr *) blkid_probe_get_buffer(pr, 0, sizeof(struct luks2_phdr));
+	if (!header)
+		return errno ? -errno : BLKID_PROBE_NONE;
+
+	if (!luks_valid(header, LUKS_MAGIC, 0))
+		return BLKID_PROBE_NONE;
+
+	version = be16_to_cpu(header->version);
+
+	if (version != 2)
+		return BLKID_PROBE_NONE;
+
+	if (memcmp(header->subsystem, LUKS2_HW_OPAL_SUBSYSTEM, sizeof(LUKS2_HW_OPAL_SUBSYSTEM)) != 0)
+		return BLKID_PROBE_NONE;
+
 	if (!blkdid_probe_is_opal_locked(pr))
 		return BLKID_PROBE_NONE;
 
-	return probe_luks(pr, mag);
+	/* Locked drive with LUKS2 HW OPAL encryption, finish probe now */
+	return luks_attributes(pr, header, 0);
 }
 
 const struct blkid_idinfo luks_idinfo =

--- a/libblkid/src/superblocks/superblocks.c
+++ b/libblkid/src/superblocks/superblocks.c
@@ -94,6 +94,9 @@ static int blkid_probe_set_usage(blkid_probe pr, int usage);
  */
 static const struct blkid_idinfo *idinfos[] =
 {
+	/* First, as access to locked OPAL region triggers IO errors */
+	&luks_opal_idinfo,
+
 	/* RAIDs */
 	&linuxraid_idinfo,
 	&ddfraid_idinfo,

--- a/libblkid/src/superblocks/superblocks.h
+++ b/libblkid/src/superblocks/superblocks.h
@@ -68,6 +68,7 @@ extern const struct blkid_idinfo snapcow_idinfo;
 extern const struct blkid_idinfo verity_hash_idinfo;
 extern const struct blkid_idinfo integrity_idinfo;
 extern const struct blkid_idinfo luks_idinfo;
+extern const struct blkid_idinfo luks_opal_idinfo;
 extern const struct blkid_idinfo highpoint37x_idinfo;
 extern const struct blkid_idinfo highpoint45x_idinfo;
 extern const struct blkid_idinfo squashfs_idinfo;


### PR DESCRIPTION
When LUKS OPAL HW encryption is enabled and the partition is locked, any read from the locked area ends in reading error. The blkid tool is used in udev rules (at least in Debian), which is executed on every close of the block device, so errors from blkid can flood the logs. Fix this by checking LUKS first.

I do not know if it is correct to check LUKS before RAID, but it is crucial to not touch LUKS area before LUKS it is unlocked.

Not checking LUKS before RAID leads to the following errors when OPAL area is not yet unlocked:

```
kernel: ata8.00: exception Emask 0x0 SAct 0x0 SErr 0x0 action 0x0
kernel: ata8.00: irq_stat 0x40000001
kernel: ata8.00: failed command: READ DMA EXT
kernel: ata8.00: cmd 25/00:08:80:af:c0/00:00:d1:01:00/e0 tag 23 dma 4096 in
                  res 51/04:08:80:af:c0/00:00:d1:01:00/e0 Emask 0x1 (device error)
kernel: ata8.00: status: { DRDY ERR }
kernel: ata8.00: error: { ABRT }
kernel: I/O error, dev sdd, sector 7814033280 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
kernel: Buffer I/O error on dev sdd1, logical block 976753904, async page read
```