### PR TITLE
meson: Don't define HAVE_ENVIRON_DECL when environ is unavailable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -456,7 +456,7 @@ have_cpu_set_t = cc.sizeof('cpu_set_t', prefix : '#define _GNU_SOURCE\n#include 
 conf.set('HAVE_CPU_SET_T', have_cpu_set_t ? 1 : false)
 
 have = cc.has_header_symbol('unistd.h', 'environ', args : '-D_GNU_SOURCE')
-conf.set10('HAVE_ENVIRON_DECL', have)
+conf.set('HAVE_ENVIRON_DECL', have ? 1 : false)
 
 have = cc.has_header_symbol('signal.h', 'sighandler_t', args : '-D_GNU_SOURCE')
 conf.set('HAVE_SIGHANDLER_T', have ? 1 : false)


### PR DESCRIPTION
HAVE_ENVIRON_DECL is being defined to 0 by cfg_data.set10(). The code only checks whether or not is defined. This leads to it not being declared appropriately. Use cfg_data.set() instead of cfg_data.set10() to define it when true.

Fixes #2884.