### PR TITLE
tests: (test_mkfds::sockdiag) verify the recieved message to detect whether the socket is usable or not

### DIFF
--- a/misc-utils/lsfd.c
+++ b/misc-utils/lsfd.c
@@ -84,6 +84,14 @@ static int kcmp(pid_t pid1 __attribute__((__unused__)),
 
 #include "lsfd.h"
 
+UL_DEBUG_DEFINE_MASK(lsfd);
+UL_DEBUG_DEFINE_MASKNAMES(lsfd) = UL_DEBUG_EMPTY_MASKNAMES;
+
+static void lsfd_init_debug(void)
+{
+	__UL_INIT_DEBUG_FROM_ENV(lsfd, LSFD_DEBUG_, 0, LSFD_DEBUG);
+}
+
 /*
  * /proc/$pid/mountinfo entries
  */
@@ -2270,6 +2278,8 @@ int main(int argc, char *argv[])
 		{ "list-columns",no_argument, NULL, 'H' },
 		{ NULL, 0, NULL, 0 },
 	};
+
+	lsfd_init_debug();
 
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);

--- a/misc-utils/lsfd.h
+++ b/misc-utils/lsfd.h
@@ -28,13 +28,28 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
+#include "debug.h"
 #include "libsmartcols.h"
 #include "list.h"
 #include "nls.h"
 #include "path.h"
 #include "strutils.h"
 #include "xalloc.h"
+
+/*
+ * debug
+ */
+UL_DEBUG_DECLARE_MASK(lsfd);
+
+#define LSFD_DEBUG_INIT	     (1 << 1)
+#define LSFD_DEBUG_ENDPOINTS (1 << 2)
+#define LSFD_DEBUG_ALL       0xFFFF
+
+#define DBG(m, x)       __UL_DBG(lsfd, LSFD_DEBUG_, m, x)
 
 /*
  * column IDs


### PR DESCRIPTION
(Rewrote in Apr  5 2024)
This pull request is for skipping the test cases reported as failed on the platform where sock diag sockets for AF_UNIX don't work.

To seek the root cause of the failure, I also added `LSFD_DEBUG` environment variable. 

(The original message)
This pull request enables debug print for inspecting #2822. This pull fixes the test helper. So, merging this to v2.40.x is optional.
