### PR TITLE
libblkid: introduce luks opal prober

### DIFF
--- a/libblkid/src/superblocks/luks.c
+++ b/libblkid/src/superblocks/luks.c
@@ -139,10 +139,26 @@ static int probe_luks(blkid_probe pr, const struct blkid_idmag *mag __attribute_
 	return BLKID_PROBE_NONE;
 }
 
+static int probe_luks_opal(blkid_probe pr, const struct blkid_idmag *mag)
+{
+	if (!blkdid_probe_is_opal_locked(pr))
+		return BLKID_PROBE_NONE;
+
+	return probe_luks(pr, mag);
+}
+
 const struct blkid_idinfo luks_idinfo =
 {
 	.name		= "crypto_LUKS",
 	.usage		= BLKID_USAGE_CRYPTO,
 	.probefunc	= probe_luks,
 	.magics		= BLKID_NONE_MAGIC
+};
+
+const struct blkid_idinfo luks_opal_idinfo =
+{
+	.name		= "crypto_LUKS",
+	.usage		= BLKID_USAGE_CRYPTO,
+	.probefunc	= probe_luks_opal,
+	.magics		= BLKID_NONE_MAGIC,
 };

--- a/libblkid/src/superblocks/superblocks.c
+++ b/libblkid/src/superblocks/superblocks.c
@@ -94,6 +94,9 @@ static int blkid_probe_set_usage(blkid_probe pr, int usage);
  */
 static const struct blkid_idinfo *idinfos[] =
 {
+	/* First, as access to locked OPAL region triggers IO errors */
+	&luks_opal_idinfo,
+
 	/* RAIDs */
 	&linuxraid_idinfo,
 	&ddfraid_idinfo,

--- a/libblkid/src/superblocks/superblocks.h
+++ b/libblkid/src/superblocks/superblocks.h
@@ -68,6 +68,7 @@ extern const struct blkid_idinfo snapcow_idinfo;
 extern const struct blkid_idinfo verity_hash_idinfo;
 extern const struct blkid_idinfo integrity_idinfo;
 extern const struct blkid_idinfo luks_idinfo;
+extern const struct blkid_idinfo luks_opal_idinfo;
 extern const struct blkid_idinfo highpoint37x_idinfo;
 extern const struct blkid_idinfo highpoint45x_idinfo;
 extern const struct blkid_idinfo squashfs_idinfo;


### PR DESCRIPTION
Accesses to a disk locked with OPAL trigger IO errors logged by the kernel which should be avoided.
Running the normal luks prober first breaks the ordering of probers leading to incorrect detections, for example detecting mdadm superblocks before version 1.1 as luks.

Introduce a new prober that only runs on OPAL-locked disks to avoid these false-positives.

See #2061, #2373 and #2882.

Cc @Vogtinator @bluca @oldium