### PR TITLE
autotools: distribute pam_lastlog2/meson.build

### DIFF
--- a/pam_lastlog2/Makemodule.am
+++ b/pam_lastlog2/Makemodule.am
@@ -3,6 +3,6 @@ if BUILD_PAM_LASTLOG2
 include pam_lastlog2/man/Makemodule.am
 include pam_lastlog2/src/Makemodule.am
 
-EXTRA_DIST     += pam_lastlog2/COPYING
+EXTRA_DIST     += pam_lastlog2/COPYING pam_lastlog2/meson.build
 
 endif # BUILD_PAM_LASTLOG2


### PR DESCRIPTION
Otherwise building the dist tarball via meson doesn't work.

Fixes #2875
Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>