### PR TITLE
pam_lastlog2: link against liblastlog

### DIFF
--- a/pam_lastlog2/src/Makemodule.am
+++ b/pam_lastlog2/src/Makemodule.am
@@ -10,8 +10,9 @@ EXTRA_pam_lastlog2_la_DEPENDENCIES = \
 pam_lastlog2_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	 $(SOLIB_CFLAGS) \
-	 -I$(ul_liblastlog2_incdir) \
-	 -Iliblastlog2/src
+	 -I$(ul_liblastlog2_incdir)
+
+pam_lastlog2_la_LIBADD = liblastlog2.la
 
 pam_lastlog2_la_LDFLAGS = $(SOLIB_LDFLAGS) -module -avoid-version -shared
 if HAVE_VSCRIPT


### PR DESCRIPTION
While at it also drop the duplicated include path.

Fixes #2897
