### PR TITLE
tests: (test_mkfds::netlink) pass a correct file descriptor to bind(2)

### DIFF
--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -2293,6 +2293,7 @@ static void *make_netlink(const struct factory *factory, struct fdesc fdescs[],
 			err(EXIT_FAILURE, "failed to dup %d -> %d", sd, fdescs[0].fd);
 		}
 		close(sd);
+		sd = fdescs[0].fd;
 	}
 
 	struct sockaddr_nl nl;


### PR DESCRIPTION
Close #2901

The original code passed a closed file descriptor to bind(2).