### PR TITLE
libsmartcols: (filter) accept prefix like k, M, G as a parts of a number

### DIFF
--- a/libsmartcols/scols-filter.5.adoc
+++ b/libsmartcols/scols-filter.5.adoc
@@ -43,6 +43,8 @@ param: integer
       | holder
 
 integer: [0-9]*
+      | [0-9]*[KMGTPEZY]
+      | [0-9]*[KMGTPEZY]iB
 
 float: integer.integer
 
@@ -103,8 +105,9 @@ The precedences within operators is `or`, `and`, and `eq`, `ne`, `le`, `gt`, `ge
 
 About `float` and `integer` typed values, the filter engine supports only
 non-negative numbers. The `integer` is unsigned 64-bit number, and `float` is
-long double.
-
+long double. The `integer` may be followed by the multiplicative suffixes KiB,
+GiB, TiB, PiB, EiB, ZiB, and YiB (the "iB" is optional, e.g., "K" has the same
+meaning as "KiB").
 
 == AUTHORS
 

--- a/libsmartcols/src/filter-parser.y
+++ b/libsmartcols/src/filter-parser.y
@@ -124,6 +124,7 @@ void yyerror (yyscan_t *locp __attribute__((__unused__)),
 	if (fmt && fltr) {
 		char *p;
 		va_list ap;
+		int e;
 
 		if (fltr->errmsg) {
 			free(fltr->errmsg);
@@ -131,10 +132,10 @@ void yyerror (yyscan_t *locp __attribute__((__unused__)),
 		}
 
 		va_start(ap, fmt);
-		vasprintf(&fltr->errmsg, fmt, ap);
+		e = vasprintf(&fltr->errmsg, fmt, ap);
 		va_end(ap);
 
-		if (!fltr->errmsg)
+		if (e < 0 || !fltr->errmsg)
 			return;
 
 		p = strstr(fltr->errmsg, "T_");

--- a/libsmartcols/src/filter-parser.y
+++ b/libsmartcols/src/filter-parser.y
@@ -12,7 +12,7 @@
 #include "filter-parser.h"
 #include "filter-scanner.h"
 
-void yyerror(yyscan_t *locp, struct libscols_filter *fltr, char const *msg);
+void yyerror(yyscan_t *locp, struct libscols_filter *fltr, char const *fmt, ...);
 
 %}
 
@@ -119,15 +119,21 @@ param:
 
 void yyerror (yyscan_t *locp __attribute__((__unused__)),
 	      struct libscols_filter *fltr,
-	      char const *msg)
+	      char const *fmt, ...)
 {
-	if (msg && fltr) {
+	if (fmt && fltr) {
 		char *p;
+		va_list ap;
 
-		if (fltr->errmsg)
+		if (fltr->errmsg) {
 			free(fltr->errmsg);
+			fltr->errmsg = NULL;
+		}
 
-		fltr->errmsg = strdup(msg);
+		va_start(ap, fmt);
+		vasprintf(&fltr->errmsg, fmt, ap);
+		va_end(ap);
+
 		if (!fltr->errmsg)
 			return;
 

--- a/libsmartcols/src/filter-parser.y
+++ b/libsmartcols/src/filter-parser.y
@@ -55,6 +55,7 @@ void yyerror(yyscan_t *locp, struct libscols_filter *fltr, char const *fmt, ...)
 %left T_OR T_AND
 %left T_EQ T_NE T_LT T_LE T_GT T_GE T_REG T_NREG T_TRUE T_FALSE T_NEG
 
+%token T_INVALID_NUMBER
 
 %destructor {
 		/* This destruct is called on error. The root node will be deallocated
@@ -111,7 +112,10 @@ param:
 		bool x = false;
 		$$ = filter_new_param(fltr, SCOLS_DATA_BOOLEAN, 0, (void *) &x);
 	}
-
+	| T_INVALID_NUMBER {		/* YYerror token is unsupported in old Bisons */
+		ignore_result( $$ );	/* supress "unset value" warning */
+		YYERROR;		/* yyerror() already called by lex() */
+	}
 ;
 
 

--- a/libsmartcols/src/filter-scanner.l
+++ b/libsmartcols/src/filter-scanner.l
@@ -1,9 +1,11 @@
 %{
 #include "smartcolsP.h"
 #include "filter-parser.h"	/* define tokens (T_*) */
+
 %}
 
 %option reentrant bison-bridge noyywrap noinput nounput
+%option extra-type="struct libscols_filter *"
 
 id	[a-zA-Z][a-zA-Z_.%:/\-0-9]*
 int	[0-9]+

--- a/libsmartcols/src/filter-scanner.l
+++ b/libsmartcols/src/filter-scanner.l
@@ -59,12 +59,12 @@ true|TRUE	return T_TRUE;
 			yyerror(yyscanner, yyextra, "\"%s\" token error: %m", yytext);
 		else
 			yyerror(yyscanner, yyextra, "\"%s\" token error", yytext);
-		return YYerror;
+		return T_INVALID_NUMBER;
        }
 
        if (res > ULLONG_MAX) {
 		yyerror(yyscanner, yyextra, "\"%s\" number too large", yytext);
-		return YYerror;
+		return T_INVALID_NUMBER;
        }
 
        yylval->param_number = (unsigned long long) res;

--- a/libsmartcols/src/filter-scanner.l
+++ b/libsmartcols/src/filter-scanner.l
@@ -2,6 +2,8 @@
 #include "smartcolsP.h"
 #include "filter-parser.h"	/* define tokens (T_*) */
 
+void yyerror(yyscan_t *locp, struct libscols_filter *fltr, char const *fmt, ...);
+
 %}
 
 %option reentrant bison-bridge noyywrap noinput nounput
@@ -44,6 +46,29 @@ true|TRUE	return T_TRUE;
 {int}+\.{int}+ {
 	yylval->param_float = strtold(yytext, NULL);
 	return T_FLOAT;
+}
+
+{int}+([KMGTPEZY](iB)?) {
+	uintmax_t res;
+	int e;
+
+	errno = 0;
+	e = strtosize(yytext, &res);
+	if (e < 0) {
+		if (errno)
+			yyerror(yyscanner, yyextra, "\"%s\" token error: %m", yytext);
+		else
+			yyerror(yyscanner, yyextra, "\"%s\" token error", yytext);
+		return YYerror;
+       }
+
+       if (res > ULLONG_MAX) {
+		yyerror(yyscanner, yyextra, "\"%s\" number too large", yytext);
+		return YYerror;
+       }
+
+       yylval->param_number = (unsigned long long) res;
+       return T_NUMBER;
 }
 
 {int}+ {

--- a/libsmartcols/src/filter.c
+++ b/libsmartcols/src/filter.c
@@ -196,6 +196,7 @@ int scols_filter_parse_string(struct libscols_filter *fltr, const char *str)
 		return -errno;
 
 	yylex_init(&sc);
+	yylex_init_extra(fltr, &sc);
 	yyset_in(fltr->src, sc);
 
 	rc = yyparse(sc, fltr);


### PR DESCRIPTION
Based on https://github.com/util-linux/util-linux/pull/2864 from @masatake.