### PR TITLE
enosys: (man) add missing word

### DIFF
--- a/misc-utils/enosys.1.adoc
+++ b/misc-utils/enosys.1.adoc
@@ -8,7 +8,7 @@
 
 == NAME
 
-enosys - utility make syscalls fail with ENOSYS
+enosys - utility to make syscalls fail with ENOSYS
 
 == SYNOPSIS
 


### PR DESCRIPTION
"utility <ins>to</ins> make syscalls fail with ENOSYS"