### PR TITLE
meson: Require Python dependency which can be embedded for pylibmount

### DIFF
--- a/libmount/python/meson.build
+++ b/libmount/python/meson.build
@@ -17,7 +17,7 @@ if build_python
     pylibmount_sources,
     include_directories : [dir_include],
     subdir : 'libmount',
-    dependencies : [mount_dep, python.dependency()],
+    dependencies : [mount_dep, python.dependency(embed: true)],
     c_args : [
       '-Wno-cast-function-type',
 


### PR DESCRIPTION
Meson doesn't properly check that the necessary Python.h header file is available for the pylibmount module.
Passing true for the embed keyword argument for the Python dependency function ensures that this header file is available.

The Python dependency function is documented [here](https://mesonbuild.com/Python-module.html#dependency).

Fixes #2923.