### PR TITLE
meson: Make tinfo and ncurses dependencies disablers when not found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -261,6 +261,7 @@ if lib_ncursesw.found()
 else
   lib_ncurses = dependency(
     'ncurses',
+    disabler : true,
     required : get_option('ncurses'))
   headers += ['ncurses.h',
               'term.h']


### PR DESCRIPTION
This disables targets that require tinfo and ncurses when they are not found. Currently, targets requiring tinfo and ncurses are built even when they are not found.

Fixes #2927
Fixes #2929