### PR TITLE
<for the stable branch>findmnt: revise the code for -I and -D option

### DIFF
--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1636,7 +1636,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'I':
 			flags &= ~FL_TREE;
-			flags |= FL_DF_INODES;
+			flags |= (FL_DF_INODES | FL_DF);
 			break;
 		case 'i':
 			flags |= FL_INVERT;
@@ -1775,22 +1775,20 @@ int main(int argc, char *argv[])
 	if (collist)
 		list_colunms();		/* print end exit */
 
-	if (!ncolumns && (flags & FL_DF_INODES)) {
+	if (!ncolumns && (flags & FL_DF)) {
 		add_column(columns, ncolumns++, COL_SOURCE);
 		add_column(columns, ncolumns++, COL_FSTYPE);
-		add_column(columns, ncolumns++, COL_INO_TOTAL);
-		add_column(columns, ncolumns++, COL_INO_USED);
-		add_column(columns, ncolumns++, COL_INO_AVAIL);
-		add_column(columns, ncolumns++, COL_INO_USEPERC);
-		add_column(columns, ncolumns++, COL_TARGET);
-	}
-	else if (!ncolumns && (flags & FL_DF)) {
-		add_column(columns, ncolumns++, COL_SOURCE);
-		add_column(columns, ncolumns++, COL_FSTYPE);
-		add_column(columns, ncolumns++, COL_SIZE);
-		add_column(columns, ncolumns++, COL_USED);
-		add_column(columns, ncolumns++, COL_AVAIL);
-		add_column(columns, ncolumns++, COL_USEPERC);
+		if (flags & FL_DF_INODES) {
+			add_column(columns, ncolumns++, COL_INO_TOTAL);
+			add_column(columns, ncolumns++, COL_INO_USED);
+			add_column(columns, ncolumns++, COL_INO_AVAIL);
+			add_column(columns, ncolumns++, COL_INO_USEPERC);
+		} else {
+			add_column(columns, ncolumns++, COL_SIZE);
+			add_column(columns, ncolumns++, COL_USED);
+			add_column(columns, ncolumns++, COL_AVAIL);
+			add_column(columns, ncolumns++, COL_USEPERC);
+		}
 		add_column(columns, ncolumns++, COL_TARGET);
 	}
 

--- a/misc-utils/findmnt.h
+++ b/misc-utils/findmnt.h
@@ -24,7 +24,7 @@ enum {
 	FL_SHADOWED	= (1 << 20),
 	FL_DELETED      = (1 << 21),
 	FL_SHELLVAR     = (1 << 22),
-	FL_DF_INODES	= (1 << 23) | FL_DF,
+	FL_DF_INODES	= (1 << 23),
 
 	/* basic table settings */
 	FL_ASCII	= (1 << 25),

--- a/tests/expected/findmnt/df-options
+++ b/tests/expected/findmnt/df-options
@@ -1,0 +1,4 @@
+-D: OK
+-I: OK
+--df: OK
+--dfi: OK

--- a/tests/ts/findmnt/df-options
+++ b/tests/ts/findmnt/df-options
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="the columns enabled with -D and -I options"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_FINDMNT"
+ts_check_prog "head"
+
+ts_cd "$TS_OUTDIR"
+
+D_expectation="SOURCE FSTYPE SIZE USED AVAIL USE% TARGET"
+I_expectation="SOURCE FSTYPE INO.TOTAL INO.USED INO.AVAIL INO.USE% TARGET"
+{
+	if [[ $($TS_CMD_FINDMNT --raw -D | head -1) == "$D_expectation" ]]; then
+	    echo "-D: OK"
+	else
+	    echo "-D: ERROR"
+	    $TS_CMD_FINDMNT --raw -D
+	    echo $?
+	fi
+
+	if [[ $($TS_CMD_FINDMNT --raw -I | head -1) == "$I_expectation" ]]; then
+	    echo "-I: OK"
+	else
+	    echo "-I: ERROR"
+	    $TS_CMD_FINDMNT --raw -I
+	    echo $?
+	fi
+
+	if [[ $($TS_CMD_FINDMNT --raw --df | head -1) == "$D_expectation" ]]; then
+	    echo "--df: OK"
+	else
+	    echo "--df: ERROR"
+	    $TS_CMD_FINDMNT --raw --df
+	    echo $?
+	fi
+
+	if [[ $($TS_CMD_FINDMNT --raw --dfi | head -1) == "$I_expectation" ]]; then
+	    echo "--dfi: OK"
+	else
+	    echo "--dfi: ERROR"
+	    $TS_CMD_FINDMNT --raw --dfi
+	    echo $?
+	fi
+} >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+
+ts_finalize


### PR DESCRIPTION
This one is the same as #2915 but for the stable branch.

---

Fixes #2913.

3dd79293b5b655da9d913dedd8facb08959a7826 added -I option. However, the code used bit flags (FL_DF and FL_DF_INODES) wrongly; the code broke the output of -D option.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>
(cherry picked from commit aa0c45e8686df509c169121473d2cfb4fe18c3ea)