### PR TITLE
Fix misplaced else in mnt_update_already_done

### DIFF
--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -982,9 +982,9 @@ int mnt_update_already_done(struct libmnt_update *upd)
 			if (mnt_optstr_get_missing(fs->user_optstr, upd->fs->user_optstr, NULL) == 0) {
 				upd->missing_options = 1;
 				DBG(UPDATE, ul_debugobj(upd, " missing options detected"));
-			}
-		} else
-			rc = 1;
+			} else
+				rc = 1;
+		}
 
 	} else if (upd->target) {
 		/* umount */


### PR DESCRIPTION
There appears to be a misplaced `else` in `mnt_update_already_done`, which, at least for CIFS mounts with the `user` option, prevents an entry from being added to `/run/mount/utab`. This prevents the non-root user who mounted the filesystem from later unmounting it.

See issue in the Arch Linux forums:
https://bbs.archlinux.org/viewtopic.php?pid=2163894

This seems to be caused by 477401f0de404aafbc7630f70c2f8b1d670e32f8. I confirmed that the `mount.foo` test outlined in that commit message still works after this change.

```sh
mount -t foo /dev/sdc1 /mnt/test -o x-bar=BAR

cat /run/mount/utab # ...OPTS=x-foo=123,x-bar=BAR
```