### PR TITLE
tests: (functions.sh) add a helper funcion making a device number from given major and minor nums

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -788,6 +788,21 @@ function ts_device_has {
 	return $res
 }
 
+# Based on __SYSMACROS_DEFINE_MAKEDEV macro
+# defined in /usr/include/bits/sysmacros.h of GNU libc.
+function ts_makedev
+{
+	local major="$1"
+	local minor="$2"
+	local dev
+
+	dev=$((      ( major & 0x00000fff ) <<  8))
+	dev=$((dev | ( major & 0xfffff000 ) << 32))
+	dev=$((dev | ( minor & 0x000000ff ) <<  0))
+	dev=$((dev | ( minor & 0xffffff00 ) << 12))
+	echo $dev
+}
+
 function ts_is_uuid()
 {
 	printf "%s\n" "$1" | grep -E -q '^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$'

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -44,7 +44,7 @@ function lsfd_compare_dev {
     echo 'DEV[RUN]:' $?
     local MAJ=${DEV%:*}
     local MIN=${DEV#*:}
-    local DEVNUM=$(( ( MAJ << 8 ) + MIN ))
+    local DEVNUM=$(ts_makedev "$MAJ" "$MIN")
     local STAT_DEVNUM=$(stat -c "%d" "$FILE")
     echo 'STAT[RUN]:' $?
     if [ "${DEVNUM}" == "${STAT_DEVNUM}" ]; then

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -40,13 +40,18 @@ function lsfd_compare_dev {
     ts_check_prog "expr"
     ts_check_prog "stat"
 
-    local DEV=$("${LSFD}" --raw -n -o DEV -Q "${EXPR}")
+    local DEV
+    DEV=$("${LSFD}" --raw -n -o DEV -Q "${EXPR}")
     echo 'DEV[RUN]:' $?
+
     local MAJ=${DEV%:*}
     local MIN=${DEV#*:}
     local DEVNUM=$(ts_makedev "$MAJ" "$MIN")
-    local STAT_DEVNUM=$(stat -c "%d" "$FILE")
+
+    local STAT_DEVNUM
+    STAT_DEVNUM=$(stat -c "%d" "$FILE")
     echo 'STAT[RUN]:' $?
+
     if [ "${DEVNUM}" == "${STAT_DEVNUM}" ]; then
 	echo 'DEVNUM[STR]:' 0
     else


### PR DESCRIPTION
Fixes #2919.
Suggested by Karel Zak <kzak@redhat.com>.

The original code used an obsolete formula to make a device number from given major and minor numbers.

ts_device_make is a new helper function based on the formula of __SYSMACROS_DEFINE_MAKEDEV macro defined in
/usr/include/bits/sysmacros.h of GNU libc.

Suggested by Karel Zak <kzak@redhat.com> in #2919.
Signed-off-by: Masatake YAMATO <yamato@redhat.com>