### PR TITLE
lsns: continue the executing even if opening a /proc/$pid fails

### DIFF
--- a/sys-utils/lsns.8.adoc
+++ b/sys-utils/lsns.8.adoc
@@ -96,6 +96,11 @@ General error.
 *2*::
 An ioctl was unknown to the kernel.
 
+== ENVIRONMENT
+
+*LSNS_DEBUG*=all::
+enables *lsns* debug output.
+
 == AUTHORS
 
 mailto:kzak@redhat.com[Karel Zak]

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -70,7 +70,7 @@ UL_DEBUG_DEFINE_MASKNAMES(lsns) = UL_DEBUG_EMPTY_MASKNAMES;
 
 #define lsns_ioctl(fildes, request, ...) __extension__ ({ \
 	int ret = ioctl(fildes, request, ##__VA_ARGS__); \
-	if (ret == -1 && errno == ENOTTY) \
+	if (ret == -1 && (errno == ENOTTY || errno == ENOSYS))	\
 		warnx("Unsupported ioctl %s", #request); \
 	ret; })
 

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -319,7 +319,11 @@ static int get_ns_ino(struct path_cxt *pc, const char *nsname, ino_t *ino, ino_t
 		return -errno;
 	if (strcmp(nsname, "pid") == 0 || strcmp(nsname, "user") == 0) {
 		if ((pfd = lsns_ioctl(fd, NS_GET_PARENT)) < 0) {
-			if (errno == EPERM)
+			if (errno == EPERM
+			    /* On the test platforms, "build (qemu-user, s390x)" and
+			     * "build (qemu-user, riscv64)", the ioctl reported ENOSYS.
+			     */
+			    || errno == ENOSYS)
 				goto user;
 			close(fd);
 			return -errno;
@@ -334,7 +338,11 @@ static int get_ns_ino(struct path_cxt *pc, const char *nsname, ino_t *ino, ino_t
 	}
  user:
 	if ((ofd = lsns_ioctl(fd, NS_GET_USERNS)) < 0) {
-		if (errno == EPERM)
+		if (errno == EPERM
+		    /* On the test platforms, "build (qemu-user, s390x)" and
+		     * "build (qemu-user, riscv64)", the ioctl reported ENOSYS.
+		     */
+		    || errno == ENOSYS)
 			goto out;
 		close(fd);
 		return -errno;

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -305,6 +305,7 @@ static int get_ns_ino(struct path_cxt *pc, const char *nsname, ino_t *ino, ino_t
 
 	snprintf(path, sizeof(path), "ns/%s", nsname);
 
+	*ino = 0;
 	if (ul_path_stat(pc, &st, 0, path) != 0)
 		return -errno;
 	*ino = st.st_ino;
@@ -573,7 +574,7 @@ static int read_process(struct lsns *ls, struct path_cxt *pc)
 			DBG(PROC, ul_debug("failed in get_ns_ino (rc: %d)", rc));
 			goto done;
 		}
-		if (i == LSNS_ID_NET)
+		if (p->ns_ids[i] && i == LSNS_ID_NET)
 			p->netnsid = get_netnsid(pc, p->ns_ids[i]);
 		rc = 0;
 	}

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -602,7 +602,17 @@ static int read_processes(struct lsns *ls)
 		DBG(PROC, ul_debug("reading %d", (int) pid));
 		rc = procfs_process_init_path(pc, pid);
 		if (rc < 0) {
-			DBG(PROC, ul_debug("failed in reading /proc/%d", (int) pid));
+			DBG(PROC, ul_debug("failed in reading /proc/%d (rc: %d)", (int) pid, rc));
+			/* This failure is acceptable. If a process ($pid) owning
+			 * a namespace is gone while running this lsns process,
+			 * procfs_process_init_path(pc, $pid) may fail.
+			 *
+			 * We must reset this `rc' here. If this `d' is the last
+			 * dentry in `dir', this read_processes() invocation
+			 * returns this `rc'. In the caller context, the
+			 * non-zero value returned from read_processes() makes
+			 * lsns prints nothing. We should avoid the behavior. */
+			rc = 0;
 			continue;
 		}
 

--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -31,6 +31,13 @@
 
 #include "mount-api-utils.h"
 
+#ifdef HAVE_LINUX_NSFS_H
+# include <linux/nsfs.h>
+# if defined(NS_GET_NSTYPE) && defined(NS_GET_OWNER_UID)
+#  define USE_NS_GET_API	1
+# endif
+#endif
+
 typedef struct {
 	const char	*name;
 	int		(*fnc)(void);
@@ -132,6 +139,18 @@ static int hlp_sz_time(void)
 	return 0;
 }
 
+static int hlp_get_nstype_ok(void)
+{
+#ifdef USE_NS_GET_API
+	errno = 0;
+	ioctl(STDOUT_FILENO, NS_GET_NSTYPE);
+#else
+	errno = ENOSYS;
+#endif
+	printf("%d\n", errno != ENOSYS);
+	return 0;
+}
+
 static const mntHlpfnc hlps[] =
 {
 	{ "WORDSIZE",	hlp_wordsize	},
@@ -147,6 +166,7 @@ static const mntHlpfnc hlps[] =
 	{ "enotty-ok",  hlp_enotty_ok   },
 	{ "fsopen-ok",  hlp_fsopen_ok   },
 	{ "sz(time_t)", hlp_sz_time     },
+	{ "ns-gettype-ok", hlp_get_nstype_ok },
 	{ NULL, NULL }
 };
 
@@ -181,4 +201,3 @@ int main(int argc, char **argv)
 
 	exit(re ? EXIT_FAILURE : EXIT_SUCCESS);
 }
-

--- a/tests/ts/lsns/filedesc
+++ b/tests/ts/lsns/filedesc
@@ -25,10 +25,15 @@ ts_init "$*"
 ts_check_test_command "$TS_CMD_LSNS"
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_HELPER_MKFDS"
+ts_check_test_command "$TS_HELPER_SYSINFO"
 
 ts_check_prog "ip"
 
 ts_skip_nonroot
+
+if [ "$($TS_HELPER_SYSINFO ns-gettype-ok)" == "0" ]; then
+    ts_skip "NS_GET_NSTYPE ioctl cmd not available"
+fi
 
 FD=4
 NS=LSNS-TEST-FILEDESC-NS

--- a/tests/ts/lsns/filedesc
+++ b/tests/ts/lsns/filedesc
@@ -62,7 +62,8 @@ trap "cleanup" EXIT
 	    echo LSFD:
 	    ${TS_CMD_LSFD} -Q "PID == $PID"
 	    echo LSNS:
-	    ${TS_CMD_LSNS}
+	    LSNS_DEBUG=all ${TS_CMD_LSNS}
+	    echo lsns_status: $?
 	fi
 	echo DONE >&"${MKFDS[1]}"
     fi

--- a/tests/ts/lsns/filter
+++ b/tests/ts/lsns/filter
@@ -34,7 +34,6 @@ ts_skip_qemu_user
 ts_cd "$TS_OUTDIR"
 PID=
 FD=4
-EXPR=
 
 {
     coproc MKFDS { "$TS_HELPER_MKFDS" --comm ABC userns $FD; }

--- a/tests/ts/lsns/filter
+++ b/tests/ts/lsns/filter
@@ -38,7 +38,7 @@ FD=4
 {
     coproc MKFDS { "$TS_HELPER_MKFDS" --comm ABC userns $FD; }
     if read -u ${MKFDS[0]} PID; then
-	lsfd_expr="PID == \"${PID}\" and ASSOC == \"user\""
+	lsfd_expr="PID == ${PID} and ASSOC == \"user\""
 	inode=$(${TS_CMD_LSFD} -n --raw -o INODE -Q "${lsfd_expr}")
 	for opt in -Q --filter; do
 	    lsns_expr="NS == $inode && NPROCS == 1"

--- a/tests/ts/lsns/filter
+++ b/tests/ts/lsns/filter
@@ -38,20 +38,30 @@ FD=4
 {
     coproc MKFDS { "$TS_HELPER_MKFDS" --comm ABC userns $FD; }
     if read -u ${MKFDS[0]} PID; then
-	expr="PID == \"${PID}\" and ASSOC == \"user\""
-	inode=$(${TS_CMD_LSFD} -n --raw -o INODE -Q "${expr}")
+	lsfd_expr="PID == \"${PID}\" and ASSOC == \"user\""
+	inode=$(${TS_CMD_LSFD} -n --raw -o INODE -Q "${lsfd_expr}")
 	for opt in -Q --filter; do
-	    pid=$(${TS_CMD_LSNS} -n --raw -o PID "$opt" "NS == $inode && NPROCS == 1")
+	    lsns_expr="NS == $inode && NPROCS == 1"
+	    pid=$(${TS_CMD_LSNS} -n --raw -o PID "$opt" "${lsns_expr}")
 	    if [[ "$pid" = "$PID" ]]; then
 		echo  "$opt: pid == PID"
 	    else
 		echo "$opt: pid != PID"
-		echo expr: "${expr}"
-		${TS_CMD_LSFD} -n --raw -o INODE -Q "${expr}"
-		echo inode: "${inode}"
-		${TS_CMD_LSNS} -n --raw -o PID -Q "NS == $inode && NPROCS == 1"
+		echo lsfd_expr: "${lsfd_expr}"
+		echo lsns_expr: "${lsns_expr}"
 		echo pid: "${pid}"
 		echo PID: "${PID}"
+		echo inode: "${inode}"
+		echo lsfd:
+		${TS_CMD_LSFD} -n --raw $opt "${lsfd_expr}"
+		echo lsns:"${lsns_expr}"
+		${TS_CMD_LSNS} -n --raw $opt "${lsns_expr}"
+		echo lsns:inode:
+		${TS_CMD_LSNS} -n --raw $opt "NS == $inode"
+		echo lsns:NPROCS:
+		${TS_CMD_LSNS} -n --raw $opt "NPROCS == 1"
+		echo lsns
+		${TS_CMD_LSNS} -n --raw
 	    fi
 	done
 	echo DONE >&"${MKFDS[1]}"


### PR DESCRIPTION
In the original code, lsns printed nothing if it failed in opening the
last dntry in /proc/[0-9]* though lsns should work partially.
    
The original behavior caused the combination of the following two
test cases failed:
    
        $ tests/ts/lsns/filter & tests/ts/lsns/ioctl_ns &
        [1] 19178
        [2] 19179
        $          lsns: ownership and hierarchy        ...         \
        lsns: -Q, --filter option            ... FAILED
         FAILED
    
        [1]-  Done                    tests/ts/lsns/filter
        [2]+  Done                    tests/ts/lsns/ioctl_ns
