### PR TITLE
lslocks: don't abort gathering per-process information even if opening a /proc/[0-9]* fails

### DIFF
--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -490,12 +490,11 @@ static int get_pid_locks(void *locks, void (*add_lock)(void *, struct lock *), s
 	return rc;
 }
 
-static int get_pids_locks(void *locks, void (*add_lock)(void *, struct lock *))
+static void get_pids_locks(void *locks, void (*add_lock)(void *, struct lock *))
 {
 	DIR *dir;
 	struct dirent *d;
 	struct path_cxt *pc = NULL;
-	int rc = 0;
 
 	pc = ul_new_path(NULL);
 	if (!pc)
@@ -526,7 +525,7 @@ static int get_pids_locks(void *locks, void (*add_lock)(void *, struct lock *))
 	closedir(dir);
 	ul_unref_path(pc);
 
-	return rc;
+	return;
 }
 
 static int get_proc_locks(void *locks, void (*add_lock)(void *, struct lock *), void *fallback)

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -513,10 +513,8 @@ static int get_pids_locks(void *locks, void (*add_lock)(void *, struct lock *))
 		if (procfs_dirent_get_pid(d, &pid) != 0)
 			continue;
 
-		if (procfs_process_init_path(pc, pid) != 0) {
-			rc = -1;
-			break;
-		}
+		if (procfs_process_init_path(pc, pid) != 0)
+			continue;
 
 		if (procfs_process_get_cmdname(pc, buf, sizeof(buf)) <= 0)
 			continue;

--- a/tests/ts/lslocks/lslocks
+++ b/tests/ts/lslocks/lslocks
@@ -53,14 +53,6 @@ OFD_METHODS=(
     lease-w
 )
 
-SLEEP()
-{
-    # It appears that there is a time lag between locking and its
-    # visibility in /proc/locks.  See the unstbale results of errors I
-    # observed in https://github.com/util-linux/util-linux/pull/2629.
-    sleep 1
-}
-
 DFD=18
 COLS_WITH_HOLDERS=COMMAND,TYPE,SIZE,MODE,START,END,HOLDERS
 run_lslocks()
@@ -71,8 +63,6 @@ run_lslocks()
 	rm -f "${FILE}"
 	coproc MKFDS { "$TS_HELPER_MKFDS" make-regular-file $FD file="$FILE" lock=$m; }
 	if read -r -u "${MKFDS[0]}" PID; then
-	    SLEEP
-
 	    "$TS_CMD_LSLOCKS" ${OPTS} --pid "${PID}" -o "${COLS}"
 	    echo "# $m + ${COLS} + ${OPTS}": $?
 	    "$TS_CMD_LSLOCKS" ${OPTS} --pid "${PID}" -o PATH | sed -e 's#.*\('"$FILE0"'\)--[0-9]\+ *$#\1#'
@@ -91,7 +81,6 @@ run_lslocks_with_co_holders()
     {
 	rm -f "${FILE}"
 	coproc MKFDS { "$TS_HELPER_MKFDS" make-regular-file $FD file="$FILE" lock=$m dupfd=$DFD; }
-	SLEEP
 	if read -r -u "${MKFDS[0]}" PID; then
 	    "$TS_CMD_LSLOCKS" ${OPTS} --pid "${PID}" -o "${COLS_WITH_HOLDERS}" | sed -e "s/${PID},/1,/g"
 	    echo "# $m + ${COLS_WITH_HOLDERS} + ${OPTS}": ${PIPESTATUS[0]}


### PR DESCRIPTION
If a process ($pid) taking a lock is gone while running lslocks,
gathering per-process information for the process may fail in opening
/proc/$pid. Though lslocks should work with incomplete information,
the original code stopped gathering per-process information for the
other processes.

As a result of the original behavior, tests/ts/lslocks/lslocks really
failed in an environment where multiple test cases ran simultaneously.

Close #2624 again.
See also #2633.
