### PR TITLE
Revert "lib/pager: Apply pager-specific fixes only when needed"

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -85,9 +85,7 @@ static int start_command(struct child_process *cmd)
 			close(cmd->in);
 		}
 
-		if (cmd->preexec_cb)
-			cmd->preexec_cb();
-
+		cmd->preexec_cb();
 		execvp(cmd->argv[0], (char *const*) cmd->argv);
 		errexec(cmd->argv[0]);
 	}
@@ -142,7 +140,7 @@ static int finish_command(struct child_process *cmd)
 	return wait_or_whine(cmd->pid);
 }
 
-static void pager_preexec_less(void)
+static void pager_preexec(void)
 {
 	/*
 	 * Work around bug in "less" by not starting it until we
@@ -243,11 +241,7 @@ static void __setup_pager(void)
 	pager_argv[2] = pager;
 	pager_process.argv = pager_argv;
 	pager_process.in = -1;
-
-	if (!strncmp(pager, "less", 4))
-		pager_process.preexec_cb = pager_preexec_less;
-	else
-		pager_process.preexec_cb = NULL;
+	pager_process.preexec_cb = pager_preexec;
 
 	if (start_command(&pager_process))
 		return;


### PR DESCRIPTION
Less is not always detectable, as it can be hidden behind symlinks or wrapper as for example in a default Debian installation. Also testing for the literal string "less" does not match full path specifications like "/usr/bin/less".

Instead always apply the fixes.

This reverts commit c10ad975895372122f72c8d9da089b6ea69f778b. Closes #2951
Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>