### PR TITLE
textutils: introduce and use fgetwc_or_err

### DIFF
--- a/include/Makemodule.am
+++ b/include/Makemodule.am
@@ -26,6 +26,7 @@ dist_noinst_HEADERS += \
 	include/env.h \
 	include/exec_shell.h \
 	include/exitcodes.h \
+	include/fgetwc_or_err.h \
 	include/fileeq.h \
 	include/fileutils.h \
 	include/fuzz.h \

--- a/include/fgetwc_or_err.h
+++ b/include/fgetwc_or_err.h
@@ -1,0 +1,23 @@
+#ifndef UTIL_LINUX_FGETWC_OR_ERR_H
+#define UTIL_LINUX_FGETWC_OR_ERR_H
+
+#include <stdio.h>
+#include <wchar.h>
+#include <errno.h>
+
+#include "widechar.h"
+#include "c.h"
+#include "nls.h"
+
+static inline wint_t fgetwc_or_err(FILE *stream) {
+	wint_t ret;
+
+	errno = 0;
+	ret = fgetwc(stream);
+	if (ret == WEOF && errno != 0)
+		err(EXIT_FAILURE, _("fgetwc() failed"));
+
+	return ret;
+}
+
+#endif /* _FGETWC_OR_ERR_H */

--- a/login-utils/islocal.c
+++ b/login-utils/islocal.c
@@ -39,7 +39,7 @@ static int is_local_in_file(const char *user, const char *filename)
 
 	match = 0u;
 	skip = 0;
-	while ((chin = getc(f)) != EOF) {
+	while ((chin = fgetc(f)) != EOF) {
 		if (skip) {
 			/* Looking for the start of the next line. */
 			if ('\n' == chin) {

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -1843,9 +1843,9 @@ static int issuefile_read_stream(
 		ie->output = open_memstream(&ie->mem, &ie->mem_sz);
 	}
 
-	while ((c = getc(f)) != EOF) {
+	while ((c = fgetc(f)) != EOF) {
 		if (c == '\\')
-			output_special_char(ie, getc(f), op, tp, f);
+			output_special_char(ie, fgetc(f), op, tp, f);
 		else
 			putc(c, ie->output);
 	}

--- a/tests/expected/colcrt/regressions-crash1
+++ b/tests/expected/colcrt/regressions-crash1
@@ -1,2 +1,1 @@
- W U;    U;  D  f U;  D  f    D  f    >     @W  ]~   K- -  ----  -- -- -  -- -- ---- -- ---- --  -  --  --- --
-return value: 0
+return value: 1

--- a/tests/expected/colcrt/regressions-crash1.err
+++ b/tests/expected/colcrt/regressions-crash1.err
@@ -1,0 +1,1 @@
+colcrt: fgetwc() failed: Invalid or incomplete multibyte or wide character

--- a/tests/expected/colcrt/regressions-crash2
+++ b/tests/expected/colcrt/regressions-crash2
@@ -7,4 +7,4 @@ MN
 MN9|
 XYZ nT RnTUV|   NXP:w
    -
-MNOP.return value: 0
+return value: 1

--- a/tests/expected/colcrt/regressions-crash2.err
+++ b/tests/expected/colcrt/regressions-crash2.err
@@ -1,0 +1,1 @@
+colcrt: fgetwc() failed: Invalid or incomplete multibyte or wide character

--- a/tests/expected/colcrt/regressions-hang1
+++ b/tests/expected/colcrt/regressions-hang1
@@ -1,3 +1,3 @@
 789:;<=>=>?IABUVNXYZ[ `abcdefgg !"#$%&'()*+,-./01234)*:,-./0123456789:;[=>?1234)*:,-./0123456789:;[=>?4456789:;<=>?IABUVN`abcdefg !"
                      -
-return value: 0
+return value: 1

--- a/tests/expected/colcrt/regressions-hang1.err
+++ b/tests/expected/colcrt/regressions-hang1.err
@@ -1,0 +1,1 @@
+colcrt: fgetwc() failed: Invalid or incomplete multibyte or wide character

--- a/tests/ts/colcrt/regressions
+++ b/tests/ts/colcrt/regressions
@@ -28,6 +28,7 @@ check_input_file() {
 	ts_init_subtest ${1##*/}
 	timeout 2 env LC_ALL=C.UTF-8 $TS_CMD_COLCRT < $1 >> $TS_OUTPUT 2>> $TS_ERRLOG
 	echo "return value: $?" >> $TS_OUTPUT
+	sed -i -e 's/Illegal byte sequence/Invalid or incomplete multibyte or wide character/' $TS_ERRLOG
 	ts_finalize_subtest
 }
 

--- a/text-utils/colcrt.c
+++ b/text-utils/colcrt.c
@@ -164,7 +164,7 @@ static void colcrt(struct colcrt_control *ctl)
 			errno = 0;
 			old_pos = ftell(ctl->f);
 
-			while (getwc(ctl->f) != L'\n') {
+			while (fgetwc(ctl->f) != L'\n') {
 				long new_pos;
 
 				if (ferror(ctl->f) || feof(ctl->f))
@@ -179,10 +179,10 @@ static void colcrt(struct colcrt_control *ctl)
 			col = -1;
 			continue;
 		}
-		c = getwc(ctl->f);
+		c = fgetwc(ctl->f);
 		switch (c) {
 		case 033:	/* ESC */
-			c = getwc(ctl->f);
+			c = fgetwc(ctl->f);
 			if (c == L'8') {
 				col = rubchars(ctl, col, 1);
 				continue;

--- a/text-utils/colcrt.c
+++ b/text-utils/colcrt.c
@@ -49,6 +49,7 @@
 #include "c.h"
 #include "widechar.h"
 #include "closestream.h"
+#include "fgetwc_or_err.h"
 
 /*
  * colcrt - replaces col for crts with new nroff esp. when using tbl.
@@ -164,7 +165,7 @@ static void colcrt(struct colcrt_control *ctl)
 			errno = 0;
 			old_pos = ftell(ctl->f);
 
-			while (fgetwc(ctl->f) != L'\n') {
+			while (fgetwc_or_err(ctl->f) != L'\n') {
 				long new_pos;
 
 				if (ferror(ctl->f) || feof(ctl->f))
@@ -179,10 +180,10 @@ static void colcrt(struct colcrt_control *ctl)
 			col = -1;
 			continue;
 		}
-		c = fgetwc(ctl->f);
+		c = fgetwc_or_err(ctl->f);
 		switch (c) {
 		case 033:	/* ESC */
-			c = fgetwc(ctl->f);
+			c = fgetwc_or_err(ctl->f);
 			if (c == L'8') {
 				col = rubchars(ctl, col, 1);
 				continue;

--- a/text-utils/colrm.c
+++ b/text-utils/colrm.c
@@ -81,7 +81,7 @@ static int process_input(unsigned long first, unsigned long last)
 	int padding;
 
 	for (;;) {
-		c = getwc(stdin);
+		c = fgetwc(stdin);
 		if (c == WEOF)
 			return 0;
 		if (c == '\t')
@@ -112,7 +112,7 @@ static int process_input(unsigned long first, unsigned long last)
 
 	/* Loop getting rid of characters */
 	while (!last || ct < last) {
-		c = getwc(stdin);
+		c = fgetwc(stdin);
 		if (c == WEOF)
 			return 0;
 		if (c == '\n') {
@@ -135,7 +135,7 @@ static int process_input(unsigned long first, unsigned long last)
 
 	/* Output last of the line */
 	for (;;) {
-		c = getwc(stdin);
+		c = fgetwc(stdin);
 		if (c == WEOF)
 			break;
 		if (c == '\n') {

--- a/text-utils/colrm.c
+++ b/text-utils/colrm.c
@@ -48,6 +48,7 @@
 #include "c.h"
 #include "widechar.h"
 #include "closestream.h"
+#include "fgetwc_or_err.h"
 
 /*
 COLRM removes unwanted columns from a file
@@ -81,7 +82,7 @@ static int process_input(unsigned long first, unsigned long last)
 	int padding;
 
 	for (;;) {
-		c = fgetwc(stdin);
+		c = fgetwc_or_err(stdin);
 		if (c == WEOF)
 			return 0;
 		if (c == '\t')
@@ -112,7 +113,7 @@ static int process_input(unsigned long first, unsigned long last)
 
 	/* Loop getting rid of characters */
 	while (!last || ct < last) {
-		c = fgetwc(stdin);
+		c = fgetwc_or_err(stdin);
 		if (c == WEOF)
 			return 0;
 		if (c == '\n') {
@@ -135,7 +136,7 @@ static int process_input(unsigned long first, unsigned long last)
 
 	/* Output last of the line */
 	for (;;) {
-		c = fgetwc(stdin);
+		c = fgetwc_or_err(stdin);
 		if (c == WEOF)
 			break;
 		if (c == '\n') {

--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -379,7 +379,7 @@ static void more_fseek(struct more_control *ctl, off_t pos)
 
 static int more_getc(struct more_control *ctl)
 {
-	int ret = getc(ctl->current_file);
+	int ret = fgetc(ctl->current_file);
 	ctl->file_position = ftello(ctl->current_file);
 	return ret;
 }

--- a/text-utils/rev.c
+++ b/text-utils/rev.c
@@ -63,6 +63,7 @@
 #include "widechar.h"
 #include "c.h"
 #include "closestream.h"
+#include "fgetwc_or_err.h"
 
 static void sig_handler(int signo __attribute__ ((__unused__)))
 {
@@ -100,7 +101,7 @@ static size_t read_line(wchar_t sep, wchar_t *str, size_t n, FILE *stream)
 {
 	size_t r = 0;
 	while (r < n) {
-		wint_t c = fgetwc(stream);
+		wint_t c = fgetwc_or_err(stream);
 		if (c == WEOF)
 			break;
 		str[r++] = c;

--- a/text-utils/ul.c
+++ b/text-utils/ul.c
@@ -439,7 +439,7 @@ static int handle_escape(struct ul_ctl *ctl, struct term_caps const *const tcs, 
 {
 	wint_t c;
 
-	switch (c = getwc(f)) {
+	switch (c = fgetwc(f)) {
 	case HREV:
 		if (0 < ctl->half_position) {
 			ctl->mode &= ~SUBSCRIPT;
@@ -479,7 +479,7 @@ static void filter(struct ul_ctl *ctl, struct term_caps const *const tcs, FILE *
 	wint_t c;
 	int i, width;
 
-	while ((c = getwc(f)) != WEOF) {
+	while ((c = fgetwc(f)) != WEOF) {
 		switch (c) {
 		case '\b':
 			set_column(ctl, ctl->column && 0 < ctl->column ? ctl->column - 1 : 0);
@@ -498,7 +498,7 @@ static void filter(struct ul_ctl *ctl, struct term_caps const *const tcs, FILE *
 			continue;
 		case ESC:
 			if (handle_escape(ctl, tcs, f)) {
-				c = getwc(f);
+				c = fgetwc(f);
 				errx(EXIT_FAILURE,
 				     _("unknown escape sequence in input: %o, %o"), ESC, c);
 			}

--- a/text-utils/ul.c
+++ b/text-utils/ul.c
@@ -62,6 +62,7 @@
 #include "widechar.h"
 #include "c.h"
 #include "closestream.h"
+#include "fgetwc_or_err.h"
 
 #define	ESC	'\033'
 #define	SO	'\016'
@@ -439,7 +440,7 @@ static int handle_escape(struct ul_ctl *ctl, struct term_caps const *const tcs, 
 {
 	wint_t c;
 
-	switch (c = fgetwc(f)) {
+	switch (c = fgetwc_or_err(f)) {
 	case HREV:
 		if (0 < ctl->half_position) {
 			ctl->mode &= ~SUBSCRIPT;
@@ -479,7 +480,7 @@ static void filter(struct ul_ctl *ctl, struct term_caps const *const tcs, FILE *
 	wint_t c;
 	int i, width;
 
-	while ((c = fgetwc(f)) != WEOF) {
+	while ((c = fgetwc_or_err(f)) != WEOF) {
 		switch (c) {
 		case '\b':
 			set_column(ctl, ctl->column && 0 < ctl->column ? ctl->column - 1 : 0);
@@ -498,7 +499,7 @@ static void filter(struct ul_ctl *ctl, struct term_caps const *const tcs, FILE *
 			continue;
 		case ESC:
 			if (handle_escape(ctl, tcs, f)) {
-				c = fgetwc(f);
+				c = fgetwc_or_err(f);
 				errx(EXIT_FAILURE,
 				     _("unknown escape sequence in input: %o, %o"), ESC, c);
 			}


### PR DESCRIPTION
A return value of WEOF of fgetwc() can either mean end-of-file or an
error in errno. The error was ignored and interpreted as end-of-file.
Introduce a new helper that aborts on error and use it in text-utils.
   
This replaces all calls to plain fgetwc().
    
Closes #2909

@jidanni Your testcase from #2909 now:

```
perl -wle 'print pack("CCC",0xef,0xbb,0xbf), 1 x 22;'|env - LC_CTYPE=zh_TW.UTF-8 ./colrm 11|wc
colrm: fgetwc() failed: Invalid or incomplete multibyte or wide character
      0       0       0
```