### PR TITLE
meson: Only use the --version-script linker flag where it is supported

### DIFF
--- a/libblkid/meson.build
+++ b/libblkid/meson.build
@@ -131,14 +131,22 @@ if build_libblkid and not have_dirfd and not have_ddfd
   error('neither dirfd nor ddfd are available')
 endif
 
+libblkid_link_depends = []
+libblkid_link_args = []
+
+if cc.has_link_argument('-Wl,--version-script=@0@'.format(libblkid_sym_path))
+	libblkid_link_depends += [libblkid_sym]
+	libblkid_link_args += ['-Wl,--version-script=@0@'.format(libblkid_sym_path)]
+endif
+
 lib_blkid = both_libraries(
   'blkid',
   list_h,
   lib_blkid_sources,
   include_directories : [dir_include, dir_libblkid],
-  link_depends : libblkid_sym,
+  link_depends : libblkid_link_depends,
   version : libblkid_version,
-  link_args : ['-Wl,--version-script=@0@'.format(libblkid_sym_path)],
+  link_args : libblkid_link_args,
   link_with : lib_common,
   dependencies : build_libblkid ? [lib_econf] : disabler(),
   install : build_libblkid)

--- a/libuuid/meson.build
+++ b/libuuid/meson.build
@@ -20,6 +20,14 @@ unparse_c = files('src/unparse.c')
 libuuid_sym = 'src/libuuid.sym'
 libuuid_sym_path = '@0@/@1@'.format(meson.current_source_dir(), libuuid_sym)
 
+libuuid_link_depends = []
+libuuid_link_args = []
+
+if cc.has_link_argument('-Wl,--version-script=@0@'.format(libuuid_sym_path))
+	libuuid_link_depends += [libuuid_sym]
+	libuuid_link_args += ['-Wl,--version-script=@0@'.format(libuuid_sym_path)]
+endif
+
 lib_uuid = both_libraries(
   'uuid',
   list_h,
@@ -31,9 +39,9 @@ lib_uuid = both_libraries(
   md5_c,
   sha1_c,
   include_directories : [dir_include, dir_libuuid],
-  link_depends : libuuid_sym,
+  link_depends : libuuid_link_depends,
   version : libuuid_version,
-  link_args : ['-Wl,--version-script=@0@'.format(libuuid_sym_path)],
+  link_args : libuuid_link_args,
   dependencies : [socket_libs,
                   build_libuuid ? [] : disabler()],
   install : build_libuuid)


### PR DESCRIPTION
Cherry-pick of #2943 to the `stable/v2.40` branch.
This change is required to build `libuuid` on macOS.