### PR TITLE
meson: Remove lingering mq_libs variable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2720,9 +2720,6 @@ if opt and not is_disabler(exe)
   bashcompletions += ['lsblk']
 endif
 
-mq_libs = []
-mq_libs += cc.find_library('rt', required : true)
-
 opt = not get_option('build-lsfd').require(lib_rt.found()).disabled()
 exe = executable(
   'lsfd',


### PR DESCRIPTION
The cherry-pick of #2879 in PR #2941 to the stable/v2.40 branch didn't include the removal of `mq_libs` like it should have. I must have resolved a conflict incorrectly in the cherry-pick. This just removes the lingering definitions which are no longer used. The extra `find_library` call for `rt` is a problem and this fixes that.