### PR TITLE
all_errnos/all_syscalls: use sed to extract defines from headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,7 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_MKDIR_P
 AC_PROG_YACC
-AC_PROG_AWK
+AC_PROG_SED
 
 # Don't use autotools integrated LEX/YACC support for libsmartcols
 AC_PATH_PROG([FLEX], [flex])

--- a/meson.build
+++ b/meson.build
@@ -904,7 +904,7 @@ conf.set('USE_TTY_GROUP', have ? 1 : false)
 
 bison = find_program('bison')
 flex = find_program('flex')
-awk = find_program('gawk', 'mawk', 'nawk', 'awk')
+sed = find_program('sed')
 
 build_hwclock = not get_option('build-hwclock').disabled()
 bison_gen = generator(
@@ -2777,7 +2777,7 @@ endif
 errnos_h = custom_target('errnos.h',
   input : 'tools/all_errnos',
   output : 'errnos.h',
-  command : ['tools/all_errnos', awk.full_path(),
+  command : ['tools/all_errnos', sed.full_path(),
              cc.cmd_array(), get_option('c_args')],
 )
 
@@ -3095,7 +3095,7 @@ endif
 syscalls_h = custom_target('syscalls.h',
   input : 'tools/all_syscalls',
   output : 'syscalls.h',
-  command : ['tools/all_syscalls', awk.full_path(),
+  command : ['tools/all_syscalls', sed.full_path(),
              cc.cmd_array(), get_option('c_args')],
 )
 

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -1,6 +1,6 @@
 errnos.h: $(top_srcdir)/tools/all_errnos
 	@echo '  GEN      $@'
-	@$(top_srcdir)/tools/all_errnos "$(AWK)" $(CC) $(CFLAGS)
+	@$(top_srcdir)/tools/all_errnos "$(SED)" $(CC) $(CFLAGS)
 
 -include errnos.h.deps
 CLEANFILES += errnos.h errnos.h.deps
@@ -338,7 +338,7 @@ misc-utils/enosys.c: syscalls.h errnos.h
 
 syscalls.h: $(top_srcdir)/tools/all_syscalls
 	@echo '  GEN      $@'
-	@$(top_srcdir)/tools/all_syscalls "$(AWK)" $(CC) $(CFLAGS)
+	@$(top_srcdir)/tools/all_syscalls "$(SED)" $(CC) $(CFLAGS)
 
 -include syscalls.h.deps
 CLEANFILES += syscalls.h syscalls.h.deps

--- a/tools/all_errnos
+++ b/tools/all_errnos
@@ -5,7 +5,7 @@
 set -e
 set -o pipefail
 
-AWK="$1"
+SED="$1"
 shift
 OUTPUT=errnos.h
 ERRNO_INCLUDES="
@@ -15,6 +15,6 @@ ERRNO_INCLUDES="
 trap 'rm -f $OUTPUT $OUTPUT.deps' ERR
 
 "$@" -MD -MF "$OUTPUT.deps" <<< "$ERRNO_INCLUDES" -dM -E - \
-	| "$AWK" 'match($0, /^#[ \t]*define[ \t]*E([^ ]+)/, res) { print "UL_ERRNO(\"E" res[1] "\", E" res[1] ")" }' \
+	| "$SED" -n -e 's/^[ \t]*#define[ \t]*E\([^ ]*\).*$/UL_ERRNO("E\1", E\1)/p' \
 	| sort \
 	> "$OUTPUT"

--- a/tools/all_syscalls
+++ b/tools/all_syscalls
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-AWK="$1"
+SED="$1"
 shift
 OUTPUT=syscalls.h
 SYSCALL_INCLUDES="
@@ -13,6 +13,6 @@ SYSCALL_INCLUDES="
 trap 'rm -f $OUTPUT $OUTPUT.deps' ERR
 
 "$@" -MD -MF "$OUTPUT.deps" <<< "$SYSCALL_INCLUDES" -dM -E - \
-	| "$AWK" 'match($0, /^#define __NR_([^ ]+)/, res) { print "UL_SYSCALL(\"" res[1] "\", __NR_" res[1] ")" }' \
+	| "$SED" -n -e 's/^#define __NR_\([^ ]*\).*$/UL_SYSCALL("\1", __NR_\1)/p' \
 	| sort \
 	> "$OUTPUT"


### PR DESCRIPTION
Posix-compliant awk does not seem capable of matching lines and extracting capture groups of them.
Use sed instead.

Reported-by: John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
Link: https://lore.kernel.org/util-linux/051624b9256db27a731d62c031cb627d9f5a256e.camel@physik.fu-berlin.de/