### PR TITLE
meson: Use is_absolute to determine if the prefix directory is absolute

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ libsmartcols_version = '1.1.0'
 libfdisk_version = '1.1.0'
 
 prefixdir = get_option('prefix')
-if not prefixdir.startswith('/')
+if not fs.is_absolute(prefixdir)
         error('Prefix is not absolute: "@0@"'.format(prefixdir))
 endif
 bindir = join_paths(prefixdir, get_option('bindir'))


### PR DESCRIPTION
Meson's check for an absolute path does not work on Windows. Meson 0.54.0 introduced the [fs.is_absolute](https://mesonbuild.com/Fs-module.html#is_absolute) function. Use this instead.