### PR TITLE
meson: Add build-dmesg option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1535,16 +1535,18 @@ if opt and not is_disabler(exe)
   exes += exe
   manadocs += ['sys-utils/fstrim.8.adoc']
   bashcompletions += ['fstrim']
-endif  
+endif
 
+opt = get_option('build-dmesg').require(cc.has_header('sys/klog.h')).allowed()
 exe = executable(
   'dmesg',
   dmesg_sources,
   include_directories : includes,
   link_with : [lib_common,
                lib_tcolors],
-  install : true)
-if not is_disabler(exe)
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
   exes += exe
   manadocs += ['sys-utils/dmesg.1.adoc']
   bashcompletions += ['dmesg']

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -139,6 +139,8 @@ option('build-tunelp', type : 'feature',
        description : 'build tunelp')
 option('build-fstrim', type : 'feature',
        description : 'build fstrim')
+option('build-dmesg', type : 'feature',
+       description : 'build dmesg')
 option('build-kill', type : 'feature',
        description : 'build kill')
 option('build-last', type : 'feature',


### PR DESCRIPTION
Require the `sys/klog.h` header to exist in order to enable the feature.