### PR TITLE
v2.40: all_syscalls: use sed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,7 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_MKDIR_P
 AC_PROG_YACC
+AC_PROG_AWK
 
 # Don't use autotools integrated LEX/YACC support for libsmartcols
 AC_PATH_PROG([FLEX], [flex])

--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,7 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_MKDIR_P
 AC_PROG_YACC
-AC_PROG_AWK
+AC_PROG_SED
 
 # Don't use autotools integrated LEX/YACC support for libsmartcols
 AC_PATH_PROG([FLEX], [flex])

--- a/meson.build
+++ b/meson.build
@@ -895,6 +895,7 @@ conf.set('USE_TTY_GROUP', have ? 1 : false)
 
 bison = find_program('bison')
 flex = find_program('flex')
+awk = find_program('gawk', 'mawk', 'nawk', 'awk')
 
 build_hwclock = not get_option('build-hwclock').disabled()
 bison_gen = generator(
@@ -3034,7 +3035,8 @@ endif
 syscalls_h = custom_target('syscalls.h',
   input : 'tools/all_syscalls',
   output : 'syscalls.h',
-  command : ['tools/all_syscalls', cc.cmd_array(), get_option('c_args')] 
+  command : ['tools/all_syscalls', awk.full_path(),
+             cc.cmd_array(), get_option('c_args')],
 )
 
 if cc.compiles(fs.read('include/audit-arch.h'), name : 'has AUDIT_ARCH_NATIVE')

--- a/meson.build
+++ b/meson.build
@@ -895,7 +895,7 @@ conf.set('USE_TTY_GROUP', have ? 1 : false)
 
 bison = find_program('bison')
 flex = find_program('flex')
-awk = find_program('gawk', 'mawk', 'nawk', 'awk')
+sed = find_program('sed')
 
 build_hwclock = not get_option('build-hwclock').disabled()
 bison_gen = generator(
@@ -3035,7 +3035,7 @@ endif
 syscalls_h = custom_target('syscalls.h',
   input : 'tools/all_syscalls',
   output : 'syscalls.h',
-  command : ['tools/all_syscalls', awk.full_path(),
+  command : ['tools/all_syscalls', sed.full_path(),
              cc.cmd_array(), get_option('c_args')],
 )
 

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -326,7 +326,7 @@ misc-utils/enosys.c: syscalls.h
 
 syscalls.h: $(top_srcdir)/tools/all_syscalls
 	@echo '  GEN      $@'
-	@$(top_srcdir)/tools/all_syscalls $(CC) $(CFLAGS)
+	@$(top_srcdir)/tools/all_syscalls "$(AWK)" $(CC) $(CFLAGS)
 
 -include syscalls.h.deps
 CLEANFILES += syscalls.h syscalls.h.deps

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -326,7 +326,7 @@ misc-utils/enosys.c: syscalls.h
 
 syscalls.h: $(top_srcdir)/tools/all_syscalls
 	@echo '  GEN      $@'
-	@$(top_srcdir)/tools/all_syscalls "$(AWK)" $(CC) $(CFLAGS)
+	@$(top_srcdir)/tools/all_syscalls "$(SED)" $(CC) $(CFLAGS)
 
 -include syscalls.h.deps
 CLEANFILES += syscalls.h syscalls.h.deps

--- a/tools/all_syscalls
+++ b/tools/all_syscalls
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 OUTPUT=syscalls.h
 SYSCALL_INCLUDES="

--- a/tools/all_syscalls
+++ b/tools/all_syscalls
@@ -8,7 +8,7 @@ SYSCALL_INCLUDES="
 #include <sys/syscall.h>
 "
 
-trap 'rm $OUTPUT $OUTPUT.deps' ERR
+trap 'rm -f $OUTPUT $OUTPUT.deps' ERR
 
 "$@" -MD -MF "$OUTPUT.deps" <<< "$SYSCALL_INCLUDES" -dM -E - \
 	| gawk 'match($0, /^#define __NR_([^ ]+)/, res) { print "UL_SYSCALL(\"" res[1] "\", __NR_" res[1] ")" }' \

--- a/tools/all_syscalls
+++ b/tools/all_syscalls
@@ -3,6 +3,8 @@
 set -e
 set -o pipefail
 
+AWK="$1"
+shift
 OUTPUT=syscalls.h
 SYSCALL_INCLUDES="
 #include <sys/syscall.h>
@@ -11,6 +13,6 @@ SYSCALL_INCLUDES="
 trap 'rm -f $OUTPUT $OUTPUT.deps' ERR
 
 "$@" -MD -MF "$OUTPUT.deps" <<< "$SYSCALL_INCLUDES" -dM -E - \
-	| gawk 'match($0, /^#define __NR_([^ ]+)/, res) { print "UL_SYSCALL(\"" res[1] "\", __NR_" res[1] ")" }' \
+	| "$AWK" 'match($0, /^#define __NR_([^ ]+)/, res) { print "UL_SYSCALL(\"" res[1] "\", __NR_" res[1] ")" }' \
 	| sort \
 	> "$OUTPUT"

--- a/tools/all_syscalls
+++ b/tools/all_syscalls
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-AWK="$1"
+SED="$1"
 shift
 OUTPUT=syscalls.h
 SYSCALL_INCLUDES="
@@ -13,6 +13,6 @@ SYSCALL_INCLUDES="
 trap 'rm -f $OUTPUT $OUTPUT.deps' ERR
 
 "$@" -MD -MF "$OUTPUT.deps" <<< "$SYSCALL_INCLUDES" -dM -E - \
-	| "$AWK" 'match($0, /^#define __NR_([^ ]+)/, res) { print "UL_SYSCALL(\"" res[1] "\", __NR_" res[1] ")" }' \
+	| "$SED" -n -e 's/^#define __NR_\([^ ]*\).*$/UL_SYSCALL("\1", __NR_\1)/p' \
 	| sort \
 	> "$OUTPUT"


### PR DESCRIPTION
Backport of #2960 and #2964 , without the changes to `all_syscalls` as that doesn't exist there.