### PR TITLE
meson: Add missing check for build-ipcrm option and the seminfo type

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1387,16 +1387,20 @@ exes += exe
 manadocs += ['sys-utils/ipcmk.1.adoc']
 bashcompletions += ['ipcmk']
 
+opt = get_option('build-ipcrm').allowed()
 exe = executable(
   'ipcrm',
   ipcrm_sources,
   include_directories : includes,
   link_with : [lib_common],
   install_dir : usrbin_exec_dir,
-  install : true)
-exes += exe
-manadocs += ['sys-utils/ipcrm.1.adoc']
-bashcompletions += ['ipcrm']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['sys-utils/ipcrm.1.adoc']
+  bashcompletions += ['ipcrm']
+endif
 
 opt = not get_option('build-ipcs').disabled()
 exe = executable(

--- a/meson.build
+++ b/meson.build
@@ -1376,16 +1376,20 @@ exe = executable(
 exes += exe
 manadocs += ['sys-utils/choom.1.adoc']
 
+opt = get_option('build-ipcmk').allowed()
 exe = executable(
   'ipcmk',
   ipcmk_sources,
   include_directories : includes,
   link_with : [lib_common],
   install_dir : usrbin_exec_dir,
-  install : true)
-exes += exe
-manadocs += ['sys-utils/ipcmk.1.adoc']
-bashcompletions += ['ipcmk']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['sys-utils/ipcmk.1.adoc']
+  bashcompletions += ['ipcmk']
+endif
 
 opt = get_option('build-ipcrm').allowed()
 exe = executable(

--- a/meson.build
+++ b/meson.build
@@ -1376,7 +1376,9 @@ exe = executable(
 exes += exe
 manadocs += ['sys-utils/choom.1.adoc']
 
-opt = get_option('build-ipcmk').allowed()
+has_seminfo_type = cc.has_type('struct seminfo', args : '-D_GNU_SOURCE', prefix : '#include <sys/sem.h>')
+
+opt = get_option('build-ipcmk').require(has_seminfo_type).allowed()
 exe = executable(
   'ipcmk',
   ipcmk_sources,
@@ -1391,7 +1393,7 @@ if opt and not is_disabler(exe)
   bashcompletions += ['ipcmk']
 endif
 
-opt = get_option('build-ipcrm').allowed()
+opt = get_option('build-ipcrm').require(has_seminfo_type).allowed()
 exe = executable(
   'ipcrm',
   ipcrm_sources,
@@ -1406,7 +1408,7 @@ if opt and not is_disabler(exe)
   bashcompletions += ['ipcrm']
 endif
 
-opt = not get_option('build-ipcs').disabled()
+opt = not get_option('build-ipcs').require(has_seminfo_type).disabled()
 exe = executable(
   'ipcs',
   ipcs_sources,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -127,6 +127,8 @@ option('build-irqtop', type : 'feature',
        description : 'build irqtop')
 option('build-chmem', type : 'feature',
        description : 'build chmem')
+option('build-ipcmk', type : 'feature',
+       description : 'build ipcmk')
 option('build-ipcrm', type : 'feature',
        description : 'build ipcrm')
 option('build-ipcs', type : 'feature',


### PR DESCRIPTION
Cherry-pick of #2972 to the `stable/v2.40` branch.