### PR TITLE
agetty: Don't override TERM passed by the user

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -1196,7 +1196,8 @@ static void open_tty(const char *tty, struct termios *tp, struct options *op)
 #endif
 	}
 
-	op->term = get_terminal_default_type(op->tty, !(op->flags & F_VCONSOLE));
+	if (!op->term)
+		op->term = get_terminal_default_type(op->tty, !(op->flags & F_VCONSOLE));
 	if (!op->term)
 		log_err(_("failed to allocate memory: %m"));
 


### PR DESCRIPTION
Before 4869b259d68f65ea88df625ce8df9c0177d55a01, any TERM passed on the agetty command line would be used instead of the default TERM. After 4869b259d68f65ea88df625ce8df9c0177d55a01, the default TERM is used unconditionally.

Fix the regression by checking if the user passed a custom TERM.

Fixes: 4869b259d68f65ea88df625ce8df9c0177d55a01