### PR TITLE
lsns:  enhance the way to debug lsns::ioctl_ns test case

### DIFF
--- a/tests/ts/lsns/ioctl_ns
+++ b/tests/ts/lsns/ioctl_ns
@@ -95,7 +95,7 @@ init
 	cleanup
     fi
     exit $RESULT
-) &
+) >> $TS_ERRLOG 2>&1 &
 mainpid=$!
 (
     exec 4< $FIFO_WAIT

--- a/tests/ts/lsns/ioctl_ns
+++ b/tests/ts/lsns/ioctl_ns
@@ -80,6 +80,8 @@ init
 	echo
 	echo userns expected: "$expected"
 	echo userns actual:   "$actual"
+	echo "$TS_CMD_LSNS":
+	LSNS_DEBUG=all "$TS_CMD_LSNS"
 	cleanup
 	exit $RESULT
     fi
@@ -92,6 +94,8 @@ init
 	echo
 	echo pidns expected: "$expected"
 	echo pidns actual:   "$actual"
+	echo "$TS_CMD_LSNS":
+	LSNS_DEBUG=all "$TS_CMD_LSNS"
 	cleanup
     fi
     exit $RESULT


### PR DESCRIPTION
See #2967.

On the stable branch, we have rarely observed the lsns::ioctl_ns test case.
The changes in this pull request make the case print more information when it fails, which will be useful for future debugging of the case and lsns command.