### PR TITLE
findmnt: always zero-terminate SOURCES data

### DIFF
--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -552,7 +552,6 @@ static char *get_vfs_attr(struct libmnt_fs *fs, int sizetype)
 static char *get_data_col_sources(struct libmnt_fs *fs, int evaluate, size_t *datasiz)
 {
 	const char *tag = NULL, *p = NULL;
-	int i = 0;
 	const char *device = NULL;
 	char *val = NULL;
 	blkid_dev_iterate iter;
@@ -602,10 +601,8 @@ static char *get_data_col_sources(struct libmnt_fs *fs, int evaluate, size_t *da
 		dev = blkid_verify(blk_cache, dev);
 		if (!dev)
 			continue;
-		if (i != 0)
-			ul_buffer_append_data(&buf, "\0", 1);
 		ul_buffer_append_string(&buf, blkid_dev_devname(dev));
-		i++;
+		ul_buffer_append_data(&buf, "\0", 1);
 	}
 	blkid_dev_iterate_end(iter);
 	free(val);


### PR DESCRIPTION
libsmartcols expects it's data fields to be zero terminated. See the call to strlen() in scols_column_greatest_wrap(). ul_buffer however does not guarantee that termination, ul_buffer_append_strings() discard the zero-termination.

Always zero-terminate in get_data_col_sources() and drop the now unnecessary variable "i".

Closes: https://github.com/util-linux/util-linux/issues/2980

Notes:
The issue need root to reproduce.
This should also be backported.