### PR TITLE
libmount: Fix access check for utab in context

### DIFF
--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -367,8 +367,7 @@ const char *mnt_context_get_writable_tabpath(struct libmnt_context *cxt)
 {
 	assert(cxt);
 
-	context_init_paths(cxt, 1);
-	return cxt->utab_path;
+	return mnt_context_utab_writable(cxt) ? cxt->utab_path : NULL;
 }
 
 


### PR DESCRIPTION
The function mnt_has_regular_utab() properly detects that the utab is not writable, but this is ignored by the high-level context API. As a result, the library later attempts to update the file and ends up with a warning in mount(8):

 $ mkdir sys
 $ unshare --map-root-user --mount
 $ mount --rbind /sys sys
 $ umount --lazy sys; echo $?
 umount: /home/user/sys: filesystem was unmounted, but failed to update userspace mount table.
 16

In this case, the utab should be ignored.

Fixes: https://github.com/util-linux/util-linux/issues/2981