### PR TITLE
lsns: fix netns use

### DIFF
--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -835,6 +835,9 @@ static void interpolate_missing_namespaces(struct lsns *ls, struct lsns_namespac
 	int fd_orphan, fd_missing;
 	struct stat st;
 
+	if (!orphan->proc)
+		return;
+
 	orphan->related_ns[rela] = get_namespace(ls, orphan->related_id[rela]);
 	if (orphan->related_ns[rela])
 		return;


### PR DESCRIPTION
```
 # ip netns add vpn
 # lsns -T -t net
 Segmentation fault (core dumped)
```
The function interpolate_missing_namespaces() reads data from /proc. However, in the case of a persistent namespace, there is no procfs entry for the namespace. Therefore, this function should ignore it.

Fixes: https://github.com/util-linux/util-linux/issues/2982