### PR TITLE
meson: Add missing build options to enable building on macOS

### DIFF
--- a/include/strutils.h
+++ b/include/strutils.h
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/types.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/include/xalloc.h
+++ b/include/xalloc.h
@@ -13,6 +13,7 @@
 #ifndef UTIL_LINUX_XALLOC_H
 #define UTIL_LINUX_XALLOC_H
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/meson.build
+++ b/meson.build
@@ -3167,19 +3167,22 @@ syscalls_h = custom_target('syscalls.h',
              cc.cmd_array(), get_option('c_args')],
 )
 
-if cc.compiles(fs.read('include/audit-arch.h'), name : 'has AUDIT_ARCH_NATIVE')
-  exe = executable(
-    'enosys',
-    'misc-utils/enosys.c', syscalls_h, errnos_h,
-    include_directories : includes,
-    link_with : [lib_common],
-    install_dir : usrbin_exec_dir,
-    install : true)
-  if not is_disabler(exe)
-    exes += exe
-    manadocs += ['misc-utils/enosys.1.adoc']
-    bashcompletions += ['enosys']
-  endif
+have_linux_audit_h = cc.has_header('linux/audit.h')
+have_audit_arch_native = cc.compiles(fs.read('include/audit-arch.h'), name : 'has AUDIT_ARCH_NATIVE')
+
+opt = get_option('build-enosys').require(have_linux_audit_h and have_audit_arch_native).allowed()
+exe = executable(
+  'enosys',
+  'misc-utils/enosys.c', syscalls_h, errnos_h,
+  include_directories : includes,
+  link_with : [lib_common],
+  install_dir : usrbin_exec_dir,
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['misc-utils/enosys.1.adoc']
+  bashcompletions += ['enosys']
 endif
 
 exe = executable(

--- a/meson.build
+++ b/meson.build
@@ -3096,14 +3096,15 @@ if not is_disabler(exe)
   bashcompletions += ['hardlink']
 endif
 
-opt = not get_option('build-pipesz').disabled()
+opt = get_option('build-pipesz').allowed()
 exe = executable(
   'pipesz',
   pipesz_sources,
   include_directories : includes,
   link_with : [lib_common],
   install_dir : usrbin_exec_dir,
-  install : true)
+  install : opt,
+  build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
   manadocs += ['misc-utils/pipesz.1.adoc']

--- a/meson.build
+++ b/meson.build
@@ -460,8 +460,7 @@ endforeach
 
 have = cc.has_header('sched.h')
 conf.set10('HAVE_DECL_CPU_ALLOC', have)
-# We get -1 if the size cannot be determined
-have_cpu_set_t = cc.sizeof('cpu_set_t', prefix : '#define _GNU_SOURCE\n#include <sched.h>') > 0
+have_cpu_set_t = cc.has_type('cpu_set_t', args : '-D_GNU_SOURCE', prefix : '#include <sched.h>')
 conf.set('HAVE_CPU_SET_T', have_cpu_set_t ? 1 : false)
 
 have = cc.has_header_symbol('unistd.h', 'environ', args : '-D_GNU_SOURCE')

--- a/meson.build
+++ b/meson.build
@@ -3123,14 +3123,18 @@ if not is_disabler(exe)
   exes += exe
 endif
 
+have_posix_fadvise = conf.get('HAVE_POSIX_FADVISE').to_string() == '1'
+
+opt = get_option('build-fadvise').require(have_posix_fadvise).allowed()
 exe = executable(
   'fadvise',
   fadvise_sources,
   include_directories : includes,
   link_with : [lib_common],
   install_dir : usrbin_exec_dir,
-  install : true)
-if not is_disabler(exe)
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
   exes += exe
   manadocs += ['misc-utils/fadvise.1.adoc']
   bashcompletions += ['fadvise']

--- a/meson.build
+++ b/meson.build
@@ -2511,6 +2511,7 @@ endif
 
 ############################################################
 
+opt = get_option('build-script').require(have_pty).allowed()
 exe = executable(
   'script',
   script_sources,
@@ -2521,10 +2522,13 @@ exe = executable(
                   realtime_libs,
                   math_libs],
   install_dir : usrbin_exec_dir,
-  install : true)
-exes += exe
-manadocs += ['term-utils/script.1.adoc']
-bashcompletions += ['script']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['term-utils/script.1.adoc']
+  bashcompletions += ['script']
+endif
 
 exe = executable(
   'test_script',
@@ -2536,8 +2540,10 @@ exe = executable(
                   lib_utempter,
                   realtime_libs,
                   math_libs],
-  build_by_default : program_tests)
-exes += exe
+  build_by_default : opt and program_tests)
+if opt and not is_disabler(exe)
+  exes += exe
+endif
 
 exe = executable(
   'scriptlive',

--- a/meson.build
+++ b/meson.build
@@ -2545,6 +2545,7 @@ if opt and not is_disabler(exe)
   exes += exe
 endif
 
+opt = get_option('build-scriptlive').require(have_pty).allowed()
 exe = executable(
   'scriptlive',
   scriptlive_sources,
@@ -2554,10 +2555,13 @@ exe = executable(
                   realtime_libs,
                   math_libs],
   install_dir : usrbin_exec_dir,
-  install : true)
-exes += exe
-manadocs += ['term-utils/scriptlive.1.adoc']
-bashcompletions += ['scriptlive']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['term-utils/scriptlive.1.adoc']
+  bashcompletions += ['scriptlive']
+endif
 
 exe = executable(
   'scriptreplay',

--- a/meson.build
+++ b/meson.build
@@ -1610,14 +1610,16 @@ if cc.has_header('linux/blkzoned.h')
   bashcompletions += ['blkzone']
 endif
 
-if cc.has_header('linux/pr.h')
-  exe = executable(
-    'blkpr',
-    blkpr_sources,
-    include_directories : includes,
-    link_with : [lib_common],
-    install_dir : sbindir,
-    install : true)
+opt = get_option('build-blkpr').require(cc.has_header('linux/pr.h')).allowed()
+exe = executable(
+  'blkpr',
+  blkpr_sources,
+  include_directories : includes,
+  link_with : [lib_common],
+  install_dir : sbindir,
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
   exes += exe
   manadocs += ['sys-utils/blkpr.8.adoc']
 endif

--- a/meson.build
+++ b/meson.build
@@ -1651,16 +1651,20 @@ if opt and not is_disabler(exe)
   bashcompletions += ['ldattach']
 endif
 
+opt = get_option('build-rtcwake').require(cc.has_header('linux/rtc.h')).allowed()
 exe = executable(
   'rtcwake',
   rtcwake_sources,
   include_directories : includes,
   link_with : [lib_common],
   install_dir : usrsbin_exec_dir,
-  install : true)
-exes += exe
-manadocs += ['sys-utils/rtcwake.8.adoc']
-bashcompletions += ['rtcwake']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['sys-utils/rtcwake.8.adoc']
+  bashcompletions += ['rtcwake']
+endif
 
 exe = executable(
   'setarch',

--- a/meson.build
+++ b/meson.build
@@ -1654,7 +1654,9 @@ if opt and not is_disabler(exe)
   bashcompletions += ['ldattach']
 endif
 
-opt = get_option('build-rtcwake').require(cc.has_header('linux/rtc.h')).allowed()
+have_linux_rtc_h = cc.has_header('linux/rtc.h')
+
+opt = get_option('build-rtcwake').require(have_linux_rtc_h).allowed()
 exe = executable(
   'rtcwake',
   rtcwake_sources,
@@ -3185,14 +3187,16 @@ if opt and not is_disabler(exe)
   bashcompletions += ['enosys']
 endif
 
+opt = get_option('build-lsclocks').require(have_linux_rtc_h).allowed()
 exe = executable(
   'lsclocks',
   lsclocks_sources,
   include_directories : includes,
   link_with : [lib_common, lib_smartcols],
   install_dir : usrbin_exec_dir,
-  install : true)
-if not is_disabler(exe)
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
   exes += exe
   manadocs += ['misc-utils/lsclocks.1.adoc']
   bashcompletions += ['lsclocks']

--- a/meson.build
+++ b/meson.build
@@ -1575,15 +1575,19 @@ exes += exe
 manadocs += ['sys-utils/ctrlaltdel.8.adoc']
 bashcompletions += ['ctrlaltdel']
 
+opt = get_option('build-fsfreeze').require(conf.get('HAVE_LINUX_FS_H').to_string() == '1').allowed()
 exe = executable(
   'fsfreeze',
   fsfreeze_sources,
   include_directories : includes,
   install_dir : sbindir,
-  install : true)
-exes += exe
-manadocs += ['sys-utils/fsfreeze.8.adoc']
-bashcompletions += ['fsfreeze']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['sys-utils/fsfreeze.8.adoc']
+  bashcompletions += ['fsfreeze']
+endif
 
 exe = executable(
   'blkdiscard',

--- a/meson.build
+++ b/meson.build
@@ -1666,36 +1666,42 @@ if opt and not is_disabler(exe)
   bashcompletions += ['rtcwake']
 endif
 
+opt = get_option('build-setarch').require(cc.has_header('sys/personality.h')).allowed()
 exe = executable(
   'setarch',
   setarch_sources,
   include_directories : includes,
   link_with : [lib_common],
   install_dir : usrbin_exec_dir,
-  install : true)
-exes += exe
-manadocs += ['sys-utils/setarch.8.adoc']
-bashcompletions += ['setarch']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['sys-utils/setarch.8.adoc']
+  bashcompletions += ['setarch']
+endif
 
-setarch_links = ['uname26', 'linux32', 'linux64']
-setarch_links_arch = {
-  's390x' :   ['s390', 's390x'],
-  'x86' :     ['i386'],
-  'x86_64' :  ['i386', 'x86_64'],
-  'ppc64' :   ['ppc', 'ppc64', 'ppc32'],
-  'space64' : ['sparc', 'sparc64', 'sparc32', 'sparc32bash'],
-  'mips64' :  ['mips', 'mips64', 'mips32'],
-  'ia64' :    ['i386', 'ia64'],
-  'hppa' :    ['parisc', 'parisc64', 'parisc32'],
-}
-setarch_links += setarch_links_arch.get(host_machine.cpu_family(), [])
+if opt
+  setarch_links = ['uname26', 'linux32', 'linux64']
+  setarch_links_arch = {
+    's390x' :   ['s390', 's390x'],
+    'x86' :     ['i386'],
+    'x86_64' :  ['i386', 'x86_64'],
+    'ppc64' :   ['ppc', 'ppc64', 'ppc32'],
+    'space64' : ['sparc', 'sparc64', 'sparc32', 'sparc32bash'],
+    'mips64' :  ['mips', 'mips64', 'mips32'],
+    'ia64' :    ['i386', 'ia64'],
+    'hppa' :    ['parisc', 'parisc64', 'parisc32'],
+  }
+  setarch_links += setarch_links_arch.get(host_machine.cpu_family(), [])
 
-foreach link: setarch_links
-  meson.add_install_script(meson_make_symlink,
-                           'setarch',
-                           join_paths(usrbin_exec_dir, link))
-  manlinks += {link + '.8': 'setarch.8'}
-endforeach
+  foreach link: setarch_links
+    meson.add_install_script(meson_make_symlink,
+                            'setarch',
+                            join_paths(usrbin_exec_dir, link))
+    manlinks += {link + '.8': 'setarch.8'}
+  endforeach
+endif
 
 opt = not get_option('build-eject').disabled()
 exe = executable(

--- a/meson.build
+++ b/meson.build
@@ -1636,16 +1636,20 @@ if opt and not is_disabler(exe)
   manadocs += ['sys-utils/blkpr.8.adoc']
 endif
 
+opt = get_option('build-ldattach').require(cc.has_header('linux/if.h')).allowed()
 exe = executable(
   'ldattach',
   ldattach_sources,
   include_directories : includes,
   link_with : [lib_common],
   install_dir : usrsbin_exec_dir,
-  install : true)
-exes += exe
-manadocs += ['sys-utils/ldattach.8.adoc']
-bashcompletions += ['ldattach']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['sys-utils/ldattach.8.adoc']
+  bashcompletions += ['ldattach']
+endif
 
 exe = executable(
   'rtcwake',

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,10 @@ vendordir = get_option('vendordir')
 
 add_project_arguments('-D_GNU_SOURCE', '-fsigned-char', language : 'c')
 
+if host_machine.system() == 'darwin'
+  add_project_arguments('-D_DARWIN_C_SOURCE', language : 'c')
+endif
+
 cc = meson.get_compiler('c')
 
 conf = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -796,9 +796,9 @@ int main(void) {
 have = cc.compiles(code, name : 'using __progname')
 conf.set('HAVE___PROGNAME', have ? 1 : false)
 
-have = conf.get('HAVE_PTY_H').to_string() == '1' \
-       and conf.get('HAVE_SYS_SIGNALFD_H').to_string() == '1'
-conf.set('HAVE_PTY', have ? 1 : false)
+have_pty = conf.get('HAVE_PTY_H').to_string() == '1' \
+           and conf.get('HAVE_SYS_SIGNALFD_H').to_string() == '1'
+conf.set('HAVE_PTY', have_pty ? 1 : false)
 
 have_opal_get_status= cc.has_header_symbol('linux/sed-opal.h', 'IOC_OPAL_GET_STATUS')
 conf.set('HAVE_OPAL_GET_STATUS', have_opal_get_status ? 1 : false)
@@ -3327,7 +3327,7 @@ if conf.get('HAVE_OPENAT').to_string() == '1' \
   exes += exe
 endif
 
-if conf.get('HAVE_PTY').to_string() == '1'
+if have_pty
   exe = executable(
     'test_pty',
     pty_session_c,

--- a/meson.build
+++ b/meson.build
@@ -1091,7 +1091,7 @@ if opt and not is_disabler(exe)
   bashcompletions += ['utmpdump']
 endif
 
-opt = not get_option('build-su').disabled()
+opt = get_option('build-su').require(have_pty).allowed()
 exe = executable(
   'su',
   'login-utils/su.c',
@@ -1173,7 +1173,7 @@ if opt and not is_disabler(exe)
                            join_paths(mandir, 'man8/vigr.8'))
 endif
 
-opt = not get_option('build-runuser').disabled()
+opt = get_option('build-runuser').require(have_pty).allowed()
 exe = executable(
   'runuser',
   'login-utils/runuser.c',

--- a/meson.build
+++ b/meson.build
@@ -1903,16 +1903,20 @@ if not is_disabler(exe)
   bashcompletions += ['lscpu']
 endif
 
+opt = get_option('build-chcpu').require(have_cpu_set_t).allowed()
 exe = executable(
   'chcpu',
   chcpu_sources,
   include_directories : includes,
   link_with : [lib_common],
   install_dir : sbindir,
-  install : true)
-exes += exe
-manadocs += ['sys-utils/chcpu.8.adoc']
-bashcompletions += ['chcpu']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['sys-utils/chcpu.8.adoc']
+  bashcompletions += ['chcpu']
+endif
 
 exe = executable(
   'wdctl',

--- a/meson.build
+++ b/meson.build
@@ -1597,14 +1597,16 @@ exes += exe
 manadocs += ['sys-utils/blkdiscard.8.adoc']
 bashcompletions += ['blkdiscard']
 
-if cc.has_header('linux/blkzoned.h')
-  exe = executable(
-    'blkzone',
-    blkzone_sources,
-    include_directories : includes,
-    link_with : [lib_common],
-    install_dir : sbindir,
-    install : true)
+opt = get_option('build-blkzone').require(cc.has_header('linux/blkzoned.h')).allowed()
+exe = executable(
+  'blkzone',
+  blkzone_sources,
+  include_directories : includes,
+  link_with : [lib_common],
+  install_dir : sbindir,
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
   exes += exe
   manadocs += ['sys-utils/blkzone.8.adoc']
   bashcompletions += ['blkzone']

--- a/meson.build
+++ b/meson.build
@@ -2314,15 +2314,20 @@ if opt and not is_disabler(exe)
   bashcompletions += ['fdformat']
 endif
 
+opt = get_option('build-blockdev').require(LINUX).allowed()
 exe = executable(
   'blockdev',
   blockdev_sources,
   include_directories : includes,
   link_with : [lib_common],
   install_dir : sbindir,
-  install : true)
-manadocs += ['disk-utils/blockdev.8.adoc']
-bashcompletions += ['blockdev']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['disk-utils/blockdev.8.adoc']
+  bashcompletions += ['blockdev']
+endif
 
 opt = not get_option('build-fdisks').disabled()
 if opt and not have_dirfd and not have_ddfd

--- a/meson.build
+++ b/meson.build
@@ -1575,7 +1575,9 @@ exes += exe
 manadocs += ['sys-utils/ctrlaltdel.8.adoc']
 bashcompletions += ['ctrlaltdel']
 
-opt = get_option('build-fsfreeze').require(conf.get('HAVE_LINUX_FS_H').to_string() == '1').allowed()
+have_linux_fs_h = conf.get('HAVE_LINUX_FS_H').to_string() == '1'
+
+opt = get_option('build-fsfreeze').require(have_linux_fs_h).allowed()
 exe = executable(
   'fsfreeze',
   fsfreeze_sources,
@@ -1589,6 +1591,7 @@ if opt and not is_disabler(exe)
   bashcompletions += ['fsfreeze']
 endif
 
+opt = get_option('build-blkdiscard').require(have_linux_fs_h).allowed()
 exe = executable(
   'blkdiscard',
   blkdiscard_sources,
@@ -1596,12 +1599,15 @@ exe = executable(
   link_with : [lib_common],
   dependencies : [blkid_dep],
   install_dir : sbindir,
-  install : true)
-exes += exe
-manadocs += ['sys-utils/blkdiscard.8.adoc']
-bashcompletions += ['blkdiscard']
+  install : opt,
+  build_by_default : opt)
+if opt and not is_disabler(exe)
+  exes += exe
+  manadocs += ['sys-utils/blkdiscard.8.adoc']
+  bashcompletions += ['blkdiscard']
+endif
 
-opt = get_option('build-blkzone').require(cc.has_header('linux/blkzoned.h')).allowed()
+opt = get_option('build-blkzone').require(have_linux_fs_h).allowed()
 exe = executable(
   'blkzone',
   blkzone_sources,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -69,6 +69,8 @@ option('build-fsck', type : 'feature',
        description : 'build fsck')
 option('build-partx', type : 'feature',
        description : 'build addpart, delpart, partx')
+option('build-script', type : 'feature',
+       description : 'build script')
 
 option('build-uuidd', type : 'feature',
        description : 'build the uuid daemon')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -205,6 +205,8 @@ option('build-fadvise', type : 'feature',
        description : 'build fadvise')
 option('build-enosys', type : 'feature',
        description : 'build enosys')
+option('build-lsclocks', type : 'feature',
+       description : 'build lsclocks')
 option('build-setterm', type : 'feature',
        description : 'build setterm')
 option('build-schedutils', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -143,6 +143,8 @@ option('build-dmesg', type : 'feature',
        description : 'build dmesg')
 option('build-fsfreeze', type : 'feature',
        description : 'build fsfreeze')
+option('build-blkdiscard', type : 'feature',
+       description : 'build blkdiscard')
 option('build-blkzone', type : 'feature',
        description : 'build blkzone')
 option('build-blkpr', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -149,6 +149,8 @@ option('build-blkzone', type : 'feature',
        description : 'build blkzone')
 option('build-blkpr', type : 'feature',
        description : 'build blkpr')
+option('build-ldattach', type : 'feature',
+       description : 'build ldattach')
 option('build-kill', type : 'feature',
        description : 'build kill')
 option('build-last', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -141,6 +141,8 @@ option('build-fstrim', type : 'feature',
        description : 'build fstrim')
 option('build-dmesg', type : 'feature',
        description : 'build dmesg')
+option('build-blkpr', type : 'feature',
+       description : 'build blkpr')
 option('build-kill', type : 'feature',
        description : 'build kill')
 option('build-last', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -201,6 +201,8 @@ option('build-pg', type : 'feature',
        description : 'build pg')
 option('build-pipesz', type : 'feature',
        description : 'build pipesz')
+option('build-fadvise', type : 'feature',
+       description : 'build fadvise')
 option('build-setterm', type : 'feature',
        description : 'build setterm')
 option('build-schedutils', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -141,6 +141,8 @@ option('build-fstrim', type : 'feature',
        description : 'build fstrim')
 option('build-dmesg', type : 'feature',
        description : 'build dmesg')
+option('build-fsfreeze', type : 'feature',
+       description : 'build fsfreeze')
 option('build-blkzone', type : 'feature',
        description : 'build blkzone')
 option('build-blkpr', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -151,6 +151,8 @@ option('build-blkpr', type : 'feature',
        description : 'build blkpr')
 option('build-ldattach', type : 'feature',
        description : 'build ldattach')
+option('build-rtcwake', type : 'feature',
+       description : 'build rtcwake')
 option('build-kill', type : 'feature',
        description : 'build kill')
 option('build-last', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -57,6 +57,8 @@ option('build-swapon', type : 'feature',
        description : 'build swapon')
 option('build-swapoff', type : 'feature',
        description : 'build swapoff')
+option('build-chcpu', type : 'feature',
+       description : 'build chcpu')
 option('build-losetup', type : 'feature',
        description : 'build losetup')
 option('build-zramctl', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -71,6 +71,8 @@ option('build-partx', type : 'feature',
        description : 'build addpart, delpart, partx')
 option('build-script', type : 'feature',
        description : 'build script')
+option('build-scriptlive', type : 'feature',
+       description : 'build scriptlive')
 
 option('build-uuidd', type : 'feature',
        description : 'build the uuid daemon')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -141,6 +141,8 @@ option('build-fstrim', type : 'feature',
        description : 'build fstrim')
 option('build-dmesg', type : 'feature',
        description : 'build dmesg')
+option('build-blkzone', type : 'feature',
+       description : 'build blkzone')
 option('build-blkpr', type : 'feature',
        description : 'build blkpr')
 option('build-kill', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -203,6 +203,8 @@ option('build-pipesz', type : 'feature',
        description : 'build pipesz')
 option('build-fadvise', type : 'feature',
        description : 'build fadvise')
+option('build-enosys', type : 'feature',
+       description : 'build enosys')
 option('build-setterm', type : 'feature',
        description : 'build setterm')
 option('build-schedutils', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -153,6 +153,8 @@ option('build-ldattach', type : 'feature',
        description : 'build ldattach')
 option('build-rtcwake', type : 'feature',
        description : 'build rtcwake')
+option('build-setarch', type : 'feature',
+       description : 'build setarch')
 option('build-kill', type : 'feature',
        description : 'build kill')
 option('build-last', type : 'feature',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -99,6 +99,8 @@ option('build-minix', type : 'feature',
        description : 'build fsck.minix, mkfs.minix')
 option('build-fdformat', type : 'feature', value : 'disabled',
        description : 'build fdformat')
+option('build-blockdev', type : 'feature',
+       description : 'build blockdev')
 option('build-hwclock', type : 'feature',
        description : 'build hwclock')
 option('build-lslogins', type : 'feature',


### PR DESCRIPTION
Sorry for the large PR, I can break into smaller PR's as necessary. I tried to keep the commits as small and focused as possible.

These are the remaining build options and tweaks to get Meson building on macOS, at least when using `meson setup -Dauto_features=disabled ...`. Still, macOS builds will continue to be blocked by issue #2873.

I should be able to follow up with additional fixes for when `-Dauto_features=disabled` is omitted.