### PR TITLE
lsfd: include linux/fcntl.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -317,8 +317,6 @@ AC_CHECK_HEADERS([linux/compiler.h linux/blkpg.h linux/major.h], [], [], [
 #endif
 ])
 AC_CHECK_HEADERS([ \
-	asm-generic/fcntl.h \
-	asm/fcntl.h \
 	asm/io.h \
 	byteswap.h \
 	endian.h \

--- a/lsfd-cmd/decode-file-flags.c
+++ b/lsfd-cmd/decode-file-flags.c
@@ -24,30 +24,24 @@
 
 /* lsfd_decode_file_flags() is for decoding `flags' field of
  * /proc/$pid/fdinfo/$fd. Bits of the field have name defined
- * in fctl.h.
+ * in fcntl.h.
  * A system on which lsfd is built may have multiple
- * fctl.h files:
+ * fcntl.h files:
  *
+ * - /usr/include/linux/fcntl.h       (a part of Linux kernel)
  * - /usr/include/asm/fcntl.h         (a part of Linux kernel)
  * - /usr/include/asm-generic/fcntl.h (a part of Linux kernel)
  * - /usr/include/fcntl.h             (a part of glibc)
  * - /usr/include/bits/fcntl.h        (a part of glibc)
  *
- * For decoding purpose, /usr/include/asm/fcntl.h or
- * /usr/include/asm-generic/fcntl.h is needed.
+ * For decoding purpose, /usr/include/linuc/fcntl.h is needed.
  *
  * /usr/include/bits/fcntl.h and /usr/include/fcntl.h are
  * not suitable for decoding. They should not be included.
  * /usr/include/fcntl.h includes /usr/include/bits/fcntl.h.
  */
 
-#if defined HAVE_ASM_FCNTL_H
-#include <asm/fcntl.h>
-#elif defined HAVE_ASM_GENERIC_FCNTL_H
-#include <asm-generic/fcntl.h>
-#else
-#error "kernel's fcntl.h is not available"
-#endif
+#include <linux/fcntl.h>
 
 #include <stddef.h>		/* for size_t */
 struct ul_buffer;

--- a/meson.build
+++ b/meson.build
@@ -189,8 +189,6 @@ headers = '''
         unistd.h
         utmp.h
         utmpx.h
-        asm-generic/fcntl.h
-        asm/fcntl.h
         asm/io.h
         linux/blkzoned.h
         linux/capability.h


### PR DESCRIPTION
asm/-headers are implementation details and not meant to be included directly. Instead use the linux/ header which will always include the correct asm/-headers.