### PR TITLE
bcachefs: Remove BCACHEFS_SB_MAX_SIZE & check

### DIFF
--- a/libblkid/src/superblocks/bcache.c
+++ b/libblkid/src/superblocks/bcache.c
@@ -164,8 +164,6 @@ struct bcachefs_super_block {
 #define BCACHEFS_SECTOR_SIZE   512U
 /* maximum superblock size shift */
 #define BCACHEFS_SB_MAX_SIZE_SHIFT   0x10U
-/* maximum superblock size */
-#define BCACHEFS_SB_MAX_SIZE   (1U << BCACHEFS_SB_MAX_SIZE_SHIFT)
 /* fields offset within super block */
 #define BCACHEFS_SB_FIELDS_OFF offsetof(struct bcachefs_super_block, _start)
 /* tag value for members field */
@@ -359,9 +357,6 @@ static int probe_bcachefs(blkid_probe pr, const struct blkid_idmag *mag)
 		return BLKID_PROBE_NONE;
 
 	sb_size = BCACHEFS_SB_FIELDS_OFF + BYTES(bcs);
-
-	if (sb_size > BCACHEFS_SB_MAX_SIZE)
-		return BLKID_PROBE_NONE;
 
 	if (bcs->layout.sb_max_size_bits > BCACHEFS_SB_MAX_SIZE_SHIFT)
 		return BLKID_PROBE_NONE;


### PR DESCRIPTION
~The size of the super block as stated in the kernel:~

```c
  sb_max_size_bits; /* base 2 of 512 byte sectors */
```

~So the existing constant is off by a factor of 512.  This was discovered as some existing bcachefs FS have super blocks which exceed (1 << 0x010) or 65536.~

This constant had an incorrect value.  However, the code already
does a max. size check which is correct.

Note: bcachefs can theoretically have a superblock of 32MiB, but
this is very unlikely to happen.