### PR TITLE
losetup.8: Clarify --direct-io

### DIFF
--- a/sys-utils/losetup.8.adoc
+++ b/sys-utils/losetup.8.adoc
@@ -93,7 +93,7 @@ Force the kernel to scan the partition table on a newly created loop device. Not
 Set up a read-only loop device.
 
 *--direct-io*[**=on**|*off*]::
-Enable or disable direct I/O for the backing file. The optional argument can be either *on* or *off*. If the optional argument is omitted, it defaults to *on*.
+Enable or disable direct I/O for the backing file. The default is *off*. Specifying either *--direct-io* or *--direct-io=on* will enable it. But, *--direct-io=off* can be provided to explicitly turn it off.
 
 *-v*, *--verbose*::
 Verbose mode.


### PR DESCRIPTION
See e.g. https://github.com/containers/bootc/pull/375#issuecomment-1981109022

The phrasing here was in my opinion technically correct but quite confusing and easy to misunderstand.

Let's be very clear:

- The default is *off*
- You can turn it on in two ways
- You can also explicitly turn it off