### PR TITLE
libsmartcols: fix column reduction

### DIFF
--- a/libsmartcols/src/calculate.c
+++ b/libsmartcols/src/calculate.c
@@ -379,9 +379,14 @@ static int reduce_column(struct libscols_table *tb,
 			/* columns are reduced in "bad first" way, be more
 			 * agresive for the the worst column */
 			reduce = 3;
-		if (cl->width - reduce < st->width_min)
-			reduce = cl->width - st->width_min;
-		cl->width -= reduce;
+
+		if (cl->width < reduce)
+			reduce = cl->width;
+
+		if (cl->width - reduce > st->width_min)
+			cl->width -= reduce;
+		else
+			cl->width = st->width_min;
 		break;
 	default:
 		return -1;	/* no more stages */


### PR DESCRIPTION
4013986: libsmartcols:      TAB: [0x5626b97f8e10]: #5 reduce stage (width=38, term=1)
4013986: libsmartcols:      COL: [0x5626b97f9130]:  [01] (null) reduced 2-->18446744073709551615

Fixes: https://github.com/util-linux/util-linux/issues/3003