### PR TITLE
This re-enables build on macOS.

### DIFF
--- a/libuuid/src/uuid_time.c
+++ b/libuuid/src/uuid_time.c
@@ -85,6 +85,10 @@ time_t __uuid_time(const uuid_t uu, struct timeval *ret_tv)
 }
 #if defined(__USE_TIME_BITS64) && defined(__GLIBC__)
 extern time_t uuid_time64(const uuid_t uu, struct timeval *ret_tv) __attribute__((weak, alias("__uuid_time")));
+#elif defined(__clang__) && defined(__APPLE__)
+__asm__(".globl _uuid_time");
+__asm__(".set _uuid_time, ___uuid_time");
+extern time_t uuid_time(const uuid_t uu, struct timeval *ret_tv);
 #else
 extern time_t uuid_time(const uuid_t uu, struct timeval *ret_tv) __attribute__((weak, alias("__uuid_time")));
 #endif


### PR DESCRIPTION
Weak aliases are not supported by clang on Darwin. Instead this fix uses inline asm to make `_uuid_time` and alias to `___uuid_time`

Fixes util-linux/util-linux#2873