### PR TITLE
scriptreplay: add interactive playback controls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -510,6 +510,7 @@ CONTRIBUTORS:
       John Paul Morrison <jmorriso@rflab.ee.ubc.ca>
       John W Higgins <wishdev@gmail.com>
       John W. Linville <linville@tuxdriver.com>
+      Jonathan Ketchker <jonathan@ketchker.com>
       Jonathan Liu <net147@gmail.com>
       Jon Grant <jg@jguk.org>
       Jon Ringle <jon@ringle.org>

--- a/term-utils/script-playutils.c
+++ b/term-utils/script-playutils.c
@@ -8,6 +8,7 @@
 #include <math.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <stdbool.h>
 
 #include "c.h"
 #include "xalloc.h"
@@ -59,6 +60,7 @@ struct replay_setup {
 	size_t			nlogs;
 
 	struct replay_step	step;	/* current step */
+	bool pause;
 
 	FILE			*timing_fp;
 	const char		*timing_filename;
@@ -102,7 +104,10 @@ static inline void timerinc(struct timeval *a, struct timeval *b)
 
 struct replay_setup *replay_new_setup(void)
 {
-	return  xcalloc(1, sizeof(struct replay_setup));
+	struct replay_setup *ret;
+	ret = xcalloc(1, sizeof(struct replay_setup));
+	ret->pause = false;
+	return  ret;
 }
 
 void replay_free_setup(struct replay_setup *stp)
@@ -297,6 +302,17 @@ int replay_step_is_empty(struct replay_step *step)
 	return step->size == 0 && step->type == 0;
 }
 
+bool replay_get_is_paused(struct replay_setup *setup)
+{
+	assert(setup);
+	return setup->pause;
+}
+
+void replay_toggle_pause(struct replay_setup *setup)
+{
+	assert(setup);
+	setup->pause = !setup->pause;
+}
 
 static int read_multistream_step(struct replay_step *step, FILE *f, char type)
 {

--- a/term-utils/script-playutils.h
+++ b/term-utils/script-playutils.h
@@ -1,6 +1,8 @@
 #ifndef UTIL_LINUX_SCRIPT_PLAYUTILS_H
 #define UTIL_LINUX_SCRIPT_PLAYUTILS_H
 
+#include <stdbool.h>
+
 #include "c.h"
 #include "debug.h"
 
@@ -46,5 +48,8 @@ int replay_step_is_empty(struct replay_step *step);
 int replay_get_next_step(struct replay_setup *stp, char *streams, struct replay_step **xstep);
 
 int replay_emit_step_data(struct replay_setup *stp, struct replay_step *step, int fd);
+
+bool replay_get_is_paused(struct replay_setup *setup);
+void replay_toggle_pause(struct replay_setup *setup);
 
 #endif /* UTIL_LINUX_SCRIPT_PLAYUTILS_H */

--- a/term-utils/scriptreplay.1.adoc
+++ b/term-utils/scriptreplay.1.adoc
@@ -27,6 +27,8 @@ By default, the typescript to display is assumed to be named _typescript_, but o
 
 If the third parameter or *--divisor* is specified, it is used as a speed-up multiplier. For example, a speed-up of 2 makes *scriptreplay* go twice as fast, and a speed-down of 0.1 makes it go ten times slower than the original session.
 
+During the replay, you can interactively speed up, slow down, or pause the playback using key bindings.
+
 == OPTIONS
 
 *-I*, *--log-in* _file_::
@@ -75,6 +77,14 @@ Script started, file is script.out
 Script done, file is script.out
 % scriptreplay --log-timing file.tm --log-out script.out
 ....
+
+== KEY BINDINGS
+
+The following keys control the playback of the script:
+
+- *Space*: Toggles pause and unpause. Press this key to pause the playback, and press it again to resume.
+- *Up Arrow*: Increases the playback speed. Each press of this key will make the script replay faster by x0.1.
+- *Down Arrow*: Decreases the playback speed. Each press of this key will slow down the script replay by x0.1.
 
 == AUTHORS
 

--- a/term-utils/scriptreplay.1.adoc
+++ b/term-utils/scriptreplay.1.adoc
@@ -98,6 +98,9 @@ Copyright {copyright} 2008 James Youngman
 //TRANSLATORS: Keep {copyright} untranslated.
 Copyright {copyright} 2008-2019 Karel Zak
 
+//TRANSLATORS: Keep {copyright} untranslated.
+Copyright {copyright} 2024 Jonathan Ketchker
+
 This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 Released under the GNU General Public License version 2 or later.

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -159,7 +159,6 @@ main(int argc, char *argv[])
 	int saved_flag;
 	struct termios saved;
 
-	wint_t c;
 	struct replay_setup *setup = NULL;
 	struct replay_step *step = NULL;
 	char streams[6] = {0};		/* IOSI - in, out, signal,info */
@@ -323,8 +322,7 @@ main(int argc, char *argv[])
 	isterm = setterm(&saved, &saved_flag);
 
 	do {
-		c = fgetwc(stdin);
-		switch (c) {
+		switch (fgetwc(stdin)) {
 			case ' ':
 				replay_toggle_pause(setup);
 				break;

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -327,19 +327,18 @@ main(int argc, char *argv[])
 				replay_toggle_pause(setup);
 				break;
 			case '\033':
-				int first_char = fgetc(stdin);
-				if (first_char == '[') {
-					int second_char = fgetc(stdin);
-
-					if (second_char == 'A') { /* Up arrow */
+				ch = fgetc(stdin);
+				if (ch == '[') {
+					ch = fgetc(stdin);
+					if (ch == 'A') { /* Up arrow */
 						divi += 0.1;
 						replay_set_delay_div(setup, divi);
-					} else if (second_char == 'B') { /* Down arrow */
+					} else if (ch == 'B') { /* Down arrow */
 						divi -= 0.1;
 						if (divi < 0.1)
 							divi = 0.1;
 						replay_set_delay_div(setup, divi);
-					} else if (second_char == 'C') { /* Right arrow */
+					} else if (ch == 'C') { /* Right arrow */
 						rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
 						if (!rc) {
 							rc = replay_get_next_step(setup, streams, &step);

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2024, Jonathan Ketchker <jonathan@ketchker.com>
  * Copyright (C) 2008-2019, Karel Zak <kzak@redhat.com>
  * Copyright (C) 2008, James Youngman <jay@gnu.org>
  *

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -328,6 +328,25 @@ main(int argc, char *argv[])
 			case ' ':
 				replay_toggle_pause(setup);
 				break;
+			case '\033':
+				switch (fgetwc(stdin)) {
+					case '[':
+						switch (fgetwc(stdin)) {
+							case 'A':	// Up arrow
+								divi += 0.1;
+								replay_set_delay_div(setup, divi);
+								break;
+							case 'B': 	// Down arrow
+								divi -= 0.1;
+								if (divi < 0.1)
+									divi = 0.1;
+								replay_set_delay_div(setup, divi);
+								break;
+						}
+						break;
+				
+				}
+				break;
 		}
 
 		if (replay_get_is_paused(setup))

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -332,15 +332,15 @@ main(int argc, char *argv[])
 				if (first_char == '[') {
 					wchar_t second_char = fgetwc(stdin);
 
-					if (second_char == 'A') { // Up arrow
+					if (second_char == 'A') { /* Up arrow */
 						divi += 0.1;
 						replay_set_delay_div(setup, divi);
-					} else if (second_char == 'B') { // Down arrow
+					} else if (second_char == 'B') { /* Down arrow */
 						divi -= 0.1;
 						if (divi < 0.1)
 							divi = 0.1;
 						replay_set_delay_div(setup, divi);
-					} else if (second_char == 'C') { // Right arrow
+					} else if (second_char == 'C') { /* Right arrow */
 						rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
 						if (!rc) {
 							rc = replay_get_next_step(setup, streams, &step);
@@ -357,14 +357,12 @@ main(int argc, char *argv[])
 		if (rc)
 			break;
 
-		if (replay_get_is_paused(setup))
-		{
+		if (replay_get_is_paused(setup)) {
 			delay_for(&input_delay);
 			continue;
 		}
 
-		if (timerisset(&step_delay))
-		{
+		if (timerisset(&step_delay)) {
 			const struct timeval *timeout = (timercmp(&step_delay, &input_delay, <) ? (&step_delay) : (&input_delay));
 			delay_for(timeout);
 			timersub(&step_delay, timeout, &step_delay);
@@ -390,8 +388,7 @@ main(int argc, char *argv[])
 		}
 	} while (rc == 0);
 
-	if (isterm)
-	{
+	if (isterm) {
 		fcntl(STDIN_FILENO, F_SETFL, &saved_flag);
 		tcsetattr(STDOUT_FILENO, TCSADRAIN, &saved);
 	}

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -31,7 +31,6 @@
 #include <sys/time.h>
 #include <termios.h>
 #include <fcntl.h>
-#include <wchar.h>
 #include <stdbool.h>
 
 #include "c.h"
@@ -323,14 +322,14 @@ main(int argc, char *argv[])
 	isterm = setterm(&saved, &saved_flag);
 
 	do {
-		switch (fgetwc(stdin)) {
+		switch (fgetc(stdin)) {
 			case ' ':
 				replay_toggle_pause(setup);
 				break;
 			case '\033':
-				wchar_t first_char = fgetwc(stdin);
+				int first_char = fgetc(stdin);
 				if (first_char == '[') {
-					wchar_t second_char = fgetwc(stdin);
+					int second_char = fgetc(stdin);
 
 					if (second_char == 'A') { /* Up arrow */
 						divi += 0.1;

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -340,12 +340,22 @@ main(int argc, char *argv[])
 									divi = 0.1;
 								replay_set_delay_div(setup, divi);
 								break;
+							case 'C':	// Right arrow
+								rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
+								if (rc)
+									break;
+								rc = replay_get_next_step(setup, streams, &step);
+								struct timeval *delay = replay_step_get_delay(step);
+								if (delay && timerisset(delay))
+									stepDelay = *delay;
+								break;
 						}
 						break;
-				
 				}
 				break;
 		}
+		if (rc)
+			break;
 
 		if (replay_get_is_paused(setup))
 		{

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -152,8 +152,8 @@ int
 main(int argc, char *argv[])
 {
 	static const struct timeval mindelay = { .tv_sec = 0, .tv_usec = 100 };
-	static const struct timeval inputDelay = { .tv_sec = 0, .tv_usec = 100000 };
-	struct timeval stepDelay = { 0, 0 };
+	static const struct timeval input_delay = { .tv_sec = 0, .tv_usec = 100000 };
+	struct timeval step_delay = { 0, 0 };
 	struct timeval maxdelay;
 
 	int isterm;
@@ -328,26 +328,26 @@ main(int argc, char *argv[])
 				replay_toggle_pause(setup);
 				break;
 			case '\033':
-				wchar_t firstChar = fgetwc(stdin);
-				if (firstChar == '[') {
-					wchar_t secondChar = fgetwc(stdin);
+				wchar_t first_char = fgetwc(stdin);
+				if (first_char == '[') {
+					wchar_t second_char = fgetwc(stdin);
 
-					if (secondChar == 'A') { // Up arrow
+					if (second_char == 'A') { // Up arrow
 						divi += 0.1;
 						replay_set_delay_div(setup, divi);
-					} else if (secondChar == 'B') { // Down arrow
+					} else if (second_char == 'B') { // Down arrow
 						divi -= 0.1;
 						if (divi < 0.1)
 							divi = 0.1;
 						replay_set_delay_div(setup, divi);
-					} else if (secondChar == 'C') { // Right arrow
+					} else if (second_char == 'C') { // Right arrow
 						rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
 						if (!rc) {
 							rc = replay_get_next_step(setup, streams, &step);
 							if (!rc) {
 								struct timeval *delay = replay_step_get_delay(step);
 								if (delay && timerisset(delay))
-									stepDelay = *delay;
+									step_delay = *delay;
 							}
 						}
 					}
@@ -359,21 +359,21 @@ main(int argc, char *argv[])
 
 		if (replay_get_is_paused(setup))
 		{
-			delay_for(&inputDelay);
+			delay_for(&input_delay);
 			continue;
 		}
 
-		if (timerisset(&stepDelay))
+		if (timerisset(&step_delay))
 		{
-			const struct timeval *timeout = (timercmp(&stepDelay, &inputDelay, <) ? (&stepDelay) : (&inputDelay));
+			const struct timeval *timeout = (timercmp(&step_delay, &input_delay, <) ? (&step_delay) : (&input_delay));
 			delay_for(timeout);
-			timersub(&stepDelay, timeout, &stepDelay);
-			if (stepDelay.tv_sec < 0 || stepDelay.tv_usec < 0)
-				timerclear(&stepDelay);
+			timersub(&step_delay, timeout, &step_delay);
+			if (step_delay.tv_sec < 0 || step_delay.tv_usec < 0)
+				timerclear(&step_delay);
 			continue;
 		}
 
-		if (!timerisset(&stepDelay) && step)
+		if (!timerisset(&step_delay) && step)
 			rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
 		if (rc)
 			break;
@@ -386,7 +386,7 @@ main(int argc, char *argv[])
 			struct timeval *delay = replay_step_get_delay(step);
 
 			if (delay && timerisset(delay))
-				stepDelay = *delay;
+				step_delay = *delay;
 		}
 	} while (rc == 0);
 

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -88,7 +88,7 @@ getnum(const char *s)
 }
 
 static void
-delay_for(struct timeval *delay)
+delay_for(const struct timeval *delay)
 {
 #ifdef HAVE_NANOSLEEP
 	struct timespec ts, remainder;

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -323,34 +323,34 @@ main(int argc, char *argv[])
 
 	do {
 		switch (fgetc(stdin)) {
-			case ' ':
-				replay_toggle_pause(setup);
-				break;
-			case '\033':
+		case ' ':
+			replay_toggle_pause(setup);
+			break;
+		case '\033':
+			ch = fgetc(stdin);
+			if (ch == '[') {
 				ch = fgetc(stdin);
-				if (ch == '[') {
-					ch = fgetc(stdin);
-					if (ch == 'A') { /* Up arrow */
-						divi += 0.1;
-						replay_set_delay_div(setup, divi);
-					} else if (ch == 'B') { /* Down arrow */
-						divi -= 0.1;
-						if (divi < 0.1)
-							divi = 0.1;
-						replay_set_delay_div(setup, divi);
-					} else if (ch == 'C') { /* Right arrow */
-						rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
+				if (ch == 'A') { /* Up arrow */
+					divi += 0.1;
+					replay_set_delay_div(setup, divi);
+				} else if (ch == 'B') { /* Down arrow */
+					divi -= 0.1;
+					if (divi < 0.1)
+						divi = 0.1;
+					replay_set_delay_div(setup, divi);
+				} else if (ch == 'C') { /* Right arrow */
+					rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
+					if (!rc) {
+						rc = replay_get_next_step(setup, streams, &step);
 						if (!rc) {
-							rc = replay_get_next_step(setup, streams, &step);
-							if (!rc) {
-								struct timeval *delay = replay_step_get_delay(step);
-								if (delay && timerisset(delay))
-									step_delay = *delay;
-							}
+							struct timeval *delay = replay_step_get_delay(step);
+							if (delay && timerisset(delay))
+								step_delay = *delay;
 						}
 					}
 				}
-				break;
+			}
+			break;
 		}
 		if (rc)
 			break;

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -328,34 +328,29 @@ main(int argc, char *argv[])
 				replay_toggle_pause(setup);
 				break;
 			case '\033':
-				switch (fgetwc(stdin)) {
-					case '[':
-						switch (fgetwc(stdin)) {
-							case 'A':	// Up arrow
-								divi += 0.1;
-								replay_set_delay_div(setup, divi);
-								break;
-							case 'B': 	// Down arrow
-								divi -= 0.1;
-								if (divi < 0.1)
-									divi = 0.1;
-								replay_set_delay_div(setup, divi);
-								break;
-							case 'C':	// Right arrow
-								rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
-								if (rc)
-									break;
+				wchar_t firstChar = fgetwc(stdin);
+				if (firstChar == '[') {
+					wchar_t secondChar = fgetwc(stdin);
 
-								rc = replay_get_next_step(setup, streams, &step);
-								if (rc)
-									break;
-
+					if (secondChar == 'A') { // Up arrow
+						divi += 0.1;
+						replay_set_delay_div(setup, divi);
+					} else if (secondChar == 'B') { // Down arrow
+						divi -= 0.1;
+						if (divi < 0.1)
+							divi = 0.1;
+						replay_set_delay_div(setup, divi);
+					} else if (secondChar == 'C') { // Right arrow
+						rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
+						if (!rc) {
+							rc = replay_get_next_step(setup, streams, &step);
+							if (!rc) {
 								struct timeval *delay = replay_step_get_delay(step);
 								if (delay && timerisset(delay))
 									stepDelay = *delay;
-								break;
+							}
 						}
-						break;
+					}
 				}
 				break;
 		}

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -345,7 +345,11 @@ main(int argc, char *argv[])
 								rc = replay_emit_step_data(setup, step, STDOUT_FILENO);
 								if (rc)
 									break;
+
 								rc = replay_get_next_step(setup, streams, &step);
+								if (rc)
+									break;
+
 								struct timeval *delay = replay_step_get_delay(step);
 								if (delay && timerisset(delay))
 									stepDelay = *delay;
@@ -385,6 +389,7 @@ main(int argc, char *argv[])
 
 		if (!summary) {
 			struct timeval *delay = replay_step_get_delay(step);
+
 			if (delay && timerisset(delay))
 				stepDelay = *delay;
 		}


### PR DESCRIPTION
Adds interactive playback controls based of #2999 .

Status:
- [x] Pausing and resuming playback: space to toggle.
- [x] Adjusting playback speed: up/down (arrows), +/- 0.1x steps
- [x] Stepwise navigation: right (arrow) for step forward
- [x] Add this info and key-bindings to docs/man.

I did not add all suggested in #2999 , These are what i think the most important.
Adding a backward step is non trivial without rewriting lots of how the playback works, and most terminals allow to scroll back the stream anyway.
Speed for holding the key-bind is also self emerging from the `inputDelay`.

So i think its best to attempt to merge this basic form so it ships the core features with less complex changes.