### PR TITLE
Revert "include: define pidfd syscalls if needed"

### DIFF
--- a/include/pidfd-utils.h
+++ b/include/pidfd-utils.h
@@ -8,20 +8,6 @@
 #ifdef HAVE_SYS_SYSCALL_H
 # include <sys/syscall.h>
 # include <unistd.h>
-
-/*
- * If the kernel headers are too old to provide the syscall numbers, let's
- * define them ourselves. This can be helpful while cross-compiling.
- */
-#ifndef __NR_pidfd_send_signal
-#define __NR_pidfd_send_signal 424
-#define SYS_pidfd_send_signal __NR_pidfd_send_signal
-#endif
-#ifndef __NR_pidfd_open
-#define __NR_pidfd_open 434
-#define SYS_pidfd_open __NR_pidfd_open
-#endif
-
 # if defined(SYS_pidfd_send_signal) && defined(SYS_pidfd_open)
 #  ifdef HAVE_SYS_PIDFD_H
 #   include <sys/pidfd.h>

--- a/misc-utils/lsfd-file.c
+++ b/misc-utils/lsfd-file.c
@@ -657,9 +657,10 @@ static unsigned long get_minor_for_mqueue(void)
 
 static unsigned long get_minor_for_pidfs(void)
 {
+	unsigned long ret = 0;
+#ifdef UL_HAVE_PIDFD
 	int fd = pidfd_open(getpid(), 0);
 	struct stat sb;
-	unsigned long ret = 0;
 
 	if (fd < 0)
 		return 0;
@@ -668,6 +669,7 @@ static unsigned long get_minor_for_pidfs(void)
 		ret = minor(sb.st_dev);
 
 	close(fd);
+#endif
 	return ret;
 }
 


### PR DESCRIPTION
This reverts commit 7f45939f24d640ec742b857888e29a2bf2bf1fd5.

Syscall numbers are not the same on all architectures. pidfd_open is 544 on alpha; 4434, 5434, or 6434 on mips; etc.