### PR TITLE
meson: Fix handling of the Python dependency

### DIFF
--- a/libmount/python/meson.build
+++ b/libmount/python/meson.build
@@ -13,6 +13,11 @@ if LINUX
   pylibmount_sources += 'context.c'
 endif
 
+python_module = import('python')
+python = python_module.find_installation(
+    get_option('python'),
+    required : true,
+    disabler : true)
 python.extension_module(
   'pylibmount',
   pylibmount_sources,

--- a/libmount/python/meson.build
+++ b/libmount/python/meson.build
@@ -1,4 +1,6 @@
-build_python = python.found()
+if get_option('build-python').disabled()
+  subdir_done()
+endif
 
 pylibmount_sources = '''
   pylibmount.c
@@ -11,24 +13,22 @@ if LINUX
   pylibmount_sources += 'context.c'
 endif
 
-if build_python
-  python.extension_module(
-    'pylibmount',
-    pylibmount_sources,
-    include_directories : [dir_include],
-    subdir : 'libmount',
-    dependencies : [mount_dep, python.dependency(embed: true)],
-    c_args : [
-      '-Wno-cast-function-type',
+python.extension_module(
+  'pylibmount',
+  pylibmount_sources,
+  include_directories : [dir_include],
+  subdir : 'libmount',
+  dependencies : [mount_dep, python.dependency(embed: true)],
+  c_args : [
+    '-Wno-cast-function-type',
 
-      # https://github.com/util-linux/util-linux/issues/2366
-      python.language_version().version_compare('>=3.12') ?
-        [ '-Wno-error=redundant-decls' ] : [],
-    ],
-    install : true)
+    # https://github.com/util-linux/util-linux/issues/2366
+    python.language_version().version_compare('>=3.12') ?
+      [ '-Wno-error=redundant-decls' ] : [],
+  ],
+  install : true)
 
-  python.install_sources(
-    '__init__.py',
-    subdir : 'libmount',
-    pure : false)
-endif
+python.install_sources(
+  '__init__.py',
+  subdir : 'libmount',
+  pure : false)

--- a/libmount/python/meson.build
+++ b/libmount/python/meson.build
@@ -18,6 +18,11 @@ python = python_module.find_installation(
     get_option('python'),
     required : true,
     disabler : true)
+if meson.version().version_compare('<1.4.1')
+  cc.has_header('Python.h',
+    include_directories : include_directories(python.get_path('include')),
+    required : true)
+endif
 python.extension_module(
   'pylibmount',
   pylibmount_sources,

--- a/meson.build
+++ b/meson.build
@@ -913,11 +913,7 @@ bison_gen = generator(
   output : ['@BASENAME@.tab.c', '@BASENAME@.tab.h'],
   arguments : ['@INPUT@', '--defines=@OUTPUT1@', '--output=@OUTPUT0@'])
 
-python_module = import('python')
-python = python_module.find_installation(
-    get_option('python'),
-    required : true,
-    disabler : true)
+python_program = find_program('python3', 'python', native : true)
 
 meson_make_symlink = meson.current_source_dir() + '/tools/meson-make-symlink.sh'
 meson_make_manpage_stub = meson.current_source_dir() + '/tools/meson-make-manpage-stub.sh'
@@ -3784,7 +3780,7 @@ configure_file(output : 'meson.conf',
                           '''asan=@0@
 PYTHON=@1@
 '''.format(get_option('b_sanitize')=='address' ? 'yes' : '',
-           python.full_path())])
+           python_program.full_path())])
 
 run_sh = find_program('tests/run.sh')
 run_target(


### PR DESCRIPTION
This PR fixes a couple of issues with the current Python handling in Meson.

1. I inadvertently rendered the `build-python` option useless in commit b6799cc. This caused issue #3014.
2. The `embed` argument for the Python dependency used to incorporate the `Python.h` header file worked around an issue in Meson itself, see https://github.com/mesonbuild/meson/issues/12862 and the discussion in #2924. Meson should actually require the `Python.h` header file be present when `find_installation` is called for the Python module. This has an additional side-effect that Meson 1.4.1 will require `Python.h` in order to run the tests which use `find_installation`. The tests just need the path to the Python executable, not the `Python.h` header file.

This PR fixes these problems by making sure to use the `build-python` option to determine whether or not to build `pylibmount`. It fixes the check for `Python.h` by checking for it explicitly when building `pylibmount` when using versions of Meson prior to 1.4.1. Finally, the Python module and `find_installation` are only used for `pylibmount` and `find_program` is used to incorporate the Python path for tests to ensure that the `Python.h` header file is not unnecessarily required for tests when using Meson version 1.4.1 or later.

Fixes #3014