### PR TITLE
meson: Fix build-python option

### DIFF
--- a/libmount/python/meson.build
+++ b/libmount/python/meson.build
@@ -1,4 +1,6 @@
-build_python = python.found()
+if get_option('build-python').disabled()
+  subdir_done()
+endif
 
 pylibmount_sources = '''
   pylibmount.c
@@ -11,24 +13,22 @@ if LINUX
   pylibmount_sources += 'context.c'
 endif
 
-if build_python
-  python.extension_module(
-    'pylibmount',
-    pylibmount_sources,
-    include_directories : [dir_include],
-    subdir : 'libmount',
-    dependencies : [mount_dep, python.dependency(embed: true)],
-    c_args : [
-      '-Wno-cast-function-type',
+python.extension_module(
+  'pylibmount',
+  pylibmount_sources,
+  include_directories : [dir_include],
+  subdir : 'libmount',
+  dependencies : [mount_dep, python.dependency(embed: true)],
+  c_args : [
+    '-Wno-cast-function-type',
 
-      # https://github.com/util-linux/util-linux/issues/2366
-      python.language_version().version_compare('>=3.12') ?
-        [ '-Wno-error=redundant-decls' ] : [],
-    ],
-    install : true)
+    # https://github.com/util-linux/util-linux/issues/2366
+    python.language_version().version_compare('>=3.12') ?
+      [ '-Wno-error=redundant-decls' ] : [],
+  ],
+  install : true)
 
-  python.install_sources(
-    '__init__.py',
-    subdir : 'libmount',
-    pure : false)
-endif
+python.install_sources(
+  '__init__.py',
+  subdir : 'libmount',
+  pure : false)


### PR DESCRIPTION
The `build-python` option is for controlling whether or not `pylibmount` is built. Unfortunately, commit b6799cc rendered the option unused. This change uses the `build-python` option again.

Fixes #3014