### PR TITLE
Fix fstab order in `column` manpage example.

### DIFF
--- a/text-utils/column.1.adoc
+++ b/text-utils/column.1.adoc
@@ -211,7 +211,7 @@ Historical versions of this tool indicated that "rows are filled before columns"
 Print fstab with header line and align number to the right:
 
 ....
-sed 's/#.*//' /etc/fstab | column --table --table-columns SOURCE,TARGET,TYPE,OPTIONS,PASS,FREQ --table-right PASS,FREQ
+sed 's/#.*//' /etc/fstab | column --table --table-columns SOURCE,TARGET,TYPE,OPTIONS,FREQ,PASS --table-right FREQ,PASS
 ....
 
 Print fstab and hide unnamed columns:


### PR DESCRIPTION
fstab is:

1. fs_spec
2. fs_file
3. fs_vfstype
4. fs_mntops
5. fs_freq
6. fs_passno

In other words it's:

    SOURCE,TARGET,TYPE,OPTIONS,FREQ,PASS