### PR TITLE
Conditionally add uuid_time64 to sym. version map

### DIFF
--- a/libuuid/src/libuuid.sym
+++ b/libuuid/src/libuuid.sym
@@ -57,7 +57,7 @@ global:
  */
 UUID_2.40 {
 global:
-        uuid_time64; /* only on 32bit architectures with 64bit time_t */
+        uuid_time64*; /* only on 32bit architectures with 64bit time_t */
 } UUID_2.36;
 
 /*


### PR DESCRIPTION
The symbol uuid_time64 is conditionally defined. It only exists on 32-bit platforms that use the glibc library and enable support for the 64-bit time_t type.

For all other platforms, the symbol is undefined. As a result, when ld.lld version 17 or newer is used with default flags, ld.lld will reject the symbol map with the error:

    version script assignment of 'UUID_2.40' to symbol 'uuid_time64'
    failed: symbol not defined

To fix this issue, configure.ac and libuuid/src/Makemodule.am are updated to determine which version of the symbol map is needed, and supply the proper symbol map to ld.lld when linking.

fixes util-linux/util-linux#3036
fixes Gentoo bug #931328