### PR TITLE
include/pidfd-utils: provide ENOSYS stubs if pidfd functions are missing

### DIFF
--- a/include/pidfd-utils.h
+++ b/include/pidfd-utils.h
@@ -5,6 +5,9 @@
 #ifndef UTIL_LINUX_PIDFD_UTILS
 #define UTIL_LINUX_PIDFD_UTILS
 
+#include <sys/types.h>
+#include <sys/wait.h>
+
 #ifdef HAVE_SYS_SYSCALL_H
 # include <sys/syscall.h>
 # include <unistd.h>
@@ -13,9 +16,7 @@
 #  ifdef HAVE_SYS_PIDFD_H
 #   include <sys/pidfd.h>
 #  endif
-#  include <sys/types.h>
 #  ifndef HAVE_PIDFD_SEND_SIGNAL
-#   include <sys/wait.h>
 static inline int pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
 				    unsigned int flags)
 {
@@ -34,4 +35,23 @@ static inline int pidfd_open(pid_t pid, unsigned int flags)
 
 # endif	/* SYS_pidfd_send_signal */
 #endif /* HAVE_SYS_SYSCALL_H */
+
+#ifndef UL_HAVE_PIDFD
+static inline int pidfd_send_signal(int pidfd __attribute__((unused)),
+				    int sig __attribute__((unused)),
+				    siginfo_t *info __attribute__((unused)),
+				    unsigned int flags __attribute__((unused)))
+{
+	errno = ENOSYS;
+	return -1;
+}
+
+static inline int pidfd_open(pid_t pid __attribute__((unused)),
+			     unsigned int flags __attribute__((unused)))
+{
+	errno = ENOSYS;
+	return -1;
+}
+#endif
+
 #endif /* UTIL_LINUX_PIDFD_UTILS */


### PR DESCRIPTION
This allows code which can gracefully fall back to compile.

This should fix the CI on Ubuntu 18.04.