### PR TITLE
pam_lastlog2: drop duplicate assignment pam_lastlog2_la_LDFLAGS

### DIFF
--- a/pam_lastlog2/src/Makemodule.am
+++ b/pam_lastlog2/src/Makemodule.am
@@ -16,7 +16,7 @@ pam_lastlog2_la_LIBADD = liblastlog2.la
 
 pam_lastlog2_la_LDFLAGS = $(SOLIB_LDFLAGS) -module -avoid-version -shared
 if HAVE_VSCRIPT
-pam_lastlog2_la_LDFLAGS += pam_lastlog2_la_LDFLAGS += $(VSCRIPT_LDFLAGS),$(top_srcdir)/pam_lastlog2/src/pam_lastlog2.sym
+pam_lastlog2_la_LDFLAGS += $(VSCRIPT_LDFLAGS),$(top_srcdir)/pam_lastlog2/src/pam_lastlog2.sym
 endif
 
 EXTRA_DIST += pam_lastlog2/src/pam_lastlog2.sym


### PR DESCRIPTION
The second assignment ends up on the linker/libtool commandline, potentially confusing the tools.