### PR TITLE
libmount improve error messages

### DIFF
--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -2635,8 +2635,35 @@ void mnt_context_syscall_reset_status(struct libmnt_context *cxt)
 	cxt->syscall_status = 0;
 	cxt->syscall_name = NULL;
 
-	free(cxt->syscall_errmsg);
-	cxt->syscall_errmsg = NULL;
+	free(cxt->errmsg);
+	cxt->errmsg = NULL;
+}
+
+int mnt_context_set_errmsg(struct libmnt_context *cxt, const char *msg)
+{
+	char *p = NULL;
+
+	if (msg) {
+		p = strdup(msg);
+		if (!p)
+			return -ENOMEM;
+	}
+
+	free(cxt->errmsg);
+	cxt->errmsg = p;
+
+	return 0;
+}
+
+int mnt_context_append_errmsg(struct libmnt_context *cxt, const char *msg)
+{
+	if (cxt->errmsg) {
+		int rc = strappend(&cxt->errmsg, "; ");
+		if (rc)
+			return rc;
+	}
+
+	return strappend(&cxt->errmsg, msg);
 }
 
 /**

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -41,6 +41,7 @@
 #include "namespace.h"
 #include "match.h"
 
+#include <stdarg.h>
 #include <sys/wait.h>
 
 /**
@@ -2664,6 +2665,25 @@ int mnt_context_append_errmsg(struct libmnt_context *cxt, const char *msg)
 	}
 
 	return strappend(&cxt->errmsg, msg);
+}
+
+int mnt_context_sprintf_errmsg(struct libmnt_context *cxt, const char *msg, ...)
+{
+	int rc;
+	va_list ap;
+	char *p = NULL;
+
+	va_start(ap, msg);
+	rc = vasprintf(&p, msg, ap);
+	va_end(ap);
+
+	if (rc < 0 || !p)
+		return rc;
+
+	free(cxt->errmsg);
+	cxt->errmsg = p;
+
+	return 0;
 }
 
 /**

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1572,10 +1572,13 @@ int mnt_context_get_mount_excode(
 	 */
 	syserr = mnt_context_get_syscall_errno(cxt);
 
-	if (buf && cxt->syscall_errmsg) {
-		snprintf(buf, bufsz, _("%s system call failed: %s"),
-					cxt->syscall_name ? : "mount",
-					cxt->syscall_errmsg);
+	if (buf && cxt->errmsg) {
+		if (cxt->syscall_name)
+			snprintf(buf, bufsz, _("%s system call failed: %s"),
+					cxt->syscall_name, cxt->errmsg);
+		else
+			xstrncpy(buf, cxt->errmsg, bufsz);
+
 		return MNT_EX_FAIL;
 	}
 

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1433,6 +1433,11 @@ int mnt_context_get_mount_excode(
 	mnt_context_get_user_mflags(cxt, &uflags);	/* userspace flags */
 
 	if (!mnt_context_syscall_called(cxt)) {
+		if (buf && cxt->errmsg) {
+			xstrncpy(buf, cxt->errmsg, bufsz);
+			return MNT_EX_USAGE;
+		}
+
 		/*
 		 * libmount errors (extra library checks)
 		 */

--- a/libmount/src/hook_loopdev.c
+++ b/libmount/src/hook_loopdev.c
@@ -277,6 +277,14 @@ static int setup_loopdev(struct libmnt_context *cxt,
 		goto done_no_deinit;
 	if (mnt_opt_has_value(loopopt)) {
 		rc = loopcxt_set_device(&lc, mnt_opt_get_value(loopopt));
+		if (rc == 0 && loopcxt_is_lost(&lc)) {
+			DBG(LOOP, ul_debugobj(cxt, "node lost"));
+
+			dev_t devno = loopcxt_get_devno(&lc);
+			mnt_context_sprintf_errmsg(cxt, _("device node %s (%u:%u) is lost"),
+					loopcxt_get_device(&lc), major(devno), minor(devno));
+			rc = -EINVAL;
+		}
 		if (rc == 0)
 			loopdev = loopcxt_get_device(&lc);
 	}

--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -92,7 +92,7 @@ static void hookset_set_syscall_status(struct libmnt_context *cxt,
 {
 	struct libmnt_sysapi *api;
 
-	set_syscall_status(cxt, name, x);
+	mnt_context_syscall_save_status(cxt, name, x);
 
 	if (!x) {
 		api = get_sysapi(cxt);
@@ -819,7 +819,7 @@ enosys:
 	/* we need to recover from this error, so hook_mount_legacy.c
 	 * can try to continue */
 	DBG(HOOK, ul_debugobj(hs, "failed to init new API"));
-	reset_syscall_status(cxt);
+	mnt_context_syscall_reset_status(cxt);
 	hookset_deinit(cxt, hs);
 	return 1;
 }

--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -70,8 +70,7 @@ static void save_fd_messages(struct libmnt_context *cxt, int fd)
 	uint8_t buf[BUFSIZ];
 	int rc;
 
-	free(cxt->syscall_errmsg);
-	cxt->syscall_errmsg = NULL;
+	mnt_context_set_errmsg(cxt, NULL);
 
 	while ((rc = read(fd, buf, sizeof(buf))) != -1) {
 		if (rc > 0 && buf[rc - 1] == '\n')
@@ -80,10 +79,7 @@ static void save_fd_messages(struct libmnt_context *cxt, int fd)
 
 		if (rc < 3 || strncmp((char *) buf, "e ", 2) != 0)
 			continue;
-		if (cxt->syscall_errmsg)
-			strappend(&cxt->syscall_errmsg, "; ");
-
-		strappend(&cxt->syscall_errmsg, ((char *) buf) + 2);
+		mnt_context_append_errmsg(cxt, ((char *) buf) + 2);
 	}
 }
 

--- a/libmount/src/hook_mount_legacy.c
+++ b/libmount/src/hook_mount_legacy.c
@@ -76,10 +76,8 @@ static int hook_propagation(struct libmnt_context *cxt,
 
 	if (rc) {
 		/* Update global syscall status if only this function called */
-		if (mnt_context_propagation_only(cxt)) {
-			cxt->syscall_status = -errno;
-			cxt->syscall_name = "mount";
-		}
+		if (mnt_context_propagation_only(cxt))
+			mnt_context_syscall_save_status(cxt, "mount", rc == 0);
 
 		DBG(HOOK, ul_debugobj(hs, "  mount(2) failed [errno=%d %m]", errno));
 		rc = -MNT_ERR_APPLYFLAGS;
@@ -240,10 +238,7 @@ static int hook_mount(struct libmnt_context *cxt,
 			  options : "<none>"));
 
 	if (mount(src, target, type, flags, options)) {
-		cxt->syscall_status = -errno;
-		cxt->syscall_name = "mount";
-		DBG(HOOK, ul_debugobj(hs, "  mount(2) failed [errno=%d %m]",
-					-cxt->syscall_status));
+		mnt_context_syscall_save_status(cxt, "mount", 0);
 		rc = -cxt->syscall_status;
 		return rc;
 	}

--- a/libmount/src/hook_subdir.c
+++ b/libmount/src/hook_subdir.c
@@ -189,7 +189,7 @@ static int do_mount_subdir(
 		DBG(HOOK, ul_debug("attach subdir  %s", subdir));
 		fd = open_tree(api->fd_tree, subdir,
 					OPEN_TREE_CLOEXEC | OPEN_TREE_CLONE);
-		set_syscall_status(cxt, "open_tree", fd >= 0);
+		mnt_context_syscall_save_status(cxt, "open_tree", fd >= 0);
 		if (fd < 0)
 			rc = -errno;
 
@@ -201,7 +201,7 @@ static int do_mount_subdir(
 			setns(hsd->old_ns_fd, CLONE_NEWNS);
 
 			rc = move_mount(fd, "", AT_FDCWD, target, MOVE_MOUNT_F_EMPTY_PATH);
-			set_syscall_status(cxt, "move_mount", rc == 0);
+			mnt_context_syscall_save_status(cxt, "move_mount", rc == 0);
 			if (rc)
 				rc = -errno;
 
@@ -223,8 +223,7 @@ static int do_mount_subdir(
 		/* Classic mount(2) based way */
 		DBG(HOOK, ul_debug("mount subdir %s to %s", src, target));
 		rc = mount(src, target, NULL, MS_BIND, NULL);
-
-		set_syscall_status(cxt, "mount", rc == 0);
+		mnt_context_syscall_save_status(cxt, "mount", rc == 0);
 		if (rc)
 			rc = -errno;
 		free(src);
@@ -233,7 +232,7 @@ static int do_mount_subdir(
 	if (!rc) {
 		DBG(HOOK, ul_debug("umount old root %s", root));
 		rc = umount(root);
-		set_syscall_status(cxt, "umount", rc == 0);
+		mnt_context_syscall_save_status(cxt, "umount", rc == 0);
 		if (rc)
 			rc = -errno;
 		hsd->tmp_umounted = 1;

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -628,6 +628,7 @@ extern int mnt_context_mount_setopt(struct libmnt_context *cxt, int c, char *arg
 
 extern int mnt_context_set_errmsg(struct libmnt_context *cxt, const char *msg);
 extern int mnt_context_append_errmsg(struct libmnt_context *cxt, const char *msg);
+extern int mnt_context_sprintf_errmsg(struct libmnt_context *cxt, const char *msg, ...);
 
 extern int mnt_context_propagation_only(struct libmnt_context *cxt)
 			__attribute__((nonnull));

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -480,27 +480,6 @@ struct libmnt_context
 /* Flags usable with MS_BIND|MS_REMOUNT */
 #define MNT_BIND_SETTABLE	(MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_NOATIME|MS_NODIRATIME|MS_RELATIME|MS_RDONLY|MS_NOSYMFOLLOW)
 
-static inline void set_syscall_status(struct libmnt_context *cxt, const char *name, int x)
-{
-	if (!x) {
-		DBG(CXT, ul_debug("syscall '%s' [%m]", name));
-		cxt->syscall_status = -errno;
-		cxt->syscall_name = name;
-	} else {
-		DBG(CXT, ul_debug("syscall '%s' [success]", name));
-		cxt->syscall_status = 0;
-	}
-}
-
-static inline void reset_syscall_status(struct libmnt_context *cxt)
-{
-	DBG(CXT, ul_debug("reset syscall status"));
-	cxt->syscall_status = 0;
-	cxt->syscall_name = NULL;
-
-	free(cxt->syscall_errmsg);
-	cxt->syscall_errmsg = NULL;
-}
 
 /* optmap.c */
 extern const struct libmnt_optmap *mnt_optmap_get_entry(
@@ -621,6 +600,10 @@ extern int __mnt_fs_set_target_ptr(struct libmnt_fs *fs, char *tgt)
 			__attribute__((nonnull(1)));
 
 /* context.c */
+extern void mnt_context_syscall_save_status(struct libmnt_context *cxt,
+                                        const char *syscallname, int success);
+extern void mnt_context_syscall_reset_status(struct libmnt_context *cxt);
+
 extern struct libmnt_context *mnt_copy_context(struct libmnt_context *o);
 extern int mnt_context_utab_writable(struct libmnt_context *cxt);
 extern const char *mnt_context_get_writable_tabpath(struct libmnt_context *cxt);

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -432,7 +432,7 @@ struct libmnt_context
 
 	int	syscall_status;	/* 1: not called yet, 0: success, <0: -errno */
 	const char *syscall_name;	/* failed syscall name */
-	char	*syscall_errmsg;	/* message from kernel */
+	char	*errmsg;	/* library or kernel message */
 
 	struct libmnt_ns	ns_orig;	/* original namespace */
 	struct libmnt_ns	ns_tgt;		/* target namespace */
@@ -625,6 +625,9 @@ extern int mnt_context_update_tabs(struct libmnt_context *cxt);
 
 extern int mnt_context_umount_setopt(struct libmnt_context *cxt, int c, char *arg);
 extern int mnt_context_mount_setopt(struct libmnt_context *cxt, int c, char *arg);
+
+extern int mnt_context_set_errmsg(struct libmnt_context *cxt, const char *msg);
+extern int mnt_context_append_errmsg(struct libmnt_context *cxt, const char *msg);
 
 extern int mnt_context_propagation_only(struct libmnt_context *cxt)
 			__attribute__((nonnull));


### PR DESCRIPTION
Let's keep it simple and stupid :-) 

This set of patches only cleanups and extends the current internal API for the error messages generated by kernel or library modules. It does not introduce any replacement. This way seems the best.