### PR TITLE
pam_lastlog2: remove symbol that doesn't exist from version script

### DIFF
--- a/pam_lastlog2/src/pam_lastlog2.sym
+++ b/pam_lastlog2/src/pam_lastlog2.sym
@@ -3,7 +3,6 @@
   global:
     pam_sm_acct_mgmt;
     pam_sm_authenticate;
-    pam_sm_chauthtok;
     pam_sm_close_session;
     pam_sm_open_session;
     pam_sm_setcred;


### PR DESCRIPTION
otherwise ld.lld by default errors with
ld: error: version script assignment of 'global' to symbol 'pam_sm_chauthtok' failed: symbol not defined

since the symbol is not in the library