### PR TITLE
libuuid: link test_uuid_time with pthread

### DIFF
--- a/libuuid/src/Makemodule.am
+++ b/libuuid/src/Makemodule.am
@@ -7,7 +7,7 @@ test_uuid_parser_CFLAGS = $(AM_CFLAGS) -I$(ul_libuuid_incdir)
 check_PROGRAMS += test_uuid_time
 test_uuid_time_SOURCES = libuuid/src/gen_uuid.c \
 	libuuid/src/pack.c libuuid/src/unpack.c lib/randutils.c lib/md5.c lib/sha1.c
-test_uuid_time_LDADD = libuuid.la $(SOCKET_LIBS) $(LDADD)
+test_uuid_time_LDADD = libuuid.la $(SOCKET_LIBS) $(LDADD) -lpthread
 test_uuid_time_CFLAGS = $(AM_CFLAGS) -I$(ul_libuuid_incdir) -DTEST_PROGRAM
 
 # includes


### PR DESCRIPTION
Since commit a3f1255f1891 ("libuuid: clear uuidd cache on fork()") compilation of gen_uuid.c requires libpthreads.