### PR TITLE
libsmartcols/src/Makemodule.am: ensure filter-scanner/paser.c file is…

### DIFF
--- a/libsmartcols/src/Makemodule.am
+++ b/libsmartcols/src/Makemodule.am
@@ -58,6 +58,7 @@ $(SCOLS_YACC_STEMP): $(SCOLS_YACC_BASENAME).y
 	@rm -f $(SCOLS_YACC_STEMP).tmp
 	@touch -f $(SCOLS_YACC_STEMP).tmp
 	$(AM_V_YACC) $(BISON) $< --output=${basename $@}.c --defines=${basename $@}.h
+	@touch -f ${basename $@}.c
 	@mv -f $(SCOLS_YACC_STEMP).tmp $@
 
 $(SCOLS_YACC_BASENAME).c $(SCOLS_YACC_BASENAME).h: $(SCOLS_YACC_STEMP)
@@ -69,6 +70,7 @@ $(SCOLS_LEX_STEMP): $(SCOLS_LEX_BASENAME).l
 	@rm -f $(SCOLS_LEX_STEMP).tmp
 	@touch -f $(SCOLS_LEX_STEMP).tmp
 	$(AM_V_GEN) $(FLEX) --header-file=${basename $@}.h --outfile=${basename $@}.c $<
+	@touch -f ${basename $@}.c
 	@mv -f $(SCOLS_LEX_STEMP).tmp $@
 
 $(SCOLS_LEX_BASENAME).c $(SCOLS_LEX_BASENAME).h: $(SCOLS_LEX_STEMP)


### PR DESCRIPTION
… newer than the .h file

In released tarball, for filter-scanner/parser, the .h and the .c file has the same mtime. The 'make' tool thinks .h is newer than the .c file, thus deciding to remake it. This will not only cause unnecessary rebuild, but also parallel make error. For example, after 'make', when running 'make install', the libmount.la and findmnt are both rebuilt and findmnt building will somethings error out complaining 'libmount.so: no such file or directory' or 'libmount.so: file format not recognized'.

Touch the generated .c file to ensure it's newer than the .h file. In this way, in new released tarballs in the future, there will be no unnecessary remake.

fixes util-linux/util-linux#3061