### PR TITLE
libmount: expose exec errors

### DIFF
--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -241,6 +241,13 @@ enum {
  * filesystem mounted, but subsequent X-mount.idmap= failed
  */
 #define MNT_ERR_IDMAP    5013
+/**
+ * MNT_ERR_EXEC:
+ *
+ * failed to execute external program
+ */
+#define MNT_ERR_EXEC	5014
+
 
 
 /*
@@ -305,6 +312,12 @@ enum {
  */
 #define MNT_EX_SOMEOK	64
 
+/**
+ * MNT_EX_EXEC:
+ *
+ * [u]mount(8) exit code: external program execution failed
+ */
+#define MNT_EX_EXEC	126
 
 
 #ifndef __GNUC_PREREQ

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1612,6 +1612,9 @@ some mount succeeded
 +
 The command *mount -a* returns 0 (all succeeded), 32 (all failed), or 64 (some failed, some succeeded).
 
+*126*::
+failed to execute external /sbin/mount.<type> mount helper (since util-linux v2.41)
+
 == EXTERNAL HELPERS
 
 The syntax of external mount helpers is:
@@ -1621,6 +1624,8 @@ The syntax of external mount helpers is:
 where the _suffix_ is the filesystem type and the *-sfnvoN* options have the same meaning as the normal mount options. The *-t* option is used for filesystems with subtypes support (for example */sbin/mount.fuse -t fuse.sshfs*).
 
 The command *mount* does not pass the mount options *unbindable*, *runbindable*, *private*, *rprivate*, *slave*, *rslave*, *shared*, *rshared*, *auto*, *noauto*, *comment*, *x-**, *loop*, *offset* and *sizelimit* to the mount.<suffix> helpers. All other options are used in a comma-separated list as an argument to the *-o* option.
+
+The exit status value of the helper is returned as the exit status of *mount*(8). The value 126 is sed if the mount helper program is found, but the execl() failed.
 
 == ENVIRONMENT
 

--- a/sys-utils/umount.8.adoc
+++ b/sys-utils/umount.8.adoc
@@ -127,6 +127,39 @@ The *umount* command will automatically detach loop device previously initialize
 
 In this case the device is initialized with "autoclear" flag (see *losetup*(8) output for more details), otherwise it's necessary to use the option *--detach-loop* or call *losetup -d* _device_. The autoclear feature is supported since Linux 2.6.25.
 
+== EXIT STATUS
+
+*umount* has the following exit status values (the bits can be ORed):
+
+*0*::
+success
+
+*1*::
+incorrect invocation or permissions
+
+*2*::
+system error (out of memory, cannot fork, no more loop devices)
+
+*4*::
+internal *mount* bug
+
+*8*::
+user interrupt
+
+*16*::
+problems writing or locking _/etc/mtab_
+
+*32*::
+mount failure
+
+*64*::
+some umount succeeded
++
+The command *umount -a* returns 0 (all succeeded), 32 (all failed), or 64 (some failed, some succeeded).
+
+*126*::
+failed to execute external /sbin/umount.<type> mount helper (since util-linux v2.41)
+
 == EXTERNAL HELPERS
 
 The syntax of external unmount helpers is:
@@ -146,6 +179,8 @@ A **uhelper=**__something__ marker (unprivileged helper) can appear in the _/etc
 A **helper=**__type__ marker in the _mtab_ file will redirect all unmount requests to the **/sbin/umount.**__type__ helper independently of UID.
 
 Note that _/etc/mtab_ is currently deprecated and *helper=* and other userspace mount options are maintained by *libmount*.
+
+The exit status value of the helper is returned as the exit status of *umount*(8). The value 126 is used if the mount helper program is found, but the execl() failed.
 
 == ENVIRONMENT
 


### PR DESCRIPTION
* Introduce special exit status 126 to inform about failed execl of the /sbin/[u]mount.<type> helpers.

* Introduce MNT_ERR_EXEC as an API return code to inform about failed execl() calls.

* Add mount and umount messages for failed execl() calls.

* Add EXIT STATUS section to umount man page.

Addresses: https://github.com/util-linux/util-linux/pull/3063