### PR TITLE
lscpu: New Arm Cortex part numbers

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -94,6 +94,8 @@ static const struct id_part arm_part[] = {
     { 0xd81, "Cortex-A720" },
     { 0xd82, "Cortex-X4" },
     { 0xd84, "Neoverse-V3" },
+    { 0xd85, "Cortex-X925" },
+    { 0xd87, "Cortex-A725" },
     { 0xd8e, "Neoverse-N3" },
     { -1, "unknown" },
 };


### PR DESCRIPTION
Arm has announced the Cortex-X925 and published the TRM here: https://developer.arm.com/documentation/102807/0001/?lang=en

As well as the Cortex-A725 with a TRM here:
https://developer.arm.com/documentation/107652/0001/?lang=en