### PR TITLE
Add Cortex-X925 and A725 cores

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -94,6 +94,8 @@ static const struct id_part arm_part[] = {
     { 0xd81, "Cortex-A720" },
     { 0xd82, "Cortex-X4" },
     { 0xd84, "Neoverse-V3" },
+    { 0xd85, "Cortex-X925" },
+    { 0xd87, "Cortex-A725" },
     { 0xd8e, "Neoverse-N3" },
     { -1, "unknown" },
 };


### PR DESCRIPTION
Values derived from ARM's documentation:

https://developer.arm.com/documentation/102807/0001/AArch64-System-registers/AArch64-Identification-registers-summary/MIDR-EL1--Main-ID-Register?lang=en

https://developer.arm.com/documentation/107652/0001/AArch64-registers/AArch64-Identification-registers-summary/MIDR-EL1--Main-ID-Register?lang=en