### PR TITLE
wdctl: always query device node when sysfs is unavailable

### DIFF
--- a/sys-utils/wdctl.c
+++ b/sys-utils/wdctl.c
@@ -608,6 +608,9 @@ static int read_governors(struct wd_device *wd)
 
 static bool should_read_from_device(struct wd_device *wd)
 {
+	if (wd->no_sysfs)
+		return true;
+
 	if (!wd->has_nowayout)
 		return false;
 


### PR DESCRIPTION
When there is no sysfs at all for the watchdog, fall back to reading from the device node.
This is also useful if the legacy compat /dev/watchdog device which never has a sysfs interface.

Closes: #3073