### PR TITLE
libmount statmount support

### DIFF
--- a/bash-completion/findmnt
+++ b/bash-completion/findmnt
@@ -112,6 +112,8 @@ _findmnt_module()
 				--tab-file
 				--first-only
 				--hyperlink
+				--id
+				--uniq-id
 				--invert
 				--json
 				--list

--- a/configure.ac
+++ b/configure.ac
@@ -717,7 +717,20 @@ AS_IF([test "x$ul_cv_syscall_fsconfig" = xno ||
 	have_mountfd_api="no"
    ],[
         have_mountfd_api="yes"
-	AC_DEFINE([HAVE_MOUNTFD_API], [1], [Define to 1 if you want mount API based on FDs.])
+	AC_DEFINE([HAVE_MOUNTFD_API], [1], [Define to 1 if you want to use mount API based on FDs.])
+   ])
+
+
+UL_CHECK_SYSCALL([statmount])
+UL_CHECK_SYSCALL([listmount])
+
+AS_IF([test "x$ul_cv_syscall_statmount" = xno ||
+       test "x$ul_cv_syscall_listmount" = xno],
+   [
+	have_statmount_api="no"
+   ],[
+	have_statmount_api="yes"
+	AC_DEFINE([HAVE_STATMOUNT_API], [1], [Define to 1 if you want to use statmount API.])
    ])
 
 

--- a/include/c.h
+++ b/include/c.h
@@ -37,6 +37,8 @@
 # define NAME_MAX PATH_MAX
 #endif
 
+#define BIT(n)                 (1 << (n))
+
 /*
  * __GNUC_PREREQ is deprecated in favour of __has_attribute() and
  * __has_feature(). The __has macros are supported by clang and gcc>=5.

--- a/include/mount-api-utils.h
+++ b/include/mount-api-utils.h
@@ -324,7 +324,7 @@ struct ul_statmount {
 # define LSMT_ROOT		0xffffffffffffffff	/* root mount */
 #endif
 
-#ifndef LISTMOUNT_REVERS
+#ifndef LISTMOUNT_REVERSE
 # define LISTMOUNT_REVERSE      BIT(0) /* List later mounts first */
 #endif
 

--- a/include/mount-api-utils.h
+++ b/include/mount-api-utils.h
@@ -5,10 +5,16 @@
 #ifndef UTIL_LINUX_MOUNT_API_UTILS
 #define UTIL_LINUX_MOUNT_API_UTILS
 
-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
-
-#include <sys/syscall.h>
+#ifdef HAVE_LINUX_MOUNT_H
+#include <sys/mount.h>
 #include <linux/mount.h>
+#include <sys/syscall.h>
+#include <inttypes.h>
+
+/*
+ * File descritors based mount API
+ */
+#ifdef HAVE_MOUNTFD_API
 
 /* Accepted by both open_tree() and mount_setattr(). */
 #ifndef AT_RECURSIVE
@@ -203,6 +209,207 @@ static inline int fspick(int dfd, const char *pathname, unsigned int flags)
 }
 #endif
 
-#endif /* HAVE_MOUNTFD_API && HAVE_LINUX_MOUNT_H */
-#endif /* UTIL_LINUX_MOUNT_API_UTILS */
+#endif /* HAVE_MOUNTFD_API */
 
+/*
+ * statmount() and listmount()
+ */
+#ifdef HAVE_STATMOUNT_API
+
+#ifndef MNT_ID_REQ_SIZE_VER0
+# define MNT_ID_REQ_SIZE_VER0    24 /* sizeof first published struct */
+#endif
+#ifndef MNT_ID_REQ_SIZE_VER1
+# define MNT_ID_REQ_SIZE_VER1    32 /* sizeof second published struct */
+#endif
+
+/*
+ * The structs mnt_id_req and statmount may differ between kernel versions, so
+ * we must ensure that the structs contain everything we need. For now (during
+ * development), it seems best to define local copies of the structs to avoid
+ * relying on installed kernel headers and to avoid a storm of #ifdefs.
+ */
+
+/*
+ * listmount() and statmount() request
+ */
+struct ul_mnt_id_req {
+	uint32_t size;
+	uint32_t spare;
+	uint64_t mnt_id;
+	uint64_t param;
+	uint64_t mnt_ns_id;
+};
+
+/*
+ * Please note that due to the variable length of the statmount buffer, the
+ * struct cannot be versioned by size (like struct mnt_id_req).
+ */
+struct ul_statmount {
+	uint32_t size;		/* Total size, including strings */
+	uint32_t mnt_opts;	/* [str] Mount options of the mount */
+	uint64_t mask;		/* What results were written */
+	uint32_t sb_dev_major;	/* Device ID */
+	uint32_t sb_dev_minor;
+	uint64_t sb_magic;		/* ..._SUPER_MAGIC */
+	uint32_t sb_flags;		/* SB_{RDONLY,SYNCHRONOUS,DIRSYNC,LAZYTIME} */
+	uint32_t fs_type;		/* [str] Filesystem type */
+	uint64_t mnt_id;		/* Unique ID of mount */
+	uint64_t mnt_parent_id;	/* Unique ID of parent (for root == mnt_id) */
+	uint32_t mnt_id_old;	/* Reused IDs used in proc/.../mountinfo */
+	uint32_t mnt_parent_id_old;
+	uint64_t mnt_attr;		/* MOUNT_ATTR_... */
+	uint64_t mnt_propagation;	/* MS_{SHARED,SLAVE,PRIVATE,UNBINDABLE} */
+	uint64_t mnt_peer_group;	/* ID of shared peer group */
+	uint64_t mnt_master;	/* Mount receives propagation from this ID */
+	uint64_t propagate_from;	/* Propagation from in current namespace */
+	uint32_t mnt_root;		/* [str] Root of mount relative to root of fs */
+	uint32_t mnt_point;	/* [str] Mountpoint relative to current root */
+	uint64_t mnt_ns_id;	 /* ID of the mount namespace */
+	uint64_t __spare2[49];
+	char str[];		/* Variable size part containing strings */
+};
+
+/* sb_flags (defined in kernel include/linux/fs.h) */
+#ifndef SB_RDONLY
+# define SB_RDONLY       BIT(0)	/* Mount read-only */
+# define SB_NOSUID       BIT(1)	/* Ignore suid and sgid bits */
+# define SB_NODEV        BIT(2)	/* Disallow access to device special files */
+# define SB_NOEXEC       BIT(3)	/* Disallow program execution */
+# define SB_SYNCHRONOUS  BIT(4)	/* Writes are synced at once */
+# define SB_MANDLOCK     BIT(6)	/* Allow mandatory locks on an FS */
+# define SB_DIRSYNC      BIT(7)	/* Directory modifications are synchronous */
+# define SB_NOATIME      BIT(10)	/* Do not update access times. */
+# define SB_NODIRATIME   BIT(11)	/* Do not update directory access times */
+# define SB_SILENT       BIT(15)
+# define SB_POSIXACL     BIT(16)	/* Supports POSIX ACLs */
+# define SB_INLINECRYPT  BIT(17)	/* Use blk-crypto for encrypted files */
+# define SB_KERNMOUNT    BIT(22)	/* this is a kern_mount call */
+# define SB_I_VERSION    BIT(23)	/* Update inode I_version field */
+# define SB_LAZYTIME     BIT(25)	/* Update the on-disk [acm]times lazily */
+#endif
+
+/*
+ * @mask bits for statmount(2)
+ */
+#ifndef STATMOUNT_SB_BASIC
+# define STATMOUNT_SB_BASIC		0x00000001U     /* Want/got sb_... */
+#endif
+#ifndef STATMOUNT_MNT_BASIC
+# define STATMOUNT_MNT_BASIC		0x00000002U	/* Want/got mnt_... */
+#endif
+#ifndef STATMOUNT_PROPAGATE_FROM
+# define STATMOUNT_PROPAGATE_FROM	0x00000004U	/* Want/got propagate_from */
+#endif
+#ifndef STATMOUNT_MNT_ROOT
+# define STATMOUNT_MNT_ROOT		0x00000008U	/* Want/got mnt_root  */
+#endif
+#ifndef STATMOUNT_MNT_POINT
+# define STATMOUNT_MNT_POINT		0x00000010U	/* Want/got mnt_point */
+#endif
+#ifndef STATMOUNT_FS_TYPE
+# define STATMOUNT_FS_TYPE		0x00000020U	/* Want/got fs_type */
+#endif
+#ifndef STATMOUNT_MNT_NS_ID
+# define STATMOUNT_MNT_NS_ID		0x00000040U     /* Want/got mnt_ns_id */
+#endif
+#ifndef STATMOUNT_MNT_OPTS
+# define STATMOUNT_MNT_OPTS		0x00000080U     /* Want/got mnt_opts */
+#endif
+
+/*
+ * Special @mnt_id values that can be passed to listmount
+ */
+#ifdef LSMT_ROOT
+# define LSMT_ROOT		0xffffffffffffffff	/* root mount */
+#endif
+
+#ifndef LISTMOUNT_REVERS
+# define LISTMOUNT_REVERSE      BIT(0) /* List later mounts first */
+#endif
+
+#if defined(SYS_statmount)
+static inline int ul_statmount(uint64_t mnt_id,
+			uint64_t ns_id,
+			uint64_t mask,
+			struct ul_statmount *buf,
+			size_t bufsize, unsigned int flags)
+{
+       struct ul_mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER1,
+		.mnt_id = mnt_id,
+		.param = mask,
+		.mnt_ns_id = ns_id
+       };
+
+       return syscall(SYS_statmount, &req, buf, bufsize, flags);
+}
+#endif
+
+#if defined(SYS_listmount)
+static inline ssize_t ul_listmount(uint64_t mnt_id,
+			uint64_t ns_id,
+			uint64_t last_mnt_id,
+			uint64_t list[], size_t num,
+			unsigned int flags)
+{
+       struct ul_mnt_id_req req = {
+		.size = MNT_ID_REQ_SIZE_VER1,
+		.mnt_id = mnt_id,
+		.param = last_mnt_id,
+		.mnt_ns_id = ns_id
+       };
+
+       return syscall(SYS_listmount, &req, list, num, flags);
+}
+#endif
+
+/* This is a version of statmount() that reallocates @buf to be large enough to
+ * store data for the requested @id. This function never deallocates; it is the
+ * caller's responsibility.
+ */
+static inline int sys_statmount(uint64_t id,
+			uint64_t ns_id,
+			uint64_t mask,
+			struct ul_statmount **buf,
+			size_t *bufsiz,
+			unsigned int flags)
+{
+	size_t sz;
+	int rc = 0;
+
+	if (!buf || !bufsiz)
+		return -EINVAL;
+
+	sz = *bufsiz;
+	if (!sz)
+		sz = 32 * 1024;
+
+	do {
+		if (sz > *bufsiz) {
+			struct ul_statmount *tmp = realloc(*buf, sz);
+			if (!tmp)
+				return -ENOMEM;
+			*buf = tmp;
+			*bufsiz = sz;
+		}
+
+		errno = 0;
+		rc = ul_statmount(id, ns_id, mask, *buf, *bufsiz, flags);
+		if (!rc)
+			break;
+		if (errno != EOVERFLOW)
+			break;
+		if (sz >= SIZE_MAX / 2)
+			break;
+		sz <<= 1;
+	} while (rc);
+
+	return rc;
+}
+
+#endif /* HAVE_STATMOUNT_API */
+
+#endif /* HAVE_LINUX_MOUNT_H */
+
+#endif /* UTIL_LINUX_MOUNT_API_UTILS */

--- a/include/timeutils.h
+++ b/include/timeutils.h
@@ -112,4 +112,8 @@ static inline bool is_timespecset(const struct timespec *t)
 	return t->tv_sec || t->tv_nsec;
 }
 
+static inline double time_diff(const struct timeval *a, const struct timeval *b)
+{
+	return (a->tv_sec - b->tv_sec) + (a->tv_usec - b->tv_usec) / (double) USEC_PER_SEC;
+}
 #endif /* UTIL_LINUX_TIME_UTIL_H */

--- a/libmount/docs/libmount-docs.xml
+++ b/libmount/docs/libmount-docs.xml
@@ -83,4 +83,24 @@ available from https://www.kernel.org/pub/linux/utils/util-linux/.
     <title>Index of new symbols in 2.35</title>
     <xi:include href="xml/api-index-2.35.xml"><xi:fallback /></xi:include>
   </index>
+  <index role="2.37">
+    <title>Index of new symbols in 2.37</title>
+    <xi:include href="xml/api-index-2.37.xml"><xi:fallback /></xi:include>
+  </index>
+  <index role="2.38">
+    <title>Index of new symbols in 2.38</title>
+    <xi:include href="xml/api-index-2.38.xml"><xi:fallback /></xi:include>
+  </index>
+  <index role="2.39">
+    <title>Index of new symbols in 2.39</title>
+    <xi:include href="xml/api-index-2.39.xml"><xi:fallback /></xi:include>
+  </index>
+  <index role="2.40">
+    <title>Index of new symbols in 2.40</title>
+    <xi:include href="xml/api-index-2.40.xml"><xi:fallback /></xi:include>
+  </index>
+  <index role="2.41">
+    <title>Index of new symbols in 2.41</title>
+    <xi:include href="xml/api-index-2.41.xml"><xi:fallback /></xi:include>
+  </index>
 </book>

--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -368,7 +368,9 @@ mnt_table_add_fs
 mnt_table_append_intro_comment
 mnt_table_append_trailing_comment
 mnt_table_enable_comments
+mnt_table_enable_listmount
 mnt_table_enable_noautofs
+mnt_table_fetch_listmount
 mnt_table_find_devno
 mnt_table_find_fs
 mnt_table_find_mountpoint
@@ -391,6 +393,9 @@ mnt_table_is_empty
 mnt_table_is_fs_mounted
 mnt_table_is_noautofs
 mnt_table_last_fs
+mnt_table_listmount_set_id
+mnt_table_listmount_set_ns
+mnt_table_listmount_set_stepsiz
 mnt_table_move_fs
 mnt_table_next_child_fs
 mnt_table_next_fs

--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -373,6 +373,7 @@ mnt_table_enable_noautofs
 mnt_table_fetch_listmount
 mnt_table_find_devno
 mnt_table_find_fs
+mnt_table_find_id
 mnt_table_find_mountpoint
 mnt_table_find_next_fs
 mnt_table_find_pair
@@ -381,6 +382,7 @@ mnt_table_find_srcpath
 mnt_table_find_tag
 mnt_table_find_target
 mnt_table_find_target_with_option
+mnt_table_find_uniq_id
 mnt_table_first_fs
 mnt_table_get_cache
 mnt_table_get_intro_comment

--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -229,10 +229,12 @@ mnt_fs_get_freq
 mnt_fs_get_fs_options
 mnt_fs_get_fstype
 mnt_fs_get_id
+mnt_fs_get_uniq_id
 mnt_fs_get_option
 mnt_fs_get_optional_fields
 mnt_fs_get_options
 mnt_fs_get_parent_id
+mnt_fs_get_parent_uniq_id
 mnt_fs_get_passno
 mnt_fs_get_priority
 mnt_fs_get_propagation
@@ -273,6 +275,7 @@ mnt_fs_set_priority
 mnt_fs_set_root
 mnt_fs_set_source
 mnt_fs_set_target
+mnt_fs_set_uniq_id
 mnt_fs_set_userdata
 mnt_fs_strdup_options
 mnt_fs_streq_srcpath

--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -281,8 +281,25 @@ mnt_fs_strdup_options
 mnt_fs_streq_srcpath
 mnt_fs_streq_target
 mnt_fs_to_mntent
+mnt_fs_fetch_statmount
+mnt_fs_get_ns
+mnt_fs_set_ns
 mnt_new_fs
 mnt_reset_fs
+</SECTION>
+
+<SECTION>
+<FILE>statmount</FILE>
+libmnt_statmnt
+mnt_new_statmnt
+mnt_ref_statmnt
+mnt_unref_statmnt
+mnt_statmnt_disable_fetching
+mnt_statmnt_set_mask
+mnt_fs_fetch_statmount
+mnt_fs_get_statmnt
+mnt_fs_refer_statmnt
+mnt_table_refer_statmnt
 </SECTION>
 
 <SECTION>

--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -430,6 +430,7 @@ mnt_get_mtab_path
 mnt_get_swaps_path
 mnt_guess_system_root
 mnt_has_regular_mtab
+mnt_id_from_path
 mnt_mangle
 mnt_match_fstype
 mnt_tag_is_valid

--- a/libmount/meson.build
+++ b/libmount/meson.build
@@ -43,6 +43,7 @@ lib_mount_sources = '''
 
 if LINUX
   lib_mount_sources += '''
+    src/fs_statmount.c
     src/hooks.c
     src/monitor.c
     src/optlist.c

--- a/libmount/meson.build
+++ b/libmount/meson.build
@@ -44,6 +44,7 @@ lib_mount_sources = '''
 if LINUX
   lib_mount_sources += '''
     src/fs_statmount.c
+    src/tab_listmount.c
     src/hooks.c
     src/monitor.c
     src/optlist.c

--- a/libmount/samples/Makemodule.am
+++ b/libmount/samples/Makemodule.am
@@ -2,7 +2,8 @@
 if LINUX
 check_PROGRAMS += \
 	sample-mount-overwrite \
-	sample-mount-statmount
+	sample-mount-statmount \
+	sample-mount-listmount
 endif
 
 sample_mount_overwrite_SOURCES = libmount/samples/overwrite.c
@@ -12,3 +13,7 @@ sample_mount_overwrite_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 sample_mount_statmount_SOURCES = libmount/samples/statmount.c
 sample_mount_statmount_LDADD =  libmount.la $(LDADD) libcommon.la
 sample_mount_statmount_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
+
+sample_mount_listmount_SOURCES = libmount/samples/listmount.c
+sample_mount_listmount_LDADD =  libmount.la $(LDADD) libcommon.la
+sample_mount_listmount_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)

--- a/libmount/samples/Makemodule.am
+++ b/libmount/samples/Makemodule.am
@@ -1,13 +1,14 @@
 
 if LINUX
 check_PROGRAMS += \
-	sample-mount-overwrite
+	sample-mount-overwrite \
+	sample-mount-statmount
 endif
 
-sample_mount_cflags = $(AM_CFLAGS) -I$(ul_libmount_incdir)
-sample_mount_ldadd = libmount.la $(LDADD)
-
-
 sample_mount_overwrite_SOURCES = libmount/samples/overwrite.c
-sample_mount_overwrite_LDADD =  $(sample_mount_ldadd)
-sample_mount_overwrite_CFLAGS = $(sample_mount_cflags)
+sample_mount_overwrite_LDADD =  libmount.la $(LDADD)
+sample_mount_overwrite_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
+
+sample_mount_statmount_SOURCES = libmount/samples/statmount.c
+sample_mount_statmount_LDADD =  libmount.la $(LDADD) libcommon.la
+sample_mount_statmount_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)

--- a/libmount/samples/listmount.c
+++ b/libmount/samples/listmount.c
@@ -77,7 +77,9 @@ int main(int argc, char *argv[])
 
 	/* Without this mask setting, the library will make two statmount() calls
 	 * for each node. */
+#if defined(STATMOUNT_MNT_POINT) && defined(STATMOUNT_FS_TYPE)
 	mnt_statmnt_set_mask(sm, STATMOUNT_MNT_POINT | STATMOUNT_FS_TYPE);
+#endif
 
 	/* force fetch all data
 	mnt_statmnt_set_mask(sm,

--- a/libmount/samples/listmount.c
+++ b/libmount/samples/listmount.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2024 Karel Zak <kzak@redhat.com>
+ *
+ * This file may be redistributed under the terms of the
+ * GNU Lesser General Public License.
+ */
+#include <stdlib.h>
+
+#include "c.h"
+#include "strutils.h"
+#include "timeutils.h"
+#include "pathnames.h"
+
+#include "libmount.h"
+
+#include "mount-api-utils.h"	/* fallback for old linux/mount.h */
+
+static void __iter_table(	struct libmnt_table *tb,
+			struct libmnt_iter *itr, int output, int reverse)
+{
+	struct libmnt_fs *fs = NULL;
+	int rc;
+
+	mnt_reset_iter(itr, reverse ? MNT_ITER_BACKWARD : MNT_ITER_FORWARD);
+	while ((rc = mnt_table_next_fs(tb, itr, &fs)) == 0) {
+		const char *tgt = mnt_fs_get_target(fs);
+		const char *type = mnt_fs_get_fstype(fs);
+
+		if (output)
+			printf (" %15s %s\n", type, tgt);
+	}
+	if (rc < 0)
+		warn("cannot iterate on filesystems");
+}
+
+#define fetch_data(t, i)		__iter_table(t, i, 0, 0)
+#define print_table(t, i)		__iter_table(t, i, 1, 0)
+#define print_table_reverse(t, i)	__iter_table(t, i, 1, 1)
+
+
+int main(int argc, char *argv[])
+{
+	struct libmnt_table *tb;
+	struct libmnt_statmnt *sm;
+	struct libmnt_iter *itr;
+	struct timeval start, end;
+	uint64_t id = 0;
+	double sec_lsmnt, sec_lsstmnt, sec_mountinfo;
+
+	mnt_init_debug(0);
+
+
+	if (argc == 2) {
+		const char *arg = argv[1];
+		if (!isdigit_string(arg))
+			mnt_id_from_path(arg, &id, NULL);
+		else
+			id = strtou64_or_err(arg, "cannot ID");
+	}
+
+	itr = mnt_new_iter(MNT_ITER_FORWARD);
+	if (!itr)
+		err(MNT_EX_SYSERR, "failed to initialize libmount iterator");
+
+	tb = mnt_new_table();
+	if (!tb)
+		err(EXIT_FAILURE, "failed to allocate table handler");
+	if (id)
+		mnt_table_listmount_set_id(tb, id);
+
+	/*
+	 * A) listmount() and statmount() based table
+	 */
+	sm = mnt_new_statmnt();
+	if (!sm)
+		err(EXIT_FAILURE, "failed to allocate statmnt handler");
+
+	/* Without this mask setting, the library will make two statmount() calls
+	 * for each node. */
+	mnt_statmnt_set_mask(sm, STATMOUNT_MNT_POINT | STATMOUNT_FS_TYPE);
+
+	/* force fetch all data
+	mnt_statmnt_set_mask(sm,
+			STATMOUNT_SB_BASIC |
+			STATMOUNT_MNT_BASIC |
+			STATMOUNT_PROPAGATE_FROM |
+			STATMOUNT_MNT_ROOT |
+			STATMOUNT_MNT_POINT |
+			STATMOUNT_FS_TYPE
+			STATMOUNT_MNT_OPTS);
+	*/
+
+	/* enable don-demand statmount() call for all filesystems in the table */
+	mnt_table_refer_statmnt(tb, sm);
+
+	/* listmount() only */
+	gettimeofday(&start, NULL);
+	if (mnt_table_fetch_listmount(tb) != 0)
+		warn("failed to read mount table by listmount()");
+	gettimeofday(&end, NULL);
+	sec_lsmnt = time_diff(&end, &start);
+
+	/* force statmount() for all nodes */
+	fetch_data(tb, itr);
+	gettimeofday(&end, NULL);
+	sec_lsstmnt = time_diff(&end, &start);
+
+	fprintf(stdout, "listmount() based table:\n");
+	print_table(tb, itr);
+
+
+	/* disable statmount() and listmount(); reset table */
+	mnt_statmnt_disable_fetching(sm, 1);
+	mnt_table_enable_listmount(tb, 0);
+	mnt_reset_table(tb);
+
+	/*
+	 * B) /proc/self/mountinfo based table
+	 */
+	gettimeofday(&start, NULL);
+	mnt_table_parse_file(tb, _PATH_PROC_MOUNTINFO);
+	gettimeofday(&end, NULL);
+	sec_mountinfo = time_diff(&end, &start);
+
+	fprintf(stdout, "\nprocfs based table:\n");
+	print_table(tb, itr);
+
+	fprintf(stdout, "\n"
+			"%f sec listmount()\n"
+			"%f sec listmount()+statmount()\n"
+			"%f sec /proc/sef/mountinfo"
+			"\n\n",
+			sec_lsmnt, sec_lsstmnt, sec_mountinfo);
+
+
+	mnt_reset_table(tb);
+
+	/*
+	 * C) Instead of reading the entire mount table with one listmount() call, read
+	 * it in smaller steps. This is particularly useful for systems with large
+	 * mount tables, where we may only need to access one specific node (usually the
+	 * last one).
+	 *
+	 * By default, libmount reads 512 nodes in one call. To test this sample
+	 * on normal systems, we will reduce this number to 5 nodes. The listmount()
+	 * function is used as a backend for regular mnt_table_next_fs().
+	 * There is no need to make any changes to the application, just enable
+	 * on-demand listmount() by using mnt_table_enable_listmount().
+	 */
+	if (mnt_table_listmount_set_stepsiz(tb, 5) != 0)
+		warn("failed to initialize listmount()");
+	mnt_table_enable_listmount(tb, 1);
+
+	/* enable also statmount() */
+	mnt_statmnt_disable_fetching(sm, 0);
+
+	fprintf(stdout, "\nlistmount() - small steps (reverse):\n");
+	print_table_reverse(tb, itr);
+
+
+	mnt_unref_table(tb);
+	mnt_unref_statmnt(sm);
+	mnt_free_iter(itr);
+
+	return EXIT_SUCCESS;
+}

--- a/libmount/samples/statmount.c
+++ b/libmount/samples/statmount.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Karel Zak <kzak@redhat.com>
+ *
+ * This file may be redistributed under the terms of the
+ * GNU Lesser General Public License.
+ */
+#include <stdlib.h>
+
+#include "c.h"
+#include "strutils.h"
+#include "libmount.h"
+
+#include <linux/mount.h>	/* STATMOUNT_* masks */
+
+#include "mount-api-utils.h"	/* fallback for old linux/mount.h */
+
+int main(int argc, char *argv[])
+{
+        struct libmnt_fs *fs;
+	struct libmnt_statmnt *sm;
+	const char *mnt;
+	uint64_t id = 0;
+
+	if (argc != 2)
+		errx(EXIT_FAILURE, "usage: %s <mountpoint | id>",
+				program_invocation_short_name);
+
+	mnt_init_debug(0);
+
+	fs = mnt_new_fs();
+	if (!fs)
+		err(EXIT_FAILURE, "failed to allocate fs handler");
+
+	/* define target (mountpoint) or mount ID */
+	mnt = argv[1];
+	if (isdigit_string(mnt)) {
+		id = strtou64_or_err(mnt, "cannot ID");
+		mnt_fs_set_uniq_id(fs, id);
+	} else
+		mnt_fs_set_target(fs, mnt);
+
+	/*
+	 * A) fetch all data without reference to libmnt_statmnt
+	 */
+	if (mnt_fs_fetch_statmount(fs, 0) != 0)
+		warn("failed to read data by statmount()");
+	mnt_fs_print_debug(fs, stdout);
+
+	/* reset */
+	id = mnt_fs_get_uniq_id(fs);
+	mnt_reset_fs(fs);
+	mnt_fs_set_uniq_id(fs, id);
+
+	/*
+	 * B) fetch data by on-demand way
+	 */
+	sm = mnt_new_statmnt();
+	if (!sm)
+		err(EXIT_FAILURE, "failed to allocate statmount handler");
+
+	mnt_fs_refer_statmnt(fs, sm);
+
+	/* read fs type, but nothing else */
+	mnt_fs_get_fstype(fs);
+	mnt_fs_print_debug(fs, stdout);
+
+	/* read fs root, but nothing else */
+        mnt_fs_get_root(fs);
+        mnt_fs_print_debug(fs, stdout);
+
+	/* read all mising data */
+	mnt_fs_fetch_statmount(fs, 0);
+	mnt_fs_print_debug(fs, stdout);
+
+	/* see debug, this is no-op for statmount() */
+	mnt_fs_get_fstype(fs);
+
+	mnt_unref_fs(fs);
+	mnt_unref_statmnt(sm);
+
+	return EXIT_SUCCESS;
+}

--- a/libmount/samples/statmount.c
+++ b/libmount/samples/statmount.c
@@ -10,8 +10,6 @@
 #include "strutils.h"
 #include "libmount.h"
 
-#include <linux/mount.h>	/* STATMOUNT_* masks */
-
 #include "mount-api-utils.h"	/* fallback for old linux/mount.h */
 
 int main(int argc, char *argv[])

--- a/libmount/src/Makemodule.am
+++ b/libmount/src/Makemodule.am
@@ -30,6 +30,7 @@ libmount_la_SOURCES += \
 	libmount/src/context.c \
 	libmount/src/context_mount.c \
 	libmount/src/context_umount.c \
+	libmount/src/fs_statmount.c \
 	libmount/src/hooks.c \
 	libmount/src/hook_mount.c \
 	libmount/src/hook_mount_legacy.c \

--- a/libmount/src/Makemodule.am
+++ b/libmount/src/Makemodule.am
@@ -31,6 +31,7 @@ libmount_la_SOURCES += \
 	libmount/src/context_mount.c \
 	libmount/src/context_umount.c \
 	libmount/src/fs_statmount.c \
+	libmount/src/tab_listmount.c \
 	libmount/src/hooks.c \
 	libmount/src/hook_mount.c \
 	libmount/src/hook_mount_legacy.c \

--- a/libmount/src/btrfs.c
+++ b/libmount/src/btrfs.c
@@ -15,7 +15,6 @@
 #include <dirent.h>
 #include <sys/ioctl.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <linux/btrfs.h>
 
 #include "mountP.h"

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -44,8 +44,6 @@
 #include <stdarg.h>
 #include <sys/wait.h>
 
-#include "mount-api-utils.h"
-
 /**
  * mnt_new_context:
  *

--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -1694,7 +1694,7 @@ int mnt_fs_match_target(struct libmnt_fs *fs, const char *target,
 	if (!fs || !target)
 		return 0;
 #ifdef HAVE_STATMOUNT_API
-	mnt_fs_try_statmount(fs, target, STATMOUNT_MNT_BASIC);
+	mnt_fs_try_statmount(fs, target, STATMOUNT_MNT_POINT);
 #endif
 	if (!fs->target)
 		return 0;

--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -1361,11 +1361,50 @@ int mnt_fs_set_bindsrc(struct libmnt_fs *fs, const char *src)
  * mnt_fs_get_id:
  * @fs: /proc/self/mountinfo entry
  *
- * Returns: mount ID (unique identifier of the mount) or negative number in case of error.
+ * This ID is "old" and used in mountinfo only. Since Linux v6.8 there is also unique
+ * 64-bit ID, see mnt_fs_get_uniq_id().
+ *
+ * Returns: mount ID or negative number in case of error.
  */
 int mnt_fs_get_id(struct libmnt_fs *fs)
 {
 	return fs ? fs->id : -EINVAL;
+}
+
+/**
+ * mnt_fs_get_uniq_id:
+ * @fs: filesystem instance
+ *
+ * This ID is provided by statmount() or statx(STATX_MNT_ID_UNIQUE) since Linux
+ * kernel since v6.8.
+ *
+ * Returns: unique mount ID
+ *
+ * Since: 2.41
+ */
+uint64_t mnt_fs_get_uniq_id(struct libmnt_fs *fs)
+{
+	return fs ? fs->uniq_id : 0;
+}
+
+/**
+ * mnt_fs_set_uniq_id:
+ * @fs: filesystem instance
+ * @id: mount node ID
+ *
+ * This ID is provided by statmount() or statx(STATX_MNT_ID_UNIQUE) since Linux
+ * kernel since v6.8.
+ *
+ * Returns: 0 or negative number in case of error.
+ *
+ * Since: 2.41
+ */
+int mnt_fs_set_uniq_id(struct libmnt_fs *fs, uint64_t id)
+{
+	if (!fs)
+		return -EINVAL;
+	fs->uniq_id = id;
+	return 0;
 }
 
 /**
@@ -1377,6 +1416,19 @@ int mnt_fs_get_id(struct libmnt_fs *fs)
 int mnt_fs_get_parent_id(struct libmnt_fs *fs)
 {
 	return fs ? fs->parent : -EINVAL;
+}
+
+/**
+ * mnt_fs_get_parent_uniq_id:
+ * @fs: filesystem instance
+ *
+ * This ID is provided by statmount() since Linux kernel since v6.8.
+ *
+ * Returns: parent mount ID or 0 if not avalable
+ */
+uint64_t mnt_fs_get_parent_uniq_id(struct libmnt_fs *fs)
+{
+	return fs ? fs->uniq_parent : 0;
 }
 
 /**
@@ -1714,6 +1766,10 @@ int mnt_fs_print_debug(struct libmnt_fs *fs, FILE *file)
 		fprintf(file, "id:     %d\n", mnt_fs_get_id(fs));
 	if (mnt_fs_get_parent_id(fs))
 		fprintf(file, "parent: %d\n", mnt_fs_get_parent_id(fs));
+	if (mnt_fs_get_uniq_id(fs))
+		fprintf(file, "uniq-id:     %" PRIu64 "\n", mnt_fs_get_uniq_id(fs));
+	if (mnt_fs_get_parent_uniq_id(fs))
+		fprintf(file, "uniq-parent: %" PRIu64 "\n", mnt_fs_get_parent_uniq_id(fs));
 	if (mnt_fs_get_devno(fs))
 		fprintf(file, "devno:  %d:%d\n", major(mnt_fs_get_devno(fs)),
 						minor(mnt_fs_get_devno(fs)));

--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -1852,7 +1852,6 @@ int mnt_fs_print_debug(struct libmnt_fs *fs, FILE *file)
 		stmnt_disabled = mnt_statmnt_disable_fetching(fs->stmnt, 1);
 
 	fprintf(file, "------ fs:\n");
-	fprintf(file, "auto-statmount: %s\n", stmnt_disabled ? "off" : "on");
 	if (mnt_fs_get_source(fs))
 		fprintf(file, "source: %s\n", mnt_fs_get_source(fs));
 	if (mnt_fs_get_target(fs))

--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -617,8 +617,9 @@ const char *mnt_fs_get_target(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return NULL;
-	if (!fs->target && mnt_fs_want_statmount(fs, STATMOUNT_MNT_POINT))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_POINT);
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, target, STATMOUNT_MNT_POINT);
+#endif
 	return fs->target;;
 }
 
@@ -665,9 +666,9 @@ int mnt_fs_get_propagation(struct libmnt_fs *fs, unsigned long *flags)
 {
 	if (!fs || !flags)
 		return -EINVAL;
-	if (!fs->propagation && mnt_fs_want_statmount(fs, STATMOUNT_MNT_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, propagation, STATMOUNT_MNT_BASIC);
+#endif
 	if (!fs->propagation && fs->opt_fields) {
 		 /*
 		 * The optional fields format is incompatible with mount options
@@ -719,9 +720,9 @@ int mnt_fs_is_pseudofs(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return 0;
-	if (!fs->fstype && mnt_fs_want_statmount(fs, STATMOUNT_FS_TYPE))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_FS_TYPE);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, fstype, STATMOUNT_FS_TYPE);
+#endif
 	return mnt_fs_get_flags(fs) & MNT_FS_PSEUDO ? 1 : 0;
 }
 
@@ -735,9 +736,9 @@ int mnt_fs_is_netfs(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return 0;
-	if (!fs->fstype && mnt_fs_want_statmount(fs, STATMOUNT_FS_TYPE))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_FS_TYPE);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, fstype, STATMOUNT_FS_TYPE);
+#endif
 	return mnt_fs_get_flags(fs) & MNT_FS_NET ? 1 : 0;
 }
 
@@ -766,10 +767,9 @@ const char *mnt_fs_get_fstype(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return NULL;
-
-	if (!fs->fstype && mnt_fs_want_statmount(fs, STATMOUNT_FS_TYPE))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_FS_TYPE);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, fstype, STATMOUNT_FS_TYPE);
+#endif
 	return fs->fstype;
 }
 
@@ -892,9 +892,10 @@ char *mnt_fs_strdup_options(struct libmnt_fs *fs)
 		return NULL;
 	if (fs->optlist)
 		sync_opts_from_optlist(fs, fs->optlist);
-	else if (!fs->optstr && mnt_fs_want_statmount(fs, STATMOUNT_SB_BASIC | STATMOUNT_MNT_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_SB_BASIC | STATMOUNT_MNT_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	else
+		mnt_fs_try_statmount(fs, optstr, STATMOUNT_SB_BASIC | STATMOUNT_MNT_BASIC);
+#endif
 	errno = 0;
 	if (fs->optstr)
 		return strdup(fs->optstr);
@@ -922,9 +923,10 @@ const char *mnt_fs_get_options(struct libmnt_fs *fs)
 	       return NULL;
 	if (fs->optlist)
 		sync_opts_from_optlist(fs, fs->optlist);
-	else if (!fs->optstr && mnt_fs_want_statmount(fs, STATMOUNT_SB_BASIC | STATMOUNT_MNT_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_SB_BASIC | STATMOUNT_MNT_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	else
+		mnt_fs_try_statmount(fs, optstr, STATMOUNT_SB_BASIC | STATMOUNT_MNT_BASIC);
+#endif
 	return fs->optstr;
 }
 
@@ -1094,9 +1096,10 @@ const char *mnt_fs_get_fs_options(struct libmnt_fs *fs)
 		return NULL;
 	if (fs->optlist)
 		sync_opts_from_optlist(fs, fs->optlist);
-	else if (!fs->fs_optstr && mnt_fs_want_statmount(fs, STATMOUNT_SB_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_SB_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	else
+		mnt_fs_try_statmount(fs, fs_optstr, STATMOUNT_SB_BASIC);
+#endif
 	return fs->fs_optstr;
 }
 
@@ -1112,9 +1115,10 @@ const char *mnt_fs_get_vfs_options(struct libmnt_fs *fs)
 		return NULL;
 	if (fs->optlist)
 		sync_opts_from_optlist(fs, fs->optlist);
-	else if (!fs->vfs_optstr && mnt_fs_want_statmount(fs, STATMOUNT_MNT_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	else
+		mnt_fs_try_statmount(fs, vfs_optstr, STATMOUNT_MNT_BASIC);
+#endif
 	return fs->vfs_optstr;
 }
 
@@ -1299,9 +1303,9 @@ const char *mnt_fs_get_root(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return NULL;
-	if (!fs->root && mnt_fs_want_statmount(fs, STATMOUNT_MNT_ROOT))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_ROOT);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, root, STATMOUNT_MNT_ROOT);
+#endif
 	return fs->root;
 }
 
@@ -1414,9 +1418,9 @@ int mnt_fs_get_id(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return 0;
-	if (!fs->id && mnt_fs_want_statmount(fs, STATMOUNT_MNT_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, id, STATMOUNT_MNT_BASIC);
+#endif
 	return fs->id;
 }
 
@@ -1435,9 +1439,9 @@ uint64_t mnt_fs_get_uniq_id(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return 0;
-	if (!fs->uniq_id && mnt_fs_want_statmount(fs, STATMOUNT_MNT_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, uniq_id, STATMOUNT_MNT_BASIC);
+#endif
 	return fs->uniq_id;
 }
 
@@ -1471,9 +1475,9 @@ int mnt_fs_get_parent_id(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return 0;
-	if (!fs->parent && mnt_fs_want_statmount(fs, STATMOUNT_MNT_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, parent, STATMOUNT_MNT_BASIC);
+#endif
 	return fs->parent;
 }
 
@@ -1489,9 +1493,9 @@ uint64_t mnt_fs_get_parent_uniq_id(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return 0;
-	if (!fs->uniq_parent && mnt_fs_want_statmount(fs, STATMOUNT_MNT_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, uniq_parent, STATMOUNT_MNT_BASIC);
+#endif
 	return fs->uniq_parent;
 }
 
@@ -1509,8 +1513,9 @@ uint64_t mnt_fs_get_ns(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return 0;
-	if (!fs->ns_id && mnt_fs_want_statmount(fs, STATMOUNT_MNT_NS_ID))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_NS_ID);
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, ns_id, STATMOUNT_MNT_NS_ID);
+#endif
 	return fs->ns_id;
 }
 
@@ -1542,9 +1547,9 @@ dev_t mnt_fs_get_devno(struct libmnt_fs *fs)
 {
 	if (!fs)
 		return 0;
-	if (!fs->devno && mnt_fs_want_statmount(fs, STATMOUNT_SB_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_SB_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, devno, STATMOUNT_SB_BASIC);
+#endif
 	return fs->devno;
 }
 
@@ -1578,9 +1583,10 @@ int mnt_fs_get_option(struct libmnt_fs *fs, const char *name,
 
 	if (fs->optlist)
 		sync_opts_from_optlist(fs, fs->optlist);
-	else if (!fs->vfs_optstr && mnt_fs_want_statmount(fs, STATMOUNT_MNT_BASIC | STATMOUNT_SB_BASIC))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_BASIC | STATMOUNT_SB_BASIC);
-
+#ifdef HAVE_STATMOUNT_API
+	else
+		mnt_fs_try_statmount(fs, vfs_optstr, STATMOUNT_SB_BASIC | STATMOUNT_MNT_BASIC);
+#endif
 	if (fs->fs_optstr)
 		rc = mnt_optstr_get_option(fs->fs_optstr, name, value, valsz);
 	if (rc == 1 && fs->vfs_optstr)
@@ -1686,8 +1692,9 @@ int mnt_fs_match_target(struct libmnt_fs *fs, const char *target,
 
 	if (!fs || !target)
 		return 0;
-	if (!fs->target && mnt_fs_want_statmount(fs, STATMOUNT_MNT_POINT))
-		mnt_fs_fetch_statmount(fs, STATMOUNT_MNT_POINT);
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, target, STATMOUNT_MNT_BASIC);
+#endif
 	if (!fs->target)
 		return 0;
 

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -305,9 +305,15 @@ int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask)
 	/* add default mask if on-demand enabled */
 	if (fs->stmnt
 	    && !fs->stmnt->disabled
-	    && fs->stmnt->mask
-	    && !(fs->stmnt_done & fs->stmnt->mask))
+	    && fs->stmnt->mask)
 		mask |= fs->stmnt->mask;
+
+	/* call only for missing stuff */
+	if (mask && fs->stmnt_done) {
+		mask &= ~fs->stmnt_done;	/* remove what is already done */
+		if (!mask)
+			return 0;
+	}
 
 	/* ignore repeated requests */
 	if (mask && fs->stmnt_done & mask)

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -29,6 +29,7 @@
  */
 struct libmnt_statmnt *mnt_new_statmnt(void)
 {
+#ifdef HAVE_STATMOUNT_API
 	struct libmnt_statmnt *sm;
 
 	errno = 0;
@@ -44,6 +45,10 @@ struct libmnt_statmnt *mnt_new_statmnt(void)
 	sm->refcount = 1;
 	DBG(STATMNT, ul_debugobj(sm, "alloc"));
 	return sm;
+#else
+	errno = ENOSYS;
+	return NULL;
+#endif
 }
 
 /**

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -1,0 +1,389 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of libmount from util-linux project.
+ *
+ * Copyright (C) 2024 Karel Zak <kzak@redhat.com>
+ *
+ * libmount is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * SECTION: statmount
+ * @title: statmount setting
+ * @short_description: Fetches information about mount node from the kernel.
+ */
+#include "mountP.h"
+
+#include "mangle.h"
+
+/**
+ * mnt_new_statmnt:
+ *
+ * The initial refcount is 1, and needs to be decremented to
+ * release the resources of the filesystem.
+ *
+ * Returns: newly allocated struct libmnt_statmnt.
+ */
+struct libmnt_statmnt *mnt_new_statmnt(void)
+{
+	struct libmnt_statmnt *sm;
+
+	errno = 0;
+	if (ul_statmount(0, 0, 0, NULL, 0, 0) < 0 && errno == ENOSYS) {
+		DBG(FS, ul_debug("statmount: unsuppported"));
+		return NULL;
+	}
+
+	sm = calloc(1, sizeof(*sm));
+	if (!sm)
+		return NULL;
+
+	sm->refcount = 1;
+	DBG(STATMNT, ul_debugobj(sm, "alloc"));
+	return sm;
+}
+
+/**
+ * mnt_ref_statmount:
+ * @sm: statmount setting
+ *
+ * Increments reference counter.
+ */
+void mnt_ref_statmnt(struct libmnt_statmnt *sm)
+{
+	if (sm) {
+		sm->refcount++;
+		/*DBG(STATMNT, ul_debugobj(sm, "ref=%d", sm->refcount));*/
+	}
+}
+
+/**
+ * mnt_unref_statmnt:
+ * @sm: statmount setting
+ *
+ * De-increments reference counter, on zero the @sm is automatically
+ * deallocated.
+ */
+void mnt_unref_statmnt(struct libmnt_statmnt *sm)
+{
+	if (sm) {
+		sm->refcount--;
+		/*DBG(STATMNT, ul_debugobj(sm, "unref=%d", sm->refcount));*/
+		if (sm->refcount <= 0) {
+			free(sm->buf);
+			free(sm);
+		}
+	}
+}
+
+/**
+ * mnt_statmnt_set_mask:
+ * @sm: statmount setting
+ * @mask: default mask for statmount() or 0
+ *
+ * Returns: 0 on succees or  or <0 on error.
+ */
+int mnt_statmnt_set_mask(struct libmnt_statmnt *sm, uint64_t mask)
+{
+	if (!sm)
+		return -EINVAL;
+	sm->mask = mask;
+
+	DBG(STATMNT, ul_debugobj(sm, "mask=0x%" PRIx64, sm->mask));
+	return 0;
+}
+
+/**
+ * mnt_statmnt_disable_fetching:
+ * @sm: statmount setting
+ * @disable: 0 or 1
+ *
+ * Disable or enable on-demand statmount() in all libmnt_table of libmnt_fs
+ * onjects that references this @sm.
+ *
+ * Returns: current setting (0 or 1) or <0 on error.
+ *
+ * Since: 2.41
+ */
+int mnt_statmnt_disable_fetching(struct libmnt_statmnt *sm, int disable)
+{
+	int old;
+
+	if (!sm)
+		return -EINVAL;
+	old = sm->disabled;
+	sm->disabled = disable ? 1 : 0;
+
+	DBG(STATMNT, ul_debugobj(sm, "statmount() %s",
+				sm->disabled ? "off" : "on"));
+	return old;
+}
+
+/**
+ * mnt_fs_refer_statmnt:
+ * @fs: filesystem
+ * @sm: statmount() setting
+ *
+ * Add a reference to the statmount() setting. This setting can be overwritten
+ * if you add @fs into a table that uses a different statmount() setting. See
+ * mnt_table_refer_statmnt(). It is recommended to use the statmount() setting
+ * on a table level if you do not want to work with complete mount table.
+ *
+ * The function mnt_reset_fs() removes this reference too.
+ *
+ * Returns: 0 on success or negative number in case of error.
+ *
+ * Since: 2.41
+ */
+int mnt_fs_refer_statmnt(struct libmnt_fs *fs, struct libmnt_statmnt *sm)
+{
+	if (!fs)
+		return -EINVAL;
+	if (fs->stmnt == sm)
+		return 0;
+
+	mnt_unref_statmnt(fs->stmnt);
+	mnt_ref_statmnt(sm);
+
+	fs->stmnt = sm;
+	return 0;
+}
+
+/**
+ * mnt_fs_get_statmnt:
+ * @fs: filesystem
+ *
+ * Returns: pointer to linmnt_statmnt instance used for the filesystem or NULL
+ *
+ * Since: 2.41
+ */
+struct libmnt_statmnt *mnt_fs_get_statmnt(struct libmnt_fs *fs)
+{
+	return fs ? fs->stmnt : NULL;
+}
+
+#ifdef HAVE_STATMOUNT_API
+
+static inline const char *sm_str(struct ul_statmount *sm, uint32_t offset)
+{
+	return sm->str + offset;
+}
+
+static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
+{
+	int rc = 0, merge = 0;
+
+	if (!sm || !sm->size || !fs)
+		return -EINVAL;
+
+	merge = !fs->vfs_optstr || fs->fs_optstr;
+
+	if ((sm->mask & STATMOUNT_FS_TYPE) && !fs->fstype)
+		rc = mnt_fs_set_fstype(fs, sm_str(sm, sm->fs_type));
+
+	if (!rc && (sm->mask & STATMOUNT_MNT_POINT) && !fs->target)
+		rc = mnt_fs_set_target(fs, sm_str(sm, sm->mnt_point));
+
+	if (!rc && (sm->mask & STATMOUNT_MNT_ROOT) && !fs->root)
+		rc = mnt_fs_set_root(fs, sm_str(sm, sm->mnt_root));
+
+	if (!rc && (sm->mask & STATMOUNT_MNT_BASIC)) {
+		if (!fs->propagation)
+			fs->propagation = sm->mnt_propagation;
+		if (!fs->parent)
+			fs->parent = sm->mnt_parent_id_old;
+		if (!fs->uniq_parent)
+			fs->uniq_parent = sm->mnt_parent_id;
+		if (!fs->id)
+			fs->id = sm->mnt_id_old;
+		if (!fs->uniq_id)
+			fs->uniq_id = sm->mnt_id;
+		if (!fs->vfs_optstr) {
+			rc = mnt_optstr_append_option(&fs->vfs_optstr,
+					sm->mnt_attr & MOUNT_ATTR_RDONLY ? "ro" : "rw", NULL);
+			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NOSUID))
+				rc = mnt_optstr_append_option(&fs->vfs_optstr, "nosuid", NULL);
+			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NODEV))
+				rc = mnt_optstr_append_option(&fs->vfs_optstr, "nodev", NULL);
+			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NOEXEC))
+				rc = mnt_optstr_append_option(&fs->vfs_optstr, "noexec", NULL);
+			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NODIRATIME))
+				rc = mnt_optstr_append_option(&fs->vfs_optstr, "nodiratime", NULL);
+			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NOSYMFOLLOW))
+				rc = mnt_optstr_append_option(&fs->vfs_optstr, "nosymfollow", NULL);
+
+			switch (sm->mnt_attr & MOUNT_ATTR__ATIME) {
+			case MOUNT_ATTR_STRICTATIME:
+				rc = mnt_optstr_append_option(&fs->vfs_optstr, "strictatime", NULL);
+				break;
+			case MOUNT_ATTR_NOATIME:
+				rc = mnt_optstr_append_option(&fs->vfs_optstr, "noatime", NULL);
+				break;
+			case MOUNT_ATTR_RELATIME:
+				rc = mnt_optstr_append_option(&fs->vfs_optstr, "relatime", NULL);
+				break;
+			}
+
+		}
+	}
+
+	if (!rc && (sm->mask & STATMOUNT_MNT_NS_ID) && !fs->ns_id)
+		fs->ns_id = sm->mnt_ns_id;
+
+	if (!rc && (sm->mask & STATMOUNT_MNT_OPTS) && !fs->fs_optstr)
+		fs->fs_optstr = unmangle(sm_str(sm, sm->mnt_opts), NULL);
+
+	if (!rc && (sm->mask & STATMOUNT_SB_BASIC)) {
+		if (!fs->devno)
+			fs->devno = makedev(sm->sb_dev_major, sm->sb_dev_minor);
+		if (!fs->fs_optstr) {
+			rc = mnt_optstr_append_option(&fs->fs_optstr,
+					sm->sb_flags & SB_RDONLY ? "ro" : "rw", NULL);
+			if (!rc && (sm->sb_flags & SB_SYNCHRONOUS))
+				rc = mnt_optstr_append_option(&fs->fs_optstr, "sync", NULL);
+			if (!rc && (sm->sb_flags & SB_DIRSYNC))
+				rc = mnt_optstr_append_option(&fs->fs_optstr, "dirsync", NULL);
+			if (!rc && (sm->sb_flags & SB_LAZYTIME))
+				rc = mnt_optstr_append_option(&fs->fs_optstr, "lazytime", NULL);
+		}
+	}
+
+	if (!rc && merge) {
+		free(fs->optstr);
+
+		/* merge VFS and FS options to one string (we do the same in mountinfo parser) */
+		fs->optstr = mnt_fs_strdup_options(fs);
+	}
+
+	fs->flags |= MNT_FS_KERNEL;
+
+	return rc;
+}
+
+/**
+ * mnt_fs_fetch_statmount:
+ * @fs: filesystem instance
+ * @mask: extends the default statmount() mask.
+ *
+ * This function retrieves mount node information from the kernel and applies it
+ * to the @fs. If the @fs is associated with any libmnt_statmnt object (see
+ * mnt_fs_refer_statmnt()), then this object is used to reduce the overhead of
+ * allocating statmount buffer and to define default statmount() mask.
+ *
+ * The @mask is extended (bitwise-OR) by the mask specified for
+ * mnt_statmnt_set_mask() if on-demand fetching is enabled. If the mask is
+ * still 0, then a mask is generated for all missing data in @fs.
+ *
+ * The default namespace is the current namespace. This default can be
+ * overwritten by mnt_fs_set_ns_id(). The namespace ID is also set when @fs
+ * has been created by mnt_table_fetch_statmount() or on-demand (see
+ * mnt_table_enable_listmount()).
+ *
+ * Returns: 0 or negative number in case of error (if @fs is NULL).
+ *
+ * Since: 2.41
+ */
+int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask)
+{
+	int rc = 0, status = 0;
+	struct ul_statmount *buf = NULL;
+	size_t bufsiz = 0;
+	uint64_t ns = 0;
+
+	if (!fs)
+		return -EINVAL;
+
+	DBG(FS, ul_debugobj(fs, "statmount fetch"));
+
+	/* add default mask if on-demand enabled */
+	if (fs->stmnt
+	    && !fs->stmnt->disabled
+	    && fs->stmnt->mask
+	    && !(fs->stmnt_done & fs->stmnt->mask))
+		mask |= fs->stmnt->mask;
+
+	/* ignore repeated requests */
+	if (mask && fs->stmnt_done & mask)
+		return 0;
+
+	/* temporary disable statmount() to avoid recursive
+	 * mnt_fs_fetch_statmount() from mnt_fs_get...() functions */
+	if (fs->stmnt)
+		status = mnt_statmnt_disable_fetching(fs->stmnt, 1);
+
+	if (!fs->uniq_id) {
+		if (!fs->target) {
+			rc = -EINVAL;
+			goto done;
+		}
+		rc = mnt_id_from_path(fs->target, &fs->uniq_id, NULL);
+		if (rc)
+			goto done;
+		DBG(FS, ul_debugobj(fs, " uniq-ID=%" PRIu64, fs->uniq_id));
+	}
+
+	/* fetch all missing information by default */
+	if (!mask) {
+		mask = STATMOUNT_SB_BASIC | STATMOUNT_MNT_BASIC;
+		if (!fs->fstype)
+			mask |= STATMOUNT_FS_TYPE;
+		if (!fs->target)
+			mask |= STATMOUNT_MNT_POINT;
+		if (!fs->root)
+			mask |= STATMOUNT_MNT_ROOT;
+		if (!fs->fs_optstr)
+			mask |= STATMOUNT_MNT_OPTS;
+		if (!fs->ns_id)
+			mask |= STATMOUNT_MNT_NS_ID;
+	}
+	if (!mask)
+		goto done;
+
+	if (fs->ns_id)
+		ns = fs->ns_id;
+
+	if (fs->stmnt) {
+		DBG(FS, ul_debugobj(fs, " reuse libmnt_stmnt"));
+		memset(fs->stmnt->buf, 0, fs->stmnt->bufsiz);
+		rc = sys_statmount(fs->uniq_id, 0, mask,
+				   &fs->stmnt->buf, &fs->stmnt->bufsiz, 0);
+		buf = fs->stmnt->buf;
+		bufsiz = fs->stmnt->bufsiz;
+	} else {
+		DBG(FS, ul_debugobj(fs, " use private buffer"));
+		rc = sys_statmount(fs->uniq_id, 0, mask, &buf, &bufsiz, 0);
+	}
+	DBG(FS, ul_debugobj(fs, " statmount [rc=%d bufsiz=%zu ns=%" PRIu64 " mask: %s%s%s%s%s%s]",
+				rc, bufsiz, ns,
+				mask & STATMOUNT_SB_BASIC ? "sb-basic " : "",
+				mask & STATMOUNT_MNT_BASIC ? "mnt-basic " : "",
+				mask & STATMOUNT_MNT_ROOT ? "mnt-root " : "",
+				mask & STATMOUNT_MNT_POINT ? "mnt-point " : "",
+				mask & STATMOUNT_FS_TYPE ? "fs-type " : "",
+				mask & STATMOUNT_MNT_OPTS ? "mnt-opts " : ""));
+
+	if (!rc)
+		rc = apply_statmount(fs, buf);
+done:
+
+	if (fs->stmnt)
+		mnt_statmnt_disable_fetching(fs->stmnt, status);
+	else
+		free(buf);
+
+	fs->stmnt_done |= mask;
+	return rc;
+}
+
+#else /* HAVE_STATMOUNT_API */
+
+int mnt_fs_fetch_statmount(struct libmnt_fs *fs __attribute__((__unused__)),
+			   uint64_t mask __attribute__((__unused__)))
+{
+	return -ENOTSUP;
+}
+
+#endif /* HAVE_STATMOUNT_API */

--- a/libmount/src/fuzz.c
+++ b/libmount/src/fuzz.c
@@ -4,7 +4,6 @@
 
 #include <stdlib.h>
 #include <stddef.h>
-#include <stdint.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         struct libmnt_table *tb = NULL;

--- a/libmount/src/hook_idmap.c
+++ b/libmount/src/hook_idmap.c
@@ -25,7 +25,6 @@
 #include "strutils.h"
 #include "all-io.h"
 #include "namespace.h"
-#include "mount-api-utils.h"
 
 #include "mountP.h"
 

--- a/libmount/src/hook_idmap.c
+++ b/libmount/src/hook_idmap.c
@@ -20,7 +20,6 @@
 #include <sys/wait.h>
 #include <sys/ioctl.h>
 #include <sys/mount.h>
-#include <inttypes.h>
 
 #include "strutils.h"
 #include "all-io.h"

--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -46,7 +46,6 @@
 #include "mountP.h"
 #include "fileutils.h"	/* statx() fallback */
 #include "strutils.h"
-#include "mount-api-utils.h"
 #include "linux_version.h"
 
 #include <inttypes.h>

--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -48,8 +48,6 @@
 #include "strutils.h"
 #include "linux_version.h"
 
-#include <inttypes.h>
-
 #ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
 
 #define get_sysapi(_cxt) mnt_context_get_sysapi(_cxt)

--- a/libmount/src/hook_subdir.c
+++ b/libmount/src/hook_subdir.c
@@ -19,7 +19,6 @@
 
 #include "mountP.h"
 #include "fileutils.h"
-#include "mount-api-utils.h"
 
 struct hookset_data {
 	char *subdir;

--- a/libmount/src/hooks.c
+++ b/libmount/src/hooks.c
@@ -27,7 +27,6 @@
  *   Usually implemented by locally defined 'struct hook_data' in hook_*.c.
  */
 #include "mountP.h"
-#include "mount-api-utils.h"
 
 /* built-in hooksets */
 static const struct libmnt_hookset *const hooksets[] =

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -369,6 +369,8 @@ extern char *mnt_get_mountpoint(const char *path)
 extern int mnt_guess_system_root(dev_t devno, struct libmnt_cache *cache, char **path)
 			__ul_attribute__((nonnull(3)));
 
+extern int mnt_id_from_path(const char *path, uint64_t *uniq_id, int *id);
+
 /* cache.c */
 extern struct libmnt_cache *mnt_new_cache(void)
 			__ul_attribute__((warn_unused_result));

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -141,6 +141,13 @@ struct libmnt_tabdiff;
  */
 struct libmnt_ns;
 
+/**
+ * libmnt_statmnt
+ *
+ * Setting for statmount()
+ */
+struct libmnt_statmnt;
+
 /*
  * Actions
  */
@@ -541,6 +548,9 @@ extern int mnt_fs_set_uniq_id(struct libmnt_fs *fs, uint64_t id);
 extern int mnt_fs_get_parent_id(struct libmnt_fs *fs);
 extern uint64_t mnt_fs_get_parent_uniq_id(struct libmnt_fs *fs);
 
+extern uint64_t mnt_fs_get_ns(struct libmnt_fs *fs);
+extern int mnt_fs_set_ns(struct libmnt_fs *fs, uint64_t id);
+
 extern dev_t mnt_fs_get_devno(struct libmnt_fs *fs);
 extern pid_t mnt_fs_get_tid(struct libmnt_fs *fs);
 
@@ -571,6 +581,17 @@ extern int mnt_fs_is_regularfs(struct libmnt_fs *fs);
 extern void mnt_free_mntent(struct mntent *mnt);
 extern int mnt_fs_to_mntent(struct libmnt_fs *fs, struct mntent **mnt);
 
+/* fs_statmount.c */
+extern struct libmnt_statmnt *mnt_new_statmnt(void);
+extern void mnt_ref_statmnt(struct libmnt_statmnt *sm);
+extern void mnt_unref_statmnt(struct libmnt_statmnt *sm);
+extern int mnt_statmnt_set_mask(struct libmnt_statmnt *sm, uint64_t mask);
+extern int mnt_statmnt_disable_fetching(struct libmnt_statmnt *sm, int disable);
+
+extern int mnt_fs_refer_statmnt(struct libmnt_fs *fs, struct libmnt_statmnt *sm);
+extern struct libmnt_statmnt *mnt_fs_get_statmnt(struct libmnt_fs *fs);
+extern int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask);
+
 /* tab-parse.c */
 extern struct libmnt_table *mnt_new_table_from_file(const char *filename)
 			__ul_attribute__((warn_unused_result));
@@ -598,6 +619,8 @@ extern void mnt_unref_table(struct libmnt_table *tb);
 extern int mnt_reset_table(struct libmnt_table *tb);
 extern int mnt_table_get_nents(struct libmnt_table *tb);
 extern int mnt_table_is_empty(struct libmnt_table *tb);
+
+extern int mnt_table_refer_statmnt(struct libmnt_table *tb, struct libmnt_statmnt *sm);
 
 extern int mnt_table_set_userdata(struct libmnt_table *tb, void *data);
 extern void *mnt_table_get_userdata(struct libmnt_table *tb);

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -31,6 +31,7 @@ extern "C" {
 #include <stdio.h>
 #include <mntent.h>
 #include <sys/types.h>
+#include <stdint.h>
 
 /* Make sure libc MS_* definitions are used by default. Note that MS_* flags
  * may be already defined by linux/fs.h or another file -- in this case we
@@ -530,8 +531,14 @@ extern const char *mnt_fs_get_root(struct libmnt_fs *fs);
 extern int mnt_fs_set_root(struct libmnt_fs *fs, const char *path);
 extern const char *mnt_fs_get_bindsrc(struct libmnt_fs *fs);
 extern int mnt_fs_set_bindsrc(struct libmnt_fs *fs, const char *src);
+
 extern int mnt_fs_get_id(struct libmnt_fs *fs);
+extern uint64_t mnt_fs_get_uniq_id(struct libmnt_fs *fs);
+extern int mnt_fs_set_uniq_id(struct libmnt_fs *fs, uint64_t id);
+
 extern int mnt_fs_get_parent_id(struct libmnt_fs *fs);
+extern uint64_t mnt_fs_get_parent_uniq_id(struct libmnt_fs *fs);
+
 extern dev_t mnt_fs_get_devno(struct libmnt_fs *fs);
 extern pid_t mnt_fs_get_tid(struct libmnt_fs *fs);
 

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -681,6 +681,8 @@ extern struct libmnt_fs *mnt_table_find_pair(struct libmnt_table *tb,
 				const char *target, int direction);
 extern struct libmnt_fs *mnt_table_find_devno(struct libmnt_table *tb,
 				dev_t devno, int direction);
+extern struct libmnt_fs *mnt_table_find_uniq_id(struct libmnt_table *tb, uint64_t id);
+extern struct libmnt_fs *mnt_table_find_id(struct libmnt_table *tb, int id);
 
 extern int mnt_table_find_next_fs(struct libmnt_table *tb,
 			struct libmnt_iter *itr,

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -592,7 +592,7 @@ extern int mnt_fs_refer_statmnt(struct libmnt_fs *fs, struct libmnt_statmnt *sm)
 extern struct libmnt_statmnt *mnt_fs_get_statmnt(struct libmnt_fs *fs);
 extern int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask);
 
-/* tab-parse.c */
+/* tab_parse.c */
 extern struct libmnt_table *mnt_new_table_from_file(const char *filename)
 			__ul_attribute__((warn_unused_result));
 extern struct libmnt_table *mnt_new_table_from_dir(const char *dirname)
@@ -689,6 +689,14 @@ extern int mnt_table_find_next_fs(struct libmnt_table *tb,
 		        struct libmnt_fs **fs);
 
 extern int mnt_table_is_fs_mounted(struct libmnt_table *tb, struct libmnt_fs *fstab_fs);
+
+/* tab_listmount.c */
+extern int mnt_table_listmount_set_id(struct libmnt_table *tb, uint64_t id);
+extern int mnt_table_listmount_set_ns(struct libmnt_table *tb, uint64_t ns);
+extern int mnt_table_listmount_set_stepsiz(struct libmnt_table *tb, size_t sz);
+
+extern int mnt_table_enable_listmount(struct libmnt_table *tb, int enable);
+extern int mnt_table_fetch_listmount(struct libmnt_table *tb);
 
 /* tab_update.c */
 extern struct libmnt_update *mnt_new_update(void)

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -396,6 +396,11 @@ MOUNT_2_41 {
 	mnt_ref_statmnt;
 	mnt_statmnt_disable_fetching;
 	mnt_statmnt_set_mask;
+	mnt_table_enable_listmount;
+	mnt_table_fetch_listmount;
+	mnt_table_listmount_set_id;
+	mnt_table_listmount_set_ns;
+	mnt_table_listmount_set_stepsiz;
 	mnt_table_refer_statmnt;
 	mnt_unref_statmnt;
 } MOUNT_2_40;

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -398,6 +398,8 @@ MOUNT_2_41 {
 	mnt_statmnt_set_mask;
 	mnt_table_enable_listmount;
 	mnt_table_fetch_listmount;
+	mnt_table_find_id;
+	mnt_table_find_uniq_id;
 	mnt_table_listmount_set_id;
 	mnt_table_listmount_set_ns;
 	mnt_table_listmount_set_stepsiz;

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -384,7 +384,7 @@ MOUNT_2_40 {
 
 MOUNT_2_41 {
 	mnt_fs_fetch_statmount;
-	mnt_fs_get_ns_id;
+	mnt_fs_get_ns;
 	mnt_fs_get_parent_uniq_id;
 	mnt_fs_get_statmnt;
 	mnt_fs_get_uniq_id;

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -381,3 +381,9 @@ MOUNT_2_40 {
 	mnt_unref_lock;
 	mnt_monitor_veil_kernel;
 } MOUNT_2_39;
+
+MOUNT_2_41 {
+	mnt_fs_get_uniq_id;
+	mnt_fs_get_parent_uniq_id;
+	mnt_fs_set_uniq_id;
+} MOUNT_2_40;

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -386,4 +386,5 @@ MOUNT_2_41 {
 	mnt_fs_get_uniq_id;
 	mnt_fs_get_parent_uniq_id;
 	mnt_fs_set_uniq_id;
+	mnt_id_from_path;
 } MOUNT_2_40;

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -383,8 +383,19 @@ MOUNT_2_40 {
 } MOUNT_2_39;
 
 MOUNT_2_41 {
-	mnt_fs_get_uniq_id;
+	mnt_fs_fetch_statmount;
+	mnt_fs_get_ns_id;
 	mnt_fs_get_parent_uniq_id;
+	mnt_fs_get_statmnt;
+	mnt_fs_get_uniq_id;
+	mnt_fs_refer_statmnt;
+	mnt_fs_set_ns;
 	mnt_fs_set_uniq_id;
 	mnt_id_from_path;
+	mnt_new_statmnt;
+	mnt_ref_statmnt;
+	mnt_statmnt_disable_fetching;
+	mnt_statmnt_set_mask;
+	mnt_table_refer_statmnt;
+	mnt_unref_statmnt;
 } MOUNT_2_40;

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -291,7 +291,7 @@ struct libmnt_fs {
 			if (!(FS)->MEMBER					\
 			    && (FS)->stmnt					\
 			    && !(FS)->stmnt->disabled				\
-			    && !((FS)->stmnt_done & (FLAGS)))			\
+			    && ((FLAGS) & ~((FS)->stmnt_done)))			\
 				mnt_fs_fetch_statmount((FS), (FLAGS)); })
 #endif
 

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -99,6 +99,9 @@ struct libmnt_test {
 extern int mnt_run_test(struct libmnt_test *tests, int argc, char *argv[]);
 #endif
 
+/* private tab_listmount.c */
+struct libmnt_listmnt;
+
 /* utils.c */
 extern int mnt_valid_tagname(const char *tagname);
 
@@ -160,6 +163,11 @@ extern int __mnt_table_is_fs_mounted(	struct libmnt_table *tb,
 
 extern int mnt_table_enable_noautofs(struct libmnt_table *tb, int ignore);
 extern int mnt_table_is_noautofs(struct libmnt_table *tb);
+
+/* tab_listmount.c */
+extern int mnt_table_next_lsmnt(struct libmnt_table *tb, int direction);
+extern int mnt_table_reset_listmount(struct libmnt_table *tb);
+extern int mnt_table_want_listmount(struct libmnt_table *tb);
 
 /*
  * Generic iterator
@@ -297,6 +305,7 @@ struct libmnt_table {
 	int		(*fltrcb)(struct libmnt_fs *fs, void *data);
 	void		*fltrcb_data;
 
+	struct libmnt_listmnt	*lsmnt;	/* listmount() stuff */
 	struct libmnt_statmnt	*stmnt; /* statmount() stuff */
 
 	int		noautofs;	/* ignore autofs mounts */

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -136,6 +136,8 @@ extern int mnt_is_path(const char *target);
 extern int mnt_tmptgt_unshare(int *old_ns_fd);
 extern int mnt_tmptgt_cleanup(int old_ns_fd);
 
+extern int mnt_id_from_fd(int fd, uint64_t *uniq_id, int *id);
+
 /* tab.c */
 extern int is_mountinfo(struct libmnt_table *tb);
 extern int mnt_table_set_parser_fltrcb(	struct libmnt_table *tb,

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -201,7 +201,9 @@ struct libmnt_fs {
 	struct libmnt_optlist *optlist;
 
 	int		id;		/* mountinfo[1]: ID */
+	uint64_t	uniq_id;	/* unique node ID; statx(STATX_MNT_ID_UNIQUE); statmount->mnt_id */
 	int		parent;		/* mountinfo[2]: parent */
+	uint64_t	uniq_parent;	/* unique parent ID; statmount->mnt_parent_id */
 	dev_t		devno;		/* mountinfo[3]: st_dev */
 
 	char		*bindsrc;	/* utab, full path from fstab[1] for bind mounts */

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -283,8 +283,15 @@ struct libmnt_fs {
 #define MNT_FS_KERNEL	(1 << 4) /* data from /proc/{mounts,self/mountinfo} */
 #define MNT_FS_MERGED	(1 << 5) /* already merged data from /run/mount/utab */
 
-#define mnt_fs_want_statmount(_x, _m) \
-		((_x)->stmnt && !(_x)->stmnt->disabled && !((_x)->stmnt_done & (_m)))
+#ifdef HAVE_STATMOUNT_API
+# define	mnt_fs_try_statmount(FS, MEMBER, FLAGS) __extension__ ({	\
+			if (!(FS)->MEMBER					\
+			    && (FS)->stmnt					\
+			    && !(FS)->stmnt->disabled				\
+			    && !((FS)->stmnt_done & (FLAGS)))			\
+				mnt_fs_fetch_statmount((FS), (FLAGS)); })
+#endif
+
 
 /*
  * fstab/mountinfo file

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -23,8 +23,11 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdint.h>
+#include <inttypes.h>
 
 #include "c.h"
+
 #include "list.h"
 #include "debug.h"
 #include "buffer.h"

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -30,6 +30,8 @@
 #include "buffer.h"
 #include "libmount.h"
 
+#include "mount-api-utils.h"
+
 /*
  * Debug
  */

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -217,7 +217,10 @@ struct libmnt_fs {
 
 	char		*optstr;	/* fstab[4], merged options */
 	char		*vfs_optstr;	/* mountinfo[6]: fs-independent (VFS) options */
+
 	char		*opt_fields;	/* mountinfo[7]: optional fields */
+	uint64_t	propagation;	/* statmmount() or parsed opt_fields */
+
 	char		*fs_optstr;	/* mountinfo[11]: fs-dependent options */
 	char		*user_optstr;	/* userspace mount options */
 	char		*attrs;		/* mount attributes */

--- a/libmount/src/optlist.c
+++ b/libmount/src/optlist.c
@@ -16,7 +16,6 @@
 #include "strutils.h"
 #include "list.h"
 #include "mountP.h"
-#include "mount-api-utils.h"
 
 #define MNT_OL_MAXMAPS	8
 

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -855,7 +855,7 @@ int mnt_table_next_fs(struct libmnt_table *tb, struct libmnt_iter *itr, struct l
 		return -EINVAL;
 	if (fs)
 		*fs = NULL;
-
+#ifdef HAVE_STATMOUNT_API
 	if (mnt_table_want_listmount(tb) &&
 	    (list_empty(&tb->ents) || itr->p == itr->head)) {
 		struct list_head *prev = NULL;
@@ -871,7 +871,7 @@ int mnt_table_next_fs(struct libmnt_table *tb, struct libmnt_iter *itr, struct l
 			MNT_ITER_ITERATE(itr);
 		}
 	}
-
+#endif
 	if (!itr->head)
 		MNT_ITER_INIT(itr, &tb->ents);
 	if (itr->p != itr->head) {

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -1541,6 +1541,67 @@ struct libmnt_fs *mnt_table_find_devno(struct libmnt_table *tb,
 	return NULL;
 }
 
+/**
+ * mnt_table_find_id:
+ * @tb: mount table
+ * @id: classic mount ID
+ *
+ * See also mnt_id_from_path().
+ *
+ * Returns: a tab entry or NULL.
+ *
+ * Since: 2.41
+ */
+struct libmnt_fs *mnt_table_find_id(struct libmnt_table *tb, int id)
+{
+	struct libmnt_fs *fs = NULL;
+	struct libmnt_iter itr;
+
+	if (!tb)
+		return NULL;
+
+	DBG(TAB, ul_debugobj(tb, "lookup ID: %d", id));
+	mnt_reset_iter(&itr, MNT_ITER_BACKWARD);
+
+	while (mnt_table_next_fs(tb, &itr, &fs) == 0) {
+		if (mnt_fs_get_id(fs) == id)
+			return fs;
+	}
+
+	return NULL;
+}
+
+/**
+ * mnt_table_find_uniq_id:
+ * @tb: mount table
+ * @id: uniqie 64-bit mount ID
+ *
+ * See also mnt_id_from_path().
+ *
+ * Returns: a tab entry or NULL.
+ *
+ * Since: 2.41
+ */
+struct libmnt_fs *mnt_table_find_uniq_id(struct libmnt_table *tb, uint64_t id)
+{
+	struct libmnt_fs *fs = NULL;
+	struct libmnt_iter itr;
+
+	if (!tb)
+		return NULL;
+
+	DBG(TAB, ul_debugobj(tb, "lookup uniq-ID: %" PRIu64, id));
+	mnt_reset_iter(&itr, MNT_ITER_BACKWARD);
+
+	while (mnt_table_next_fs(tb, &itr, &fs) == 0) {
+		if (mnt_fs_get_uniq_id(fs) == id)
+			return fs;
+	}
+
+	return NULL;
+}
+
+
 static char *remove_mountpoint_from_path(const char *path, const char *mnt)
 {
         char *res;

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -504,18 +504,22 @@ static int __table_insert_fs(
 			struct libmnt_table *tb, int before,
 			struct libmnt_fs *pos, struct libmnt_fs *fs)
 {
-	struct list_head *head = pos ? &pos->ents : &tb->ents;
-
-	if (before)
-		list_add(&fs->ents, head);
+	if (!pos)
+		list_add_tail(&fs->ents, &tb->ents);
+	else if (before)
+		list_add_tail(&fs->ents, &pos->ents);
 	else
-		list_add_tail(&fs->ents, head);
+		list_add(&fs->ents, &pos->ents);
 
 	fs->tab = tb;
 	tb->nents++;
 
-	DBG(TAB, ul_debugobj(tb, "insert entry: %s %s",
+	if (mnt_fs_get_uniq_id(fs)) {
+		DBG(TAB, ul_debugobj(tb, "insert entry: %" PRIu64, mnt_fs_get_uniq_id(fs)));
+	} else {
+		DBG(TAB, ul_debugobj(tb, "insert entry: %s %s",
 			mnt_fs_get_source(fs), mnt_fs_get_target(fs)));
+	}
 
 	if (tb->stmnt)
 		mnt_fs_refer_statmnt(fs, tb->stmnt);

--- a/libmount/src/tab_listmount.c
+++ b/libmount/src/tab_listmount.c
@@ -100,6 +100,7 @@ static int table_init_listmount(struct libmnt_table *tb, size_t stepsiz)
 				DBG(TAB, ul_debugobj(tb, "listmount: unsuppported"));
 			if (errno == EINVAL)
 				DBG(TAB, ul_debugobj(tb, "listmount: reverse unsuppported"));
+			errno = ENOSYS;
 			return -ENOSYS;
 		}
 	}

--- a/libmount/src/tab_listmount.c
+++ b/libmount/src/tab_listmount.c
@@ -11,6 +11,54 @@
  */
 #include "mountP.h"
 
+#ifndef HAVE_STATMOUNT_API
+
+int mnt_table_listmount_set_id(
+		struct libmnt_table *tb __attribute__((__unused__)),
+		uint64_t id __attribute__((__unused__)))
+{
+	return -ENOSYS;
+}
+
+int mnt_table_listmount_set_ns(
+		struct libmnt_table *tb __attribute__((__unused__)),
+		uint64_t ns __attribute__((__unused__)))
+{
+	return -ENOSYS;
+}
+
+int mnt_table_listmount_set_stepsiz(
+		struct libmnt_table *tb __attribute__((__unused__)),
+		size_t sz __attribute__((__unused__)))
+{
+	return -ENOSYS;
+}
+
+int mnt_table_enable_listmount(
+		struct libmnt_table *tb __attribute__((__unused__)),
+		int enable __attribute__((__unused__)))
+{
+	return -ENOSYS;
+}
+
+int mnt_table_fetch_listmount(struct libmnt_table *tb __attribute__((__unused__)))
+{
+	return -ENOSYS;
+}
+
+int mnt_table_reset_listmount(struct libmnt_table *tb __attribute__((__unused__)))
+{
+	return -ENOSYS;
+}
+
+int mnt_table_next_lsmnt(struct libmnt_table *tb __attribute__((__unused__)),
+			int direction __attribute__((__unused__)))
+{
+	return -ENOSYS;
+}
+
+#else /* HAVE_STATMOUNT_API */
+
 /*
 * This struct is not shared between multiple tables, so reference counting is
 * not used for it.
@@ -371,4 +419,4 @@ int mnt_table_fetch_listmount(struct libmnt_table *tb)
 	return rc;
 }
 
-
+#endif /* HAVE_STATMOUNT_API */

--- a/libmount/src/tab_listmount.c
+++ b/libmount/src/tab_listmount.c
@@ -276,6 +276,7 @@ static int lsmnt_to_table(
 
 		fs = mnt_new_fs();
 		if (fs) {
+			fs->flags |= MNT_FS_KERNEL;
 			mnt_fs_set_uniq_id(fs, id);
 			if (ls && ls->ns)
 				mnt_fs_set_ns(fs, ls->ns);

--- a/libmount/src/tab_listmount.c
+++ b/libmount/src/tab_listmount.c
@@ -1,0 +1,374 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of libmount from util-linux project.
+ *
+ * Copyright (C) 2024 Karel Zak <kzak@redhat.com>
+ *
+ * libmount is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ */
+#include "mountP.h"
+
+/*
+* This struct is not shared between multiple tables, so reference counting is
+* not used for it.
+ */
+struct libmnt_listmnt {
+
+	uint64_t	id;		/* node ID (LSMT_ROOT for "/") */
+	uint64_t	ns;		/* namespce ID or zero for the current */
+	uint64_t	last;		/* last ID from previous listmount() call */
+	size_t		stepsiz;	/* how many IDs read in one step */
+	uint64_t	*list;		/* buffer for IDs */
+
+	unsigned int	enabled : 1,	/* on-demand listmount status */
+			done : 1,	/* we already have all data */
+			reverse : 1;	/* current setting */
+};
+
+/* default number of IDs read by one listmount() call */
+#define MNT_LSMNT_STEPSIZ	512
+
+static int table_init_listmount(struct libmnt_table *tb, size_t stepsiz)
+{
+	struct libmnt_listmnt *ls = NULL;;
+
+	if (!tb)
+		return -EINVAL;
+	if (!stepsiz)
+		stepsiz = MNT_LSMNT_STEPSIZ;
+
+	ls = tb->lsmnt;
+
+	/* check if supported by current kernel */
+	if (!ls) {
+		uint64_t dummy;
+
+		errno = 0;
+		if (ul_listmount(LSMT_ROOT, 0, 0, &dummy, 1, LISTMOUNT_REVERSE) != 1) {
+			if (errno == ENOSYS)
+				DBG(TAB, ul_debugobj(tb, "listmount: unsuppported"));
+			if (errno == EINVAL)
+				DBG(TAB, ul_debugobj(tb, "listmount: reverse unsuppported"));
+			return -ENOSYS;
+		}
+	}
+
+	/* reset if allocated for a different size */
+	if (ls && ls->stepsiz != stepsiz)
+		ls = NULL;
+
+	/* alloc libmnt_listmnt together with list buffer */
+	if (!ls) {
+		char *x = calloc(1, sizeof(struct libmnt_listmnt)
+				    + (sizeof(uint64_t) * stepsiz));
+		if (!x)
+			return -ENOMEM;
+
+		ls = (struct libmnt_listmnt *) x;
+		ls->list = (uint64_t *) (x + sizeof(struct libmnt_listmnt));
+		ls->stepsiz = stepsiz;
+		ls->id = LSMT_ROOT;	/* default */
+	}
+
+	/* reuse old setting */
+	if (tb->lsmnt) {
+		ls->id = tb->lsmnt->id;
+		ls->ns = tb->lsmnt->ns;
+		ls->last = tb->lsmnt->last;
+		ls->enabled = tb->lsmnt->enabled;
+		ls->reverse = tb->lsmnt->reverse;
+		free(tb->lsmnt);
+	}
+
+	tb->lsmnt = ls;
+
+	DBG(TAB, ul_debugobj(tb, "listmount: init [step=%zu]", ls->stepsiz));
+	return 0;
+}
+
+/**
+ * mnt_table_listmount_set_id:
+ * @tb: mount table
+ * @id: root ID
+ *
+ * Set root ID for the table if the table is read from kernel by
+ * listmount() syscall. The default is to read all filesystems; use
+ * statx(STATX_MNT_ID_UNIQUE) for subdirectory.
+ *
+ * Returns: 0 on sucess, < 0 on error
+ * Since: 2.41
+ */
+int mnt_table_listmount_set_id(struct libmnt_table *tb, uint64_t id)
+{
+	int rc = 0;
+
+	if (!tb)
+		return -EINVAL;
+	if (!tb->lsmnt && (rc = table_init_listmount(tb, 0)) != 0)
+		return rc;
+	tb->lsmnt->id = id;
+	return 0;
+}
+
+/**
+ * mnt_table_listmount_set_ns:
+ * @tb: mount table
+ * @id: namespace ID
+ *
+ * Set namespace ID for listmount().
+ *
+ * Returns: 0 on sucess, < 0 on error
+ * Since: 2.41
+ */
+int mnt_table_listmount_set_ns(struct libmnt_table *tb, uint64_t ns)
+{
+	int rc = 0;
+
+	if (!tb)
+		return -EINVAL;
+	if (!tb->lsmnt && (rc = table_init_listmount(tb, 0)) != 0)
+		return rc;
+	tb->lsmnt->ns = ns;
+	return 0;
+}
+
+/**
+ * mnt_table_listmount_set_stepsiz:
+ * @tb: mount table
+ * @sz: number of nodes read by one libmount() call
+ *
+ * Returns: 0 on sucess, < 0 on error
+ * Since: 2.41
+ */
+int mnt_table_listmount_set_stepsiz(struct libmnt_table *tb, size_t sz)
+{
+	if (!tb)
+		return -EINVAL;
+
+	return table_init_listmount(tb, sz);
+}
+
+/*
+ * This function is called by mnt_reset_table() and the table must already be
+ * empty.
+ *
+ * Private; not export to library API!
+ **/
+int mnt_table_reset_listmount(struct libmnt_table *tb)
+{
+	if (!tb || !tb->lsmnt)
+	       return 0;
+	if (tb->nents)
+		return -EINVAL;
+
+	tb->lsmnt->done = 0;
+	tb->lsmnt->reverse = 0;
+	tb->lsmnt->last = 0;
+	return 0;
+}
+
+/**
+ * mnt_table_enable_listmount:
+ * @tb: table
+ * @enable: 0 or 1
+ *
+ * Enable or disable on-demand listmount() to make it usable by
+ * mnt_table_next_fs(). This function does not affect
+ * mnt_table_fetch_listmont().
+ *
+ * Returns: old status (1 or 0)
+ * Since: 2.41
+ */
+int mnt_table_enable_listmount(struct libmnt_table *tb, int enable)
+{
+	int old = 0;
+
+	if (tb && tb->lsmnt) {
+		old = tb->lsmnt->enabled;
+		tb->lsmnt->enabled = enable;
+		DBG(TAB, ul_debugobj(tb, "listmount() %s",
+					enable ? "on" : "off"));
+	}
+	return old;
+}
+
+/* private; returns 1 if on-demand listmount() possible */
+int mnt_table_want_listmount(struct libmnt_table *tb)
+{
+	return tb && tb->lsmnt && tb->lsmnt->enabled;
+}
+
+/* add new entries from list[] to table */
+static int lsmnt_to_table(
+		struct libmnt_table *tb, struct libmnt_listmnt *ls,
+		size_t nitems, int reverse)
+{
+	int rc = 0;
+	size_t i;
+	struct libmnt_fs *prev = NULL;
+
+	if (reverse)
+		mnt_table_first_fs(tb, &prev);
+	else
+		mnt_table_last_fs(tb, &prev);
+	if (prev)
+		mnt_ref_fs(prev);
+
+	DBG(TAB, ul_debugobj(tb, "listmount: insert %zu", nitems));
+
+	for (i = 0; rc == 0 && i < nitems; i++) {
+		struct libmnt_fs *fs;
+		uint64_t id = ls->list[i];
+
+		if (!id)
+			continue;
+
+		fs = mnt_new_fs();
+		if (fs) {
+			mnt_fs_set_uniq_id(fs, id);
+			if (ls && ls->ns)
+				mnt_fs_set_ns(fs, ls->ns);
+
+			rc = mnt_table_insert_fs(tb, reverse, prev, fs);
+		} else
+			rc = -ENOMEM;
+
+		mnt_unref_fs(prev);
+		prev = fs;
+	}
+
+	mnt_unref_fs(prev);
+	return rc;
+}
+
+/*
+ * Private function, backed of mnt_table_next_fs().
+ *
+ * Return: 0 on success, 1 if not more data, <0 on error.
+ */
+int mnt_table_next_lsmnt(struct libmnt_table *tb, int direction)
+{
+	ssize_t n;
+	int reverse = direction == MNT_ITER_BACKWARD;
+	struct libmnt_listmnt *ls = NULL;
+	int rc = 0;
+
+	if (!tb || !tb->lsmnt)
+		return -EINVAL;
+	if (tb->lsmnt->done || !tb->lsmnt->enabled)
+		return 1;
+
+	ls = tb->lsmnt;
+
+	/* disable on-demand fetching */
+	mnt_table_enable_listmount(tb, 0);
+
+	/* read all to avoid mixing order in the table */
+	if (!mnt_table_is_empty(tb) && ls->reverse != reverse) {
+		rc = mnt_table_fetch_listmount(tb);
+		goto done;
+	}
+
+	ls->reverse = reverse;
+
+	DBG(TAB, ul_debugobj(tb, "listmount: call "
+				 "[id=%" PRIu64", ns=%" PRIu64
+				 "last=%" PRIu64", sz=%zu %s]",
+				ls->id, ls->ns,
+				ls->last, ls->stepsiz,
+				ls->reverse ? "reverse" : ""));
+
+	n = ul_listmount(ls->id, ls->ns, ls->last, ls->list, ls->stepsiz,
+			reverse ? LISTMOUNT_REVERSE : 0);
+	if (n < 0) {
+		rc = -errno;
+		goto done;
+	}
+
+	if (n < (ssize_t) ls->stepsiz)
+		ls->done = 1;
+	if (n > 0) {
+		ls->last = ls->list[ n - 1 ];
+		rc = lsmnt_to_table(tb, ls, n, reverse);
+	} else
+		rc = 0;
+done:
+	mnt_table_enable_listmount(tb, 1);
+
+	DBG(TAB, ul_debugobj(tb, "listmount: on-demand done [rc=%d]", rc));
+	return rc;		/* nothing */
+}
+
+/**
+ * mnt_table_fetch_listmount:
+ * @tb: table instance
+ *
+ * By default, this function reads all mount nodes in the current namespace
+ * from the kernel and adds them to the @tb table. This default behavior can
+ * be modified using mnt_table_listmount_set_...().
+ *
+ * The table is reset (all file systems removed) before new data is added.
+ *
+ * Return: 0 on success, <0 on error.
+ * Since: 2.41
+ */
+int mnt_table_fetch_listmount(struct libmnt_table *tb)
+{
+	int rc = 0, stmnt_status = 0, lsmnt_status = 0;
+	struct libmnt_listmnt *ls = NULL;
+	ssize_t n;
+
+	if (!tb)
+		return -EINVAL;
+
+	DBG(TAB, ul_debugobj(tb, "listmount: fetching all"));
+
+	if (!tb->lsmnt && (rc = table_init_listmount(tb, 0)) != 0)
+		return rc;
+
+	/* disable on-demand statmount() */
+	if (tb->stmnt)
+		stmnt_status = mnt_statmnt_disable_fetching(tb->stmnt, 1);
+	/* disable on-demand listmount() */
+	lsmnt_status = mnt_table_enable_listmount(tb, 0);
+
+	mnt_reset_table(tb);
+
+	ls = tb->lsmnt;
+
+	do {
+		DBG(TAB, ul_debugobj(tb, "listmount: call "
+				 "[id=%" PRIu64", ns=%" PRIu64
+				 "last=%" PRIu64", sz=%zu]",
+				ls->id, ls->ns,
+				ls->last, ls->stepsiz));
+
+		n = ul_listmount(ls->id, ls->ns, ls->last,
+				 ls->list, ls->stepsiz, 0);
+		if (n < 0) {
+			rc = -errno;
+			break;
+		}
+		ls->last = ls->list[ n - 1 ];
+		rc = lsmnt_to_table(tb, ls, n, 0);
+
+	} while (rc == 0 && n == (ssize_t) ls->stepsiz);
+
+	/* Avoid using on-demand mnt_table_next_lsmnt() if we already
+	 * have all the necessary data (or on error) */
+	tb->lsmnt->done = 1;
+
+	/* restore */
+	if (tb->stmnt)
+		mnt_statmnt_disable_fetching(tb->stmnt, stmnt_status);
+	mnt_table_enable_listmount(tb, lsmnt_status);
+
+	DBG(TAB, ul_debugobj(tb, "listmount: fetching done [rc=%d]", rc));
+
+	return rc;
+}
+
+

--- a/libmount/src/tab_parse.c
+++ b/libmount/src/tab_parse.c
@@ -323,7 +323,14 @@ static int mnt_parse_utab_line(struct libmnt_fs *fs, const char *s)
 		if (!*p)
 			break;
 
-		if (!fs->id && !strncmp(p, "ID=", 3)) {
+		if (!fs->uniq_id && !strncmp(p, "UNIQID=", 7)) {
+			int rc = 0;
+
+			end = next_u64(p + 7, &fs->uniq_id, &rc);
+			if (!end || rc)
+				return rc;
+
+		} else if (!fs->id && !strncmp(p, "ID=", 3)) {
 			int rc = 0;
 
 			end = next_s32(p + 3, &fs->id, &rc);
@@ -1178,6 +1185,7 @@ static struct libmnt_fs *mnt_table_merge_user_fs(struct libmnt_table *tb, struct
 	struct libmnt_iter itr;
 	const char *optstr, *src, *target, *root, *attrs;
 	int id;
+	uint64_t uniq_id;
 
 	if (!tb || !uf)
 		return NULL;
@@ -1190,6 +1198,7 @@ static struct libmnt_fs *mnt_table_merge_user_fs(struct libmnt_table *tb, struct
 	attrs = mnt_fs_get_attributes(uf);
 	root = mnt_fs_get_root(uf);
 	id = mnt_fs_get_id(uf);
+	uniq_id = mnt_fs_get_uniq_id(uf);
 
 	if (!src || !target || !root || (!attrs && !optstr))
 		return NULL;
@@ -1202,10 +1211,16 @@ static struct libmnt_fs *mnt_table_merge_user_fs(struct libmnt_table *tb, struct
 		if (fs->flags & MNT_FS_MERGED)
 			continue;
 
-		if (id > 0 && mnt_fs_get_id(fs)) {
+		if (uniq_id > 0 && mnt_fs_get_uniq_id(fs)) {
+			DBG(TAB, ul_debugobj(tb, " using uniq ID"));
+			if (mnt_fs_get_uniq_id(fs) == uniq_id)
+				break;
+
+		} else if (id > 0 && mnt_fs_get_id(fs)) {
 			DBG(TAB, ul_debugobj(tb, " using ID"));
 			if (mnt_fs_get_id(fs) == id)
 				break;
+
 		} else if (r && strcmp(r, root) == 0
 		    && mnt_fs_streq_target(fs, target)
 		    && mnt_fs_streq_srcpath(fs, src))

--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -446,9 +446,11 @@ static int fprintf_utab_fs(FILE *f, struct libmnt_fs *fs)
 	if (!fs || !f)
 		return -EINVAL;
 
-	if (mnt_fs_get_id(fs) > 0) {
+	if (mnt_fs_get_id(fs) > 0)
 		rc = fprintf(f, "ID=%d ", mnt_fs_get_id(fs));
-	}
+	if (mnt_fs_get_uniq_id(fs) > 0)
+		rc = fprintf(f, "UNIQID=%" PRIu64, mnt_fs_get_uniq_id(fs));
+
 	if (rc >= 0) {
 		p = mangle(mnt_fs_get_source(fs));
 		if (p) {

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -319,8 +319,8 @@ int mnt_id_from_fd(int fd, uint64_t *uniq_id, int *id)
 /**
  * mnt_id_from_path:
  * @path: mountpoint
- * @uniq_id: returns STATX_MNT_ID_UNIQUE
- * @id: returns STATX_MNT_ID
+ * @uniq_id: returns STATX_MNT_ID_UNIQUE (optional)
+ * @id: returns STATX_MNT_ID (optional)
  *
  * Converts @path to ID.
  *

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -285,6 +285,7 @@ static int get_mnt_id(	int fd, const char *path,
 		*id = sx.stx_mnt_id;
 	}
 	if (uniq_id) {
+# ifdef STATX_MNT_ID_UNIQUE
 		errno = 0;
 		rc = statx(fd, path ? path : "", flags,
 				STATX_MNT_ID_UNIQUE, &sx);
@@ -294,6 +295,9 @@ static int get_mnt_id(	int fd, const char *path,
 		if (rc)
 			return rc;
 		*uniq_id = sx.stx_mnt_id;
+# else
+		return -ENOSYS;
+# endif
 	}
 	return 0;
 #else

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -266,10 +266,10 @@ int mnt_is_readonly(const char *path)
 	return 0;
 }
 
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(HAVE_STRUCT_STATX_STX_MNT_ID)
 static int get_mnt_id(	int fd, const char *path,
 			uint64_t *uniq_id, int *id)
 {
-#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(HAVE_STRUCT_STATX_STX_MNT_ID)
 	int rc;
 	struct statx sx = { 0 };
 	int flags = AT_STATX_DONT_SYNC | AT_NO_AUTOMOUNT;
@@ -300,10 +300,16 @@ static int get_mnt_id(	int fd, const char *path,
 # endif
 	}
 	return 0;
-#else
-	return -ENOSYS;
-#endif
 }
+#else /* HAVE_STATX && HAVE_STRUCT_STATX && AVE_STRUCT_STATX_STX_MNT_ID */
+static int get_mnt_id(	int fd __attribute__((__unused__)),
+			const char *path __attribute__((__unused__)),
+			uint64_t *uniq_id __attribute__((__unused__)),
+			int *id __attribute__((__unused__)))
+{
+	return -ENOSYS;
+}
+#endif
 
 int mnt_id_from_fd(int fd, uint64_t *uniq_id, int *id)
 {

--- a/libmount/src/version.c
+++ b/libmount/src/version.c
@@ -43,6 +43,9 @@ static const char *lib_features[] = {
 #ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
 	"fd-based-mount",
 #endif
+#ifdef HAVE_STATMOUNT_API
+	"statmount",
+#endif
 #if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(AT_STATX_DONT_SYNC)
 	"statx",
 #endif

--- a/libmount/src/version.c
+++ b/libmount/src/version.c
@@ -19,7 +19,6 @@
 #include <ctype.h>
 
 #include "mountP.h"
-#include "mount-api-utils.h"
 
 static const char *lib_version = LIBMOUNT_VERSION;
 static const char *lib_features[] = {

--- a/libsmartcols/samples/continuous.c
+++ b/libsmartcols/samples/continuous.c
@@ -14,6 +14,7 @@
 #include "c.h"
 #include "nls.h"
 #include "strutils.h"
+#include "timeutils.h"
 #include "xalloc.h"
 
 #include "libsmartcols.h"
@@ -21,11 +22,6 @@
 #define TIME_PERIOD	3.0	/* seconds */
 
 enum { COL_NUM, COL_DATA, COL_TIME };
-
-static double time_diff(struct timeval *a, struct timeval *b)
-{
-	return (a->tv_sec - b->tv_sec) + (a->tv_usec - b->tv_usec) / 1E6;
-}
 
 /* add columns to the @tb */
 static void setup_columns(struct libscols_table *tb)

--- a/meson.build
+++ b/meson.build
@@ -103,8 +103,27 @@ have_mountfd_api = cc.has_type('struct mount_attr', prefix : '#include <linux/mo
 conf.set('HAVE_STRUCT_MOUNT_ATTR', have_mountfd_api ? 1 : false)
 conf.set('HAVE_MOUNTFD_API', have_mountfd_api ? 1 : false)
 
+
 have_struct_statx = cc.has_type('struct statx', prefix : '#include <sys/stat.h>')
 conf.set('HAVE_STRUCT_STATX', have_struct_statx ? 1 : false)
+have = cc.has_member('struct statx', 'stx_mnt_id',
+                     prefix : '#include <linux/stat.h>')
+conf.set('HAVE_STRUCT_STATX_STX_MNT_ID', have ? 1 : false)
+
+
+have_statmount = cc.has_type('struct statmount', prefix : '#include <linux/mount.h>') > 0
+have_listmount = cc.has_header_symbol('linux/mount.h', 'LSMT_ROOT')
+
+# kernel headers provides the syscall, but there is not SYS_xxx yet
+if have_statmount and not cc.has_header_symbol('bits/syscall.h', 'SYS_statmount')
+  conf.set('SYS_statmount', '__NR_statmount')
+endif
+if have_listmount and not cc.has_header_symbol('bits/syscall.h', 'SYS_listmount')
+  conf.set('SYS_listmount', '__NR_listmount')
+endif
+
+conf.set('HAVE_STATMOUNT_API', have_statmount and have_listmount ? 1 : false)
+
 
 have_sys_vfs_header = cc.has_header('sys/vfs.h')
 
@@ -696,10 +715,6 @@ have = cc.has_member('struct stat', 'st_mtim.tv_nsec',
                      args : '-D_GNU_SOURCE',
                      prefix : '#include <sys/stat.h>')
 conf.set('HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC', have ? 1 : false)
-
-have = cc.has_member('struct statx', 'stx_mnt_id',
-                     prefix : '#include <sys/stat.h>')
-conf.set('HAVE_STRUCT_STATX_STX_MNT_ID', have ? 1 : false)
 
 # replacement for AC_STRUCT_TIMEZONE
 have = cc.has_member('struct tm', 'tm_zone',

--- a/meson.build
+++ b/meson.build
@@ -111,7 +111,7 @@ have = cc.has_member('struct statx', 'stx_mnt_id',
 conf.set('HAVE_STRUCT_STATX_STX_MNT_ID', have ? 1 : false)
 
 
-have_statmount = cc.has_type('struct statmount', prefix : '#include <linux/mount.h>') > 0
+have_statmount = cc.has_type('struct statmount', prefix : '#include <linux/mount.h>')
 have_listmount = cc.has_header_symbol('linux/mount.h', 'LSMT_ROOT')
 
 # kernel headers provides the syscall, but there is not SYS_xxx yet

--- a/misc-utils/findmnt.8.adoc
+++ b/misc-utils/findmnt.8.adoc
@@ -75,6 +75,12 @@ Imitate the output of *df*(1) with its *-i* option. This option is equivalent to
 *-i*, *--invert*::
 Invert the sense of matching.
 
+*--id* _number_::
+Select a filesystem using the mount node ID.
+
+*--uniq-id* _number_::
+Select a filesystem using the mount node 64-bit ID, use with *--kernel=listmount* option.
+
 *-J*, *--json*::
 Use JSON output format.
 

--- a/misc-utils/findmnt.8.adoc
+++ b/misc-utils/findmnt.8.adoc
@@ -78,8 +78,14 @@ Invert the sense of matching.
 *-J*, *--json*::
 Use JSON output format.
 
-*-k*, *--kernel*::
-Search in _/proc/self/mountinfo_. The output is in the tree-like format. This is the default. The output contains only mount options maintained by kernel (see also *--mtab*).
+*-k*, *--kernel*[_=method_]::
+Reads information about filesystems from the kernel. This is the default output. The format is tree-like and only includes mount options managed by the kernel (see also *--mtab*).
++
+The optional argument _method_ can be either:
++
+* *mountinfo* - this is the default method and it reads data from the _/proc/self/mountinfo_ file.
++
+* *listmount* - This is an EXPERIMENTAL method that uses the listmount() and statmount() syscalls to generate the mount table. The output may not contain all details about mount nodes (for example, SOURCE is currently missing).
 
 *-l*, *--list*::
 Use the list output format. This output format is automatically enabled if the output is restricted by the *-t*, *-O*, *-S* or *-T* option and the option *--submounts* is not used or if more that one source file (the option *-F*) is specified.

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -83,6 +83,7 @@ enum {
 	COL_SOURCES,
 	COL_TARGET,
 	COL_TID,
+	COL_UNIQ_ID,
 	COL_USED,
 	COL_USEPERC,
 	COL_UUID,
@@ -135,6 +136,7 @@ static struct colinfo infos[] = {
 	[COL_SOURCE]       = { "SOURCE",       0.25, SCOLS_FL_NOEXTREMES, N_("source device") },
 	[COL_TARGET]       = { "TARGET",       0.30, SCOLS_FL_TREE| SCOLS_FL_NOEXTREMES, N_("mountpoint") },
 	[COL_TID]          = { "TID",             4, SCOLS_FL_RIGHT, N_("task ID") },
+	[COL_UNIQ_ID]      = { "UNIQ-ID",        10, SCOLS_FL_RIGHT, N_("mount 64-bit ID (requires --kernel=listmount)") },
 	[COL_USED]         = { "USED",            5, SCOLS_FL_RIGHT, N_("filesystem size used, use <number> if --bytes is given") },
 	[COL_USEPERC]      = { "USE%",            3, SCOLS_FL_RIGHT, N_("filesystem use percentage") },
 	[COL_UUID]         = { "UUID",           36, 0, N_("filesystem UUID") },
@@ -724,6 +726,10 @@ static char *get_data(struct libmnt_fs *fs, int num, size_t *datasiz, struct fin
 	case COL_ID:
 		if (mnt_fs_get_id(fs))
 			xasprintf(&str, "%d", mnt_fs_get_id(fs));
+		break;
+	case COL_UNIQ_ID:
+		if (mnt_fs_get_uniq_id(fs))
+			xasprintf(&str, "%" PRIu64, mnt_fs_get_uniq_id(fs));
 		break;
 	case COL_PARENT:
 		if (mnt_fs_get_parent_id(fs))
@@ -1471,6 +1477,7 @@ static int get_column_json_type(int id, int scols_flags, int *multi, unsigned in
 			break;
 		/* fallthrough */
 	case COL_ID:
+	case COL_UNIQ_ID:
 	case COL_PARENT:
 	case COL_FREQ:
 	case COL_PASSNO:

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1510,59 +1510,65 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Find a (mounted) filesystem.\n"), out);
 
-	fputs(USAGE_OPTIONS, out);
-	fputs(_(" -s, --fstab            search in static table of filesystems\n"), out);
+
+	fputs(_("\nData sources:\n"), out);
+	fputs(_(" -F, --tab-file <path>  alternative file for -s, -m or -k options\n"), out);
 	fputs(_(" -m, --mtab             search in table of mounted filesystems\n"
 		"                          (includes user space mount options)\n"), out);
 	fputs(_(" -k, --kernel[=<method>] search in kernel mount table (default)\n"
 		"                          <method> is mountinfo or listmount\n"), out);
-	fputc('\n', out);
+	fputs(_(" -N, --task <tid>       use alternative namespace (/proc/<tid>/mountinfo file)\n"), out);
 	fputs(_(" -p, --poll[=<list>]    monitor changes in table of mounted filesystems\n"), out);
-	fputs(_(" -w, --timeout <num>    upper limit in milliseconds that --poll will block\n"), out);
-	fputc('\n', out);
+	fputs(_(" -s, --fstab            search in static table of filesystems\n"), out);
 
+
+
+	fputs(_("\nData filters:\n"), out);
 	fputs(_(" -A, --all              disable all built-in filters, print all filesystems\n"), out);
+	fputs(_(" -d, --direction <word> direction of search, 'forward' or 'backward'\n"), out);
+	fputs(_(" -f, --first-only       print the first found filesystem only\n"), out);
+	fputs(_(" -i, --invert           invert the sense of matching\n"), out);
+	fputs(_("     --pseudo           print only pseudo-filesystems\n"), out);
+	fputs(_(" -Q, --filter <expr>    apply display filter\n"), out);
+	fputs(_(" -M, --mountpoint <dir> the mountpoint directory\n"), out);
+	fputs(_("     --shadowed         print only filesystems over-mounted by another filesystem\n"), out);
+	fputs(_(" -R, --submounts        print all submounts for the matching filesystems\n"), out);
+	fputs(_("     --real             print only real filesystems\n"), out);
+	fputs(_(" -S, --source <string>  the device to mount (by name, maj:min, \n"
+	        "                          LABEL=, UUID=, PARTUUID=, PARTLABEL=)\n"), out);
+	fputs(_(" -T, --target <path>    the path to the filesystem to use\n"), out);
+	fputs(_(" -t, --types <list>     limit the set of filesystems by FS types\n"), out);
+	fputs(_(" -U, --uniq             ignore filesystems with duplicate target\n"), out);
+
+
+	fputs(USAGE_OPTIONS, out);
 	fputs(_(" -a, --ascii            use ASCII chars for tree formatting\n"), out);
 	fputs(_(" -b, --bytes            print sizes in bytes rather than in human readable format\n"), out);
 	fputs(_(" -C, --nocanonicalize   don't canonicalize when comparing paths\n"), out);
 	fputs(_(" -c, --canonicalize     canonicalize printed paths\n"), out);
 	fputs(_(" -D, --df               imitate the output of df(1)\n"), out);
-	fputs(_(" -d, --direction <word> direction of search, 'forward' or 'backward'\n"), out);
 	fputs(_(" -e, --evaluate         convert tags (LABEL,UUID,PARTUUID,PARTLABEL) \n"
 	        "                          to device names\n"), out);
-	fputs(_(" -F, --tab-file <path>  alternative file for -s, -m or -k options\n"), out);
-	fputs(_(" -f, --first-only       print the first found filesystem only\n"), out);
 	fputs(_(" -I, --dfi              imitate the output of df(1) with -i option\n"), out);
-	fputs(_(" -i, --invert           invert the sense of matching\n"), out);
 	fputs(_(" -J, --json             use JSON output format\n"), out);
 	fputs(_(" -l, --list             use list format output\n"), out);
-	fputs(_(" -N, --task <tid>       use alternative namespace (/proc/<tid>/mountinfo file)\n"), out);
 	fputs(_(" -n, --noheadings       don't print column headings\n"), out);
 	fputs(_(" -O, --options <list>   limit the set of filesystems by mount options\n"), out);
 	fputs(_(" -o, --output <list>    output columns (see --list-columns)\n"), out);
 	fputs(_("     --output-all       output all available columns\n"), out);
 	fputs(_(" -P, --pairs            use key=\"value\" output format\n"), out);
-	fputs(_("     --pseudo           print only pseudo-filesystems\n"), out);
-	fputs(_("     --shadowed         print only filesystems over-mounted by another filesystem\n"), out);
-	fputs(_(" -Q, --filter <expr>    apply display filter\n"), out);
-	fputs(_(" -R, --submounts        print all submounts for the matching filesystems\n"), out);
 	fputs(_(" -r, --raw              use raw output format\n"), out);
-	fputs(_("     --real             print only real filesystems\n"), out);
-	fputs(_(" -S, --source <string>  the device to mount (by name, maj:min, \n"
-	        "                          LABEL=, UUID=, PARTUUID=, PARTLABEL=)\n"), out);
-	fputs(_(" -T, --target <path>    the path to the filesystem to use\n"), out);
 	fputs(_("     --tree             enable tree format output if possible\n"), out);
-	fputs(_(" -M, --mountpoint <dir> the mountpoint directory\n"), out);
-	fputs(_(" -t, --types <list>     limit the set of filesystems by FS types\n"), out);
-	fputs(_(" -U, --uniq             ignore filesystems with duplicate target\n"), out);
 	fputs(_(" -u, --notruncate       don't truncate text in columns\n"), out);
 	fputs(_(" -v, --nofsroot         don't print [/dir] for bind or btrfs mounts\n"), out);
+	fputs(_(" -w, --timeout <num>    upper limit in milliseconds that --poll will block\n"), out);
 	fputs(_(" -y, --shell            use column names to be usable as shell variable identifiers\n"), out);
 
 	fputc('\n', out);
 	fputs(_(" -x, --verify           verify mount table content (default is fstab)\n"), out);
 	fputs(_("     --verbose          print more details\n"), out);
 	fputs(_("     --vfs-all          print all VFS options\n"), out);
+
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_(" -H, --list-columns     list the available columns\n"), out);

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -92,7 +92,7 @@ enum {
 enum {
 	TABTYPE_FSTAB = 1,
 	TABTYPE_MTAB,
-	TABTYPE_KERNEL
+	TABTYPE_KERNEL_MOUNTINFO
 };
 
 /* column names */
@@ -1049,13 +1049,16 @@ static struct libmnt_table *parse_tabfiles(char **files,
 		case TABTYPE_MTAB:
 			rc = mnt_table_parse_mtab(tb, path);
 			break;
-		case TABTYPE_KERNEL:
+		case TABTYPE_KERNEL_MOUNTINFO:
 			if (!path)
 				path = access(_PATH_PROC_MOUNTINFO, R_OK) == 0 ?
 					      _PATH_PROC_MOUNTINFO :
 					      _PATH_PROC_MOUNTS;
 
 			rc = mnt_table_parse_file(tb, path);
+			break;
+		default:
+			rc = -EINVAL;
 			break;
 		}
 		if (rc) {
@@ -1714,7 +1717,7 @@ int main(int argc, char *argv[])
 		{ "help",	    no_argument,       NULL, 'h'		 },
 		{ "invert",	    no_argument,       NULL, 'i'		 },
 		{ "json",	    no_argument,       NULL, 'J'		 },
-		{ "kernel",	    no_argument,       NULL, 'k'		 },
+		{ "kernel",	    optional_argument, NULL, 'k'		 },
 		{ "list",	    no_argument,       NULL, 'l'		 },
 		{ "mountpoint",	    required_argument, NULL, 'M'		 },
 		{ "mtab",	    no_argument,       NULL, 'm'		 },
@@ -1775,7 +1778,7 @@ int main(int argc, char *argv[])
 	findmnt.flags |= FL_TREE;
 
 	while ((c = getopt_long(argc, argv,
-				"AabCcDd:ehIiJfF:o:O:p::PQ:klmM:nN:rst:uvRS:T:Uw:VxyH",
+				"AabCcDd:ehIiJfF:o:O:p::PQ:k::lmM:nN:rst:uvRS:T:Uw:VxyH",
 				longopts, NULL)) != -1) {
 
 		err_exclusive_options(c, longopts, excl, excl_st);
@@ -1871,8 +1874,14 @@ int main(int argc, char *argv[])
 			tabtype = TABTYPE_FSTAB;
 			findmnt.flags &= ~FL_TREE;
 			break;
-		case 'k':		/* kernel (mountinfo) */
-			tabtype = TABTYPE_KERNEL;
+		case 'k':
+			if (optarg) {
+				if (strcmp(optarg, "mountinfo") == 0)
+					tabtype = TABTYPE_KERNEL_MOUNTINFO;
+				else
+					errx(EXIT_FAILURE, _("invalid --kernel argument"));
+			} else
+				tabtype = TABTYPE_KERNEL_MOUNTINFO;
 			break;
 		case 't':
 			set_match(COL_FSTYPE, optarg);
@@ -1888,7 +1897,7 @@ int main(int argc, char *argv[])
 			findmnt.flags |= FL_NOHEADINGS;
 			break;
 		case 'N':
-			tabtype = TABTYPE_KERNEL;
+			tabtype = TABTYPE_KERNEL_MOUNTINFO;
 			tabfiles = append_pid_tabfile(tabfiles, &ntabfiles,
 					strtou32_or_err(optarg,
 						_("invalid TID argument")));
@@ -1993,7 +2002,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 
 	if (!tabtype)
-		tabtype = verify ? TABTYPE_FSTAB : TABTYPE_KERNEL;
+		tabtype = verify ? TABTYPE_FSTAB : TABTYPE_KERNEL_MOUNTINFO;
 
 	if ((findmnt.flags & FL_POLL) && ntabfiles > 1)
 		errx(EXIT_FAILURE, _("--poll accepts only one file, but more specified by --tab-file"));
@@ -2042,7 +2051,7 @@ int main(int argc, char *argv[])
 	mnt_table_set_userdata(tb, &findmnt);
 
 	if (tabtype == TABTYPE_MTAB && tab_is_kernel(tb))
-		tabtype = TABTYPE_KERNEL;
+		tabtype = TABTYPE_KERNEL_MOUNTINFO;
 
 	istree = tab_is_tree(tb);
 	if (istree && force_tree)
@@ -2059,7 +2068,7 @@ int main(int argc, char *argv[])
 		}
 		mnt_table_set_cache(tb, findmnt.cache);
 
-		if (tabtype != TABTYPE_KERNEL)
+		if (tabtype != TABTYPE_KERNEL_MOUNTINFO)
 			cache_set_targets(findmnt.cache);
 	}
 
@@ -2097,7 +2106,7 @@ int main(int argc, char *argv[])
 		rc = add_matching_lines(tb, table, direction, &findmnt);
 
 		if (rc != 0
-		    && tabtype == TABTYPE_KERNEL
+		    && tabtype == TABTYPE_KERNEL_MOUNTINFO
 		    && (findmnt.flags & FL_NOSWAPMATCH)
 		    && !(findmnt.flags & FL_STRICTTARGET)
 		    && get_match(COL_TARGET)) {

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -320,6 +320,8 @@ int is_listall_mode(unsigned int flags)
 		!is_defined_match(COL_TARGET) &&
 		!is_defined_match(COL_FSTYPE) &&
 		!is_defined_match(COL_OPTIONS) &&
+		!is_defined_match(COL_ID) &&
+		!is_defined_match(COL_UNIQ_ID) &&
 		!is_defined_match(COL_MAJMIN));
 }
 
@@ -365,7 +367,10 @@ static int is_mount_compatible_mode(unsigned int flags)
 {
 	if (!is_defined_match(COL_SOURCE))
 	       return 0;		/* <devname|TAG=|mountpoint> is required */
-	if (is_defined_match(COL_FSTYPE) || is_defined_match(COL_OPTIONS))
+	if (is_defined_match(COL_FSTYPE)
+	    || is_defined_match(COL_OPTIONS)
+	    || is_defined_match(COL_ID)
+	    || is_defined_match(COL_UNIQ_ID))
 		return 0;		/* cannot be restricted by -t or -O */
 	if (!(flags & FL_FIRSTONLY))
 		return 0;		/* we have to return the first entry only */
@@ -1181,6 +1186,14 @@ static int match_func(struct libmnt_fs *fs,
 	const char *m;
 	void *md;
 
+	md = get_match_data(COL_ID);
+	if (md && mnt_fs_get_id(fs) != *((int *) md))
+		return rc;
+
+	md = get_match_data(COL_UNIQ_ID);
+	if (md && mnt_fs_get_uniq_id(fs) != *((uint64_t *) md))
+		return rc;
+
 	m = get_match(COL_FSTYPE);
 	if (m && !mnt_fs_match_fstype(fs, m))
 		return rc;
@@ -1522,12 +1535,13 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -s, --fstab            search in static table of filesystems\n"), out);
 
 
-
 	fputs(_("\nData filters:\n"), out);
 	fputs(_(" -A, --all              disable all built-in filters, print all filesystems\n"), out);
 	fputs(_(" -d, --direction <word> direction of search, 'forward' or 'backward'\n"), out);
 	fputs(_(" -f, --first-only       print the first found filesystem only\n"), out);
 	fputs(_(" -i, --invert           invert the sense of matching\n"), out);
+	fputs(_("     --id <num>         filter by mount node ID\n"), out);
+	fputs(_("     --uniq-id <num>    filter by mount node 64-bit ID (requires --kernel=listmount)\n"), out);
 	fputs(_("     --pseudo           print only pseudo-filesystems\n"), out);
 	fputs(_(" -Q, --filter <expr>    apply display filter\n"), out);
 	fputs(_(" -M, --mountpoint <dir> the mountpoint directory\n"), out);
@@ -1745,7 +1759,9 @@ int main(int argc, char *argv[])
 		FINDMNT_OPT_REAL,
 		FINDMNT_OPT_VFS_ALL,
 		FINDMNT_OPT_SHADOWED,
-		FINDMNT_OPT_HYPERLINK
+		FINDMNT_OPT_HYPERLINK,
+		FINDMNT_OPT_ID,
+		FINDMNT_OPT_UNIQ_ID
 	};
 
 	static const struct option longopts[] = {
@@ -1795,6 +1811,8 @@ int main(int argc, char *argv[])
 		{ "vfs-all",	    no_argument,       NULL, FINDMNT_OPT_VFS_ALL },
 		{ "shadowed",       no_argument,       NULL, FINDMNT_OPT_SHADOWED },
 		{ "hyperlink",      optional_argument, NULL, FINDMNT_OPT_HYPERLINK },
+		{ "id",             required_argument, NULL, FINDMNT_OPT_ID },
+		{ "uniq-id",        required_argument, NULL, FINDMNT_OPT_UNIQ_ID },
 		{ "list-columns",   no_argument,       NULL, 'H' },
 		{ NULL, 0, NULL, 0 }
 	};
@@ -2001,6 +2019,22 @@ int main(int argc, char *argv[])
 					_("invalid hyperlink argument")))
 				findmnt.uri = xgethosturi(NULL);
 			break;
+		case FINDMNT_OPT_ID:
+			{
+				int *id = xmalloc(sizeof(int));
+
+				*id = strtos32_or_err(optarg, _("invalid id argument"));
+				set_match_data(COL_ID, (void *) id);
+				break;
+			}
+		case FINDMNT_OPT_UNIQ_ID:
+			{
+				uint64_t *id = xmalloc(sizeof(uint64_t));
+
+				*id = strtou64_or_err(optarg, _("invalid uniq-id argument"));
+				set_match_data(COL_UNIQ_ID, (void *) id);
+				break;
+			}
 		case 'H':
 			collist = 1;
 			break;

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1505,8 +1505,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -s, --fstab            search in static table of filesystems\n"), out);
 	fputs(_(" -m, --mtab             search in table of mounted filesystems\n"
 		"                          (includes user space mount options)\n"), out);
-	fputs(_(" -k, --kernel           search in kernel table of mounted\n"
-		"                          filesystems (default)\n"), out);
+	fputs(_(" -k, --kernel[=<method>] search in kernel mount table (default)\n"
+		"                          <method> is mountinfo or listmount\n"), out);
 	fputc('\n', out);
 	fputs(_(" -p, --poll[=<list>]    monitor changes in table of mounted filesystems\n"), out);
 	fputs(_(" -w, --timeout <num>    upper limit in milliseconds that --poll will block\n"), out);

--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -602,11 +602,6 @@ static const char *parse_kmsg_timestamp(const char *str0, struct timeval *tv)
 	return end + 1;	/* skip separator */
 }
 
-static double time_diff(struct timeval *a, struct timeval *b)
-{
-	return (a->tv_sec - b->tv_sec) + (a->tv_usec - b->tv_usec) / (double) USEC_PER_SEC;
-}
-
 static int get_syslog_buffer_size(void)
 {
 	int n = klogctl(SYSLOG_ACTION_SIZE_BUFFER, NULL, 0);

--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -212,7 +212,7 @@ static int busywait_for_rtc_clock_tick(const struct hwclock_control *ctl,
 		if (rc || start_time.tm_sec != nowtime.tm_sec)
 			break;
 		gettime_monotonic(&now);
-		if (time_diff(now, begin) > 1.5) {
+		if (time_diff(&now, &begin) > 1.5) {
 			warnx(_("Timed out waiting for time change."));
 			return 1;
 		}

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -171,15 +171,6 @@ static struct timeval t2tv(time_t timet)
 }
 
 /*
- * The difference in seconds between two times in "timeval" format.
- */
-double time_diff(struct timeval subtrahend, struct timeval subtractor)
-{
-	return (subtrahend.tv_sec - subtractor.tv_sec)
-	    + (subtrahend.tv_usec - subtractor.tv_usec) / 1E6;
-}
-
-/*
  * The time, in "timeval" format, which is <increment> seconds after the
  * time <addend>. Of course, <increment> may be negative.
  */
@@ -572,8 +563,8 @@ set_hardware_clock_exact(const struct hwclock_control *ctl,
 		ON_DBG(RANDOM_SLEEP, up_to_1000ms_sleep());
 
 		gettimeofday(&nowsystime, NULL);
-		deltavstarget = time_diff(nowsystime, targetsystime);
-		ticksize = time_diff(nowsystime, prevsystime);
+		deltavstarget = time_diff(&nowsystime, &targetsystime);
+		ticksize = time_diff(&nowsystime, &prevsystime);
 		prevsystime = nowsystime;
 
 		if (ticksize < 0) {
@@ -624,7 +615,7 @@ set_hardware_clock_exact(const struct hwclock_control *ctl,
 	}
 
 	newhwtime = sethwtime
-		    + round(time_diff(nowsystime, refsystime)
+		    + round(time_diff(&nowsystime, &refsystime)
 			    - delay /* don't count this */);
 	if (ctl->verbose)
 		printf(_("%"PRId64".%06"PRId64" is close enough to %"PRId64".%06"PRId64" (%.6f < %.6f)\n"
@@ -821,8 +812,8 @@ adjust_drift_factor(const struct hwclock_control *ctl,
 		 * hclocktime is fully corrected with the current drift factor.
 		 * Its difference from nowtime is the missed drift correction.
 		 */
-		factor_adjust = time_diff(nowtime, hclocktime) /
-				(time_diff(nowtime, last_calib) / sec_per_day);
+		factor_adjust = time_diff(&nowtime, &hclocktime) /
+				(time_diff(&nowtime, &last_calib) / sec_per_day);
 
 		drift_factor = adjtime_p->drift_factor + factor_adjust;
 		if (fabs(drift_factor) > MAX_DRIFT) {
@@ -838,8 +829,8 @@ adjust_drift_factor(const struct hwclock_control *ctl,
 					 "%f seconds\nin spite of a drift factor of "
 					 "%f seconds/day.\n"
 					 "Adjusting drift factor by %f seconds/day\n"),
-				       time_diff(nowtime, hclocktime),
-				       time_diff(nowtime, last_calib),
+				       time_diff(&nowtime, &hclocktime),
+				       time_diff(&nowtime, &last_calib),
 				       adjtime_p->drift_factor, factor_adjust);
 		}
 
@@ -1101,7 +1092,7 @@ manipulate_clock(const struct hwclock_control *ctl, const time_t set_time,
 			hclocktime = time_inc(tdrift, hclocktime.tv_sec);
 
 		startup_hclocktime =
-		 time_inc(hclocktime, time_diff(startup_time, read_time));
+		 time_inc(hclocktime, time_diff(&startup_time, &read_time));
 	}
 	if (ctl->show || ctl->get) {
 		return display_time(startup_hclocktime);

--- a/sys-utils/hwclock.h
+++ b/sys-utils/hwclock.h
@@ -81,9 +81,6 @@ struct clock_ops {
 extern const struct clock_ops *probe_for_cmos_clock(void);
 extern const struct clock_ops *probe_for_rtc_clock(const struct hwclock_control *ctl);
 
-/* hwclock.c */
-extern double time_diff(struct timeval subtrahend, struct timeval subtractor);
-
 /* rtc.c */
 #if defined(__linux__) && defined(__alpha__)
 extern int get_epoch_rtc(const struct hwclock_control *ctl, unsigned long *epoch);

--- a/tests/expected/libmount/tabfiles-parse-mountinfo
+++ b/tests/expected/libmount/tabfiles-parse-mountinfo
@@ -358,6 +358,7 @@ optstr: rw,relatime
 VFS-optstr: rw,relatime
 FS-opstr: rw
 optional-fields: 'shared:323'
+propagation: shared  
 root:   /
 id:     49
 parent: 20

--- a/tests/expected/libmount/tabfiles-parse-mountinfo-nosrc
+++ b/tests/expected/libmount/tabfiles-parse-mountinfo-nosrc
@@ -72,6 +72,7 @@ optstr: rw,relatime
 VFS-optstr: rw,relatime
 FS-opstr: rw
 optional-fields: 'shared:212'
+propagation: shared  
 root:   /
 id:     21
 parent: 20

--- a/tests/expected/libmount/tabfiles-parse-swaps
+++ b/tests/expected/libmount/tabfiles-parse-swaps
@@ -1,6 +1,5 @@
 ------ fs:
 source: /dev/dm-2
-target: (null)
 fstype: swap
 swaptype: partition
 size: 8151036
@@ -8,14 +7,12 @@ usedsize: 2283436
 priority: -2
 ------ fs:
 source: /some/swapfile
-target: (null)
 fstype: swap
 swaptype: file
 size: 111
 usedsize: 111
 ------ fs:
 source: /some/swapfile2
-target: (null)
 fstype: swap
 swaptype: file
 size: 111

--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -130,7 +130,7 @@ static int hlp_enotty_ok(void)
 
 static int hlp_fsopen_ok(void)
 {
-#ifdef FSOPEN_CLOEXEC
+#if defined(HAVE_FSOPEN) && defined(FSOPEN_CLOEXEC)
 	errno = 0;
 	fsopen(NULL, FSOPEN_CLOEXEC);
 #else

--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -163,7 +163,7 @@ static int hlp_listmount_ok(void)
 #else
 	errno = ENOSYS;
 #endif
-	printf("%d\n", errno != ENOSYS);
+	printf("%d\n", !(errno == ENOSYS || errno == EINVAL));
 	return 0;
 }
 

--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -28,6 +28,8 @@
 #include <time.h>
 #include <sys/ioctl.h>
 
+#include "c.h"
+
 #ifdef __linux__
 # include <sys/mount.h>
 # include "mount-api-utils.h"
@@ -140,6 +142,31 @@ static int hlp_fsopen_ok(void)
 	return 0;
 }
 
+static int hlp_statmount_ok(void)
+{
+#ifdef HAVE_STATMOUNT_API
+	errno = 0;
+	ul_statmount(0, 0, 0, NULL, 0, 0);
+#else
+	errno = ENOSYS;
+#endif
+	printf("%d\n", errno != ENOSYS);
+	return 0;
+}
+
+static int hlp_listmount_ok(void)
+{
+#ifdef HAVE_STATMOUNT_API
+	uint64_t dummy;
+	errno = 0;
+	ul_listmount(LSMT_ROOT, 0, 0, &dummy, 1, LISTMOUNT_REVERSE);
+#else
+	errno = ENOSYS;
+#endif
+	printf("%d\n", errno != ENOSYS);
+	return 0;
+}
+
 static int hlp_sz_time(void)
 {
 	printf("%zu\n", sizeof(time_t));
@@ -191,6 +218,8 @@ static const mntHlpfnc hlps[] =
 	{ "wcsspn-ok",  hlp_wcsspn_ok   },
 	{ "enotty-ok",  hlp_enotty_ok   },
 	{ "fsopen-ok",  hlp_fsopen_ok   },
+	{ "statmount-ok", hlp_statmount_ok },
+	{ "listmount-ok", hlp_listmount_ok },
 	{ "sz(time_t)", hlp_sz_time     },
 	{ "ns-gettype-ok", hlp_get_nstype_ok },
 	{ "ns-getuserns-ok", hlp_get_userns_ok },

--- a/tests/ts/findmnt/listmount
+++ b/tests/ts/findmnt/listmount
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="listmount & statmount"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_FINDMNT"
+
+[ "$("$TS_HELPER_SYSINFO" statmount-ok)" = "1" ] || ts_skip "no statmount"
+[ "$("$TS_HELPER_SYSINFO" listmount-ok)" = "1" ] || ts_skip "no listmount"
+
+function check_field {
+	local name="$1"
+
+	data=$( $TS_CMD_FINDMNT --noheadings --kernel=listmount --output "$name" --target /proc )
+	[ -n "$data" ] || echo "$name empty"
+}
+
+
+ts_init_subtest "target"
+check_field "TARGET" >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "vfs-options"
+check_field "VFS-OPTIONS" >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "fs-options"
+check_field "FS-OPTIONS" >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "options"
+check_field "OPTIONS" >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "fstype"
+check_field "FSTYPE" >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "propagation"
+check_field "PROPAGATION" >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "fsroot"
+check_field "FSROOT" >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "parent"
+check_field "PARENT" >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "id"
+check_field "ID" >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_finalize


### PR DESCRIPTION
Plan:
- [x] use statmount() in libmnt_fs
- [x] fill libmnt_table by listmount()
- [x] on-demand read nodes from kernel by listmount() in mnt_table_next_fs() loops (mnt_table_next_lsmnt() as backend)
- [x] allocate/share buffer for statmount() between statmount() calls (move the buffer to struct libmnt_stmnt)
- [x] verify LISTMOUNT_REVERSE use in loops
- [x] cleanup filenames
- [x] cleanup code to pass old tests
- [x] add new tests (based on findmnt/)
- [ ] add support for mount source (not supported by statmount() syscall for now)
