### PR TITLE
lsblk: add --properties-by option

### DIFF
--- a/misc-utils/lsblk.8.adoc
+++ b/misc-utils/lsblk.8.adoc
@@ -180,6 +180,20 @@ Print the zone related information for each device.
 *--sysroot* _directory_::
 Gather data for a Linux instance other than the instance from which the *lsblk* command is issued. The specified directory is the system root of the Linux instance to be inspected. The real device nodes in the target directory can be replaced by text files with udev attributes.
 
+*--properties-by* _list_::
+This option specifies the methods used by *lsblk* to gather information about
+filesystems and partition tables. The list is a comma-separated list of method
+names. The default setting is "file,udev,blkid". The supported methods are:
++
+*udev*;;
+Reads data from udev DB. If unsuccessful, it continues to the next probing method.
+*blkid*;;
+Reads data directly from the device using libblkid. If unsuccessful, it continues to the next probing method.
+*file*;;
+Reads data from a file. This method is only used if the --sysroot option is specified. This method always stops probing if used.
+*none*;;
+Does not probe. This method always stops probing.
+
 == EXIT STATUS
 
 0::

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -2389,7 +2389,9 @@ int main(int argc, char *argv[])
 		.sort_id = -1,
 		.dedup_id = -1,
 		.flags = LSBLK_TREE,
-		.tree_id = COL_NAME
+		.tree_id = COL_NAME,
+		.properties_by = { LSBLK_METHOD_FILE, LSBLK_METHOD_UDEV,
+				     LSBLK_METHOD_BLKID, LSBLK_METHOD_NONE }
 	};
 	struct lsblk_devtree *tr = NULL;
 	int c, status = EXIT_FAILURE, collist = 0;
@@ -2403,6 +2405,7 @@ int main(int argc, char *argv[])
 		OPT_COUNTER_FILTER,
 		OPT_COUNTER,
 		OPT_HIGHLIGHT,
+		OPT_PROPERTIES_BY
 	};
 
 	static const struct option longopts[] = {
@@ -2443,6 +2446,7 @@ int main(int argc, char *argv[])
 		{ "width",	required_argument, NULL, 'w' },
 		{ "ct-filter",  required_argument, NULL, OPT_COUNTER_FILTER },
 		{ "ct",         required_argument, NULL, OPT_COUNTER },
+		{ "properties-by", required_argument, NULL, OPT_PROPERTIES_BY },
 		{ "list-columns", no_argument,     NULL, 'H' },
 		{ NULL, 0, NULL, 0 },
 	};
@@ -2657,7 +2661,10 @@ int main(int argc, char *argv[])
 		case OPT_HIGHLIGHT:
 			lsblk->hlighter = new_filter(optarg);
 			break;
-
+		case OPT_PROPERTIES_BY:
+			if (lsblk_set_properties_method(optarg) < 0)
+				errtryhelp(EXIT_FAILURE);
+			break;
 		case 'H':
 			collist = 1;
 			break;

--- a/misc-utils/lsblk.h
+++ b/misc-utils/lsblk.h
@@ -32,6 +32,16 @@ UL_DEBUG_DECLARE_MASK(lsblk);
 #define UL_DEBUG_CURRENT_MASK	UL_DEBUG_MASK(lsblk)
 #include "debugobj.h"
 
+/* --properties-by items */
+enum lsblk_devprop_method {
+	LSBLK_METHOD_NONE = 0,
+	LSBLK_METHOD_UDEV,
+	LSBLK_METHOD_BLKID,
+	LSBLK_METHOD_FILE,
+
+	__LSBLK_NMETHODS	/* keep last */
+};
+
 struct lsblk {
 	struct libscols_table *table;	/* output table */
 	struct libscols_column *sort_col;/* sort output by this column */
@@ -50,6 +60,8 @@ struct lsblk {
 
 	const char *sysroot;
 	int flags;			/* LSBLK_* */
+
+	int properties_by[__LSBLK_NMETHODS];
 
 	unsigned int all_devices:1;	/* print all devices, including empty */
 	unsigned int bytes:1;		/* print SIZE in bytes */
@@ -93,6 +105,8 @@ struct lsblk_devprop {
 	char *group;		/* group name */
 	char *mode;		/* access mode in ls(1)-like notation */
 };
+
+
 
 /* Device dependence
  *
@@ -232,6 +246,8 @@ extern struct lsblk_devprop *lsblk_device_get_properties(struct lsblk_device *de
 extern void lsblk_properties_deinit(void);
 
 extern const char *lsblk_parttype_code_to_string(const char *code, const char *pttype);
+
+extern int lsblk_set_properties_method(const char *opts);
 
 /* lsblk-devtree.c */
 void lsblk_reset_iter(struct lsblk_iter *itr, int direction);


### PR DESCRIPTION
This new option allows for controlling the method(s) used by lsblk to gather file system and partition data about devices.

Fixes: https://github.com/util-linux/util-linux/issues/2047