### PR TITLE
lsmem: make lsmem to check for the nodes more robust

### DIFF
--- a/sys-utils/lsmem.c
+++ b/sys-utils/lsmem.c
@@ -485,6 +485,7 @@ static int memory_block_filter(const struct dirent *de)
 static void read_basic_info(struct lsmem *lsmem)
 {
 	char dir[PATH_MAX];
+	int i = 0;
 
 	if (ul_path_access(lsmem->sysmem, F_OK, "block_size_bytes") != 0)
 		errx(EXIT_FAILURE, _("This system does not support memory blocks"));
@@ -495,8 +496,14 @@ static void read_basic_info(struct lsmem *lsmem)
 	if (lsmem->ndirs <= 0)
 		err(EXIT_FAILURE, _("Failed to read %s"), dir);
 
-	if (memory_block_get_node(lsmem, lsmem->dirs[0]->d_name) != -1)
-		lsmem->have_nodes = 1;
+	for (i = 0; i < lsmem->ndirs; i++)
+	{
+		if (memory_block_get_node(lsmem, lsmem->dirs[i]->d_name) != -1)
+		{
+			lsmem->have_nodes = 1;
+			break;
+		}
+	}
 
 	/* The valid_zones sysmem attribute was introduced with kernel 3.18 */
 	if (ul_path_access(lsmem->sysmem, F_OK, "memory0/valid_zones") == 0)


### PR DESCRIPTION
Some systems may occupy the first memory block. As a result, the NUMA node is not printed. Add new option for force output all numa nodes of memory.
https://github.com/util-linux/util-linux/issues/3110