### PR TITLE
Prevent problems with period after the URL

### DIFF
--- a/man-common/bugreports.adoc
+++ b/man-common/bugreports.adoc
@@ -1,3 +1,3 @@
 == REPORTING BUGS
 
-For bug reports, use the issue tracker at https://github.com/util-linux/util-linux/issues.
+For bug reports, use the https://github.com/util-linux/util-linux/issues[issue tracker].


### PR DESCRIPTION
Otherwise, the period gets included in the URL which makes it not work.