### PR TITLE
tests: include <sys/mount.h> only on Linux

### DIFF
--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -27,7 +27,9 @@
 #include <errno.h>
 #include <time.h>
 #include <sys/ioctl.h>
-#include <sys/mount.h>
+#ifdef __linux__
+# include <sys/mount.h>
+#endif
 
 #include "mount-api-utils.h"
 


### PR DESCRIPTION
Include `<sys/mount.h>` only on Linux; it is used for `fsopen()`, which is available only on Linux.