### PR TITLE
build-sys: build sample-mount-overwrite only on Linux

### DIFF
--- a/libmount/samples/Makemodule.am
+++ b/libmount/samples/Makemodule.am
@@ -1,6 +1,8 @@
 
+if LINUX
 check_PROGRAMS += \
 	sample-mount-overwrite
+endif
 
 sample_mount_cflags = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 sample_mount_ldadd = libmount.la $(LDADD)


### PR DESCRIPTION
This sample uses the libmnt_context API, which is available only on Linux.