### PR TITLE
libuuid: set variant in the corrrect byte: __uuid_set_variant_and_ver…

### DIFF
--- a/libuuid/src/gen_uuid.c
+++ b/libuuid/src/gen_uuid.c
@@ -589,7 +589,7 @@ static void __uuid_set_variant_and_version(uuid_t uuid, int version)
 {
 	uuid[6] = (uuid[6] & UUID_TYPE_MASK) | version << UUID_TYPE_SHIFT;
 	/* only DCE is supported */
-	uuid[8] = (uuid[10] & 0x3F) | 0x80;
+	uuid[8] = (uuid[8] & 0x3F) | 0x80;
 }
 
 /*


### PR DESCRIPTION
https://github.com/util-linux/util-linux/issues/3127#issuecomment-2229784317