### PR TITLE
Add thread dep to libuuid meson.build to fix meson build regression in 2.40.2

### DIFF
--- a/libuuid/meson.build
+++ b/libuuid/meson.build
@@ -29,6 +29,8 @@ if cc.has_link_argument('-Wl,--version-script=@0@'.format(libuuid_sym_path))
 	libuuid_link_args += ['-Wl,--version-script=@0@'.format(libuuid_sym_path)]
 endif
 
+thread_dep = dependency('threads')
+
 lib_uuid = both_libraries(
   'uuid',
   list_h,
@@ -43,7 +45,7 @@ lib_uuid = both_libraries(
   link_depends : libuuid_link_depends,
   version : libuuid_version,
   link_args : libuuid_link_args,
-  dependencies : [socket_libs,
+  dependencies : [socket_libs, thread_dep,
                   build_libuuid ? [] : disabler()],
   install : build_libuuid)
 uuid_dep = declare_dependency(link_with: lib_uuid, include_directories: dir_libuuid)


### PR DESCRIPTION
Fixes: https://github.com/util-linux/util-linux/issues/3131

https://github.com/util-linux/util-linux/pull/3017 didn't modify the meson build system to add the threads dependency to libuuid.

Changes are as per https://mesonbuild.com/Threads.html

We have it implemented here:

https://github.com/chromebrew/chromebrew/blob/44d2749e809d2b8f3083a2766303354f09f9ae5c/packages/util_linux.rb#L46