### PR TITLE
scriptlive: echo re-run commands from in stream

### DIFF
--- a/term-utils/scriptlive.c
+++ b/term-utils/scriptlive.c
@@ -288,9 +288,8 @@ main(int argc, char *argv[])
 	cb->child_sigstop = callback_child_sigstop;
 	cb->mainloop = mainloop_cb;
 
-	if (!isatty(STDIN_FILENO))
-		/* We keep ECHO flag for compatibility with script(1) */
-		ul_pty_slave_echo(ss.pty, 1);
+	/* We keep ECHO flag for compatibility with script(1) */
+	ul_pty_slave_echo(ss.pty, 1);
 
 	if (ul_pty_setup(ss.pty))
 		err(EXIT_FAILURE, _("failed to create pseudo-terminal"));


### PR DESCRIPTION
## Versions

```
[vagrant@localhost ~]$ script --version
script from util-linux 2.40
[vagrant@localhost ~]$ scriptlive --version
scriptlive from util-linux 2.40
```
## The Issue

`scriptlive` does not echo (display) the commands it's re-running.

For example, here I create a simple "in" stream typescript.
```
[vagrant@localhost ~]$ script -ttypescript.timing -Itypescript.script
Script started, input log file is 'typescript.script', timing file is 'typescript.timing'.
[vagrant@localhost ~]$ date
Sat Jul 20 10:49:25 PM UTC 2024
[vagrant@localhost ~]$ 
exit
Script done.
```
When I re-run this, the input command `date` is not echoed.
```
[vagrant@localhost ~]$ scriptlive -ttypescript.timing -Itypescript.script
>>> scriptlive: Starting your typescript execution by /bin/bash.
[vagrant@localhost ~]$ 
Sat Jul 20 10:49:36 PM UTC 2024
[vagrant@localhost ~]$ 
exit

>>> scriptlive: done.
```

## What echos

What does echo is commands supplied to `scriptlive` stdin.
```
[vagrant@localhost ~]$ echo 'date +%s' | scriptlive -ttypescript.timing -Itypescript.script
>>> scriptlive: Starting your typescript execution by /bin/bash.
date +%s
[vagrant@localhost ~]$ date +%s
1721515796
[vagrant@localhost ~]$ 
exit

>>> scriptlive: done.
```

## A Workaround

This can be worked around in the v2.40.2 and recent older `scriptlives` by running `stty echo` as the first command in your `script` which generates an "in" stream.
```
[vagrant@localhost ~]$ script -ttypescript.timing -Itypescript.script
Script started, input log file is 'typescript.script', timing file is 'typescript.timing'.
[vagrant@localhost ~]$ stty echo
[vagrant@localhost ~]$ date
Sat Jul 20 10:50:21 PM UTC 2024
[vagrant@localhost ~]$ 
exit
Script done.
```

The `stty` command itself won't echo, but at least subsequent commands will.
```
[vagrant@localhost ~]$ scriptlive -ttypescript.timing -Itypescript.script
>>> scriptlive: Starting your typescript execution by /bin/bash.
[vagrant@localhost ~]$ 
[vagrant@localhost ~]$ date
Sat Jul 20 10:50:35 PM UTC 2024
[vagrant@localhost ~]$ 
exit

>>> scriptlive: done.
```

## The Fix

`scriptlive` already enables echo whenever stdin is not a tty. This PR makes `scriptlive` also enable echo when stdin *is a tty*.

Unlike `script`, `scriptlive` "owns" the inputs (i.e. the commands being re-run from an "in" stream). Therefore, this fix seems sensible to me.