### PR TITLE
lscpu: Skip aarch64 decode path for rest of the architectures

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -334,12 +334,47 @@ static int parse_id(const char *str)
 
 #define parse_model_id(_cxt)		(parse_id((_cxt)->model))
 
-static inline int parse_implementer_id(struct lscpu_cputype *ct)
+static inline int get_implementer_id(struct lscpu_cputype *ct)
 {
 	if (ct->vendor_id)
 		return ct->vendor_id;
-	ct->vendor_id = parse_id(ct->vendor);
+	return parse_id(ct->vendor);
+}
+
+static inline int parse_implementer_id(struct lscpu_cputype *ct)
+{
+	int id;
+
+	if (ct->vendor_id)
+		return ct->vendor_id;
+	id = get_implementer_id(ct);
+	if (id <= 0)
+		return id;
+
+	ct->vendor_id = id;
 	return ct->vendor_id;
+}
+
+int is_arm(struct lscpu_cxt *cxt)
+{
+	size_t i;
+
+	if (is_live(cxt))
+		return strcmp(cxt->arch->name, "aarch64") == 0;
+
+	/* dump; assume ARM if vendor ID is known */
+	for (i = 0; i < cxt->ncputypes; i++) {
+
+		int j, id = get_implementer_id(cxt->cputypes[i]);
+		if (id <= 0)
+			continue;
+		for (j = 0; hw_implementer[j].id != -1; j++) {
+			if (hw_implementer[j].id == id)
+				return 1;
+		}
+	}
+
+	return 0;
 }
 
 /*

--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -449,13 +449,13 @@ static int arm_rXpY_decode(struct lscpu_cputype *ct)
 
 static void arm_decode(struct lscpu_cxt *cxt, struct lscpu_cputype *ct)
 {
-	if (!cxt->noalive && access(_PATH_SYS_DMI, R_OK) == 0)
+	if (is_live(cxt) && access(_PATH_SYS_DMI, R_OK) == 0)
 		dmi_decode_cputype(ct);
 
 	arm_ids_decode(ct);
 	arm_rXpY_decode(ct);
 
-	if (!cxt->noalive && cxt->is_cluster)
+	if (is_live(cxt) && cxt->is_cluster)
 		ct->nr_socket_on_cluster = get_number_of_physical_sockets_from_dmi();
 }
 
@@ -463,7 +463,7 @@ static int is_cluster_arm(struct lscpu_cxt *cxt)
 {
 	struct stat st;
 
-	if (!cxt->noalive
+	if (is_live(cxt)
 	    && strcmp(cxt->arch->name, "aarch64") == 0
 	    && stat(_PATH_ACPI_PPTT, &st) < 0 && cxt->ncputypes == 1)
 		return 1;

--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -727,7 +727,7 @@ struct lscpu_arch *lscpu_read_architecture(struct lscpu_cxt *cxt)
 	ar = xcalloc(1, sizeof(*cxt->arch));
 	ar->name = xstrdup(utsbuf.machine);
 
-	if (cxt->noalive)
+	if (is_dump(cxt))
 		/* reading info from any /{sys,proc} dump, don't mix it with
 		 * information about our real CPU */
 		;
@@ -779,7 +779,7 @@ struct lscpu_arch *lscpu_read_architecture(struct lscpu_cxt *cxt)
 			ar->bit64 = 1;
 	}
 
-	if (ar->name && !cxt->noalive) {
+	if (ar->name && is_live(cxt)) {
 		if (strcmp(ar->name, "ppc64") == 0)
 			ar->bit32 = 1, ar->bit64 = 1;
 		else if (strcmp(ar->name, "ppc") == 0)
@@ -812,7 +812,7 @@ int lscpu_read_cpulists(struct lscpu_cxt *cxt)
 		/* note that kernel_max is maximum index [NR_CPUS-1] */
 		cxt->maxcpus += 1;
 
-	else if (!cxt->noalive)
+	else if (is_live(cxt))
 		/* the root is '/' so we are working with data from the current kernel */
 		cxt->maxcpus = get_max_number_of_cpus();
 
@@ -884,7 +884,7 @@ int lscpu_read_archext(struct lscpu_cxt *cxt)
 
 #if defined(HAVE_LIBRTAS)
 	/* Get PowerPC specific info */
-	if (!cxt->noalive) {
+	if (is_live(cxt)) {
 		int rc, len, ntypes;
 
 		ct->physsockets = ct->physchips = ct->physcoresperchip = 0;

--- a/sys-utils/lscpu-virt.c
+++ b/sys-utils/lscpu-virt.c
@@ -558,7 +558,7 @@ struct lscpu_virt *lscpu_read_virtualization(struct lscpu_cxt *cxt)
 			goto done;
 	}
 
-	if (!cxt->noalive) {
+	if (is_live(cxt)) {
 		virt->vendor = read_hypervisor_cpuid();
 		if (!virt->vendor)
 			virt->vendor = read_hypervisor_dmi();

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -1365,7 +1365,8 @@ int main(int argc, char *argv[])
 	lscpu_read_numas(cxt);
 	lscpu_read_topology(cxt);
 
-	lscpu_decode_arm(cxt);
+	if (is_arm(cxt))
+		lscpu_decode_arm(cxt);
 
 	cxt->virt = lscpu_read_virtualization(cxt);
 

--- a/sys-utils/lscpu.h
+++ b/sys-utils/lscpu.h
@@ -263,6 +263,9 @@ struct lscpu_cxt {
 	int is_cluster; /* For aarch64 if the machine doesn't have ACPI PPTT */
 };
 
+#define is_live(_cxt)	(!(_cxt)->noalive)
+#define is_dump(_cxt)	((_cxt)->noalive)
+
 #define is_cpu_online(_cxt, _cpu) \
 		((_cxt) && (_cpu) && (_cxt)->online && \
 		 CPU_ISSET_S((_cpu)->logical_id, (_cxt)->setsize, (_cxt)->online))

--- a/sys-utils/lscpu.h
+++ b/sys-utils/lscpu.h
@@ -271,6 +271,8 @@ struct lscpu_cxt {
 		((_cxt) && (_cpu) && (_cxt)->present && \
 		 CPU_ISSET_S((_cpu)->logical_id, (_cxt)->setsize, (_cxt)->present))
 
+int is_arm(struct lscpu_cxt *cxt);
+
 struct lscpu_cputype *lscpu_new_cputype(void);
 void lscpu_ref_cputype(struct lscpu_cputype *ct);
 void lscpu_unref_cputype(struct lscpu_cputype *ct);


### PR DESCRIPTION
lscpu behaves differently when run sudo vs non-sudo on AMD architectures.

On sudo runs, it adds a BIOS model name and BIOS CPU family which it does not add for the latter. However since this parsing from the DMI is primarily catered to aarch64, for AMD platform the BIOS model name is printed out as follows "AMD XXX Processor *Unknown* CPU @ X.XGHz" due to the part number is not populated on the platform.

The issue boils down to an unconditional call to arm_decode() which attempts to read the DMI path and populate the processor information such as processor version and part number which is set to Unknown on AMD CPUs.

81d6de9 (lscpu: remove the old code) changed the DMI path from /sys/firmware/dmi/entries/4-0/raw (non-existent) to /sys/firmware/dmi/tables/dmi (existent) which has brought this latent issue to light as DMI was starting to be parsed incorrectly.

Therefore, do not perform aarch64 parsing for other architectures.

Before
------
```
$ lscpu
Vendor ID:                AuthenticAMD
  Model name:             AMD EPYC XXXX X-Core Processor
    CPU family:           26

$ sudo lscpu
Vendor ID:                AuthenticAMD
  BIOS Vendor ID:         Advanced Micro Devices, Inc.
  Model name:             AMD EPYC XXXX X-Core Processor
    BIOS Model name:      AMD EPYC XXXX X-Core Processor        Unknown CPU @ X.XGHz
    BIOS CPU family:      107
    CPU family:           26
```
After
-----
```
$ lscpu
Vendor ID:                AuthenticAMD
  Model name:             AMD EPYC XXXX X-Core Processor
    CPU family:           26

$ sudo lscpu
Vendor ID:                AuthenticAMD
  Model name:             AMD EPYC XXXX X-Core Processor
    CPU family:           26
```

Having said that - this breaks existing behavior of showing BIOS model name and BIOS CPU family on sudo. However, If this behavior of populating BIOS info is intended and if we are receiving information beyond what cpuinfo has to offer (for x86), I have also written a simple patch that decuples the arch from the decode and performs a check for x86 unknown part numbers which corrects. If that is more preferred, I would be happy iterate over that branch as well - https://github.com/pratiksampat/util-linux/tree/lscpu/dmi-x86.

Any feedback/review on the approach is highly appreciated!