### PR TITLE
Fix read-only fallback with multiple filesystem types

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -630,7 +630,7 @@ static int do_mount_by_types(struct libmnt_context *cxt, const char *types)
 			rc = do_mount(cxt, p);
 		p = end ? end + 1 : NULL;
 		free(autotype);
-	} while (!is_success_status(cxt) && p);
+	} while (!is_termination_status(cxt) && p);
 
 	free(p0);
 	return rc;

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -581,6 +581,15 @@ static int is_success_status(struct libmnt_context *cxt)
 	return 0;
 }
 
+static int is_termination_status(struct libmnt_context *cxt)
+{
+	if (is_success_status(cxt))
+		return 1;
+
+	return mnt_context_get_syscall_errno(cxt) != EINVAL &&
+	       mnt_context_get_syscall_errno(cxt) != ENODEV;
+}
+
 /* try mount(2) for all items in comma separated list of the filesystem @types */
 static int do_mount_by_types(struct libmnt_context *cxt, const char *types)
 {
@@ -666,10 +675,7 @@ static int do_mount_by_pattern(struct libmnt_context *cxt, const char *pattern)
 	for (fp = filesystems; *fp; fp++) {
 		DBG(CXT, ul_debugobj(cxt, " ##### trying '%s'", *fp));
 		rc = do_mount(cxt, *fp);
-		if (is_success_status(cxt))
-			break;
-		if (mnt_context_get_syscall_errno(cxt) != EINVAL &&
-		    mnt_context_get_syscall_errno(cxt) != ENODEV)
+		if (is_termination_status(cxt))
 			break;
 	}
 	mnt_free_filesystems(filesystems);


### PR DESCRIPTION
Fix the read-only fallback for a command such as:
```
mount -t ntfs3,ntfs-3g /dev/sda1 /media
```
where `ntfs-3g` is not found and will return `ENODEV`.

This extracts the error handling logic from `do_mount_by_pattern()` and reuses it in `do_mount_by_types()` so that processing the list of filesystem types stops when a "useful" error is returned.