### PR TITLE
ci: build on MIPS

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -183,7 +183,7 @@ jobs:
             .github/workflows/cibuild.sh CHECK
 
   build-openwrt:
-    name: build (openwrt, ${{ matrix.target }})
+    name: build (openwrt, ${{ matrix.target }}/${{ matrix.subtarget}})
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ toJSON(matrix) }}-${{ github.ref }}

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -207,6 +207,12 @@ jobs:
           - target: x86
             subtarget: generic
             abi: musl
+          - target: octeon
+            subtarget: generic
+            abi: musl
+          - target: ramips
+            subtarget: mt7620
+            abi: musl
     env:
       COMPILER: none
     steps:


### PR DESCRIPTION
OpenWRT has SDKs targetting MIPS 32bit/64bit, bit and little endian. No other CI job currently builds util-linux on MIPS. Add a job for 32bit little endian and 64bit big endian, This should provide adequate coverage.