### PR TITLE
fdisk: fix sgi bootfile entry

### DIFF
--- a/disk-utils/fdisk-menu.c
+++ b/disk-utils/fdisk-menu.c
@@ -979,7 +979,7 @@ static int sgi_menu_cb(struct fdisk_context **cxt0,
 			rc = fdisk_toggle_partition_flag(cxt, n, SGI_FLAG_BOOT);
 		break;
 	case 'b':
-		fdisk_sgi_set_bootfile(cxt);
+		rc = fdisk_sgi_set_bootfile(cxt);
 		break;
 	case 'c':
 		rc = fdisk_ask_partnum(cxt, &n, FALSE);

--- a/libfdisk/src/sgi.c
+++ b/libfdisk/src/sgi.c
@@ -391,8 +391,8 @@ static int sgi_check_bootfile(struct fdisk_context *cxt, const char *name)
 
 	sz = strlen(name);
 
-	if (sz < 3) {
-		/* "/a\n" is minimum */
+	if (sz < 2) {
+		/* "/a" is minimum */
 		fdisk_warnx(cxt, _("Invalid bootfile!  The bootfile must "
 				   "be an absolute non-zero pathname, "
 				   "e.g. \"/unix\" or \"/unix.save\"."));

--- a/libfdisk/src/sgi.c
+++ b/libfdisk/src/sgi.c
@@ -447,8 +447,10 @@ int fdisk_sgi_set_bootfile(struct fdisk_context *cxt)
 	if (rc == 0)
 		rc = sgi_check_bootfile(cxt, name);
 	if (rc) {
-		if (rc == 1)
+		if (rc == 1) {
 			fdisk_info(cxt, _("Boot file is unchanged."));
+			rc = 0;
+		}
 		goto done;
 	}
 

--- a/libfdisk/src/sgi.c
+++ b/libfdisk/src/sgi.c
@@ -443,7 +443,7 @@ int fdisk_sgi_set_bootfile(struct fdisk_context *cxt)
 
 	fdisk_info(cxt, _("The current boot file is: %s"), sgilabel->boot_file);
 
-	rc = fdisk_ask_string(cxt, _("Enter of the new boot file"), &name);
+	rc = fdisk_ask_string(cxt, _("Enter full path of the new boot file"), &name);
 	if (rc == 0)
 		rc = sgi_check_bootfile(cxt, name);
 	if (rc) {


### PR DESCRIPTION
Four small fixes to entering a boot file name for an SGI disk volume header with fdisk.
1. The prompt was missing words.
2. The name minimum length was wrong.
3. The return value was wrong.
4. The return value was never passed up the chain, but the default -EINVAL instead.