### PR TITLE
meson: fix generated header paths while compiling as subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2890,7 +2890,7 @@ endif
 errnos_h = custom_target('errnos.h',
   input : 'tools/all_errnos',
   output : 'errnos.h',
-  command : ['tools/all_errnos', sed.full_path(),
+  command : ['tools/all_errnos', sed.full_path(), '@OUTPUT@',
              cc.cmd_array(), get_option('c_args')],
 )
 
@@ -3222,7 +3222,7 @@ endif
 syscalls_h = custom_target('syscalls.h',
   input : 'tools/all_syscalls',
   output : 'syscalls.h',
-  command : ['tools/all_syscalls', sed.full_path(),
+  command : ['tools/all_syscalls', sed.full_path(), '@OUTPUT@',
              cc.cmd_array(), get_option('c_args')],
 )
 

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -1,6 +1,6 @@
 errnos.h: $(top_srcdir)/tools/all_errnos
 	@echo '  GEN      $@'
-	@$(top_srcdir)/tools/all_errnos "$(SED)" $(CC) $(CFLAGS)
+	@$(top_srcdir)/tools/all_errnos "$(SED)" "$@" $(CC) $(CFLAGS)
 
 -include errnos.h.deps
 CLEANFILES += errnos.h errnos.h.deps
@@ -314,7 +314,7 @@ misc-utils/enosys.c: syscalls.h errnos.h
 
 syscalls.h: $(top_srcdir)/tools/all_syscalls
 	@echo '  GEN      $@'
-	@$(top_srcdir)/tools/all_syscalls "$(SED)" $(CC) $(CFLAGS)
+	@$(top_srcdir)/tools/all_syscalls "$(SED)" "$@" $(CC) $(CFLAGS)
 
 -include syscalls.h.deps
 CLEANFILES += syscalls.h syscalls.h.deps

--- a/tools/all_errnos
+++ b/tools/all_errnos
@@ -7,7 +7,8 @@ set -o pipefail
 
 SED="$1"
 shift
-OUTPUT=errnos.h
+OUTPUT="$1"
+shift
 ERRNO_INCLUDES="
 #include <sys/errno.h>
 "

--- a/tools/all_syscalls
+++ b/tools/all_syscalls
@@ -5,7 +5,8 @@ set -o pipefail
 
 SED="$1"
 shift
-OUTPUT=syscalls.h
+OUTPUT="$1"
+shift
 SYSCALL_INCLUDES="
 #include <sys/syscall.h>
 "


### PR DESCRIPTION
# Background and description

While creating a wrap-file for util-linux, I came across an issue with the paths of the generated
headers `syscalls.h` and `errnos.h`:

The output-path is currently the execution-path of the underlying scripts (`tools/all_syscalls` and
`tools/all_errnos`). This is by default the topmost build-directory in meson-build. However, when
adding util-linux as a subproject to any other project, it will lead to an error, as the topmost
build-directory is not an include-path (and should not!) of any of the util-linux' build-targets.

# How to reproduce

* Checkout <https://github.com/mesonbuild/wrapdb.git>
* Create the file `subprojects/util-linux.wrap` with the following content:
```
[wrap-git]
directory=util-linux
url=https://github.com/util-linux/util-linux.git
#revision=v2.40.2
revision=master
depth=1

[provide]
fdisk = fdisk_dep
mount = mount_dep
lastlog2 = lastlog2_dep
smartcols = smartcols_dep
blkid = blkid_dep
uuid = uuid_dep
program_names = chfn, chsh, last, nologin, utmpdump, su, newgrp, lslogins, vipw, runuser, col, colcrt, colrm, rev, column, line, pg, ul, more, hexdump, lsmem, chmem, choom, ipcmk, ipcrm, ipcs, rfkill, renice, setgpid, setsid, readprovile, tunelp, fstrim, dmesg, ctrlaltdel, fsfreeze, blkdiscard, blkzone, blkpr, ldattach, rtcwake, setarch, eject, losetup, zramctl, prlimit, lsns, mount, umount, swapon, swapoff, lscpu, chcpu, wdctl, mountpoint, fallocate, pivot_root, switch_root, unshare, nsenter, setpriv, flock, lsirq, irqtop, lsipc, hwclock, mkfs, isosize, mkswap, swaplabel, fsck, mkfs.minix, fsck.minix, mkfs.cramfs, fsck.cramfs, raw, fdformat, blockdev, fdisk, sfdisk, cfdisk, addpart, delpart, resizepart, partx, script scriptlive, scriptreplay, agetty, setterm, mesg, wall, write, login, sulogin, cal, logger, look, mcookie, lastlog2, namei, whereis, lslocks, lsblk, lsfd, uuidgen, uuidparse, uuidd, blkid, sample-mkfs, sample-partitions, sample-superblocks, sample-topology, findfs, wipefs, findmnt, kill, rename, getopt, fincore, hardlink, pipesz, fadvise, waitpid, enosys, lsclocks, exch, chrt, ionice, taksset, uclampset, coresched
```
* Setup and configure a build-directory with: `meson setup -Dwraps=util-linux "$BUILD_DIR"`
* Try to compile with: `meson compile -C "$BUILD_DIR"`

You will reach a similar error-message:
```
../subprojects/util-linux/lsfd-cmd/file.c:246:10: fatal error: errnos.h: No such file or directory
  246 | #include "errnos.h"
      |          ^~~~~~~~~~
compilation terminated.
```

# Proposal

There are several possible ways to correctly specify the output-path for `custom_target`s in
meson-build:
* Add explicitly the output-path to the executed command
* Use the `capture`-flag to let meson-build internally handle the output-path
* Some more fancy solutions, such as providing the output-path via a custom environment

My pull-request applies the first option.
