### PR TITLE
Revert "autotools: make pam install path configurable"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,6 @@ usrsbin_exec_PROGRAMS =
 man_MANS =
 pkgconfig_DATA =
 usrlib_exec_LTLIBRARIES =
-usrsecurelib_exec_LTLIBRARIES =
 bin_PROGRAMS =
 sbin_PROGRAMS =
 dist_usrbin_exec_SCRIPTS =

--- a/configure.ac
+++ b/configure.ac
@@ -120,9 +120,6 @@ AS_CASE([$libdir],
 )
 AC_SUBST([usrlib_execdir])
 
-usrsecurelib_execdir='${usrlib_execdir}/security'
-AC_SUBST([usrsecurelib_execdir])
-
 # static configuration maintained by packages (e.g. /usr/lib)
 AC_ARG_VAR([SYSCONFSTATICDIR],
 	   [Path to static system configuration, default ${prefix}/lib])

--- a/pam_lastlog2/src/Makemodule.am
+++ b/pam_lastlog2/src/Makemodule.am
@@ -1,4 +1,5 @@
-usrsecurelib_exec_LTLIBRARIES += pam_lastlog2.la
+securelibdir = $(libdir)/security
+securelib_LTLIBRARIES = pam_lastlog2.la
 
 pam_lastlog2_la_SOURCES = \
 	pam_lastlog2/src/pam_lastlog2.c


### PR DESCRIPTION
This reverts commit 8c03e75c0b837f4285bd34f08eae40b48d3378be.

If people want to use /lib instead of /usr/lib as $(libdir) and want lastlog2 pam module installed in /lib/security, there's no way to do so.

Beside, we have:
pam_lastlog2/meson.build:        pamlibdir = get_option('libdir') / 'security'

So things are not in sync between Makemodule.am and meson.build with the original commit.