### PR TITLE
libblkid: improve portability

### DIFF
--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -972,10 +972,19 @@ failed:
 
 #endif
 
-#ifdef BLKIOOPT
 static uint64_t blkid_get_io_size(int fd)
 {
-	static const int ioctls[] = { BLKIOOPT, BLKIOMIN, BLKBSZGET };
+	static const int ioctls[] = {
+#ifdef BLKIOOPT
+		BLKIOOPT,
+#endif
+#ifdef BLKIOMIN
+		BLKIOMIN,
+#endif
+#ifdef BLKBSZGET
+		BLKBSZGET,
+#endif
+	};
 	unsigned int s;
 	size_t i;
 	int r;
@@ -988,7 +997,6 @@ static uint64_t blkid_get_io_size(int fd)
 
 	return DEFAULT_SECTOR_SIZE;
 }
-#endif
 
 /**
  * blkid_probe_set_device:
@@ -1197,10 +1205,8 @@ int blkid_probe_set_device(blkid_probe pr, int fd,
 	}
 # endif
 
-#ifdef BLKIOOPT
 	if (S_ISBLK(sb.st_mode) && !is_floppy && !blkid_probe_is_tiny(pr))
 		pr->io_size = blkid_get_io_size(fd);
-#endif
 
 	DBG(LOWPROBE, ul_debug("ready for low-probing, offset=%"PRIu64", size=%"PRIu64", zonesize=%"PRIu64", iosize=%"PRIu64,
 				pr->off, pr->size, pr->zone_size, pr->io_size));


### PR DESCRIPTION
This PR propose to fix compilation error on Cygwin due to BLKBSZGET is missing.
In some cases where is `ioctls` is empty (may impossible?), `blkid_get_io_size()` simply and consistently returns `DEFAULT_SECTOR_SIZE` without any redundant assembly code.
Similar with util-linux/util-linux@224f299896db3021e4761e5f8abf9f2ec1d74c47, but I don't know if that's a good way to do it.