### PR TITLE
Define EXIT_ENOSYS in test helpers

### DIFF
--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -73,6 +73,7 @@
 #define EXIT_EPROTONOSUPPORT 20
 #define EXIT_EACCES 21
 #define EXIT_ENOENT 22
+#define EXIT_ENOSYS 23
 
 #define _U_ __attribute__((__unused__))
 


### PR DESCRIPTION
A bit of background, at conda-forge we target 2.17, so ENOSYS isn't really defined.

xref: https://github.com/conda-forge/util-linux-feedstock/pull/42