### PR TITLE
more: fix compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2501,7 +2501,7 @@ AC_ARG_ENABLE([more],
 )
 UL_BUILD_INIT([more])
 UL_REQUIRES_HAVE([more], [ncursesw, ncurses], [ncursesw or ncurses libraries])
-UL_REQUIRES_LINUX([more])
+UL_REQUIRES_HAVE([more], [sys_signalfd_h], [sys/signalfd.h header])
 AM_CONDITIONAL([BUILD_MORE], [test "x$build_more" = xyes])
 
 

--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -57,7 +57,6 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/file.h>
-#include <sys/ttydefaults.h>
 #include <sys/wait.h>
 #include <regex.h>
 #include <assert.h>
@@ -65,6 +64,10 @@
 #include <sys/signalfd.h>
 #include <paths.h>
 #include <getopt.h>
+
+#ifdef HAVE_SYS_TTYDEFAULTS_H
+# include <sys/ttydefaults.h>
+#endif
 
 #if defined(HAVE_NCURSESW_TERM_H)
 # include <ncursesw/term.h>


### PR DESCRIPTION
This PR is attempted to simply fixes compilation error on Cygwin due to the missing `sys/ttydefaults.h`.
These codes are taken from [2.39.3-cygwin-more.patch](https://cygwin.com/cgit/cygwin-packages/util-linux/tree/2.39.3-cygwin-more.patch) on Cygwin.
`more` maybe works properly on other platforms (like FreeBSD), however I'm not tested.