### PR TITLE
bash-completion: look: disable completion if dictionary is not available

### DIFF
--- a/bash-completion/look
+++ b/bash-completion/look
@@ -22,7 +22,17 @@ _look_module()
 	esac
 	case $COMP_CWORD in
 		1)
-			COMPREPLY=( $(compgen -W "$(look "$cur")" -- $cur) )
+			[ -f /usr/share/dict/words ] || return 0
+			if [ "$cur" ]; then
+				COMPREPLY=( $(compgen -W "$(look "$cur")" -- $cur) )
+			else
+				COMPREPLY=( $(compgen -W \
+					      "0 1 2 3 4 5 6 7 8 9 \
+					       a b c d e f g h i j k l m n o p \
+					       q r s t u v w x y z \
+					       A B C D E F G H I J K L M N O P \
+					       Q R S T U V W X Y Z") )
+			fi
 			;;
 		2)
 			local IFS=$'\n'


### PR DESCRIPTION
look(1) opens /usr/share/dict/words as dictionary by default. Doing TAB completion for look(1) without the dictionary installed will result in popups like

	$ look look: /usr/share/dict/words: No such file or directory

messing up the terminal.

As /usr/share/dict/words is not shipped by quite a few distros nowadays and it should not be listed as a hard dependency of util-linux, we make sure the dictionary exists before calling look(1) when doing completion, avoiding these error messages.