### PR TITLE
sfdisk: add --discard-free

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -52,7 +52,7 @@ jobs:
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
       - name: Upload Crash
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure() && steps.build.outcome == 'success'
         with:
           name: ${{ matrix.sanitizer }}-${{ matrix.architecture }}-artifacts

--- a/bash-completion/sfdisk
+++ b/bash-completion/sfdisk
@@ -58,6 +58,7 @@ _sfdisk_module()
 				--show-geometry
 				--list
 				--list-free
+				--discard-free
 				--disk-id
 				--reorder
 				--show-size

--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -59,9 +59,6 @@
 # ifdef HAVE_LINUX_FS_H
 #  include <linux/fs.h>
 # endif
-# ifndef BLKDISCARD
-#   define BLKDISCARD     _IO(0x12,119)
-# endif
 #endif
 
 int pwipemode = WIPEMODE_AUTO;

--- a/disk-utils/sfdisk.8.adoc
+++ b/disk-utils/sfdisk.8.adoc
@@ -116,6 +116,13 @@ Change the GPT partition UUID. If _uuid_ is not specified, then print the curren
 *--disk-id* _device_ [__id__]::
 Change the disk identifier. If _id_ is not specified, then print the current identifier. The identifier is UUID for GPT or unsigned integer for MBR.
 
+*--discard-free* _device_ ::
+Discard any unused (unpartitioned) sectors on the device. Use the *--list-free* option to get a list of the free regions. See also *blkdiscard*(8).
++
+WARNING: All data in the discarded regions on the device will be lost! Do not use this option if you are unsure.
++
+Note that the 'T' command in *fdisk* provides a dialog to specify which unused area should be discarded. However, *sfdisk* always discards all unpartitioned regions (except for the areas where it is not possible to create partitions, such as the beginning of the device).
+
 *-r*, *--reorder* _device_::
 Renumber the partitions, ordering them by their start offset.
 

--- a/include/blkdev.h
+++ b/include/blkdev.h
@@ -59,6 +59,17 @@
 #  define BLKPBSZGET _IO(0x12,123)
 # endif
 
+/* discard area on a device */
+#ifndef BLKDISCARD
+# define BLKDISCARD	_IO(0x12,119)
+#endif
+#ifndef BLKSECDISCARD
+# define BLKSECDISCARD	_IO(0x12,125)
+#endif
+#ifndef BLKZEROOUT
+# define BLKZEROOUT	_IO(0x12,127)
+#endif
+
 /* discard zeroes support, introduced in 2.6.33 (commit 98262f27) */
 # ifndef BLKDISCARDZEROES
 #  define BLKDISCARDZEROES _IO(0x12,124)
@@ -79,7 +90,6 @@
 # ifndef CDROM_GET_CAPABILITY
 #  define CDROM_GET_CAPABILITY 0x5331
 # endif
-
 #endif /* __linux */
 
 

--- a/sys-utils/blkdiscard.8.adoc
+++ b/sys-utils/blkdiscard.8.adoc
@@ -24,7 +24,7 @@ The _device_ argument is the pathname of the block device.
 
 *WARNING: All data in the discarded region on the device will be lost!*
 
-Since util-linux v2.41, fdisk has the ability to discard sectors on both partitions and unpartitioned areas using the 'T' command.
+Since util-linux v2.41, *fdisk* has the ability to discard sectors on both partitions and unpartitioned areas using the 'T' command. Additionally, *sfdisk* has the option --discard-free to discard unpartitioned areas.
 
 == OPTIONS
 

--- a/sys-utils/blkdiscard.c
+++ b/sys-utils/blkdiscard.c
@@ -48,18 +48,7 @@
 #include "closestream.h"
 #include "monotonic.h"
 #include "exitcodes.h"
-
-#ifndef BLKDISCARD
-# define BLKDISCARD	_IO(0x12,119)
-#endif
-
-#ifndef BLKSECDISCARD
-# define BLKSECDISCARD	_IO(0x12,125)
-#endif
-
-#ifndef BLKZEROOUT
-# define BLKZEROOUT	_IO(0x12,127)
-#endif
+#include "blkdev.h"
 
 enum {
 	ACT_DISCARD = 0,	/* default */


### PR DESCRIPTION
Why do we need this? It can be difficult for end-users to discard
    unpartitioned areas using blkdiscard, as it requires using fdisk to
    obtain a list of free areas and then using blkdiscard with the correct
    --offset and --length options. It is less risky for end-users to use
    (s)fdisk, as they have a better understanding of the disk layout.