### PR TITLE
lsfd + nsenter: Parse and allow to join target process's network namespace

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -628,6 +628,7 @@ AC_CHECK_FUNCS([ \
 	ntp_gettime \
 	open_tree \
 	personality \
+	pidfd_getfd \
 	pidfd_open \
 	pidfd_send_signal \
 	posix_fadvise \
@@ -682,6 +683,7 @@ AS_IF([test "x$ul_cv_syscall_setns" = xno], [
    have_setns_syscall="no"
 ])
 
+UL_CHECK_SYSCALL([pidfd_getfd])
 UL_CHECK_SYSCALL([pidfd_open])
 UL_CHECK_SYSCALL([pidfd_send_signal])
 UL_CHECK_SYSCALL([close_range])

--- a/include/pidfd-utils.h
+++ b/include/pidfd-utils.h
@@ -31,6 +31,13 @@ static inline int pidfd_open(pid_t pid, unsigned int flags)
 }
 #  endif
 
+#  ifndef HAVE_PIDFD_GETFD
+static inline int pidfd_getfd(int pidfd, int targetfd, unsigned int flags)
+{
+	return syscall(SYS_pidfd_getfd, pidfd, targetfd, flags);
+}
+#  endif
+
 #  define UL_HAVE_PIDFD 1
 
 # endif	/* SYS_pidfd_send_signal */
@@ -48,6 +55,14 @@ static inline int pidfd_send_signal(int pidfd __attribute__((unused)),
 
 static inline int pidfd_open(pid_t pid __attribute__((unused)),
 			     unsigned int flags __attribute__((unused)))
+{
+	errno = ENOSYS;
+	return -1;
+}
+
+static inline int pidfd_getfd(int pidfd __attribute__((unused)),
+			      int targetfd __attribute__((unused)),
+			      unsigned int flags __attribute__((unused)))
 {
 	errno = ENOSYS;
 	return -1;

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -881,6 +881,7 @@ static struct file *collect_file_symlink(struct path_cxt *pc,
 
 	else if (assoc >= 0) {
 		/* file-descriptor based association */
+		bool is_socket = (sb.st_mode & S_IFMT) == S_IFSOCK;
 		FILE *fdinfo;
 
 		if (ul_path_stat(pc, &sb, AT_SYMLINK_NOFOLLOW, name) == 0)
@@ -888,6 +889,9 @@ static struct file *collect_file_symlink(struct path_cxt *pc,
 
 		if (is_nsfs_dev(f->stat.st_dev))
 			load_sock_xinfo(pc, name, f->stat.st_ino);
+
+		if (is_socket)
+			load_fdsk_xinfo(proc, assoc);
 
 		fdinfo = ul_path_fopenf(pc, "r", "fdinfo/%d", assoc);
 		if (fdinfo) {

--- a/lsfd-cmd/lsfd.h
+++ b/lsfd-cmd/lsfd.h
@@ -302,6 +302,7 @@ void add_nodev(unsigned long minor, const char *filesystem);
  */
 void load_sock_xinfo(struct path_cxt *pc, const char *name, ino_t netns);
 bool is_nsfs_dev(dev_t dev);
+void load_fdsk_xinfo(struct proc *proc, int fd);
 
 /*
  * POSIX Mqueue

--- a/sys-utils/nsenter.1.adoc
+++ b/sys-utils/nsenter.1.adoc
@@ -91,6 +91,9 @@ Enter the IPC namespace. If no file is specified, enter the IPC namespace of the
 *-n*, *--net*[=_file_]::
 Enter the network namespace. If no file is specified, enter the network namespace of the target process. If _file_ is specified, enter the network namespace specified by _file_.
 
+*-N*, *--net-socket* _fd_::
+Enter the network namespace of the target process's socket. It requires *--target* process specified.
+
 *-p*, *--pid*[=_file_]::
 Enter the PID namespace. If no file is specified, enter the PID namespace of the target process. If _file_ is specified, enter the PID namespace specified by _file_.
 


### PR DESCRIPTION
Arista's userspace uses network namespaces a lot, including userspace VRFs, some form of containers, etc. Because of that, processes such as BGP may have many file descriptors in different network namespaces. There were issues with file descriptor leaks, which resulted in userspace misbehaviour and it was challenging to find which process/fd prevents some network namespace from being destructed. It resulted years ago in a kernel patch that provides `/proc/<pid>/fdns/...` links for each socket to its corresponding network namespace.

But we are in 2024 and I don't want to have or maintain such a patch. The userspace is fully capable of figuring out all the needed details about the sockets. Initially, I wrote a stand-alone tool that allows joining and showing the information about the socket's network namespaces: https://github.com/util-linux/util-linux/commit/31f071702cf6a1a6e86147687920ae2d84cb2706

But I thought it was worth giving it a chance and integrating it into existing tools.
