### PR TITLE
libmount: add X-mount.nocanonicalize[=source|target]

### DIFF
--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -1854,6 +1854,9 @@ int mnt_context_open_tree(struct libmnt_context *cxt, const char *path, unsigned
 	if (cxt->force_clone)
 		oflg |= OPEN_TREE_CLONE;
 
+	if (mnt_context_is_xnocanonicalize(cxt, "source"))
+		oflg |= AT_SYMLINK_NOFOLLOW;
+
 	DBG(CXT, ul_debugobj(cxt, "open_tree(path=%s%s%s)", path,
 				oflg & OPEN_TREE_CLONE ? " clone" : "",
 				oflg & AT_RECURSIVE ? " recursive" : ""));

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -726,7 +726,7 @@ static int prepare_target(struct libmnt_context *cxt)
 		return -MNT_ERR_NAMESPACE;
 
 	/* canonicalize the path */
-	if (rc == 0) {
+	if (rc == 0 && !mnt_context_is_xnocanonicalize(cxt, "target")) {
 		struct libmnt_cache *cache = mnt_context_get_cache(cxt);
 
 		if (cache) {

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -654,6 +654,8 @@ extern int mnt_context_apply_fs(struct libmnt_context *cxt, struct libmnt_fs *fs
 
 extern struct libmnt_optlist *mnt_context_get_optlist(struct libmnt_context *cxt);
 
+extern int mnt_context_is_xnocanonicalize(struct libmnt_context *cxt, const char *type);
+
 /* tab_update.c */
 extern int mnt_update_emit_event(struct libmnt_update *upd);
 extern int mnt_update_set_filename(struct libmnt_update *upd, const char *filename);

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -319,7 +319,7 @@ Note that it is a bad practice to use *mount -a* for _fstab_ checking. The recom
 Remount a subtree somewhere else (so that its contents are available in both places). See above, under *Bind mount operation*.
 
 *-c*, *--no-canonicalize*::
-Don't canonicalize paths. The *mount* command canonicalizes all paths (from the command line or _fstab_) by default. This option can be used together with the *-f* flag for already canonicalized absolute paths. The option is designed for mount helpers which call *mount -i*. It is strongly recommended to not use this command-line option for normal mount operations.
+Do not canonicalize any paths or tags during the mount process. The *mount* command automatically canonicalizes all paths (from the command line or _fstab_). This option can be used in conjunction with the *-f* flag for paths that are already canonicalized. This option is intended for mount helpers that call *mount -i*. It is highly recommended to not use this command-line option for regular mount operations. See also the X-mount.nocanonicalize mount options.
 +
 Note that *mount* does not pass this option to the **/sbin/mount.**__type__ helpers.
 
@@ -713,6 +713,13 @@ ____
 
 *X-mount.mkdir*[=_mode_]::
 Allow to make a target directory (mountpoint) if it does not exist yet. The optional argument _mode_ specifies the filesystem access mode used for *mkdir*(2) in octal notation. The default mode is 0755. This functionality is supported only for root users or when *mount* is executed without suid permissions. The option is also supported as *x-mount.mkdir*, but this notation is deprecated since v2.30. See also *--mkdir* command line option.
+
+*X-mount.nocanonicalize*[=_type_]::
+Allows disabling of canonicalization for mount source and target paths. By default, the `mount` command resolves all paths to their absolute paths without symlinks. However, this behavior may not be desired in certain situations, such as when bind-mounting over a symlink. The optional argument _type_ can be either "source" or "target" (mountpoint). If no _type_ is specified, then canonicalization is disabled for both types. This mount option does not affect the conversion of source tags (e.g. LABEL= or UUID=) and fstab processing.
++
+The command line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations.
++
+Note that *mount*(8) still sanitizes and canonicalizes the source and target paths specified on the command line by non-root users, regardless of the X-mount.nocanonicalize setting.
 
 **X-mount.subdir=**__directory__::
 Allow mounting sub-directory from a filesystem instead of the root directory. For now, this feature is implemented by temporary filesystem root directory mount in unshared namespace and then bind the sub-directory to the final mount point and umount the root of the filesystem. The sub-directory mount shows up atomically for the rest of the system although it is implemented by multiple *mount*(2) syscalls.

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -715,9 +715,9 @@ ____
 Allow to make a target directory (mountpoint) if it does not exist yet. The optional argument _mode_ specifies the filesystem access mode used for *mkdir*(2) in octal notation. The default mode is 0755. This functionality is supported only for root users or when *mount* is executed without suid permissions. The option is also supported as *x-mount.mkdir*, but this notation is deprecated since v2.30. See also *--mkdir* command line option.
 
 *X-mount.nocanonicalize*[=_type_]::
-Allows disabling of canonicalization for mount source and target paths. By default, the `mount` command resolves all paths to their absolute paths without symlinks. However, this behavior may not be desired in certain situations, such as when bind-mounting over a symlink. The optional argument _type_ can be either "source" or "target" (mountpoint). If no _type_ is specified, then canonicalization is disabled for both types. This mount option does not affect the conversion of source tags (e.g. LABEL= or UUID=) and fstab processing.
+Allows disabling of canonicalization for mount source and target paths. By default, the `mount` command resolves all paths to their absolute paths without symlinks. However, this behavior may not be desired in certain situations, such as when binding a mount over a symlink, or a symlink over a directory or another symlink. The optional argument _type_ can be either "source" or "target" (mountpoint). If no _type_ is specified, then canonicalization is disabled for both types. This mount option does not affect the conversion of source tags (e.g. LABEL= or UUID=) and fstab processing.
 +
-The command line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations.
+The command line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but it does not modify flags for open_tree syscalls.
 +
 Note that *mount*(8) still sanitizes and canonicalizes the source and target paths specified on the command line by non-root users, regardless of the X-mount.nocanonicalize setting.
 

--- a/tests/expected/mount/xnocanon-file-over-symlink
+++ b/tests/expected/mount/xnocanon-file-over-symlink
@@ -1,0 +1,2 @@
+A-data
+regular file

--- a/tests/expected/mount/xnocanon-symlink-over-file
+++ b/tests/expected/mount/xnocanon-symlink-over-file
@@ -1,0 +1,2 @@
+A-data
+symbolic link

--- a/tests/expected/mount/xnocanon-symlink-over-symlink
+++ b/tests/expected/mount/xnocanon-symlink-over-symlink
@@ -1,0 +1,2 @@
+A-data
+symbolic link

--- a/tests/ts/mount/xnocanon
+++ b/tests/ts/mount/xnocanon
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Karel Zak <kzak@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="X-mount.nocanonicalize"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_MOUNT"
+ts_check_test_command "$TS_CMD_UMOUNT"
+ts_check_test_command "$TS_CMD_FINDMNT"
+
+ts_skip_nonroot
+
+[ "$("$TS_HELPER_SYSINFO" fsopen-ok)" == "1" ] || ts_skip "no fs-API"
+
+[ -d $TS_MOUNTPOINT ] || mkdir -p $TS_MOUNTPOINT
+
+SYMLINK_A="$TS_OUTDIR/${TS_TESTNAME}-symlink-A"
+SYMLINK_B="$TS_OUTDIR/${TS_TESTNAME}-symlink-B"
+
+FILE_A="$TS_OUTDIR/${TS_TESTNAME}-file-A"
+FILE_B="$TS_OUTDIR/${TS_TESTNAME}-file-B"
+
+rm -f $FILE_A $FILE_B $SYMLINK_A $SYMLINK_B
+
+echo "A-data" > $FILE_A
+echo "B-data" > $FILE_B
+
+ln -s $FILE_A $SYMLINK_A
+ln -s $FILE_B $SYMLINK_B
+
+
+# Symlink converted to file
+#
+ts_init_subtest "file-over-symlink"
+$TS_CMD_MOUNT -o X-mount.nocanonicalize --bind $FILE_A $SYMLINK_B >> $TS_OUTPUT 2>> $TS_ERRLOG
+udevadm settle
+cat $SYMLINK_B >> $TS_OUTPUT
+stat -c '%F' $SYMLINK_B >> $TS_OUTPUT
+$TS_CMD_UMOUNT $SYMLINK_B >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+# File converted to symlink
+#
+ts_init_subtest "symlink-over-file"
+$TS_CMD_MOUNT -o X-mount.nocanonicalize --bind $SYMLINK_A $FILE_B >> $TS_OUTPUT 2>> $TS_ERRLOG
+udevadm settle
+cat $FILE_B >> $TS_OUTPUT
+stat -c '%F' $FILE_B >> $TS_OUTPUT
+$TS_CMD_UMOUNT $FILE_B >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+# Symlink converted to another symlink
+#
+ts_init_subtest "symlink-over-symlink"
+$TS_CMD_MOUNT -o X-mount.nocanonicalize --bind $SYMLINK_A $SYMLINK_B >> $TS_OUTPUT 2>> $TS_ERRLOG
+udevadm settle
+cat $SYMLINK_B >> $TS_OUTPUT
+stat -c '%F' $SYMLINK_B >> $TS_OUTPUT
+$TS_CMD_UMOUNT $SYMLINK_B >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+
+ts_finalize


### PR DESCRIPTION
The new kernel mount API can bind-mount over a symlink. However, this feature does not work with libmount because it canonicalizes all paths by default. A possible workaround is to use the --no-canonicalize option on the mount(8) command line, but this is a heavy-handed solution as it disables all conversions for all paths and tags (such as LABEL=) and fstab processing.

This commit introduces the X-mount.nocanonicalize userspace mount option to control canonicalization. It only affects paths used for mounting and does not affect tags and searching in fstab. Additionally, this setting possible to use in fstab.

If the optional argument [=source|target] is not specified, then paths canonicalization is disabled for both the source and target paths.

Adresses: https://github.com/util-linux/util-linux/issues/2370