### PR TITLE
partx: Fix example in man page

### DIFF
--- a/disk-utils/partx.8.adoc
+++ b/disk-utils/partx.8.adoc
@@ -122,7 +122,7 @@ Lists the length in sectors and human-readable size of partition 5 on _/dev/sda_
 partx --add --nr 3:5 /dev/sdd::
 Adds all available partitions from 3 to 5 (inclusive) on _/dev/sdd_.
 
-partx -d --nr :-1 /dev/sdd::
+partx -d --nr -1: /dev/sdd::
 Removes the last partition on _/dev/sdd_.
 
 == AUTHORS


### PR DESCRIPTION
The example is:

  partx -d --nr :-1 /dev/sdd
  Removes the last partition on _/dev/sdd_.

The documentation says:

           M:
               Specifies the lower limit only (e.g. --nr 2:).

           :N
               Specifies the upper limit only (e.g. --nr :4).

In the above example the lower limit is not set and the upper is set to the last partition, meaning all partitions. The lower limit should be set instead.

  partx -d --nr -1: /dev/sdd