### PR TITLE
CI: Downgrade checkout version for compat build

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -136,7 +136,7 @@ jobs:
       image: ${{ matrix.image }}
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v1
       - name: Ubuntu setup
         run: .github/workflows/cibuild-setup-ubuntu.sh
       - name: Configure


### PR DESCRIPTION
The current checkout action does not run on Ubuntu 18.04

/usr/bin/docker exec  90a3de3652fb2e69b0cf70fc8567dba6b1a25bf1a6645236d19bb6f1486c6158 sh -c "cat /etc/*release | grep ^ID" /__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)

Fixes: #3215