### PR TITLE
meson: test for pidfd_getfd()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -587,6 +587,7 @@ funcs = '''
         ntp_gettime
         open_tree
         personality
+        pidfd_getfd
         pidfd_open
         pidfd_send_signal
         posix_fadvise


### PR DESCRIPTION
Commit 55c7120accab ("nsenter: Provide an option to join target process's socket net namespace") added stubs for pidfd_getfd() but didn't add the code for meson to check if the function is already available.