### PR TITLE
login-utils/su-common: Validate all return values again

### DIFF
--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -423,6 +423,8 @@ static void supam_authenticate(struct su_context *su)
 	rc = pam_acct_mgmt(su->pamh, 0);
 	if (rc == PAM_NEW_AUTHTOK_REQD)
 		rc = pam_chauthtok(su->pamh, PAM_CHANGE_EXPIRED_AUTHTOK);
+	if (is_pam_failure(rc))
+		goto done;
 
 	rc = pam_get_item(su->pamh, PAM_USER, (const void **) &pam_user);
 	if (is_pam_failure(rc))


### PR DESCRIPTION
The additional coded added in commit
d6564701e812 ("login-utils/su-common: Check that the user didn't change during PAM transaction") was inserted in between the assignment and tests of "rc", making the return value unchecked.
Add a new explicit check.