### PR TITLE
tests: (test_mkfds) don't close fds and free memorobjects when exiting with EXIT_FAILURE

### DIFF
--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -2519,7 +2519,9 @@ static void *make_mqueue(const struct factory *factory, struct fdesc fdescs[],
 
 	fd = mq_open(mqueue_data->path, O_CREAT|O_EXCL | O_RDONLY, S_IRUSR | S_IWUSR, &attr);
 	if (fd < 0) {
+		int e = errno;
 		mqueue_data_free(mqueue_data);
+		errno = e;
 		err(EXIT_FAILURE, "failed in mq_open(3) for reading");
 	}
 
@@ -2599,8 +2601,10 @@ static void *make_mqueue(const struct factory *factory, struct fdesc fdescs[],
 
 		/* Wait till the child is ready. */
 		if (mq_receive(fdescs[0].fd, &c, 1, NULL) < 0) {
+			int e = errno;
 			mq_close(fdescs[0].fd);
 			mqueue_data_free(mqueue_data);
+			errno = e;
 			err(EXIT_FAILURE,
 			    "failed in mq_receive() the readiness notification from the child");
 		}

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -2796,11 +2796,8 @@ static void *make_timerfd(const struct factory *factory, struct fdesc fdescs[],
 	free_arg(&remaining);
 	free_arg(&abstime);
 
-	if (babstime) {
-		int r = clock_gettime(clockid, &now);
-		if (r == -1)
-			err(EXIT_FAILURE, "failed in clock_gettime(2)");
-	}
+	if (babstime && (clock_gettime(clockid, &now) == -1))
+		err(EXIT_FAILURE, "failed in clock_gettime(2)");
 
 	tfd = timerfd_create(clockid, 0);
 	if (tfd < 0)

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -2609,6 +2609,7 @@ static void *make_mqueue(const struct factory *factory, struct fdesc fdescs[],
 
 	return mqueue_data;
 }
+
 struct sysvshm_data {
 	void *addr;
 	int id;


### PR DESCRIPTION
As suggested by @karelzak in https://github.com/util-linux/util-linux/pull/3202#discussion_r1776568760 .

However, we keep calling unlink even when exiting with EXIT_FAILURE so as not to pollute the file system.

