### PR TITLE
blk: allow to define the default block size as env var

### DIFF
--- a/include/blkdev.h
+++ b/include/blkdev.h
@@ -21,7 +21,7 @@
 # include <sys/mkdev.h>		/* major and minor on Solaris */
 #endif
 
-#define DEFAULT_SECTOR_SIZE       512
+#define DEFAULT_SECTOR_SIZE       blkdev_get_default_sector_size()
 
 #ifdef __linux__
 /* very basic ioctls, should be available everywhere */
@@ -125,6 +125,9 @@ int blkdev_get_size(int fd, unsigned long long *bytes);
 
 /* get 512-byte sector count */
 int blkdev_get_sectors(int fd, unsigned long long *sectors);
+
+/* get the default sector size if it cannot be determined by the kernel */
+int blkdev_get_default_sector_size(void);
 
 /* get hardware sector size */
 int blkdev_get_sector_size(int fd, int *sector_size);

--- a/lib/blkdev.c
+++ b/lib/blkdev.c
@@ -194,6 +194,16 @@ blkdev_get_sectors(int fd, unsigned long long *sectors)
 	return -1;
 }
 
+int
+blkdev_get_default_sector_size(void)
+{
+	char *p = getenv("BLK_DEFAULT_SECTOR_SIZE");
+	if (!p)
+		return 512;
+
+	return atoi(p);
+}
+
 /*
  * Get logical sector size.
  *


### PR DESCRIPTION
When the block size cannot be determined in HW, a default value of 512 bytes block size is used. For UFS on the board we need to support 4kB block size. Allow to set a different default value through the environment. We can use it when building a WIC file with Yocto.