### PR TITLE
Update chsh.1.adoc to avoid duplicates in man page

### DIFF
--- a/login-utils/chsh.1.adoc
+++ b/login-utils/chsh.1.adoc
@@ -44,7 +44,7 @@ deprecated *-u*.
 Print version and exit. The short options *-V* have been used since version 2.39; old versions use
 deprecated *-v*.
 
-include::man-common/help-version.adoc[]
+// Do not include::man-common/help-version.adoc[]  as both -h and -V were already explicitly given above in more detail. 
 
 == VALID SHELLS
 


### PR DESCRIPTION
The current man page for chsh (1) contains duplicate descriptions for both options -h and -V, one given explicitly (in more detail) and another each from a standard include file. 

Excluded  man-common/help-version.adoc  to avoid duplicate -h  and -V option descriptions in the man page for  chsh(1).