### PR TITLE
The lscpu -e print the result of right-aligned is not appropriate

### DIFF
--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -133,23 +133,23 @@ struct lscpu_coldesc {
 
 static struct lscpu_coldesc coldescs_cpu[] =
 {
-	[COL_CPU_BOGOMIPS]     = { "BOGOMIPS", N_("crude measurement of CPU speed"), SCOLS_FL_RIGHT, 1, SCOLS_JSON_NUMBER },
-	[COL_CPU_CPU]          = { "CPU", N_("logical CPU number"), SCOLS_FL_RIGHT, 1, SCOLS_JSON_NUMBER },
-	[COL_CPU_CORE]         = { "CORE", N_("logical core number"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
-	[COL_CPU_CLUSTER]      = { "CLUSTER", N_("logical cluster number"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
-	[COL_CPU_SOCKET]       = { "SOCKET", N_("logical socket number"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
-	[COL_CPU_NODE]         = { "NODE", N_("logical NUMA node number"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
-	[COL_CPU_BOOK]         = { "BOOK", N_("logical book number"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
-	[COL_CPU_DRAWER]       = { "DRAWER", N_("logical drawer number"), SCOLS_FL_RIGHT, SCOLS_JSON_NUMBER },
+	[COL_CPU_BOGOMIPS]     = { "BOGOMIPS", N_("crude measurement of CPU speed"), 1, SCOLS_JSON_NUMBER },
+	[COL_CPU_CPU]          = { "CPU", N_("logical CPU number"), 1, SCOLS_JSON_NUMBER },
+	[COL_CPU_CORE]         = { "CORE", N_("logical core number"), 0, SCOLS_JSON_NUMBER },
+	[COL_CPU_CLUSTER]      = { "CLUSTER", N_("logical cluster number"), 0, SCOLS_JSON_NUMBER },
+	[COL_CPU_SOCKET]       = { "SOCKET", N_("logical socket number"), 0, SCOLS_JSON_NUMBER },
+	[COL_CPU_NODE]         = { "NODE", N_("logical NUMA node number"), 0, SCOLS_JSON_NUMBER },
+	[COL_CPU_BOOK]         = { "BOOK", N_("logical book number"), 0, SCOLS_JSON_NUMBER },
+	[COL_CPU_DRAWER]       = { "DRAWER", N_("logical drawer number"), SCOLS_JSON_NUMBER },
 	[COL_CPU_CACHE]        = { "CACHE", N_("shows how caches are shared between CPUs") },
 	[COL_CPU_POLARIZATION] = { "POLARIZATION", N_("CPU dispatching mode on virtual hardware") },
 	[COL_CPU_ADDRESS]      = { "ADDRESS", N_("physical address of a CPU") },
 	[COL_CPU_CONFIGURED]   = { "CONFIGURED", N_("shows if the hypervisor has allocated the CPU"), 0, 0, SCOLS_JSON_BOOLEAN_OPTIONAL },
-	[COL_CPU_ONLINE]       = { "ONLINE", N_("shows if Linux currently makes use of the CPU"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_BOOLEAN_OPTIONAL },
-	[COL_CPU_MHZ]          = { "MHZ", N_("shows the currently MHz of the CPU"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
-	[COL_CPU_SCALMHZ]      = { "SCALMHZ%", N_("shows scaling percentage of the CPU frequency"), SCOLS_FL_RIGHT, SCOLS_JSON_NUMBER },
-	[COL_CPU_MAXMHZ]       = { "MAXMHZ", N_("shows the maximum MHz of the CPU"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
-	[COL_CPU_MINMHZ]       = { "MINMHZ", N_("shows the minimum MHz of the CPU"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
+	[COL_CPU_ONLINE]       = { "ONLINE", N_("shows if Linux currently makes use of the CPU"), 0, SCOLS_JSON_BOOLEAN_OPTIONAL },
+	[COL_CPU_MHZ]          = { "MHZ", N_("shows the currently MHz of the CPU"), 0, SCOLS_JSON_NUMBER },
+	[COL_CPU_SCALMHZ]      = { "SCALMHZ%", N_("shows scaling percentage of the CPU frequency"), SCOLS_JSON_NUMBER },
+	[COL_CPU_MAXMHZ]       = { "MAXMHZ", N_("shows the maximum MHz of the CPU"), 0, SCOLS_JSON_NUMBER },
+	[COL_CPU_MINMHZ]       = { "MINMHZ", N_("shows the minimum MHz of the CPU"), 0, SCOLS_JSON_NUMBER },
 	[COL_CPU_MODELNAME]    = { "MODELNAME", N_("shows CPU model name"), 0, 0, SCOLS_JSON_STRING }
 };
 


### PR DESCRIPTION
The lscpu -e print the result of right-aligned is not appropriate. For example if i want to get result of lscpu -e with lines starting with number, i will use 'lscpu -e | grep ^[0-9]', this will omit the lines that are not left-aligned. So, i have modified the code to change the result of lscpu -e to left-aligned.