### PR TITLE
libsmartcols: add printf api to fill in column data

### DIFF
--- a/disk-utils/fdisk-list.c
+++ b/disk-utils/fdisk-list.c
@@ -309,9 +309,7 @@ int list_freespace_get_table(struct fdisk_context *cxt,
 			char *data = NULL;
 
 			if (tb0 && i == 0) {
-				xasprintf(&data, "%d", ct + 1);
-
-				if (scols_line_refer_data(ln, i, data)) {
+				if (scols_line_sprintf(ln, i, "%d", ct + 1)) {
 					fdisk_warn(cxt, _("failed to add output data"));
 					rc = -ENOMEM;
 					goto done;

--- a/libsmartcols/docs/libsmartcols-sections.txt
+++ b/libsmartcols/docs/libsmartcols-sections.txt
@@ -120,6 +120,10 @@ scols_line_set_color
 scols_line_set_column_data
 scols_line_set_data
 scols_line_set_userdata
+scols_line_sprintf
+scols_line_sprintf_column
+scols_line_vprintf
+scols_line_vprintf_column
 scols_new_line
 scols_ref_line
 scols_unref_line

--- a/libsmartcols/samples/continuous-json.c
+++ b/libsmartcols/samples/continuous-json.c
@@ -30,18 +30,15 @@ fail:
 
 static struct libscols_line *add_line(struct libscols_table *tb, int i)
 {
-	char *p;
 	struct libscols_line *ln = scols_table_new_line(tb, NULL);
 
 	if (!ln)
 		err(EXIT_FAILURE, "failed to create output line");
 
-	xasprintf(&p, "%d", i);
-	if (scols_line_refer_data(ln, 0, p))
+	if (scols_line_sprintf(ln, 0, "%d", i))
 		goto fail;
 
-	xasprintf(&p, "text%d", i);
-	if (scols_line_refer_data(ln, 1, p))
+	if (scols_line_sprintf(ln, 1, "text%d", i))
 		goto fail;
 
 	return ln;

--- a/libsmartcols/samples/continuous.c
+++ b/libsmartcols/samples/continuous.c
@@ -45,18 +45,16 @@ fail:
 
 static struct libscols_line *add_line(struct libscols_table *tb, size_t i)
 {
-	char *p;
 	struct libscols_line *ln = scols_table_new_line(tb, NULL);
 
 	if (!ln)
 		err(EXIT_FAILURE, "failed to create output line");
 
-	xasprintf(&p, "%zu", i);
-	if (scols_line_refer_data(ln, COL_NUM, p))
+	if (scols_line_sprintf(ln, COL_NUM, "%zu", i))
 		goto fail;
 
-	xasprintf(&p, "data-%02zu-%02zu-%02zu-end", i + 1, i + 2, i + 3);
-	if (scols_line_refer_data(ln, COL_DATA, p))
+	if (scols_line_sprintf(ln, COL_DATA,  "data-%02zu-%02zu-%02zu-end",
+			       i + 1, i + 2, i + 3))
 		goto fail;
 
 	return ln;

--- a/libsmartcols/src/libsmartcols.h.in
+++ b/libsmartcols/src/libsmartcols.h.in
@@ -14,6 +14,7 @@
 extern "C" {
 #endif
 
+#include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -291,10 +292,18 @@ extern struct libscols_cell *scols_line_get_column_cell(
 		                        struct libscols_column *cl);
 extern int scols_line_set_data(struct libscols_line *ln, size_t n, const char *data);
 extern int scols_line_refer_data(struct libscols_line *ln, size_t n, char *data);
+extern int scols_line_vprintf(struct libscols_line *ln, size_t n, const char *fmt, va_list ap)
+	__attribute__((format(printf, 3, 0)));
+extern int scols_line_sprintf(struct libscols_line *ln, size_t n, const char *fmt, ...)
+	__attribute__((format(printf, 3, 4)));
 extern int scols_line_is_filled(struct libscols_line *ln, size_t n);
 extern int scols_line_set_column_data(struct libscols_line *ln, struct libscols_column *cl, const char *data);
 extern const char *scols_line_get_column_data(struct libscols_line *ln, struct libscols_column *cl);
 extern int scols_line_refer_column_data(struct libscols_line *ln, struct libscols_column *cl, char *data);
+extern int scols_line_vprintf_column(struct libscols_line *ln, struct libscols_column *cl, const char *fmt, va_list ap)
+	__attribute__((format(printf, 3, 0)));
+extern int scols_line_sprintf_column(struct libscols_line *ln, struct libscols_column *cl, const char *fmt, ...)
+	__attribute__((format(printf, 3, 4)));
 extern struct libscols_line *scols_copy_line(const struct libscols_line *ln);
 
 /* table */

--- a/libsmartcols/src/libsmartcols.sym
+++ b/libsmartcols/src/libsmartcols.sym
@@ -244,3 +244,10 @@ SMARTCOLS_2.40 {
 	scols_column_set_data_type;
 	scols_column_get_data_type;
 } SMARTCOLS_2.39;
+
+SMARTCOLS_2.41 {
+	scols_line_vprintf;
+	scols_line_sprintf;
+	scols_line_vprintf_column;
+	scols_line_sprintf_column;
+} SMARTCOLS_2.40;

--- a/libsmartcols/src/line.c
+++ b/libsmartcols/src/line.c
@@ -505,6 +505,61 @@ int scols_line_refer_data(struct libscols_line *ln, size_t n, char *data)
 }
 
 /**
+ * scols_line_vprintf:
+ * @ln: a pointer to a struct libscols_line instance
+ * @n: number of the cell which will refer to @data
+ * @fmt: a printf(3) compatible format string used to generate cell data
+ * @ap: a variable argument list that was initialized with va_start(3)
+ *
+ * Returns: 0, a negative value in case of an error.
+ *
+ * Since: 2.41
+ */
+int scols_line_vprintf(struct libscols_line *ln, size_t n,
+		       const char *fmt, va_list ap)
+{
+	struct libscols_cell *ce = scols_line_get_cell(ln, n);
+	char *data = NULL;
+	int ret;
+
+	if (!ce)
+		return -EINVAL;
+
+	if (vasprintf(&data, fmt, ap) < 0)
+		return errno ? -errno : -ENOMEM;
+
+	ret = scols_cell_refer_data(ce, data);
+	if (ret < 0)
+		free(data);
+
+	return ret;
+}
+
+/**
+ * scols_line_sprintf:
+ * @ln: a pointer to a struct libscols_line instance
+ * @n: number of the cell which will refer to @data
+ * @fmt: an printf(3) compatible format string used to generate cell data
+ * @...: variable argument list
+ *
+ * Returns: 0, a negative value in case of an error.
+ *
+ * Since: 2.41
+ */
+int scols_line_sprintf(struct libscols_line *ln, size_t n,
+		       const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+	ret = scols_line_vprintf(ln, n, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+
+/**
  * scols_line_is_filled:
  * @ln: a pointer to a struct libscols_line instance
  * @n: number of the cell
@@ -535,6 +590,55 @@ int scols_line_refer_column_data(struct libscols_line *ln,
 			       char *data)
 {
 	return scols_line_refer_data(ln, cl->seqnum, data);
+}
+
+/**
+ * scols_line_vprintf_column:
+ * @ln: a pointer to a struct libscols_line instance
+ * @cl: column, whose data is to be set
+ * @fmt: a printf(3) compatible format string used to generate column data
+ * @ap: a variable argument list that was initialized with va_start(3)
+ *
+ * The same as scols_line_vprintf() but cell is referenced by column object.
+ *
+ * Returns: 0, a negative value in case of an error.
+ *
+ * Since: 2.41
+ */
+int scols_line_vprintf_column(struct libscols_line *ln,
+			      struct libscols_column *cl,
+			      const char *fmt,
+			      va_list ap)
+{
+	return scols_line_vprintf(ln, cl->seqnum, fmt, ap);
+}
+
+
+/**
+ * scols_line_sprintf_column:
+ * @ln: a pointer to a struct libscols_line instance
+ * @cl: column, whose data is to be set
+ * @fmt: a printf(3) compatible format string used to generate column data
+ * @...: variable argument list
+ *
+ * The same as scols_line_sprintf() but cell is referenced by column object.
+ *
+ * Returns: 0, a negative value in case of an error.
+ *
+ * Since: 2.41
+ */
+int scols_line_sprintf_column(struct libscols_line *ln,
+			      struct libscols_column *cl,
+			      const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+	ret = scols_line_vprintf(ln, cl->seqnum, fmt, ap);
+	va_end(ap);
+
+	return ret;
 }
 
 /**

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -2404,15 +2404,13 @@ static void emit_summary(struct lsfd_control *ctl)
 
 		scols_reset_iter(itr, SCOLS_ITER_FORWARD);
 		while (scols_filter_next_counter(*ct_fltr, itr, &ct) == 0) {
-			char *str = NULL;
 			struct libscols_line *ln;
 
 			ln = scols_table_new_line(tb, NULL);
 			if (!ln)
 				err(EXIT_FAILURE, _("failed to allocate summary line"));
 
-			xasprintf(&str, "%llu", scols_counter_get_result(ct));
-			if (scols_line_refer_data(ln, 0, str))
+			if (scols_line_sprintf(ln, 0, "%llu", scols_counter_get_result(ct)))
 				err(EXIT_FAILURE, _("failed to add summary data"));
 			if (scols_line_set_data(ln, 1, scols_counter_get_name(ct)))
 				err(EXIT_FAILURE, _("failed to add summary data"));

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -211,22 +211,9 @@ static void __attribute__((__noreturn__)) usage(void)
 	exit(EXIT_SUCCESS);
 }
 
-__attribute__ ((__format__ (__printf__, 3, 4)))
-static void scols_line_asprintf(struct libscols_line *ln, size_t n, const char *format, ...)
-{
-	char *data;
-	va_list args;
-
-	va_start(args, format);
-	xvasprintf(&data, format, args);
-	va_end(args);
-
-	scols_line_refer_data(ln, n, data);
-}
-
 static void scols_line_format_timespec(struct libscols_line *ln, size_t n, const struct timespec *ts)
 {
-	scols_line_asprintf(ln, n, "%ju.%09" PRId32, (uintmax_t) ts->tv_sec, (uint32_t) ts->tv_nsec);
+	scols_line_sprintf(ln, n, "%ju.%09" PRId32, (uintmax_t) ts->tv_sec, (uint32_t) ts->tv_nsec);
 }
 
 static clockid_t parse_clock(const char *name)
@@ -301,7 +288,7 @@ static void add_clock_line(struct libscols_table *tb, const int *columns,
 				break;
 			case COL_ID:
 				if (!clockinfo->no_id)
-					scols_line_asprintf(ln, i, "%ju", (uintmax_t) clockinfo->id);
+					scols_line_sprintf(ln, i, "%ju", (uintmax_t) clockinfo->id);
 				break;
 			case COL_CLOCK:
 				scols_line_set_data(ln, i, clockinfo->id_name);
@@ -350,8 +337,8 @@ static void add_clock_line(struct libscols_table *tb, const int *columns,
 				break;
 			case COL_NS_OFFSET:
 				if (clockinfo->ns_offset_name)
-					scols_line_asprintf(ln, i, "%"PRId64,
-							    get_namespace_offset(clockinfo->ns_offset_name));
+					scols_line_sprintf(ln, i, "%"PRId64,
+							   get_namespace_offset(clockinfo->ns_offset_name));
 				break;
 		}
 	}

--- a/sys-utils/irq-common.c
+++ b/sys-utils/irq-common.c
@@ -492,12 +492,13 @@ struct libscols_table *get_scols_cpus_table(struct irq_output *out,
 
 	for (i = 0, j = 0; i < curr->nr_active_cpu; i++) {
 		struct irq_cpu *cpu = &curr->cpus[i];
-		char *str;
+		double usage;
 
 		if (!cpu_in_list(i, setsize, cpuset))
 			continue;
-		xasprintf(&str, "%0.1f", (double)((long double) cpu->total / (long double) curr->total_irq * 100.0));
-		if (str && scols_line_refer_data(ln, ++j, str) != 0)
+
+		usage = (long double) cpu->total / (long double) curr->total_irq * 100.0;
+		if (scols_line_sprintf(ln, ++j, "%0.1f", usage) != 0)
 			goto err;
 	}
 
@@ -509,14 +510,14 @@ struct libscols_table *get_scols_cpus_table(struct irq_output *out,
 
 	for (i = 0, j = 0; i < curr->nr_active_cpu; i++) {
 		struct irq_cpu *cpu = &curr->cpus[i];
-		char *str;
+		double usage;
 
 		if (!cpu_in_list(i, setsize, cpuset))
 			continue;
 		if (!curr->delta_irq)
 			continue;
-		xasprintf(&str, "%0.1f", (double)((long double) cpu->delta / (long double) curr->delta_irq * 100.0));
-		if (str && scols_line_refer_data(ln, ++j, str) != 0)
+		usage = (long double) cpu->delta / (long double) curr->delta_irq * 100.0;
+		if (scols_line_sprintf(ln, ++j, "%0.1f", usage) != 0)
 			goto err;
 	}
 

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -823,12 +823,13 @@ static struct libscols_line *
 
 	/* data column */
 	if (fmt) {
-		char *data;
+		int ret;
+
 		va_start(args, fmt);
-		xvasprintf(&data, fmt, args);
+		ret = scols_line_vprintf(ln, 1, fmt, args);
 		va_end(args);
 
-		if (data && scols_line_refer_data(ln, 1, data))
+		if (ret < 0)
 			err(EXIT_FAILURE, _("failed to add output data"));
 	}
 

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -507,10 +507,10 @@ static void global_set_data(struct lsipc_control *ctl, struct libscols_table *tb
 				rc = scols_line_set_data(ln, n, "-");
 			break;
 		case COL_USEPERC:
-			if (usage) {
-				xasprintf(&arg, "%2.2f%%", (double) used / limit * 100);
-				rc = scols_line_refer_data(ln, n, arg);
-			} else
+			if (usage)
+				rc = scols_line_sprintf(ln, n, "%2.2f%%",
+					(double) used / limit * 100);
+			else
 				rc = scols_line_set_data(ln, n, "-");
 			break;
 		case COL_LIMIT:
@@ -570,12 +570,10 @@ static void do_sem(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 			int rc = 0;
 			switch (get_column_id(n)) {
 			case COL_KEY:
-				xasprintf(&arg, "0x%08x", p->sem_perm.key);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "0x%08x", p->sem_perm.key);
 				break;
 			case COL_ID:
-				xasprintf(&arg, "%d", p->sem_perm.id);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%d", p->sem_perm.id);
 				break;
 			case COL_OWNER:
 				arg = get_username(&pw, p->sem_perm.uid);
@@ -593,8 +591,7 @@ static void do_sem(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 				rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_CUID:
-				xasprintf(&arg, "%u", p->sem_perm.cuid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->sem_perm.cuid);
 				break;
 			case COL_CUSER:
 				arg = get_username(&cpw, p->sem_perm.cuid);
@@ -602,8 +599,7 @@ static void do_sem(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_CGID:
-				xasprintf(&arg, "%u", p->sem_perm.cgid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->sem_perm.cgid);
 				break;
 			case COL_CGROUP:
 				arg = get_groupname(&cgr, p->sem_perm.cgid);
@@ -611,8 +607,7 @@ static void do_sem(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_UID:
-				xasprintf(&arg, "%u", p->sem_perm.uid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->sem_perm.uid);
 				break;
 			case COL_USER:
 				arg = get_username(&pw, p->sem_perm.uid);
@@ -620,8 +615,7 @@ static void do_sem(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_GID:
-				xasprintf(&arg, "%u", p->sem_perm.gid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->sem_perm.gid);
 				break;
 			case COL_GROUP:
 				arg = get_groupname(&gr, p->sem_perm.gid);
@@ -636,8 +630,7 @@ static void do_sem(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 				}
 				break;
 			case COL_NSEMS:
-				xasprintf(&arg, "%ju", p->sem_nsems);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%ju", p->sem_nsems);
 				break;
 			case COL_OTIME:
 				if (p->sem_otime != 0) {
@@ -669,32 +662,27 @@ static void do_sem(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					err(EXIT_FAILURE, _("failed to allocate output line"));
 
 				/* SEMNUM */
-				xasprintf(&arg, "%zu", i);
-				rc = scols_line_refer_data(sln, 0, arg);
+				rc = scols_line_sprintf(sln, 0, "%zu", i);
 				if (rc)
 					break;
 
 				/* VALUE */
-				xasprintf(&arg, "%d", e->semval);
-				rc = scols_line_refer_data(sln, 1, arg);
+				rc = scols_line_sprintf(sln, 1, "%d", e->semval);
 				if (rc)
 					break;
 
 				/* NCOUNT */
-				xasprintf(&arg, "%d", e->ncount);
-				rc = scols_line_refer_data(sln, 2, arg);
+				rc = scols_line_sprintf(sln, 2, "%d", e->ncount);
 				if (rc)
 					break;
 
 				/* ZCOUNT */
-				xasprintf(&arg, "%d", e->zcount);
-				rc = scols_line_refer_data(sln, 3, arg);
+				rc = scols_line_sprintf(sln, 3, "%d", e->zcount);
 				if (rc)
 					break;
 
 				/* PID */
-				xasprintf(&arg, "%d", e->pid);
-				rc = scols_line_refer_data(sln, 4, arg);
+				rc = scols_line_sprintf(sln, 4, "%d", e->pid);
 				if (rc)
 					break;
 
@@ -775,12 +763,10 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 
 			switch (get_column_id(n)) {
 			case COL_KEY:
-				xasprintf(&arg, "0x%08x", p->msg_perm.key);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "0x%08x", p->msg_perm.key);
 				break;
 			case COL_ID:
-				xasprintf(&arg, "%d", p->msg_perm.id);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%d", p->msg_perm.id);
 				break;
 			case COL_OWNER:
 				arg = get_username(&pw, p->msg_perm.uid);
@@ -798,8 +784,7 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 				}
 				break;
 			case COL_CUID:
-				xasprintf(&arg, "%u", p->msg_perm.cuid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->msg_perm.cuid);
 				break;
 			case COL_CUSER:
 				arg = get_username(&pw, p->msg_perm.cuid);
@@ -807,8 +792,7 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_CGID:
-				xasprintf(&arg, "%u", p->msg_perm.cuid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->msg_perm.cuid);
 				break;
 			case COL_CGROUP:
 				arg = get_groupname(&gr, p->msg_perm.cgid);
@@ -816,8 +800,7 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_UID:
-				xasprintf(&arg, "%u", p->msg_perm.uid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->msg_perm.uid);
 				break;
 			case COL_USER:
 				arg = get_username(&pw, p->msg_perm.uid);
@@ -825,8 +808,7 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_GID:
-				xasprintf(&arg, "%u", p->msg_perm.gid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->msg_perm.gid);
 				break;
 			case COL_GROUP:
 				arg = get_groupname(&gr, p->msg_perm.gid);
@@ -848,8 +830,7 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 				rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_MSGS:
-				xasprintf(&arg, "%ju", p->q_qnum);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%ju", p->q_qnum);
 				break;
 			case COL_SEND:
 				if (p->q_stime != 0)
@@ -864,12 +845,10 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 							  (time_t) p->q_rtime));
 				break;
 			case COL_LSPID:
-				xasprintf(&arg, "%u", p->q_lspid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->q_lspid);
 				break;
 			case COL_LRPID:
-				xasprintf(&arg, "%u", p->q_lrpid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->q_lrpid);
 				break;
 			}
 			if (rc != 0)
@@ -934,12 +913,10 @@ static void do_shm(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 
 			switch (get_column_id(n)) {
 			case COL_KEY:
-				xasprintf(&arg, "0x%08x", p->shm_perm.key);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "0x%08x", p->shm_perm.key);
 				break;
 			case COL_ID:
-				xasprintf(&arg, "%d", p->shm_perm.id);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%d", p->shm_perm.id);
 				break;
 			case COL_OWNER:
 				arg = get_username(&pw, p->shm_perm.uid);
@@ -957,8 +934,7 @@ static void do_shm(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 				rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_CUID:
-				xasprintf(&arg, "%u", p->shm_perm.cuid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->shm_perm.cuid);
 				break;
 			case COL_CUSER:
 				arg = get_username(&pw, p->shm_perm.cuid);
@@ -966,8 +942,7 @@ static void do_shm(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_CGID:
-				xasprintf(&arg, "%u", p->shm_perm.cuid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->shm_perm.cuid);
 				break;
 			case COL_CGROUP:
 				arg = get_groupname(&gr, p->shm_perm.cgid);
@@ -975,8 +950,7 @@ static void do_shm(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_UID:
-				xasprintf(&arg, "%u", p->shm_perm.uid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->shm_perm.uid);
 				break;
 			case COL_USER:
 				arg = get_username(&pw, p->shm_perm.uid);
@@ -984,8 +958,7 @@ static void do_shm(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_GID:
-				xasprintf(&arg, "%u", p->shm_perm.gid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->shm_perm.gid);
 				break;
 			case COL_GROUP:
 				arg = get_groupname(&gr, p->shm_perm.gid);
@@ -1007,8 +980,7 @@ static void do_shm(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 				rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_NATTCH:
-				xasprintf(&arg, "%ju", p->shm_nattch);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%ju", p->shm_nattch);
 				break;
 			case COL_STATUS: {
 					int comma = 0;
@@ -1062,12 +1034,10 @@ static void do_shm(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 							  (time_t) p->shm_dtim));
 				break;
 			case COL_CPID:
-				xasprintf(&arg, "%u", p->shm_cprid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->shm_cprid);
 				break;
 			case COL_LPID:
-				xasprintf(&arg, "%u", p->shm_lprid);
-				rc = scols_line_refer_data(ln, n, arg);
+				rc = scols_line_sprintf(ln, n, "%u", p->shm_lprid);
 				break;
 			case COL_COMMAND:
 				arg = pid_get_cmdline(p->shm_cprid);


### PR DESCRIPTION
Add new API functions using printf(3) compatible format strings to fill in column data.

These can be used to avoid intermediate buffers in the calling application code.

Everywhere a string generated with `xasprintf()` is directly passed to `scols_line_refer_data()`, use `scols_line_sprintf()` to remove the need for an intermediate buffer.