### PR TITLE
lsirq and irqtop improvements

### DIFF
--- a/bash-completion/irqtop
+++ b/bash-completion/irqtop
@@ -12,6 +12,9 @@ _irqtop_module()
 		'-C'|'--cpu-list')
 			return 0
 			;;
+		'-t'|'--threshold')
+			return 0
+			;;
 		'-d'|'--delay')
 			COMPREPLY=( $(compgen -W "secs" -- $cur) )
 			return 0
@@ -43,6 +46,7 @@ _irqtop_module()
 		--sort
 		--output
 		--softirq
+		--threshold
 		--help
 		--version"
 	COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )

--- a/bash-completion/lsirq
+++ b/bash-completion/lsirq
@@ -25,6 +25,9 @@ _lsirq_module()
 		'-t'|'--threshold')
 			return 0
 			;;
+		'-C'|'--cpu-list')
+			return 0
+			;;
 		'-h'|'--help'|'-V'|'--version')
 			return 0
 			;;
@@ -36,6 +39,7 @@ _lsirq_module()
 		--softirq
 		--sort
 		--threshold
+		--cpu-list
 		--help
 		--version"
 	COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )

--- a/bash-completion/lsirq
+++ b/bash-completion/lsirq
@@ -22,6 +22,9 @@ _lsirq_module()
 			COMPREPLY=( $(compgen -W "irq total name" -- $cur) )
 			return 0
 			;;
+		'-t'|'--threshold')
+			return 0
+			;;
 		'-h'|'--help'|'-V'|'--version')
 			return 0
 			;;
@@ -32,6 +35,7 @@ _lsirq_module()
 		--output
 		--softirq
 		--sort
+		--threshold
 		--help
 		--version"
 	COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )

--- a/sys-utils/irq-common.c
+++ b/sys-utils/irq-common.c
@@ -530,6 +530,7 @@ struct libscols_table *get_scols_table(struct irq_output *out,
 					      struct irq_stat *prev,
 					      struct irq_stat **xstat,
 					      int softirq,
+					      unsigned long threshold,
 					      size_t setsize,
 					      cpu_set_t *cpuset)
 {
@@ -568,7 +569,8 @@ struct libscols_table *get_scols_table(struct irq_output *out,
 	}
 
 	for (i = 0; i < stat->nr_irq; i++)
-		add_scols_line(out, &result[i], table);
+		if (result[i].total >= threshold)
+			add_scols_line(out, &result[i], table);
 
 	free(result);
 

--- a/sys-utils/irq-common.h
+++ b/sys-utils/irq-common.h
@@ -76,6 +76,7 @@ struct libscols_table *get_scols_table(struct irq_output *out,
                                               struct irq_stat *prev,
                                               struct irq_stat **xstat,
                                               int softirq,
+                                              unsigned long threshold,
                                               size_t setsize,
                                               cpu_set_t *cpuset);
 

--- a/sys-utils/irqtop.1.adoc
+++ b/sys-utils/irqtop.1.adoc
@@ -40,6 +40,9 @@ Specify sort criteria by column name. See *--help* output to get column names. T
 *-S*, *--softirq*::
 Show softirqs information.
 
+*-t*, *--threshold* _min_::
+Only show IRQs with counters above the specified threshold. Human readable values are supported (e.g. 1.2K).
+
 include::man-common/help-version.adoc[]
 
 == INTERACTIVE MODE KEY COMMANDS
@@ -64,6 +67,7 @@ stop updates and exit program
 mailto:pizhenwei@bytedance.com[Zhenwei Pi],
 mailto:kerolasa@iki.fi[Sami Kerola],
 mailto:kzak@redhat.com[Karel Zak]
+mailto:robin@jarry.cc[Robin Jarry]
 
 include::man-common/bugreports.adoc[]
 

--- a/sys-utils/lsirq.1.adoc
+++ b/sys-utils/lsirq.1.adoc
@@ -43,6 +43,9 @@ Show softirqs information.
 *-t*, *--threshold* _min_::
 Only show IRQs with counters above the specified threshold. Human readable values are supported (e.g. 1.2K).
 
+*-C*, *--cpu-list* _list_::
+Only show interrupt counters on the specified CPU list.
+
 include::man-common/help-version.adoc[]
 
 == AUTHORS

--- a/sys-utils/lsirq.1.adoc
+++ b/sys-utils/lsirq.1.adoc
@@ -40,6 +40,9 @@ Produce output in the form of key="value" pairs. All potentially unsafe characte
 *-S*, *--softirq*::
 Show softirqs information.
 
+*-t*, *--threshold* _min_::
+Only show IRQs with counters above the specified threshold. Human readable values are supported (e.g. 1.2K).
+
 include::man-common/help-version.adoc[]
 
 == AUTHORS
@@ -47,6 +50,7 @@ include::man-common/help-version.adoc[]
 mailto:pizhenwei@bytedance.com[Zhenwei Pi],
 mailto:kerolasa@iki.fi[Sami Kerola],
 mailto:kzak@redhat.com[Karel Zak]
+mailto:robin@jarry.cc[Robin Jarry]
 
 include::man-common/bugreports.adoc[]
 

--- a/sys-utils/lsirq.c
+++ b/sys-utils/lsirq.c
@@ -5,6 +5,7 @@
  *
  * Copyright (C) 2019 zhenwei pi <pizhenwei@bytedance.com>
  * Copyright (C) 2020 Karel Zak <kzak@redhat.com>
+ * Copyright (C) 2024 Robin Jarry <robin@jarry.cc>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -31,11 +32,12 @@
 
 #include "irq-common.h"
 
-static int print_irq_data(struct irq_output *out, int softirq)
+static int print_irq_data(struct irq_output *out,
+			  int softirq, unsigned long threshold)
 {
 	struct libscols_table *table;
 
-	table = get_scols_table(out, NULL, NULL, softirq, 0, NULL);
+	table = get_scols_table(out, NULL, NULL, softirq, threshold, 0, NULL);
 	if (!table)
 		return -1;
 
@@ -59,6 +61,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -o, --output <list>  define which output columns to use\n"), stdout);
 	fputs(_(" -s, --sort <column>  specify sort column\n"), stdout);
 	fputs(_(" -S, --softirq        show softirqs instead of interrupts\n"), stdout);
+	fputs(_(" -t, --threshold <N>  only IRQs with counters above <N>\n"), stdout);
 	fputs(USAGE_SEPARATOR, stdout);
 	fprintf(stdout, USAGE_HELP_OPTIONS(22));
 
@@ -78,6 +81,7 @@ int main(int argc, char **argv)
 		{"sort", required_argument, NULL, 's'},
 		{"noheadings", no_argument, NULL, 'n'},
 		{"output", required_argument, NULL, 'o'},
+		{"threshold", required_argument, NULL, 't'},
 		{"softirq", no_argument, NULL, 'S'},
 		{"json", no_argument, NULL, 'J'},
 		{"pairs", no_argument, NULL, 'P'},
@@ -92,11 +96,12 @@ int main(int argc, char **argv)
 		{0}
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;
+	uintmax_t threshold = 0;
 	int softirq = 0;
 
 	setlocale(LC_ALL, "");
 
-	while ((c = getopt_long(argc, argv, "no:s:ShJPV", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "no:s:t:ShJPV", longopts, NULL)) != -1) {
 		err_exclusive_options(c, longopts, excl, excl_st);
 
 		switch (c) {
@@ -117,6 +122,9 @@ int main(int argc, char **argv)
 			break;
 		case 'S':
 			softirq = 1;
+			break;
+		case 't':
+			threshold = strtosize_or_err(optarg, _("error: --threshold"));
 			break;
 		case 'V':
 			print_version(EXIT_SUCCESS);
@@ -141,5 +149,8 @@ int main(int argc, char **argv)
 				irq_column_name_to_id) < 0)
 		exit(EXIT_FAILURE);
 
-	return print_irq_data(&out, softirq) == 0 ?  EXIT_SUCCESS : EXIT_FAILURE;
+	if (print_irq_data(&out, softirq, threshold) < 0)
+		return EXIT_FAILURE;
+
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Add a new option to filter out IRQs whose counters are below the specified value. The argument supports plain integers and human readable values (e.g. `1.2K`).

For consistency with `irqtop`, add a `--cpu-list` option to `lsirq` to specify a list of CPUs for which to display interrupt counters.