### PR TITLE
nsenter: support empty environ[]

### DIFF
--- a/lib/env.c
+++ b/lib/env.c
@@ -172,6 +172,7 @@ struct ul_env_list *env_list_from_fd(int fd)
 	ssize_t rc = 0;
 	struct ul_env_list *ls = NULL;
 
+	errno = 0;
 	if ((rc = read_all_alloc(fd, &buf)) < 1)
 		return NULL;
 	buf[rc] = '\0';

--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -531,7 +531,6 @@ int main(int argc, char *argv[])
 	int keepcaps = 0;
 	int sock_fd = -1;
 	int pid_fd = -1;
-	struct ul_env_list *envls;
 #ifdef HAVE_LIBSELINUX
 	bool selinux = 0;
 #endif
@@ -786,12 +785,15 @@ int main(int argc, char *argv[])
 
 	/* Pass environment variables of the target process to the spawned process */
 	if (env_fd >= 0) {
-		if ((envls = env_list_from_fd(env_fd)) == NULL)
+		struct ul_env_list *ls;
+
+		ls = env_list_from_fd(env_fd);
+		if (!ls && errno)
 			err(EXIT_FAILURE, _("failed to get environment variables"));
 		clearenv();
-		if (env_list_setenv(envls, 0) < 0)
+		if (ls && env_list_setenv(ls, 0) < 0)
 			err(EXIT_FAILURE, _("failed to set environment variables"));
-		env_list_free(envls);
+		env_list_free(ls);
 		close(env_fd);
 	}
 


### PR DESCRIPTION
There is no error when the /proc/#/environ file does not contain any NAME=value items.

Fixes: https://github.com/util-linux/util-linux/issues/3270