### PR TITLE
fincore: zero partially read data on cachestat() error

### DIFF
--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -345,6 +345,8 @@ static int fincore_fd (struct fincore_control *ctl,
 	if (errno != ENOSYS)
 		warn(_("failed to do cachestat: %s"), st->name);
 
+	memset(&st->cstat, 0, sizeof(st->cstat));
+
 	return mincore_fd(ctl, fd, st);
 }
 


### PR DESCRIPTION
If cachestat() fails then some result data may already have been written. This existing data would be added to the actual result from mincore(), resulting in incorrect data.
When falling back to mincore make sure to start from a blank slate.

This is a partial fix for #3266.