### PR TITLE
Skip tmpfs-sensitive tests if fstype cannot be determined

### DIFF
--- a/tests/ts/fadvise/drop
+++ b/tests/ts/fadvise/drop
@@ -19,9 +19,9 @@ FILE="ddtest"
 BS=65536
 COUNT=8
 
-FILE_FS="$("$TS_CMD_FINDMNT" -nr -o FSTYPE -T "$PWD")"
-if [[ "$FILE_FS" = "tmpfs" ]]; then
-	ts_skip "fincore does not work on tmpfs"
+FS="$("$TS_CMD_FINDMNT" -nr -o FSTYPE -T "$PWD")"
+if [[ "$FS" = "tmpfs" || "$FS" = "overlay" || "$FS" = "" ]]; then
+	ts_skip "fincore does not work on tmpfs or unknown fs"
 fi
 
 create_file() {

--- a/tests/ts/fincore/count
+++ b/tests/ts/fincore/count
@@ -10,8 +10,8 @@ ts_check_test_command "$TS_CMD_FINDMNT"
 ts_check_test_command "$TS_HELPER_SYSINFO"
 
 FS="$("$TS_CMD_FINDMNT" -nr -o FSTYPE -T "$PWD")"
-if [[ "$FS" = "tmpfs" ]]; then
-	ts_skip "fincore does not work on tmpfs"
+if [[ "$FS" = "tmpfs" || "$FS" = "overlay" || "$FS" = "" ]]; then
+	ts_skip "fincore does not work on tmpfs or unknown fs"
 fi
 
 function footer


### PR DESCRIPTION
In certain isolation environments (f.e. Debian's sbuild+unshare), `/proc/mounts` does not have an entry for the directory we're building in.

Then, findmnt as used in the tests returns nothing. As the build directory might very well be on tmpfs (and often is, in Debian), disable the two tests known to fail on tmpfs.

In yet another scenario, if ran in a Docker/podman container, the fstype will read "overlayfs", which in the end can also be tmpfs, and we see problems there, too.

This was noticed because torvalds/linux@e88e0d366f9cfbb810b0c8509dc5d130d5a53e02 changed the behaviour of the underlying syscalls on tmpfs in Linux 6.6.

Closes: #3266

Debian bug #1086706