### PR TITLE
mesg: tty group cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2911,6 +2911,14 @@ AC_ARG_ENABLE([makeinstall-setuid],
 AM_CONDITIONAL([MAKEINSTALL_DO_SETUID], [test "x$enable_makeinstall_setuid" = xyes])
 
 
+AC_ARG_ENABLE([makeinstall-tty-setgid],
+	      AS_HELP_STRING([--disable-makeinstall-tty-setgid], [do not setgid for wall, and write during "make install"]),
+  [], [enable_makeinstall_tty_setgid=yes]
+)
+AM_CONDITIONAL([MAKEINSTALL_DO_TTY_SETGID], [test "x$enable_makeinstall_tty_setgid" = xyes])
+
+
+
 AC_ARG_ENABLE([colors-default],
   AS_HELP_STRING([--disable-colors-default], [do not colorize output from utils by default]),
   [], [enable_colors_default=yes]

--- a/login-utils/login.1.adoc
+++ b/login-utils/login.1.adoc
@@ -97,13 +97,13 @@ Delay in seconds before being allowed another three tries after a login failure.
 
 *TTYPERM* (string)::
 
-The terminal permissions. The default value is _0600_ or _0620_ if tty group is used.
+The terminal permissions. The default value is _0600_ or _0620_ if tty group is used. See also *mesg*(1).
 
 *TTYGROUP* (string)::
 
 The login tty will be owned by the *TTYGROUP*. The default value is _tty_. If the *TTYGROUP* does not exist, then the ownership of the terminal is set to the user's primary group.
 +
-The *TTYGROUP* can be either the name of a group or a numeric group identifier.
+The *TTYGROUP* can be either the name of a group or a numeric group identifier. See also *mesg*(1).
 
 *HUSHLOGIN_FILE* (string)::
 

--- a/meson.build
+++ b/meson.build
@@ -2675,6 +2675,13 @@ if opt
   bashcompletions += ['mesg']
 endif
 
+tty_setgid = get_option('tty-setgid')
+if tty_setgid
+  tty_install_mode = [ 'rwxr-sr-x', 'root', 'tty' ]
+else
+  tty_install_mode = [ false, false, false ]
+endif
+
 opt = not get_option('build-wall').disabled()
 exe = executable(
   'wall',
@@ -2683,7 +2690,7 @@ exe = executable(
   link_with : [lib_common],
   dependencies : [lib_systemd],
   install_dir : usrbin_exec_dir,
-  install_mode : [ 'rwxr-sr-x', 'root', 'tty' ],
+  install_mode : tty_install_mode,
   install : opt,
   build_by_default : opt)
 if opt
@@ -2703,7 +2710,7 @@ exe = executable(
   link_with : [lib_common],
   dependencies : [lib_systemd],
   install_dir : usrbin_exec_dir,
-  install_mode : [ 'rwxr-sr-x', 'root', 'tty' ],
+  install_mode : tty_install_mode,
   install : opt,
   build_by_default : opt)
 if opt

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -309,3 +309,7 @@ option('lastlog-compat-symlink', type : 'boolean',
 option('login-lastlogin', type : 'boolean',
        value : false,
        description : 'program login writes lastlog entries')
+
+option('tty-setgid', type : 'boolean',
+       value : true,
+       description : 'setgid tty group for wall and write programs')

--- a/term-utils/Makemodule.am
+++ b/term-utils/Makemodule.am
@@ -108,11 +108,13 @@ wall_CFLAGS += $(SYSTEMD_CFLAGS)
 endif
 if USE_TTY_GROUP
 if MAKEINSTALL_DO_CHOWN
+if MAKEINSTALL_DO_TTY_SETGID
 install-exec-hook-wall::
 	chgrp tty $(DESTDIR)$(usrbin_execdir)/wall
 	chmod g+s $(DESTDIR)$(usrbin_execdir)/wall
 
 INSTALL_EXEC_HOOKS += install-exec-hook-wall
+endif
 endif
 endif
 endif # BUILD_WALL
@@ -133,11 +135,13 @@ endif
 
 if USE_TTY_GROUP
 if MAKEINSTALL_DO_CHOWN
+if MAKEINSTALL_DO_TTY_SETGID
 install-exec-hook-write::
 	chgrp tty $(DESTDIR)$(usrbin_execdir)/write
 	chmod g+s $(DESTDIR)$(usrbin_execdir)/write
 
 INSTALL_EXEC_HOOKS += install-exec-hook-write
+endif
 endif
 endif
 endif # BUILD_WRITE

--- a/term-utils/mesg.1.adoc
+++ b/term-utils/mesg.1.adoc
@@ -52,7 +52,23 @@ mesg - display (or do not display) messages from other users
 
 The *mesg* utility is invoked by a user to control write access others have to the terminal device associated with standard error output. If write access is allowed, then programs such as *talk*(1) and *write*(1) may display messages on the terminal.
 
-Traditionally, write access is allowed by default. However, as users become more conscious of various security risks, there is a trend to remove write access by default, at least for the primary login shell. To make sure your ttys are set the way you want them to be set, *mesg* should be executed in your login scripts.
+Traditionally, write access is allowed by default. However, as users become
+more conscious of various security risks, there is a trend to remove write
+access by default, at least for the primary login shell.
+
+The initial permissions for the terminal are set by *login*(1) according to TTYPERM
+and TTYGROUP from /etc/login.defs. The default is mode _0620_ if a tty group is used,
+and _0600_ without the group. The default tty group name is "tty".
+
+To ensure that your ttys are set in a portable and independent manner from system
+settings, *mesg* should be executed in your login scripts.
+
+*mesg* modifies the write permissions for a group on the current terminal
+device. Since version 2.41, *mesg* can no longer be compiled to make the
+terminal writable for _others_ and strictly modifies only _group_ permissions.
+The usual setup is to use a "tty" group and add relevant users to this group.
+Alternatively, a less secure solution is to set utilities like *write*(1) or
+*wall*(1) to setgid for the "tty" group.
 
 The *mesg* utility silently exits with error status 2 if not executed on a terminal. In this case executing *mesg* is pointless. The command line option *--verbose* forces *mesg* to print a warning in this situation. This behaviour has been introduced in version 2.33.
 
@@ -65,6 +81,7 @@ Disallow messages.
 Allow messages to be displayed.
 
 If no arguments are given, *mesg* shows the current message status on standard error output.
+
 
 == OPTIONS
 

--- a/term-utils/mesg.c
+++ b/term-utils/mesg.c
@@ -157,11 +157,7 @@ int main(int argc, char *argv[])
 
 	switch (rpmatch(argv[0])) {
 	case RPMATCH_YES:
-#ifdef USE_TTY_GROUP
 		if (fchmod(fd, sb.st_mode | S_IWGRP) < 0)
-#else
-		if (fchmod(fd, sb.st_mode | S_IWGRP | S_IWOTH) < 0)
-#endif
 			err(MESG_EXIT_FAILURE, _("change %s mode failed"), tty);
 		if (verbose)
 			puts(_("write access to your terminal is allowed"));


### PR DESCRIPTION
* improve mesg(1) behavior in more explicit way
* add ./configure and meson options to disable setgid tty group
* remove  fchmod(S_IWOTH)  legacy support