### PR TITLE
mkswap: set selinux label also when creating file

### DIFF
--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -754,7 +754,8 @@ int main(int argc, char **argv)
 	deinit_signature_page(&ctl);
 
 #ifdef HAVE_LIBSELINUX
-	if (S_ISREG(ctl.devstat.st_mode) && is_selinux_enabled() > 0) {
+	if ((ctl.file || S_ISREG(ctl.devstat.st_mode)) &&
+            is_selinux_enabled() > 0) {
 		const char *context_string;
 		char *oldcontext;
 		context_t newcontext;


### PR DESCRIPTION
With --file, shen the file is created by mkswap, stat() fails with -ENOENT and the st_mode field is not populated, so the IS_REG() check fails. But if we created by mkswap, we know it's just a regular file and we should apply the selinux label.

Reported in https://bugzilla.redhat.com/show_bug.cgi?id=2324811#c56.