### PR TITLE
libmount/hooks: make `hooksets` array const

### DIFF
--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -69,7 +69,7 @@
 #include "list.h"
 #include "blkdev.h"
 
-static const char *default_disks[] = {
+static const char *const default_disks[] = {
 #ifdef __GNU__
 		"/dev/hd0",
 		"/dev/sd0",
@@ -2247,7 +2247,7 @@ done:
 static int ui_help(void)
 {
 	size_t i;
-	static const char *help[] = {
+	static const char *const help[] = {
 		N_("This is cfdisk, a curses-based disk partitioning program."),
 		N_("It lets you create, delete, and modify partitions on a block device."),
 		"  ",

--- a/disk-utils/fdisk-list.c
+++ b/disk-utils/fdisk-list.c
@@ -250,7 +250,7 @@ int list_freespace_get_table(struct fdisk_context *cxt,
 	char *strsz;
 	int rc = 0, ct = 0;
 
-	static const char *colnames[] = { N_("Start"), N_("End"), N_("Sectors"), N_("Size") };
+	static const char *const colnames[] = { N_("Start"), N_("End"), N_("Sectors"), N_("Size") };
 	static const int colids[] = { FDISK_FIELD_START, FDISK_FIELD_END, FDISK_FIELD_SECTORS, FDISK_FIELD_SIZE };
 
 	rc = fdisk_get_freespaces(cxt, &tb);

--- a/disk-utils/fdisk-list.h
+++ b/disk-utils/fdisk-list.h
@@ -41,7 +41,7 @@ enum {
 static inline int wipemode_from_string(const char *str)
 {
 	size_t i;
-	static const char *modes[] = {
+	static const char *const modes[] = {
 		[WIPEMODE_AUTO]   = "auto",
 		[WIPEMODE_NEVER]  = "never",
 		[WIPEMODE_ALWAYS] = "always"

--- a/disk-utils/fdisk-menu.c
+++ b/disk-utils/fdisk-menu.c
@@ -254,7 +254,7 @@ static const struct menu menu_bsd = {
 	}
 };
 
-static const struct menu *menus[] = {
+static const struct menu *const menus[] = {
 	&menu_gpt,
 	&menu_sun,
 	&menu_sgi,

--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -75,14 +75,14 @@
 
 #define FSCK_RUNTIME_DIRNAME	"/run/fsck"
 
-static const char *ignored_types[] = {
+static const char *const ignored_types[] = {
 	"ignore",
 	"iso9660",
 	"sw",
 	NULL
 };
 
-static const char *really_wanted[] = {
+static const char *const really_wanted[] = {
 	"minix",
 	"ext2",
 	"ext3",
@@ -1097,7 +1097,7 @@ static int device_exists(const char *device)
 
 static int fs_ignored_type(struct libmnt_fs *fs)
 {
-	const char **ip, *type;
+	const char *const*ip, *type;
 
 	if (!mnt_fs_is_regularfs(fs))
 		return 1;

--- a/include/c.h
+++ b/include/c.h
@@ -484,10 +484,10 @@ static inline void __attribute__((__noreturn__)) ul_sig_err(int excode, const ch
 		exit(eval); \
 })
 
-static inline void print_features(const char **features, const char *prefix)
+static inline void print_features(const char *const*features, const char *prefix)
 {
 	if (features && *features) {
-		const char **p = features;
+		const char *const*p = features;
 		while (p && *p) {
 			if (prefix && p == features)
 				printf(" (%s ", prefix);

--- a/lib/colors.c
+++ b/lib/colors.c
@@ -729,7 +729,7 @@ const char *color_get_disable_sequence(void)
 int colormode_from_string(const char *str)
 {
 	size_t i;
-	static const char *modes[] = {
+	static const char *const modes[] = {
 		[UL_COLORMODE_AUTO]   = "auto",
 		[UL_COLORMODE_NEVER]  = "never",
 		[UL_COLORMODE_ALWAYS] = "always",

--- a/lib/randutils.c
+++ b/lib/randutils.c
@@ -191,7 +191,7 @@ const char *random_tell_source(void)
 	return _("getrandom() function");
 #else
 	size_t i;
-	static const char *random_sources[] = {
+	static const char *const random_sources[] = {
 		"/dev/urandom",
 		"/dev/random"
 	};

--- a/libblkid/src/devname.c
+++ b/libblkid/src/devname.c
@@ -147,7 +147,7 @@ done:
 }
 
 /* Directories where we will try to search for device names */
-static const char *dirlist[] = { "/dev", "/devfs", "/devices", NULL };
+static const char *const dirlist[] = { "/dev", "/devfs", "/devices", NULL };
 
 /*
  * Return 1 if the device is a device-mapper 'leaf' node
@@ -177,7 +177,7 @@ static void probe_one(blkid_cache cache, const char *ptname,
 {
 	blkid_dev dev = NULL;
 	struct list_head *p, *pnext;
-	const char **dir;
+	const char *const*dir;
 	char *devname = NULL;
 
 	/* See if we already have this device number in the cache. */
@@ -359,7 +359,7 @@ exit:
 static void
 ubi_probe_all(blkid_cache cache, int only_if_new)
 {
-	const char **dirname;
+	const char *const*dirname;
 
 	for (dirname = dirlist; *dirname; dirname++) {
 		DIR		*dir;

--- a/libblkid/src/devno.c
+++ b/libblkid/src/devno.c
@@ -159,7 +159,7 @@ void blkid__scan_dir(char *dirname, dev_t devno, struct dir_list **list,
 }
 
 /* Directories where we will try to search for device numbers */
-static const char *devdirs[] = { "/devices", "/devfs", "/dev", NULL };
+static const char *const devdirs[] = { "/devices", "/devfs", "/dev", NULL };
 
 /**
  * SECTION: misc
@@ -173,7 +173,7 @@ static char *scandev_devno_to_devpath(dev_t devno)
 {
 	struct dir_list *list = NULL, *new_list = NULL;
 	char *devname = NULL;
-	const char **dir;
+	const char *const*dir;
 
 	/*
 	 * Add the starting directories to search in reverse order of

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -125,7 +125,7 @@
 /*
  * All supported chains
  */
-static const struct blkid_chaindrv *chains_drvs[] = {
+static const struct blkid_chaindrv *const chains_drvs[] = {
 	[BLKID_CHAIN_SUBLKS] = &superblocks_drv,
 	[BLKID_CHAIN_TOPLGY] = &topology_drv,
 	[BLKID_CHAIN_PARTS] = &partitions_drv

--- a/libblkid/src/superblocks/bitlocker.c
+++ b/libblkid/src/superblocks/bitlocker.c
@@ -85,7 +85,7 @@ enum {
 static int get_bitlocker_type(const unsigned char *buf)
 {
 	size_t i;
-	static const char *map[] = {
+	static const char *const map[] = {
 		[BDE_VERSION_VISTA] = BDE_MAGIC_VISTA,
 		[BDE_VERSION_WIN7]  = BDE_MAGIC_WIN7,
 		[BDE_VERSION_TOGO]  = BDE_MAGIC_TOGO

--- a/libfdisk/src/script.c
+++ b/libfdisk/src/script.c
@@ -767,7 +767,7 @@ static int parse_line_header(struct fdisk_script *dp, char *s)
 {
 	size_t i;
 	char *name, *value;
-	static const char *supported[] = {
+	static const char *const supported[] = {
 		"label", "unit", "label-id", "device", "grain",
 		"first-lba", "last-lba", "table-length", "sector-size"
 	};

--- a/libmount/src/hooks.c
+++ b/libmount/src/hooks.c
@@ -30,7 +30,7 @@
 #include "mount-api-utils.h"
 
 /* built-in hooksets */
-static const struct libmnt_hookset *hooksets[] =
+static const struct libmnt_hookset *const hooksets[] =
 {
 #ifdef __linux__
 	&hookset_loopdev,

--- a/libsmartcols/src/filter-param.c
+++ b/libsmartcols/src/filter-param.c
@@ -32,7 +32,7 @@ static int cast_param(int type, struct filter_param *n);
 
 static inline const char *datatype2str(int type)
 {
-	static const char *types[] = {
+	static const char *const types[] = {
 		[SCOLS_DATA_NONE] = "none",
 		[SCOLS_DATA_STRING] = "string",
 		[SCOLS_DATA_U64] = "u64",

--- a/libsmartcols/src/grouping.c
+++ b/libsmartcols/src/grouping.c
@@ -142,7 +142,7 @@ void scols_groups_fix_members_order(struct libscols_table *tb)
 
 static inline const char *group_state_to_string(int state)
 {
-	static const char *grpstates[] = {
+	static const char *const grpstates[] = {
 		[SCOLS_GSTATE_NONE]		= "none",
 		[SCOLS_GSTATE_FIRST_MEMBER]	= "1st-member",
 		[SCOLS_GSTATE_MIDDLE_MEMBER]	= "middle-member",

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -1739,7 +1739,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'V':
 		{
-			static const char *features[] = {
+			static const char *const features[] = {
 #ifdef HAVE_LIBLASTLOG2
 				"lastlog2",
 #endif

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -1045,7 +1045,7 @@ int main(int argc, char **argv)
 			break;
 		case 'V':
 		{
-			static const char *features[] = {
+			static const char *const features[] = {
 #ifdef USE_SULOGIN_EMERGENCY_MOUNT
 				"emergency-mount",
 #endif

--- a/lsfd-cmd/cdev.c
+++ b/lsfd-cmd/cdev.c
@@ -649,7 +649,7 @@ static struct cdev_ops cdev_tty_ops = {
 	.get_ipc_class = cdev_tty_get_ipc_class,
 };
 
-static const struct cdev_ops *cdev_ops[] = {
+static const struct cdev_ops *const cdev_ops[] = {
 	&cdev_tun_ops,
 	&cdev_misc_ops,
 	&cdev_tty_ops,

--- a/lsfd-cmd/unkn.c
+++ b/lsfd-cmd/unkn.c
@@ -939,7 +939,7 @@ static const struct anon_ops anon_inotify_ops = {
  * Generally, we use "-" as the word separators in lsfd's output.
  * However, about bpf*, we use "_" because bpftool uses "_".
  */
-static const char *bpf_prog_type_table[] = {
+static const char *const bpf_prog_type_table[] = {
 	[0] = "unspec",		   /* BPF_PROG_TYPE_UNSPEC*/
 	[1] = "socket_filter",	   /* BPF_PROG_TYPE_SOCKET_FILTER*/
 	[2] = "kprobe",		   /* BPF_PROG_TYPE_KPROBE*/
@@ -1139,7 +1139,7 @@ static const struct anon_ops anon_bpf_prog_ops = {
 /*
  * bpf-map
  */
-static const char *bpf_map_type_table[] = {
+static const char *const bpf_map_type_table[] = {
 	[0] = "unspec",		  /* BPF_MAP_TYPE_UNSPEC */
 	[1] = "hash",		  /* BPF_MAP_TYPE_HASH */
 	[2] = "array",		  /* BPF_MAP_TYPE_ARRAY */
@@ -1332,7 +1332,7 @@ static const struct anon_ops anon_generic_ops = {
 	.handle_fdinfo = NULL,
 };
 
-static const struct anon_ops *anon_ops[] = {
+static const struct anon_ops *const anon_ops[] = {
 	&anon_pidfd_ops,
 	&anon_eventfd_ops,
 	&anon_eventpoll_ops,

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -1401,7 +1401,7 @@ static int parse_options(int argc, char *argv[])
 			usage();
 		case 'V':
 		{
-			static const char *features[] = {
+			static const char *const features[] = {
 #ifdef USE_REFLINK
 				"reflink",
 #endif

--- a/misc-utils/kill.c
+++ b/misc-utils/kill.c
@@ -293,7 +293,7 @@ static void __attribute__((__noreturn__)) usage(void)
 
 static void __attribute__((__noreturn__)) print_kill_version(void)
 {
-	static const char *features[] = {
+	static const char *const features[] = {
 #ifdef HAVE_SIGQUEUE
 		"sigqueue",
 #endif

--- a/misc-utils/whereis.c
+++ b/misc-utils/whereis.c
@@ -100,7 +100,7 @@ struct wh_dirlist {
 	struct wh_dirlist *next;
 };
 
-static const char *bindirs[] = {
+static const char *const bindirs[] = {
 	"/usr/bin",
 	"/usr/sbin",
 	"/bin",
@@ -161,7 +161,7 @@ static const char *bindirs[] = {
 	NULL
 };
 
-static const char *mandirs[] = {
+static const char *const mandirs[] = {
 	"/usr/man/*",
 	"/usr/share/man/*",
 	"/usr/X386/man/*",
@@ -172,7 +172,7 @@ static const char *mandirs[] = {
 	NULL
 };
 
-static const char *srcdirs[] = {
+static const char *const srcdirs[] = {
 	"/usr/src/*",
 	"/usr/src/lib/libc/*",
 	"/usr/src/lib/libc/net/*",
@@ -355,7 +355,7 @@ static void construct_dirlist_from_argv(struct wh_dirlist **ls,
 
 static void construct_dirlist(struct wh_dirlist **ls,
 			      int type,
-			      const char **paths)
+			      const char *const*paths)
 {
 	size_t i;
 

--- a/schedutils/ionice.c
+++ b/schedutils/ionice.c
@@ -53,7 +53,7 @@ enum {
 #define IOPRIO_PRIO_DATA(mask)	((mask) & IOPRIO_PRIO_MASK)
 #define IOPRIO_PRIO_VALUE(class, data)	(((class) << IOPRIO_CLASS_SHIFT) | data)
 
-static const char *to_prio[] = {
+static const char *const to_prio[] = {
 	[IOPRIO_CLASS_NONE] = "none",
 	[IOPRIO_CLASS_RT]   = "realtime",
 	[IOPRIO_CLASS_BE]   = "best-effort",

--- a/sys-utils/blkzone.c
+++ b/sys-utils/blkzone.c
@@ -207,14 +207,14 @@ done:
  */
 #define DEF_REPORT_LEN		(1U << 12) /* 4k zones per report (256k kzalloc) */
 
-static const char *type_text[] = {
+static const char *const type_text[] = {
 	"RESERVED",
 	"CONVENTIONAL",
 	"SEQ_WRITE_REQUIRED",
 	"SEQ_WRITE_PREFERRED",
 };
 
-static const char *condition_str[] = {
+static const char *const condition_str[] = {
 	"nw", /* Not write pointer */
 	"em", /* Empty */
 	"oi", /* Implicitly opened */

--- a/sys-utils/chmem.c
+++ b/sys-utils/chmem.c
@@ -67,7 +67,7 @@ enum zone_id {
 	ZONE_DEVICE,
 };
 
-static char *zone_names[] = {
+static const char *const zone_names[] = {
 	[ZONE_DMA]	= "DMA",
 	[ZONE_DMA32]	= "DMA32",
 	[ZONE_NORMAL]	= "Normal",

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -36,14 +36,14 @@
 
 #include "lscpu.h"
 
-static const char *virt_types[] = {
+static const char *const virt_types[] = {
 	[VIRT_TYPE_NONE]	= N_("none"),
 	[VIRT_TYPE_PARA]	= N_("para"),
 	[VIRT_TYPE_FULL]	= N_("full"),
 	[VIRT_TYPE_CONTAINER]	= N_("container"),
 };
 
-static const char *hv_vendors[] = {
+static const char *const hv_vendors[] = {
 	[VIRT_VENDOR_NONE]	= NULL,
 	[VIRT_VENDOR_XEN]	= "Xen",
 	[VIRT_VENDOR_KVM]	= "KVM",
@@ -63,7 +63,7 @@ static const char *hv_vendors[] = {
 };
 
 /* dispatching modes */
-static const char *disp_modes[] = {
+static const char *const disp_modes[] = {
 	[DISP_HORIZONTAL]	= N_("horizontal"),
 	[DISP_VERTICAL]		= N_("vertical")
 };

--- a/sys-utils/lsmem.c
+++ b/sys-utils/lsmem.c
@@ -95,7 +95,7 @@ enum {
 	COL_ZONES,
 };
 
-static char *zone_names[] = {
+static const char *const zone_names[] = {
 	[ZONE_DMA]	= "DMA",
 	[ZONE_DMA32]	= "DMA32",
 	[ZONE_NORMAL]	= "Normal",

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -141,7 +141,7 @@ enum lsns_type {
 	LSNS_TYPE_TIME
 };
 
-static char *ns_names[] = {
+static const char *const ns_names[] = {
 	/* Don't add LSNS_TYPE_UNKNOWN here.
 	 * ARRAY_SIZE(ns_names) in struct lsns_process may not work.*/
 	[LSNS_TYPE_MNT] = "mnt",

--- a/sys-utils/renice.c
+++ b/sys-utils/renice.c
@@ -50,7 +50,7 @@
 #include "c.h"
 #include "closestream.h"
 
-static const char *idtype[] = {
+static const char *const idtype[] = {
 	[PRIO_PROCESS]	= N_("process ID"),
 	[PRIO_PGRP]	= N_("process group ID"),
 	[PRIO_USER]	= N_("user ID"),

--- a/sys-utils/rfkill.c
+++ b/sys-utils/rfkill.c
@@ -100,7 +100,7 @@ enum {
 	ACT_LIST_OLD
 };
 
-static char *rfkill_actions[] = {
+static const char *const rfkill_actions[] = {
 	[ACT_LIST]	= "list",
 	[ACT_HELP]	= "help",
 	[ACT_EVENT]	= "event",

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -75,7 +75,7 @@ enum rtc_modes {	/* manual page --mode option explains these. */
 
 };
 
-static const char *rtcwake_mode_string[] = {
+static const char *const rtcwake_mode_string[] = {
 	[OFF_MODE] = "off",
 	[NO_MODE] = "no",
 	[ON_MODE] = "on",

--- a/sys-utils/wdctl.c
+++ b/sys-utils/wdctl.c
@@ -204,8 +204,8 @@ static const struct colinfo *get_column_info(unsigned num)
  */
 static const char *get_default_device(void)
 {
-	const char **p;
-	static const char *devs[] = {
+	const char *const*p;
+	static const char *const devs[] = {
 		"/dev/watchdog0",
 		"/dev/watchdog",
 		NULL

--- a/sys-utils/zramctl.c
+++ b/sys-utils/zramctl.c
@@ -99,7 +99,7 @@ enum {
 	MM_NUM_MIGRATED
 };
 
-static const char *mm_stat_names[] = {
+static const char *const mm_stat_names[] = {
 	[MM_ORIG_DATA_SIZE]  = "orig_data_size",
 	[MM_COMPR_DATA_SIZE] = "compr_data_size",
 	[MM_MEM_USED_TOTAL]  = "mem_used_total",

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -655,7 +655,7 @@ static void login_options_to_argv(char *argv[], int *argc,
 
 static void output_version(void)
 {
-	static const char *features[] = {
+	static const char *const features[] = {
 #ifdef DEBUGGING
 		"debug",
 #endif
@@ -2146,7 +2146,7 @@ static char *get_logname(struct issue *ie, struct options *op, struct termios *t
 	char c;			/* input character, full eight bits */
 	char ascval;		/* low 7 bits of input character */
 	int eightbit;
-	static char *erase[] = {	/* backspace-space-backspace */
+	static const char *const erase[] = {	/* backspace-space-backspace */
 		"\010\040\010",		/* space parity */
 		"\010\040\010",		/* odd parity */
 		"\210\240\210",		/* even parity */

--- a/term-utils/setterm.c
+++ b/term-utils/setterm.c
@@ -99,7 +99,7 @@ enum {
 	DEFAULT
 };
 
-static const char *colornames[] = {
+static const char *const colornames[] = {
 	[BLACK] = "black",
 	[RED]	= "red",
 	[GREEN]	= "green",

--- a/text-utils/hexdump-conv.c
+++ b/text-utils/hexdump-conv.c
@@ -87,7 +87,7 @@ strpr:		*pr->cchar = 's';
 void
 conv_u(struct hexdump_pr *pr, u_char *p)
 {
-	static const char *list[] = {
+	static const char *const list[] = {
 		"nul", "soh", "stx", "etx", "eot", "enq", "ack", "bel",
 		 "bs",  "ht",  "lf",  "vt",  "ff",  "cr",  "so",  "si",
 		"dle", "dc1", "dc2", "dc3", "dc4", "nak", "syn", "etb",


### PR DESCRIPTION
The pointed-to structures were const, but the pointers were not.