### PR TITLE
meson: remove unused lastlog-compat-symlink option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -303,9 +303,6 @@ option('vendordir',
 
 option('pamlibdir', type : 'string',
        description : 'directory for PAM modules')
-option('lastlog-compat-symlink', type : 'boolean',
-       value : false,
-       description : 'create lastlog compat symlink')
 option('login-lastlogin', type : 'boolean',
        value : false,
        description : 'program login writes lastlog entries')


### PR DESCRIPTION
This option was not used even when it was originally introduced in #2508.

Fixes #3163.