### PR TITLE
libmount: support X-mount.noloop

### DIFF
--- a/libmount/src/hook_loopdev.c
+++ b/libmount/src/hook_loopdev.c
@@ -423,6 +423,9 @@ static int is_loopdev_required(struct libmnt_context *cxt, struct libmnt_optlist
 	    || mnt_context_propagation_only(cxt))
 		return 0;
 
+	if (mnt_optlist_get_named(ol, "X-mount.noloop", cxt->map_userspace))
+		return 0;
+
 	src = mnt_fs_get_srcpath(cxt->fs);
 	if (!src)
 		return 0;		/* backing file not set */

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -760,7 +760,10 @@ The command line option *--no-canonicalize* overrides this mount option and affe
 +
 Note that *mount*(8) still sanitizes and canonicalizes the source and target paths specified on the command line by non-root users, regardless of the X-mount.nocanonicalize setting.
 
-**X-mount.subdir=**__directory__::
+*X-mount.noloop*::
+Do not create and mount a loop device, even if the source of the mount is a regular file.
+
+*X-mount.subdir=*__directory__::
 Allow mounting sub-directory from a filesystem instead of the root directory. For now, this feature is implemented by temporary filesystem root directory mount in unshared namespace and then bind the sub-directory to the final mount point and umount the root of the filesystem. The sub-directory mount shows up atomically for the rest of the system although it is implemented by multiple *mount*(2) syscalls.
 +
 Note that this feature will not work in session with an unshared private mount namespace (after *unshare --mount*) on old kernels or with *mount*(8) without support for file-descriptors-based mount kernel API. In this case, you need *unshare --mount --propagation shared*.


### PR DESCRIPTION
libmount automatically creates a loop device and mounts it if the source of the mount is a regular file that contains a well-known filesystem. However, in some cases, this feature may be unwanted. The new mount option "X-mount.noloop" forces libmount to use the file directly as the mount source.

Addresses: https://github.com/util-linux/util-linux/pull/3288