### PR TITLE
agetty: always read additional issue file locations

### DIFF
--- a/term-utils/agetty.8.adoc
+++ b/term-utils/agetty.8.adoc
@@ -229,9 +229,11 @@ Some programs use "--" to indicate that the rest of the command line should not 
 
 The default issue file is _/etc/issue_. If the file exists, then *agetty* also checks for _/etc/issue.d_ directory. The directory is optional extension to the default issue file and content of the directory is printed after _/etc/issue_ content. If the _/etc/issue_ does not exist, then the directory is ignored. All files *with .issue extension* from the directory are printed in version-sort order. The directory can be used to maintain 3rd-party messages independently on the primary system _/etc/issue_ file.
 
-Since version 2.35 additional locations for issue file and directory are supported. If the default _/etc/issue_ does not exist, then *agetty* checks for _/run/issue_ and _/run/issue.d_, thereafter for _/usr/lib/issue_ and _/usr/lib/issue.d_. The directory _/etc_ is expected for host specific configuration, _/run_ is expected for generated stuff and _/usr/lib_ for static distribution maintained configuration.
+Since version 2.35, additional locations for the issue file and directory are supported. *agetty* checks for the files _/run/issue_ and _/run/issue.d_, and then for _/usr/lib/issue_ and _/usr/lib/issue.d_. The directory _/etc_ is expected for host-specific configuration, _/run_ is expected for generated content, and _/usr/lib_ is used for static configuration maintained by the distribution.
 
-The default path maybe overridden by *--issue-file* option. In this case specified path has to be file or directory and all the default issue file and directory locations are ignored.
+Note that in versions 2.35 to 2.40, the additional locations were only read if the default _/etc/issue_ file did not exist. However, since version 2.41, the additional locations are always read, regardless of the existence of the _/etc/issue_ file. This change allows for the generation of issue files by default.
+
+The default paths maybe completely overridden by *--issue-file* option. In this case specified path has to be file or directory and all the default issue file and directory locations are ignored.
 
 The issue file feature can be completely disabled by *--noissue* option.
 

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -1933,8 +1933,6 @@ static void eval_issue_file(struct issue *ie,
 			    struct options *op,
 			    struct termios *tp)
 {
-	int has_file = 0;
-
 #ifdef AGETTY_RELOAD
 	netlink_groups = 0;
 #endif
@@ -1973,22 +1971,13 @@ static void eval_issue_file(struct issue *ie,
 	if (access(_PATH_ISSUE, F_OK|R_OK) == 0) {
 		issuefile_read(ie, _PATH_ISSUE, op, tp);
 		issuedir_read(ie, _PATH_ISSUEDIR, op, tp);
-		goto done;
 	}
 
-	/* Fallback @runstatedir (usually /run) -- the file is not required to
-	 * read the dir.
-	 */
-	if (issuefile_read(ie, _PATH_RUNSTATEDIR "/" _PATH_ISSUE_FILENAME, op, tp) == 0)
-		has_file++;
-	if (issuedir_read(ie, _PATH_RUNSTATEDIR "/" _PATH_ISSUE_DIRNAME, op, tp) == 0)
-		has_file++;
-	if (has_file)
-		goto done;
+	/* Fallback @runstatedir (usually /run) */
+	issuefile_read(ie, _PATH_RUNSTATEDIR "/" _PATH_ISSUE_FILENAME, op, tp);
+	issuedir_read(ie, _PATH_RUNSTATEDIR "/" _PATH_ISSUE_DIRNAME, op, tp);
 
-	/* Fallback @sysconfstaticdir (usually /usr/lib) -- the file is not
-	 * required to read the dir
-	 */
+	/* Fallback @sysconfstaticdir (usually /usr/lib)*/
 	issuefile_read(ie, _PATH_SYSCONFSTATICDIR "/" _PATH_ISSUE_FILENAME, op, tp);
 	issuedir_read(ie, _PATH_SYSCONFSTATICDIR "/" _PATH_ISSUE_DIRNAME, op, tp);
 


### PR DESCRIPTION
Currently, additional locations (such as /run or /usr/lib) are only read if /etc/issue does not exist. This behavior makes it difficult to use local settings (/etc) together with generated (/run) and distribution-specific (/usr/lib) files. Let's read all the locations.

If the output of issue files is unwanted, the option --noissue can be used, or the default locations can be ignored by using --issue-file <list>.

Fixes: https://github.com/util-linux/util-linux/issues/3279
Addresses: https://github.com/systemd/systemd/issues/35071