### PR TITLE
login,libblkid: use econf_readConfig rather than deprecated econf_rea…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2723,8 +2723,15 @@ AC_ARG_WITH([econf],
 
 have_econf=no
 AS_IF([test "x$with_econf" != xno], [
-  PKG_CHECK_MODULES([ECONF], [libeconf], [have_econf=yes], [have_econf=no])
-    AS_CASE([$with_econf:$have_econf],
+  PKG_CHECK_MODULES([ECONF], [libeconf],
+     [have_econf=yes
+      AC_CHECK_LIB([econf], [econf_readConfig], [
+	  AC_DEFINE([HAVE_ECONF_READCONFIG], [1], [Define if econf_readConfig exist in -leconf])
+	  ])
+     ],
+     [have_econf=no]
+  )
+  AS_CASE([$with_econf:$have_econf],
     [yes:no],
       [AC_MSG_ERROR([libeconf expected but libeconf not found])],
     [*:yes],

--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -236,4 +236,11 @@
 /* Maximum number of PIDs system supports */
 #define _PATH_PROC_PIDMAX	"/proc/sys/kernel/pid_max"
 
+/* econf path */
+#if USE_VENDORDIR
+# define UL_VENDORDIR_PATH      _PATH_VENDORDIR
+#else
+# define UL_VENDORDIR_PATH      NULL
+#endif
+
 #endif /* PATHNAMES_H */

--- a/lib/logindefs.c
+++ b/lib/logindefs.c
@@ -254,14 +254,13 @@ static void load_defaults(void)
 	if (file != NULL)
 	        free_getlogindefs_data();
 
-	error = econf_readDirs(&file,
-#if USE_VENDORDIR
-			_PATH_VENDORDIR,
+#ifdef HAVE_ECONF_READCONFIG
+	error = econf_readConfig(&file, NULL,
+			UL_VENDORDIR_PATH, "login", "defs", "= \t", "#");
 #else
-			NULL,
+	error = econf_readDirs(&file,
+			UL_VENDORDIR_PATH, "/etc", "login", "defs", "= \t", "#");
 #endif
-			"/etc", "login", "defs", "= \t", "#");
-
 	if (error)
 	  syslog(LOG_NOTICE, _("Error reading login.defs: %s"),
 		 econf_errString(error));

--- a/libblkid/src/config.c
+++ b/libblkid/src/config.c
@@ -23,7 +23,8 @@
 #include <stdint.h>
 #include <stdarg.h>
 #if defined (HAVE_LIBECONF)
-#include <libeconf.h>
+# include <libeconf.h>
+# include "pathnames.h"
 #endif
 
 #include "blkidP.h"
@@ -161,13 +162,13 @@ struct blkid_config *blkid_read_config(const char *filename)
 		DBG(CONFIG, ul_debug("reading config file: %s.", filename));
 		error = econf_readFile(&file, filename, "= \t", "#");
 	} else {
-		error = econf_readDirs(&file,
-#if USE_VENDORDIR
-				       _PATH_VENDORDIR,
+#ifdef HAVE_ECONF_READCONFIG
+		error = econf_readConfig(&file, NULL,
+			UL_VENDORDIR_PATH, "blkid", "conf", "= \t", "#");
 #else
-				       NULL,
+		error = econf_readDirs(&file,
+			UL_VENDORDIR_PATH, "/etc", "blkid", "conf", "= \t", "#");
 #endif
-				       "/etc", "blkid", "conf", "= \t", "#");
 	}
 
 	if (error) {

--- a/meson.build
+++ b/meson.build
@@ -431,6 +431,11 @@ lib_econf = dependency(
   required : get_option('econf'))
 conf.set('HAVE_LIBECONF', lib_econf.found() ? 1 : false)
 
+have = cc.has_function(
+  'econf_readConfig',
+  dependencies : lib_econf)
+conf.set('HAVE_ECONF_READCONFIG', have ? 1 : false)
+
 lib_audit = dependency(
   'audit',
   required : get_option('audit'))


### PR DESCRIPTION
This PR fixes:
```
lib/logindefs.c: In function ‘load_defaults’:
lib/logindefs.c:257:9: warning: ‘econf_readDirs’ is deprecated: Use the econf_readConfig/econf_readConfigWithCallback instead [-Wdeprecated-declarations]
  257 |         error = econf_readDirs(&file,
      |         ^~~~~

libblkid/src/config.c: In function 'blkid_read_config': libblkid/src/config.c:164:17: error: 'econf_readDirs' is deprecated: Use the econf_readConfig/econf_readConfigWithCallback instead [-Werror=deprecated-declarations]
  164 |                 error = econf_readDirs(&file,
      |                 ^~~~~
```

@schubi2 please review.