### PR TITLE
libblkid: zfs: fix overflow warning [coverity scan]

### DIFF
--- a/libblkid/src/superblocks/zfs.c
+++ b/libblkid/src/superblocks/zfs.c
@@ -342,7 +342,7 @@ static int probe_zfs(blkid_probe pr,
 	 * Zero out whole nvlist header including fisrt nvpair size
 	 */
 	if (blkid_probe_set_magic(pr, offset, sizeof(struct nvs_header_t),
-	    (unsigned char *) &label->nvh_first_size))
+	    (unsigned char *) label))
 		return (1);
 
 	blkid_probe_set_fsendianness(pr, !swab_endian ?


### PR DESCRIPTION
[See this discussion on PR #3274](https://github.com/util-linux/util-linux/pull/3274#discussion_r1851902649)