### PR TITLE
meson: generate man page translations

### DIFF
--- a/disk-utils/meson.build
+++ b/disk-utils/meson.build
@@ -1,14 +1,17 @@
 mkfs_sources = files(
   'mkfs.c',
 )
+mkfs_manadocs = files('mkfs.8.adoc')
 
 mkfs_bfs_sources = files(
   'mkfs.bfs.c',
 )
+mkfs_bfs_manadocs = files('mkfs.bfs.8.adoc')
 
 isosize_sources = files(
   'isosize.c',
 )
+isosize_manadocs = files('isosize.8.adoc')
 
 mkswap_sources = files(
   'mkswap.c',
@@ -17,28 +20,33 @@ mkswap_sources = files(
 if lib_selinux.found()
   mkswap_sources += selinux_utils_c
 endif
+mkswap_manadocs = files('mkswap.8.adoc')
 
 swaplabel_sources = files(
   'swaplabel.c',
 ) + \
   swapprober_c
+swaplabel_manadocs = files('swaplabel.8.adoc')
 
 fsck_sources = files(
   'fsck.c',
 ) + \
   monotonic_c
+fsck_manadocs = files('fsck.8.adoc')
 
 mkfs_minix_sources = files(
   'mkfs.minix.c',
   'minix_programs.h',
 ) + \
   ismounted_c
+mkfs_minix_manadocs = files('mkfs.minix.8.adoc')
 
 fsck_minix_sources = files(
   'fsck.minix.c',
   'minix_programs.h',
 ) + \
   ismounted_c
+fsck_minix_manadocs = files('fsck.minix.8.adoc')
 
 mkfs_cramfs_sources = files(
   'mkfs.cramfs.c',
@@ -51,18 +59,22 @@ fsck_cramfs_sources = files(
   'cramfs.h',
   'cramfs_common.c',
 )
+fsck_cramfs_manadocs = files('fsck.cramfs.8.adoc')
 
 raw_sources = files(
   'raw.c',
 )
+raw_manadocs = files('raw.8.adoc')
 
 fdformat_sources = files(
   'fdformat.c',
 )
+fdformat_manadocs = files('fdformat.8.adoc')
 
 blockdev_sources = files(
   'blockdev.c',
 )
+blockdev_manadocs = files('blockdev.8.adoc')
 
 fdisk_sources = files(
   'fdisk.c',
@@ -71,25 +83,32 @@ fdisk_sources = files(
   'fdisk-list.c',
   'fdisk-list.h') + \
   pager_c
+fdisk_manadocs = files('fdisk.8.adoc')
 
 sfdisk_sources = files(
   'sfdisk.c',
   'fdisk-list.c',
   'fdisk-list.h')
+sfdisk_manadocs = files('sfdisk.8.adoc')
 
 cfdisk_sources = files(
   'cfdisk.c',
 )
+cfdisk_manadocs = files('cfdisk.8.adoc')
 
 addpart_sources = files(
   'addpart.c',
 )
+addpart_manadocs = files('addpart.8.adoc')
 delpart_sources = files(
   'delpart.c',
 )
+delpart_manadocs = files('delpart.8.adoc')
 resizepart_sources = files(
   'resizepart.c',
 )
+resizepart_manadocs = files('resizepart.8.adoc')
 partx_sources = files(
   'partx.c',
 )
+partx_manadocs = files('partx.8.adoc')

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -106,3 +106,5 @@ lib_tcolors = static_library(
   lib_color_sources,
   include_directories : dir_include,
   dependencies : curses_libs)
+
+lib_tcolors_manadocs = files('terminal-colors.d.5.adoc')

--- a/libblkid/meson.build
+++ b/libblkid/meson.build
@@ -51,7 +51,7 @@ lib_blkid_sources = '''
   src/partitions/sun.c
   src/partitions/ultrix.c
   src/partitions/unixware.c
-  
+
   src/superblocks/adaptec_raid.c
   src/superblocks/apfs.c
   src/superblocks/bcache.c
@@ -128,6 +128,8 @@ if LINUX
     src/topology/sysfs.c
   '''.split()
 endif
+
+lib_blkid_manadocs = files('libblkid.3.adoc')
 
 libblkid_sym = 'src/libblkid.sym'
 libblkid_sym_path = '@0@/@1@'.format(meson.current_source_dir(), libblkid_sym)

--- a/liblastlog2/man/meson.build
+++ b/liblastlog2/man/meson.build
@@ -1,0 +1,10 @@
+lib_lastlog2_manadocs = files(
+  'lastlog2.3.adoc',
+  'll2_write_entry.3.adoc',
+  'll2_read_entry.3.adoc',
+  'll2_import_lastlog.3.adoc',
+  'll2_read_all.3.adoc',
+  'll2_remove_entry.3.adoc',
+  'll2_rename_user.3.adoc',
+  'll2_update_login_time.3.adoc'
+)

--- a/liblastlog2/meson.build
+++ b/liblastlog2/meson.build
@@ -5,7 +5,9 @@ lib_lastlog2_sources = '''
   src/lastlog2.h
   src/lastlog2P.h
   src/lastlog2.c
-'''.split()  
+'''.split()
+
+subdir('man')
 
 liblastlog2_sym = 'src/liblastlog2.sym'
 liblastlog2_sym_path = '@0@/@1@'.format(meson.current_source_dir(), liblastlog2_sym)
@@ -60,4 +62,4 @@ if build_liblastlog2
       check : true)
   endforeach
 
-endif  
+endif

--- a/libsmartcols/meson.build
+++ b/libsmartcols/meson.build
@@ -74,5 +74,5 @@ if build_libsmartcols
 endif
 
 if build_libsmartcols
-  manadocs += ['libsmartcols/scols-filter.5.adoc']
+  lib_smartcols_manadocs = files('scols-filter.5.adoc')
 endif

--- a/libuuid/man/meson.build
+++ b/libuuid/man/meson.build
@@ -1,0 +1,11 @@
+lib_uuid_manadocs = files(
+    'uuid.3.adoc',
+    'uuid_clear.3.adoc',
+    'uuid_compare.3.adoc',
+    'uuid_copy.3.adoc',
+    'uuid_generate.3.adoc',
+    'uuid_is_null.3.adoc',
+    'uuid_parse.3.adoc',
+    'uuid_time.3.adoc',
+    'uuid_unparse.3.adoc'
+)

--- a/libuuid/meson.build
+++ b/libuuid/meson.build
@@ -13,6 +13,8 @@ lib_uuid_sources = '''
   src/uuid_time.c
 '''.split()
 
+subdir('man')
+
 predefined_c = files('src/predefined.c')
 pack_c = files('src/pack.c')
 unpack_c = files('src/unpack.c')

--- a/login-utils/meson.build
+++ b/login-utils/meson.build
@@ -3,6 +3,10 @@ chfn_chsh_sources = files(
   'ch-common.h',
 )
 chfn_chsh_deps = [lib_readline]
+chfn_chsh_manadocs = files(
+  'chfn.1.adoc',
+  'chsh.1.adoc',
+)
 
 if chfn_chsh_password
   chfn_chsh_sources += files(
@@ -51,13 +55,30 @@ last_sources = files(
   'last.c',
 ) + \
   monotonic_c
+last_manadocs = files('last.1.adoc')
 
 login_sources = files(
   'login.c',
 )
+login_manadocs = files('login.1.adoc')
 
 sulogin_sources = files(
   'sulogin.c',
   'sulogin-consoles.c',
   'sulogin-consoles.h',
 )
+sulogin_manadocs = files('sulogin.8.adoc')
+
+lslogins_manadocs = files('lslogins.1.adoc')
+
+nologin_manadocs = files('nologin.8.adoc')
+
+newgrp_manadocs = files('newgrp.1.adoc')
+
+runuser_manadocs = files('runuser.1.adoc')
+
+su_manadocs = files('su.1.adoc')
+
+utmpdump_manadocs = files('utmpdump.1.adoc')
+
+vipw_manadocs = files('vipw.8.adoc')

--- a/lsfd-cmd/meson.build
+++ b/lsfd-cmd/meson.build
@@ -12,3 +12,5 @@ lsfd_sources = files (
   'fifo.c',
   'pidfd.c',
 )
+
+lsfd_manadocs = files('lsfd.1.adoc')

--- a/man-common/meson.build
+++ b/man-common/meson.build
@@ -1,0 +1,11 @@
+man_common_adocs = files(
+  'bugreports.adoc',
+  'colors.adoc',
+  'footer.adoc',
+  'footer-config.adoc',
+  'footer-lib.adoc',
+  'help-version.adoc',
+  'in-bytes.adoc',
+  'manpage-stub.adoc',
+  'translation.adoc',
+)

--- a/meson.build
+++ b/meson.build
@@ -984,7 +984,9 @@ subdir('pam_lastlog2')
 subdir('login-utils')
 subdir('sys-utils')
 subdir('disk-utils')
+subdir('man-common')
 subdir('misc-utils')
+subdir('schedutils')
 subdir('text-utils')
 subdir('term-utils')
 subdir('lsfd-cmd')
@@ -1026,7 +1028,7 @@ exe2 = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += [exe, exe2]
-  manadocs += ['login-utils/chfn.1.adoc', 'login-utils/chsh.1.adoc']
+  manadocs += chfn_chsh_manadocs
   bashcompletions += ['chfn', 'chsh']
 endif
 
@@ -1061,7 +1063,7 @@ if opt and not is_disabler(exe)
   meson.add_install_script(meson_make_symlink,
                            'last',
                            usrbin_exec_dir / 'lastb')
-  manadocs += ['login-utils/last.1.adoc']
+  manadocs += last_manadocs
   manlinks += {'lastb.1': 'last.1'}
   bashcompletions += ['last']
   bashcompletionslinks += {'lastb': 'last'}
@@ -1078,7 +1080,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['login-utils/nologin.8.adoc']
+  manadocs += nologin_manadocs
 endif
 
 opt = not get_option('build-utmpdump').disabled()
@@ -1092,7 +1094,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['login-utils/utmpdump.1.adoc']
+  manadocs += utmpdump_manadocs
   bashcompletions += ['utmpdump']
 endif
 
@@ -1116,7 +1118,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['login-utils/su.1.adoc']
+  manadocs += su_manadocs
   bashcompletions += ['su']
 endif
 
@@ -1132,7 +1134,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['login-utils/newgrp.1.adoc']
+  manadocs += newgrp_manadocs
   bashcompletions += ['newgrp']
 endif
 
@@ -1152,7 +1154,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['login-utils/lslogins.1.adoc']
+  manadocs += lslogins_manadocs
   bashcompletions += ['lslogins']
 endif
 
@@ -1172,7 +1174,7 @@ if opt and not is_disabler(exe)
   meson.add_install_script(meson_make_symlink,
                            'vipw',
                            usrbin_exec_dir / 'vigr')
-  manadocs += ['login-utils/vipw.8.adoc']
+  manadocs += vipw_manadocs
   meson.add_install_script(meson_make_symlink,
                            'vipw.8',
                            mandir / 'man8/vigr.8')
@@ -1198,7 +1200,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['login-utils/runuser.1.adoc']
+  manadocs += runuser_manadocs
   bashcompletionslinks += {'runuser': 'su'}
 endif
 
@@ -1214,7 +1216,7 @@ exe = executable(
   install : true)
 if opt and not is_disabler(exe)
 exes += exe
-manadocs += ['text-utils/bits.1.adoc']
+manadocs += bits_manadocs
 bashcompletions += ['bits']
 endif
 
@@ -1229,7 +1231,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['text-utils/col.1.adoc']
+  manadocs += col_manadocs
   bashcompletions += ['col']
 endif
 
@@ -1243,7 +1245,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['text-utils/colcrt.1.adoc']
+  manadocs += colcrt_manadocs
   bashcompletions += ['colcrt']
 endif
 
@@ -1258,7 +1260,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['text-utils/colrm.1.adoc']
+  manadocs += colrm_manadocs
   bashcompletions += ['colrm']
 endif
 
@@ -1272,7 +1274,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['text-utils/rev.1.adoc']
+  manadocs += rev_manadocs
   bashcompletions += ['rev']
 endif
 
@@ -1286,7 +1288,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['text-utils/column.1.adoc']
+  manadocs += column_manadocs
   bashcompletions += ['column']
 endif
 
@@ -1300,7 +1302,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['text-utils/line.1.adoc']
+  manadocs += line_manadocs
 endif
 
 opt = not get_option('build-pg').disabled()
@@ -1316,7 +1318,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['text-utils/pg.1.adoc']
+  manadocs += pg_manadocs
   bashcompletions += ['pg']
 endif
 
@@ -1332,7 +1334,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['text-utils/ul.1.adoc']
+  manadocs += ul_manadocs
   bashcompletions += ['ul']
 endif
 
@@ -1360,7 +1362,7 @@ exe2 = executable(
 exes += exe
 if opt and not is_disabler(exe)
   exes += [exe, exe2]
-  manadocs += ['text-utils/more.1.adoc']
+  manadocs += more_manadocs
   bashcompletions += ['more']
 endif
 
@@ -1377,7 +1379,7 @@ else
 endif
 if not is_disabler(exe)
     exes += exe
-    manadocs += ['text-utils/hexdump.1.adoc']
+    manadocs += hexdump_manadocs
     bashcompletions += ['hexdump']
 endif
 
@@ -1393,7 +1395,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/lsmem.1.adoc']
+  manadocs += lsmem_manadocs
   bashcompletions += ['lsmem']
 endif
 
@@ -1408,7 +1410,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/chmem.8.adoc']
+  manadocs += chmem_manadocs
   bashcompletions += ['chmem']
 endif
 
@@ -1423,7 +1425,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/choom.1.adoc']
+  manadocs += choom_manadocs
   bashcompletions += ['choom']
 endif
 
@@ -1440,7 +1442,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/ipcmk.1.adoc']
+  manadocs += ipcmk_manadocs
   bashcompletions += ['ipcmk']
 endif
 
@@ -1455,7 +1457,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/ipcrm.1.adoc']
+  manadocs += ipcrm_manadocs
   bashcompletions += ['ipcrm']
 endif
 
@@ -1470,7 +1472,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/ipcs.1.adoc']
+  manadocs += ipcs_manadocs
   bashcompletions += ['ipcs']
 endif
 
@@ -1486,7 +1488,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/rfkill.8.adoc']
+  manadocs += rfkill_manadocs
   bashcompletions += ['rfkill']
 endif
 
@@ -1500,7 +1502,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/renice.1.adoc']
+  manadocs += renice_manadocs
   bashcompletions += ['renice']
 endif
 
@@ -1514,7 +1516,7 @@ exe = executable(
   install : true)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/setpgid.1.adoc']
+  manadocs += setpgid_manadocs
   bashcompletions += ['setpgid']
 endif
 
@@ -1528,7 +1530,7 @@ exe = executable(
   install : true)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/setsid.1.adoc']
+  manadocs += setsid_manadocs
   bashcompletions += ['setsid']
 endif
 
@@ -1542,7 +1544,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/readprofile.8.adoc']
+  manadocs += readprofile_manadocs
   bashcompletions += ['readprofile']
 endif
 
@@ -1557,7 +1559,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/tunelp.8.adoc']
+  manadocs += tunelp_manadocs
   bashcompletions += ['tunelp']
 endif
 
@@ -1573,7 +1575,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/fstrim.8.adoc']
+  manadocs += fstrim_manadocs
   bashcompletions += ['fstrim']
 endif
 
@@ -1588,7 +1590,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/dmesg.1.adoc']
+  manadocs += dmesg_manadocs
   bashcompletions += ['dmesg']
 endif
 
@@ -1615,7 +1617,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/ctrlaltdel.8.adoc']
+  manadocs += ctrlaltdel_manadocs
   bashcompletions += ['ctrlaltdel']
 endif
 
@@ -1631,7 +1633,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/fsfreeze.8.adoc']
+  manadocs += fsfreeze_manadocs
   bashcompletions += ['fsfreeze']
 endif
 
@@ -1647,7 +1649,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/blkdiscard.8.adoc']
+  manadocs += blkdiscard_manadocs
   bashcompletions += ['blkdiscard']
 endif
 
@@ -1662,7 +1664,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/blkzone.8.adoc']
+  manadocs += blkzone_manadocs
   bashcompletions += ['blkzone']
 endif
 
@@ -1677,7 +1679,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/blkpr.8.adoc']
+  manadocs += blkpr_manadocs
 endif
 
 opt = get_option('build-ldattach').require(cc.has_header('linux/if.h')).allowed()
@@ -1691,7 +1693,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/ldattach.8.adoc']
+  manadocs += ldattach_manadocs
   bashcompletions += ['ldattach']
 endif
 
@@ -1708,7 +1710,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/rtcwake.8.adoc']
+  manadocs += rtcwake_manadocs
   bashcompletions += ['rtcwake']
 endif
 
@@ -1723,7 +1725,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/setarch.8.adoc']
+  manadocs += setarch_manadocs
   bashcompletions += ['setarch']
 endif
 
@@ -1761,7 +1763,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exe = exe
-  manadocs += ['sys-utils/eject.1.adoc']
+  manadocs += eject_manadocs
   bashcompletions += ['eject']
 endif
 
@@ -1776,7 +1778,7 @@ exe = executable(
   install : opt,
   build_by_default : opt)
 if opt and not is_disabler(exe)
-  manadocs += ['sys-utils/losetup.8.adoc']
+  manadocs += losetup_manadocs
   exes += exe
   bashcompletions += ['losetup']
 endif
@@ -1808,7 +1810,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/zramctl.8.adoc']
+  manadocs += zramctl_manadocs
   bashcompletions += ['zramctl']
 endif
 
@@ -1822,7 +1824,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/prlimit.1.adoc']
+  manadocs += prlimit_manadocs
   bashcompletions += ['prlimit']
 endif
 
@@ -1839,7 +1841,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/lsns.8.adoc']
+  manadocs += lsns_manadocs
   bashcompletions += ['lsns']
 endif
 
@@ -1865,9 +1867,9 @@ exe2 = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += [exe, exe2]
-  manadocs += ['sys-utils/fstab.5.adoc',
-		    'sys-utils/mount.8.adoc',
-	            'sys-utils/umount.8.adoc']
+  manadocs += [fstab_manadocs,
+              mount_manadocs,
+	            umount_manadocs]
   bashcompletions += ['mount', 'umount']
 endif
 
@@ -1915,7 +1917,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/swapon.8.adoc']
+  manadocs += swapon_manadocs
   bashcompletions += ['swapon']
 endif
 
@@ -1946,7 +1948,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/lscpu.1.adoc']
+  manadocs += lscpu_manadocs
   bashcompletions += ['lscpu']
 endif
 
@@ -1961,7 +1963,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/chcpu.8.adoc']
+  manadocs += chcpu_manadocs
   bashcompletions += ['chcpu']
 endif
 
@@ -1974,7 +1976,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/wdctl.8.adoc']
+  manadocs += wdctl_manadocs
   bashcompletions += ['wdctl']
 endif
 
@@ -1988,7 +1990,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/mountpoint.1.adoc']
+  manadocs += mountpoint_manadocs
   bashcompletions += ['mountpoint']
 endif
 
@@ -2003,7 +2005,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/fallocate.1.adoc']
+  manadocs += fallocate_manadocs
   bashcompletions += ['fallocate']
 endif
 
@@ -2017,7 +2019,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/pivot_root.8.adoc']
+  manadocs += pivot_root_manadocs
   bashcompletions += ['pivot_root']
 endif
 
@@ -2034,7 +2036,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/switch_root.8.adoc']
+  manadocs += switch_root_manadocs
 endif
 
 opt = not get_option('build-unshare').disabled()
@@ -2049,7 +2051,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/unshare.1.adoc']
+  manadocs += unshare_manadocs
   bashcompletions += ['unshare']
 endif
 
@@ -2079,7 +2081,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/nsenter.1.adoc']
+  manadocs += nsenter_manadocs
   bashcompletions += ['nsenter']
 endif
 
@@ -2109,7 +2111,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/setpriv.1.adoc']
+  manadocs += setpriv_manadocs
   bashcompletions += ['setpriv']
 endif
 
@@ -2125,7 +2127,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/flock.1.adoc']
+  manadocs += flock_manadocs
   bashcompletions += ['flock']
 endif
 
@@ -2141,7 +2143,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/lsirq.1.adoc']
+  manadocs += lsirq_manadocs
   bashcompletions += ['lsirq']
 endif
 
@@ -2159,7 +2161,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/irqtop.1.adoc']
+  manadocs += irqtop_manadocs
   bashcompletions += ['irqtop']
 endif
 
@@ -2175,7 +2177,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/lsipc.1.adoc']
+  manadocs += lsipc_manadocs
   bashcompletions += ['lsipc']
 endif
 
@@ -2192,7 +2194,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['sys-utils/hwclock.8.adoc', 'sys-utils/adjtime_config.5.adoc']
+  manadocs +=  hwclock_manadocs
   bashcompletions += ['hwclock']
 endif
 
@@ -2206,7 +2208,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/mkfs.8.adoc']
+  manadocs += mkfs_manadocs
   bashcompletions += ['mkfs']
 endif
 
@@ -2221,7 +2223,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/mkfs.bfs.8.adoc']
+  manadocs += mkfs_bfs_manadocs
   bashcompletions += ['mkfs.bfs']
 endif
 
@@ -2236,7 +2238,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/isosize.8.adoc']
+  manadocs += isosize_manadocs
   bashcompletions += ['isosize']
 endif
 
@@ -2251,7 +2253,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/mkswap.8.adoc']
+  manadocs += mkswap_manadocs
   bashcompletions += ['mkswap']
 endif
 
@@ -2266,7 +2268,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/swaplabel.8.adoc']
+  manadocs += swaplabel_manadocs
   bashcompletions += ['swaplabel']
 endif
 
@@ -2282,7 +2284,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/fsck.8.adoc']
+  manadocs += fsck_manadocs
   bashcompletions += ['fsck']
 endif
 
@@ -2312,7 +2314,7 @@ exe3 = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += [exe, exe2, exe3]
-  manadocs += ['disk-utils/mkfs.minix.8.adoc','disk-utils/fsck.minix.8.adoc']
+  manadocs += fsck_minix_manadocs
   bashcompletions += ['mkfs.minix', 'fsck.minix']
 endif
 
@@ -2337,7 +2339,7 @@ exe2 = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += [exe, exe2]
-  manadocs += ['disk-utils/mkfs.cramfs.8.adoc','disk-utils/fsck.cramfs.8.adoc']
+  manadocs += fsck_cramfs_manadocs
   bashcompletions += ['mkfs.cramfs', 'fsck.cramfs']
 endif
 
@@ -2354,7 +2356,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/raw.8.adoc']
+  manadocs += raw_manadocs
   bashcompletions += ['raw']
 endif
 
@@ -2369,7 +2371,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/fdformat.8.adoc']
+  manadocs += fdformat_manadocs
   bashcompletions += ['fdformat']
 endif
 
@@ -2384,7 +2386,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/blockdev.8.adoc']
+  manadocs += blockdev_manadocs
   bashcompletions += ['blockdev']
 endif
 
@@ -2475,9 +2477,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['disk-utils/fdisk.8.adoc',
-		    'disk-utils/sfdisk.8.adoc',
-		    'disk-utils/cfdisk.8.adoc']
+  manadocs += cfdisk_manadocs + fdisk_manadocs + sfdisk_manadocs
   bashcompletions += ['cfdisk']
 endif
 
@@ -2518,10 +2518,7 @@ exe4 = executable(
   build_by_default : opt)
 if opt
   exes += [exe, exe2, exe3, exe4]
-  manadocs += ['disk-utils/addpart.8.adoc',
-		    'disk-utils/delpart.8.adoc',
-		    'disk-utils/resizepart.8.adoc',
-		    'disk-utils/partx.8.adoc']
+  manadocs += addpart_manadocs + delpart_manadocs + resizepart_manadocs + partx_manadocs
   bashcompletions += ['addpart', 'delpart', 'resizepart', 'partx']
 endif
 opt = opt and 'partx' in static_programs
@@ -2585,7 +2582,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['term-utils/script.1.adoc']
+  manadocs += script_manadocs
   bashcompletions += ['script']
 endif
 
@@ -2618,7 +2615,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['term-utils/scriptlive.1.adoc']
+  manadocs += scriptlive_manadocs
   bashcompletions += ['scriptlive']
 endif
 
@@ -2633,7 +2630,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['term-utils/scriptreplay.1.adoc']
+  manadocs += scriptreplay_manadocs
   bashcompletions += ['scriptreplay']
 endif
 
@@ -2649,7 +2646,7 @@ exe = executable(
   build_by_default : opt)
 if opt
   exes += exe
-  manadocs += ['term-utils/agetty.8.adoc']
+  manadocs += agetty_manadocs
 endif
 
 opt = not get_option('build-setterm').disabled()
@@ -2664,7 +2661,7 @@ exe = executable(
   build_by_default : opt)
 if opt
   exes += exe
-  manadocs += ['term-utils/setterm.1.adoc']
+  manadocs += setterm_manadocs
   bashcompletions += ['setterm']
 endif
 
@@ -2679,7 +2676,7 @@ exe = executable(
   build_by_default : opt)
 if opt
   exes += exe
-  manadocs += ['term-utils/mesg.1.adoc']
+  manadocs += mesg_manadocs
   bashcompletions += ['mesg']
 endif
 
@@ -2703,7 +2700,7 @@ exe = executable(
   build_by_default : opt)
 if opt
   exes += exe
-  manadocs += ['term-utils/wall.1.adoc']
+  manadocs += wall_manadocs
   bashcompletions += ['wall']
 endif
 
@@ -2723,7 +2720,7 @@ exe = executable(
   build_by_default : opt)
 if opt
   exes += exe
-  manadocs += ['term-utils/write.1.adoc']
+  manadocs += write_manadocs
   bashcompletions += ['write']
 endif
 
@@ -2743,7 +2740,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['login-utils/login.1.adoc']
+  manadocs += login_manadocs
 endif
 
 opt = not get_option('build-sulogin').disabled()
@@ -2759,7 +2756,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['login-utils/sulogin.8.adoc']
+  manadocs += sulogin_manadocs
 endif
 
 opt = not get_option('build-cal').disabled()
@@ -2775,7 +2772,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/cal.1.adoc']
+  manadocs += cal_manadocs
   bashcompletions += ['cal']
 endif
 
@@ -2791,7 +2788,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/logger.1.adoc']
+  manadocs += logger_manadocs
   bashcompletions += ['logger']
 endif
 
@@ -2817,7 +2814,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/look.1.adoc']
+  manadocs += look_manadocs
   bashcompletions += ['look']
 endif
 
@@ -2832,7 +2829,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/mcookie.1.adoc']
+  manadocs += mcookie_manadocs
   bashcompletions += ['mcookie']
 endif
 
@@ -2845,17 +2842,9 @@ if build_liblastlog2
     install_dir : usrbin_exec_dir,
     install : true)
   exes += exe
-  manadocs += ['misc-utils/lastlog2.8.adoc']
+  manadocs += lastlog2_manadocs
   bashcompletions += ['lastlog2']
-  manadocs += ['liblastlog2/man/lastlog2.3.adoc',
-               'liblastlog2/man/ll2_write_entry.3.adoc',
-	       'liblastlog2/man/ll2_read_entry.3.adoc',
-	       'liblastlog2/man/ll2_import_lastlog.3.adoc',
-	       'liblastlog2/man/ll2_read_all.3.adoc',
-	       'liblastlog2/man/ll2_remove_entry.3.adoc',
-	       'liblastlog2/man/ll2_rename_user.3.adoc',
-	       'liblastlog2/man/ll2_update_login_time.3.adoc'
-	       ]
+  manadocs += lib_lastlog2_manadocs
 endif
 
 opt = not get_option('build-namei').disabled()
@@ -2869,7 +2858,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/namei.1.adoc']
+  manadocs += namei_manadocs
   bashcompletions += ['namei']
 endif
 
@@ -2884,7 +2873,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/whereis.1.adoc']
+  manadocs += whereis_manadocs
   bashcompletions += ['whereis']
 endif
 
@@ -2901,7 +2890,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/lslocks.8.adoc']
+  manadocs += lslocks_manadocs
   bashcompletions += ['lslocks']
 endif
 
@@ -2918,7 +2907,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/lsblk.8.adoc']
+  manadocs += lsblk_manadocs
   bashcompletions += ['lsblk']
 endif
 
@@ -2944,7 +2933,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['lsfd-cmd/lsfd.1.adoc']
+  manadocs += lsfd_manadocs
 endif
 
 exe = executable(
@@ -2957,7 +2946,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/uuidgen.1.adoc']
+  manadocs += uuidgen_manadocs
   bashcompletions += ['uuidgen']
 endif
 
@@ -2972,7 +2961,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/uuidparse.1.adoc']
+  manadocs += uuidparse_manadocs
   bashcompletions += ['uuidparse']
 endif
 
@@ -2998,7 +2987,7 @@ exe2 = executable(
   build_by_default : opt and program_tests)
 if not is_disabler(exe)
   exes += [exe, exe2]
-  manadocs += ['misc-utils/uuidd.8.adoc']
+  manadocs += uuidd_manadocs
   bashcompletions += ['uuidd']
 endif
 
@@ -3014,7 +3003,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/blkid.8.adoc']
+  manadocs += blkid_manadocs
   bashcompletions += ['blkid']
 endif
 
@@ -3089,7 +3078,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/findfs.8.adoc']
+  manadocs += findfs_manadocs
   bashcompletions += ['findfs']
 endif
 
@@ -3104,7 +3093,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/wipefs.8.adoc']
+  manadocs += wipefs_manadocs
   bashcompletions += ['wipefs']
 endif
 
@@ -3120,7 +3109,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/findmnt.8.adoc']
+  manadocs += findmnt_manadocs
   bashcompletions += ['findmnt']
 endif
 
@@ -3134,7 +3123,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/kill.1.adoc']
+  manadocs += kill_manadocs
 endif
 
 opt = not get_option('build-rename').disabled()
@@ -3148,7 +3137,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/rename.1.adoc']
+  manadocs += rename_manadocs
   bashcompletions += ['rename']
 endif
 
@@ -3163,7 +3152,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/getopt.1.adoc']
+  manadocs += getopt_manadocs
   bashcompletions += ['getopt']
 endif
 
@@ -3177,7 +3166,7 @@ exe = executable(
   install : true)
 if not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/fincore.1.adoc']
+  manadocs += fincore_manadocs
   bashcompletions += ['fincore']
 endif
 
@@ -3192,7 +3181,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/hardlink.1.adoc']
+  manadocs += hardlink_manadocs
   bashcompletions += ['hardlink']
 endif
 
@@ -3207,7 +3196,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/pipesz.1.adoc']
+  manadocs += pipesz_manadocs
   bashcompletions += ['pipesz']
 endif
 
@@ -3237,7 +3226,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/fadvise.1.adoc']
+  manadocs += fadvise_manadocs
   bashcompletions += ['fadvise']
 endif
 
@@ -3252,7 +3241,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/waitpid.1.adoc']
+  manadocs += waitpid_manadocs
   bashcompletions += ['waitpid']
 endif
 
@@ -3277,7 +3266,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/enosys.1.adoc']
+  manadocs += enosys_manadocs
   bashcompletions += ['enosys']
 endif
 
@@ -3292,7 +3281,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/lsclocks.1.adoc']
+  manadocs += lsclocks_manadocs
   bashcompletions += ['lsclocks']
 endif
 
@@ -3307,7 +3296,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
-  manadocs += ['misc-utils/exch.1.adoc']
+  manadocs += exch_manadocs
   bashcompletions += ['exch']
 endif
 
@@ -3361,11 +3350,7 @@ exe5 = executable(
 
 if opt and not is_disabler(exe)
   exes += [exe, exe2, exe3, exe4, exe5]
-  manadocs += ['schedutils/chrt.1.adoc',
-               'schedutils/ionice.1.adoc',
-               'schedutils/taskset.1.adoc',
-               'schedutils/uclampset.1.adoc',
-               'schedutils/coresched.1.adoc']
+  manadocs += schedutils_manadocs
   bashcompletions += ['chrt', 'ionice', 'taskset', 'uclampset', 'coresched']
 endif
 
@@ -3922,22 +3907,13 @@ run_target(
   depends : exes)
 
 
-manadocs += ['lib/terminal-colors.d.5.adoc']
+manadocs += lib_tcolors_manadocs
 if build_libblkid
-  manadocs += ['libblkid/libblkid.3.adoc']
+  manadocs += lib_blkid_manadocs + lib_smartcols_manadocs
 endif
 
 if build_libuuid
-  manadocs += [
-    'libuuid/man/uuid.3.adoc',
-    'libuuid/man/uuid_clear.3.adoc',
-    'libuuid/man/uuid_compare.3.adoc',
-    'libuuid/man/uuid_copy.3.adoc',
-    'libuuid/man/uuid_generate.3.adoc',
-    'libuuid/man/uuid_is_null.3.adoc',
-    'libuuid/man/uuid_parse.3.adoc',
-    'libuuid/man/uuid_time.3.adoc',
-    'libuuid/man/uuid_unparse.3.adoc']
+  manadocs += lib_uuid_manadocs
   manlinks += {
     'uuid_generate_random.3': 'uuid_generate.3',
     'uuid_generate_time.3': 'uuid_generate.3',
@@ -3948,8 +3924,8 @@ endif
 asciidoctor = find_program('asciidoctor', required : false)
 if asciidoctor.found()
   foreach adoc : manadocs
-    name = adoc.split('/')[-1]
-    page = name.split('.adoc')[0]
+    name = fs.name(adoc)
+    page = fs.stem(adoc)
     section = page.split('.')[-1]
     mandirn = mandir / 'man' + section
     input = adoc

--- a/meson.build
+++ b/meson.build
@@ -3957,6 +3957,8 @@ if asciidoctor.found()
       'man' + target_section / target,
       mandir / 'man' + link_section / link_name)
   endforeach
+
+  subdir('po-man')
 endif
 
 if bash_completion.found()

--- a/misc-utils/meson.build
+++ b/misc-utils/meson.build
@@ -1,40 +1,52 @@
+blkid_manadocs = files('blkid.8.adoc')
+
 cal_sources = files(
   'cal.c',
 )
+cal_manadocs = files('cal.1.adoc')
+
+enosys_manadocs = files('enosys.1.adoc')
 
 logger_sources = files(
   'logger.c',
 ) + \
   strutils_c + \
   strv_c
+logger_manadocs = files('logger.1.adoc')
 
 look_sources = files(
   'look.c',
 )
+look_manadocs = files('look.1.adoc')
 
 lastlog2_sources = files(
   'lastlog2.c',
 ) + \
   strutils_c
+lastlog2_manadocs = files('lastlog2.8.adoc')
 
 mcookie_sources = files(
   'mcookie.c',
 ) + \
   md5_c
+mcookie_manadocs = files('mcookie.1.adoc')
 
 namei_sources = files(
   'namei.c',
 ) + \
   strutils_c + \
   idcache_c
+namei_manadocs = files('namei.1.adoc')
 
 whereis_sources = files(
   'whereis.c',
 )
+whereis_manadocs = files('whereis.1.adoc')
 
 lslocks_sources = files(
   'lslocks.c',
 )
+lslocks_manadocs = files('lslocks.8.adoc')
 
 lsblk_sources = files(
   'lsblk.c',
@@ -43,20 +55,24 @@ lsblk_sources = files(
   'lsblk-devtree.c',
   'lsblk.h',
 )
+lsblk_manadocs = files('lsblk.8.adoc')
 
 uuidgen_sources = files(
   'uuidgen.c',
 )
+uuidgen_manadocs = files('uuidgen.1.adoc')
 
 uuidparse_sources = files(
   'uuidparse.c',
 )
+uuidparse_manadocs = files('uuidparse.1.adoc')
 
 uuidd_sources = files(
   'uuidd.c',
 ) + \
   monotonic_c + \
   timer_c
+uuidd_manadocs = files('uuidd.8.adoc')
 
 test_uuidd_sources = files(
   'test_uuidd.c',
@@ -124,28 +140,34 @@ blkid_sources = files(
 findfs_sources = files(
   'findfs.c',
 )
+findfs_manadocs = files('findfs.8.adoc')
 
 wipefs_sources = files(
   'wipefs.c',
 )
+wipefs_manadocs = files('wipefs.8.adoc')
 
 findmnt_sources = files(
   'findmnt.c',
   'findmnt-verify.c',
   'findmnt.h',
 )
+findmnt_manadocs = files('findmnt.8.adoc')
 
 kill_sources = files(
   'kill.c',
 )
+kill_manadocs = files('kill.1.adoc')
 
 rename_sources = files(
   'rename.c',
 )
+rename_manadocs = files('rename.1.adoc')
 
 getopt_sources = files(
   'getopt.c',
 )
+getopt_manadocs = files('getopt.1.adoc')
 
 if not get_option('build-getopt').disabled()
   install_data(
@@ -158,16 +180,19 @@ endif
 exch_sources = files(
   'exch.c',
 )
+exch_manadocs = files('exch.1.adoc')
 
 fincore_sources = files(
   'fincore.c',
 )
+fincore_manadocs = files('fincore.1.adoc')
 
 hardlink_sources = files(
   'hardlink.c',
 ) + \
   monotonic_c + \
   fileeq_c
+hardlink_manadocs = files('hardlink.1.adoc')
 
 cal_sources = files(
   'cal.c',
@@ -176,15 +201,19 @@ cal_sources = files(
 pipesz_sources = files(
   'pipesz.c',
 )
+pipesz_manadocs = files('pipesz.1.adoc')
 
 fadvise_sources = files(
   'fadvise.c',
 )
+fadvise_manadocs = files('fadvise.1.adoc')
 
 waitpid_sources = files(
   'waitpid.c',
 )
+waitpid_manadocs = files('waitpid.1.adoc')
 
 lsclocks_sources = files(
   'lsclocks.c',
 )
+lsclocks_manadocs = files('lsclocks.1.adoc')

--- a/pam_lastlog2/man/meson.build
+++ b/pam_lastlog2/man/meson.build
@@ -1,0 +1,1 @@
+lib_pam_lastlog2_manadocs = files('pam_lastlog2.8.adoc')

--- a/pam_lastlog2/meson.build
+++ b/pam_lastlog2/meson.build
@@ -8,7 +8,9 @@ cc = meson.get_compiler('c')
 pkg = import('pkgconfig')
 lib_pam_lastlog2_sources = '''
   src/pam_lastlog2.c
-'''.split()  
+'''.split()
+
+subdir('man')
 
 pamlibdir = get_option('pamlibdir')
 if pamlibdir == ''
@@ -32,5 +34,5 @@ if build_pam_lastlog2
     install : build_liblastlog2,
     install_dir : pamlibdir,
   )
-  manadocs += ['pam_lastlog2/man/pam_lastlog2.8.adoc']
-endif  
+  manadocs += lib_pam_lastlog2_manadocs
+endif

--- a/po-man/install-translations.sh
+++ b/po-man/install-translations.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+function usage()
+{
+    cat << HEREDOC
+
+ Usage:
+  $PROGRAM --mandir <directory> --mansrcdir <directory> [<man page name>...]
+
+Install translated man pages.
+
+ Options:
+  --help                             show this help message and exit
+  --mandir <mandir>                  directory in which to install the man pages, usually share/man
+  --mansrcdir <mansrcdir>            directory containing the man pages to install
+
+ Environment Variables:
+  MESON_INSTALL_PREFIX               install destination prefix directory
+  DESTDIR                            install destination directory
+
+HEREDOC
+}
+
+DESTDIR="${DESTDIR:-''}"
+MANPAGES=()
+PROGRAM=$(basename "$0")
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --help)
+      usage
+      exit 0
+      ;;
+    --mandir)
+      MANDIR="$2"
+      shift
+      shift
+      ;;
+    --mansrcdir)
+      MANSRCDIR="$2"
+      shift
+      shift
+      ;;
+    --*|-*)
+      echo "Unknown option $1"
+      usage
+      exit 1
+      ;;
+    *)
+      MANPAGES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -- "${MANPAGES[@]}"
+
+if [ ${#MANPAGES[@]} -eq 0 ]; then
+  shopt -s nullglob
+  MANPAGES=("$MANSRCDIR"/*/man[0-9]/*\.[0-9])
+fi
+
+for LOCALEDIR in "$MANSRCDIR"/*/; do
+    LOCALE=$(basename "$LOCALEDIR")
+    for MANPAGE in "${MANPAGES[@]}"; do
+        MANPAGE=$(basename "$MANPAGE")
+        SECTION="${MANPAGE##*.}"
+        PAGE="$LOCALEDIR/man$SECTION/$MANPAGE"
+        if [ -f "$PAGE" ]; then
+            if [ -z ${MESON_INSTALL_QUIET+x} ]; then
+                echo "Installing $PAGE to $DESTDIR/$MESON_INSTALL_PREFIX/$MANDIR/$LOCALE/man$SECTION"
+            fi
+            install -D --mode=0644 --target-directory="$DESTDIR/$MESON_INSTALL_PREFIX/$MANDIR/$LOCALE/man$SECTION" "$PAGE"
+        fi
+    done
+done

--- a/po-man/meson.build
+++ b/po-man/meson.build
@@ -1,0 +1,38 @@
+po4a = find_program('po4a', required : false)
+
+if not (asciidoctor.found() and po4a.found())
+  subdir_done()
+endif
+
+awk = find_program('awk', required : true)
+locales_output = run_command(awk, '/\[po4a_langs\]/ {for (i=2; i<=NF; i++) print $i}', 'po4a.cfg', check : true)
+locales = locales_output.stdout().strip().split('\n')
+po_files = []
+foreach locale : locales
+  po_files += locale + '.po'
+endforeach
+
+custom_target('translate',
+  build_by_default : true,
+  command : ['translate.sh',
+    '--srcdir', meson.current_source_dir(),
+    '--destdir', meson.current_build_dir() / 'translations',
+    '--asciidoctor-load-path', meson.project_source_root() / 'tools',
+    '--docdir', docdir,
+    '--po4acfg', meson.current_source_dir() / 'po4a.cfg',
+    '--util-linux-version', meson.project_version(),
+    '@INPUT@'],
+  console : true,
+  depend_files : ['po4a.cfg', 'util-linux-man.pot'] + po_files,
+  input : man_common_adocs + manadocs,
+  output : ['translations'])
+
+manpages = []
+foreach adoc : manadocs
+  manpages += fs.stem(adoc)
+endforeach
+
+meson.add_install_script('install-translations.sh',
+  '--mandir', get_option('mandir'),
+  '--mansrcdir', meson.current_build_dir() / 'translations/man',
+  manpages)

--- a/po-man/translate.sh
+++ b/po-man/translate.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+function usage()
+{
+    cat << HEREDOC
+
+ Usage: $PROGRAM --srcdir <srcdir> --destdir <destdir> --asciidoctor-load-path <directory> --docdir <docdir> --po4acfg <file> --util-linux-version <version> [<asciidoc file>...]
+
+Translate Asciidoc man page source files and generate man pages.
+
+ Options:
+  --help                               show this help message and exit
+  --srcdir <srcdir>                    directory containing the asciidoc files to translate
+  --destdir <destdir>                  directory in which to place the translated asciidoc files and man pages
+  --asciidoctor-load-path <directory>  value for the --load-path option passed to the Asciidoctor command
+  --docdir <docdir>                    directory where the package documentation will be installed
+  --util-linux-version <version>       version of util-linux to include in the man pages
+  --po4acfg <file>                     path to the po4a.cfg file
+
+HEREDOC
+}
+
+PROGRAM=$(basename "$0")
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --srcdir)
+          SRCDIR="$2"
+          shift
+          shift
+          ;;
+        --destdir)
+          DESTDIR="$2"
+          shift
+          shift
+          ;;
+        --asciidoctor-load-path)
+          ASCIIDOCTOR_LOAD_PATH="$2"
+          shift
+          shift
+          ;;
+        --docdir)
+          DOCDIR="$2"
+          shift
+          shift
+          ;;
+        --help)
+          usage
+          exit 0
+          ;;
+        --po4acfg)
+          PO4ACFG="$2"
+          shift
+          shift
+          ;;
+        --util-linux-version)
+          UTIL_LINUX_VERSION="$2"
+          shift
+          shift
+          ;;
+        --*|-*)
+          echo "Unknown option $1"
+          usage
+          exit 1
+          ;;
+        *)
+          ADOCS+=("$1")
+          shift
+          ;;
+    esac
+done
+
+set -- "${ADOCS[@]}"
+
+mapfile -t LOCALES < <( awk '/\[po4a_langs\]/ {for (i=2; i<=NF; i++) print $i}' "$PO4ACFG" )
+mapfile -t PO4ACFG_TRANSLATIONS < <( awk '/\[type:asciidoc\]/ {print $2;}' "$PO4ACFG" )
+
+mkdir --parents "$DESTDIR"
+
+DESTDIR=$( OLDPWD=- CDPATH='' cd -P -- "$DESTDIR" && pwd )
+
+MANADOCS=()
+PO4A_TRANSLATE_ONLY_FLAGS=()
+for LOCALE in "${LOCALES[@]}"; do
+    for ADOC in "${ADOCS[@]}"; do
+        if [[ ! " ${PO4ACFG_TRANSLATIONS[*]} " =~ [[:space:]]${ADOC}[[:space:]] ]]; then
+          continue
+        fi
+        PO4A_TRANSLATE_ONLY_FLAGS+=("--translate-only")
+        ADOC_NAME=$(basename "$ADOC")
+        if [[ "$ADOC" == *"/man-common/"* ]]; then
+            PO4A_TRANSLATE_ONLY_FLAGS+=("$LOCALE/man-common/$ADOC_NAME")
+        else
+            MANADOCS+=("$LOCALE/$ADOC_NAME")
+            PO4A_TRANSLATE_ONLY_FLAGS+=("$LOCALE/$ADOC_NAME")
+        fi
+    done
+done
+
+if [ ${#MANADOCS[@]} -eq 0 ] && [ ${#PO4A_TRANSLATE_ONLY_FLAGS[@]} -gt 0 ]; then
+    echo "Only man-common Asciidoc files were supplied"
+    exit 1
+fi
+
+# Only version 0.72 and later of po4a properly support the --translate-only flag.
+PO4A_VERSION=$(po4a --version | { read -r _ _ v; echo "${v%*.}"; })
+if echo "0.72" "$PO4A_VERSION" | sort --check --version-sort; then
+  PO4A_TRANSLATE_ONLY_FLAGS=("--no-update")
+fi
+
+DISCARDED_TRANSLATIONS=()
+output=$(po4a --srcdir "$SRCDIR" --destdir "$DESTDIR" "${PO4A_TRANSLATE_ONLY_FLAGS[@]}" "$PO4ACFG")
+while IFS= read -r line; do
+    DISCARDED_TRANSLATION=$(echo "$line" | awk '/Discard/ {print $2;}')
+    if [ -n "${DISCARDED_TRANSLATION+x}" ]; then
+        DISCARDED_TRANSLATIONS+=("$DISCARDED_TRANSLATION")
+    fi
+done <<< "$output"
+
+TRANSLATED_MANADOCS=()
+if [ ${#MANADOCS[@]} -eq 0 ]; then
+    for LOCALE in "${LOCALES[@]}"; do
+        shopt -s nullglob
+        TRANSLATED_MANADOCS=("$DESTDIR/$LOCALE"/*\.adoc)
+    done
+else
+    for MANADOC in "${MANADOCS[@]}"; do
+        if [[ ! " ${DISCARDED_TRANSLATIONS[*]} " =~ [[:space:]]${MANADOC}[[:space:]] ]]; then
+            TRANSLATED_MANADOCS+=("$DESTDIR/$MANADOC")
+        fi
+    done
+fi
+
+for ADOC in "${TRANSLATED_MANADOCS[@]}"; do
+    LOCALE=$(basename "$(dirname "$ADOC")")
+    PAGE="${ADOC%.*}"
+    SECTION="${PAGE##*.}"
+    asciidoctor \
+        --backend manpage \
+        --attribute VERSION="$UTIL_LINUX_VERSION" \
+        --attribute release-version="$UTIL_LINUX_VERSION" \
+        --attribute ADJTIME_PATH=/etc/adjtime \
+        --attribute package-docdir="$DOCDIR" \
+        --base-dir "$DESTDIR/$LOCALE" \
+        --destination-dir "$DESTDIR/man/$LOCALE/man$SECTION" \
+        --load-path "$ASCIIDOCTOR_LOAD_PATH" \
+        --require asciidoctor-includetracker \
+        "$ADOC"
+done

--- a/schedutils/meson.build
+++ b/schedutils/meson.build
@@ -1,0 +1,7 @@
+schedutils_manadocs = files(
+  'chrt.1.adoc',
+  'coresched.1.adoc',
+  'ionice.1.adoc',
+  'taskset.1.adoc',
+  'uclampset.1.adoc',
+)

--- a/sys-utils/meson.build
+++ b/sys-utils/meson.build
@@ -5,123 +5,158 @@ hwclock_parse_date = bison_gen.process('hwclock-parse-date.y')
 lsmem_sources = files(
   'lsmem.c',
 )
+lsmem_manadocs = files('lsmem.1.adoc')
 
 chmem_sources = files(
   'chmem.c',
 )
+chmem_manadocs = files('chmem.8.adoc')
 
 choom_sources = files(
   'choom.c',
 )
+choom_manadocs = files('choom.1.adoc')
 
 ipcmk_sources = files(
   'ipcmk.c',
 )
+ipcmk_manadocs = files('ipcmk.1.adoc')
 
 ipcrm_sources = files(
   'ipcrm.c',
 )
+ipcrm_manadocs = files('ipcrm.1.adoc')
 
 ipcs_sources = files(
   'ipcs.c',
   'ipcutils.c',
   'ipcutils.h',
 )
+ipcs_manadocs = files('ipcs.1.adoc')
 
 rfkill_sources = files(
   'rfkill.c',
 )
+rfkill_manadocs = files('rfkill.8.adoc')
 
 renice_sources = files(
   'renice.c',
 )
+renice_manadocs = files('renice.1.adoc')
 
 setpgid_sources = files(
   'setpgid.c',
 )
+setpgid_manadocs = files('setpgid.1.adoc')
 
 setsid_sources = files(
   'setsid.c',
 )
+setsid_manadocs = files('setsid.1.adoc')
 
 readprofile_sources = files(
   'readprofile.c',
 )
+readprofile_manadocs = files('readprofile.8.adoc')
 
 tunelp_sources = files(
   'tunelp.c',
 )
+tunelp_manadocs = files('tunelp.8.adoc')
 
 fstrim_sources = files(
   'fstrim.c',
 )
+fstrim_manadocs = files('fstrim.8.adoc')
 
 dmesg_sources = files(
   'dmesg.c',
 ) + \
   monotonic_c + pager_c
+dmesg_manadocs = files('dmesg.1.adoc')
 
 ctrlaltdel_sources = files(
   'ctrlaltdel.c',
 )
+ctrlaltdel_manadocs = files('ctrlaltdel.8.adoc')
 
 fsfreeze_sources = files(
   'fsfreeze.c',
 )
+fsfreeze_manadocs = files('fsfreeze.8.adoc')
 
 blkdiscard_sources = files(
   'blkdiscard.c',
 ) + \
   monotonic_c
+blkdiscard_manadocs = files('blkdiscard.8.adoc')
 
 blkzone_sources = files(
   'blkzone.c',
 )
+blkzone_manadocs = files('blkzone.8.adoc')
 
 blkpr_sources = files(
   'blkpr.c',
 )
+blkpr_manadocs = files('blkpr.8.adoc')
 
 ldattach_sources = files(
   'ldattach.c',
 )
+ldattach_manadocs = files('ldattach.8.adoc')
 
 rtcwake_sources = files(
   'rtcwake.c',
 )
+rtcwake_manadocs = files('rtcwake.8.adoc')
 
 setarch_sources = files(
   'setarch.c',
 )
+setarch_manadocs = files('setarch.8.adoc')
 
 eject_sources = files(
   'eject.c',
 ) + \
   monotonic_c
+eject_manadocs = files('eject.1.adoc')
 
 losetup_sources = files(
   'losetup.c',
 )
+losetup_manadocs = files('losetup.8.adoc')
 
 zramctl_sources = files(
   'zramctl.c',
 ) + \
   ismounted_c
+zramctl_manadocs = files('zramctl.8.adoc')
 
 prlimit_sources = files(
   'prlimit.c',
 )
+prlimit_manadocs = files('prlimit.1.adoc')
 
 lsns_sources = files(
   'lsns.c',
 )
+lsns_manadocs = files('lsns.8.adoc')
+
+fstab_manadocs = files('fstab.5.adoc')
 
 mount_sources = files(
   'mount.c',
 )
+mount_manadocs = files(
+  'mount.8.adoc'
+)
 
 umount_sources = files(
   'umount.c',
+)
+umount_manadocs = files(
+  'umount.8.adoc'
 )
 swapon_sources = files(
   'swapon.c',
@@ -129,6 +164,7 @@ swapon_sources = files(
   'swapon-common.h',
 ) + \
   swapprober_c
+swapon_manadocs = files('swapon.8.adoc')
 
 swapoff_sources = files(
   'swapoff.c',
@@ -147,40 +183,49 @@ lscpu_sources = files(
   'lscpu-arm.c',
   'lscpu-dmi.c',
 )
+lscpu_manadocs = files('lscpu.1.adoc')
 
 chcpu_sources = files(
   'chcpu.c',
 )
+chcpu_manadocs = files('chcpu.8.adoc')
 
 wdctl_sources = files(
   'wdctl.c',
 )
+wdctl_manadocs = files('wdctl.8.adoc')
 
 mountpoint_sources = files(
   'mountpoint.c',
 )
+mountpoint_manadocs = files('mountpoint.1.adoc')
 
 fallocate_sources = files(
   'fallocate.c',
 )
+fallocate_manadocs = files('fallocate.1.adoc')
 
 pivot_root_sources = files(
   'pivot_root.c',
 )
+pivot_root_manadocs = files('pivot_root.8.adoc')
 
 switch_root_sources = files(
   'switch_root.c',
 )
+switch_root_manadocs = files('switch_root.8.adoc')
 
 unshare_sources = files(
   'unshare.c',
 ) + \
     exec_shell_c
+unshare_manadocs = files('unshare.1.adoc')
 
 nsenter_sources = files(
   'nsenter.c',
 ) + \
     exec_shell_c
+nsenter_manadocs = files('nsenter.1.adoc')
 
 setpriv_sources = files(
   'setpriv.c',
@@ -188,24 +233,28 @@ setpriv_sources = files(
 if LINUX and conf.get('HAVE_LINUX_LANDLOCK_H').to_string() == '1'
   setpriv_sources += files('setpriv-landlock.c')
 endif
+setpriv_manadocs = files('setpriv.1.adoc')
 
 flock_sources = files(
   'flock.c',
 ) + \
   monotonic_c + \
   timer_c
+flock_manadocs = files('flock.1.adoc')
 
 lsipc_sources = files(
   'lsipc.c',
   'ipcutils.c',
   'ipcutils.h',
 )
+lsipc_manadocs = files('lsipc.1.adoc')
 
 lsirq_sources = files(
   'lsirq.c',
   'irq-common.c',
   'irq-common.h',
 )
+lsirq_manadocs = files('lsirq.1.adoc')
 
 irqtop_sources = files(
   'irqtop.c',
@@ -213,6 +262,7 @@ irqtop_sources = files(
   'irq-common.h',
 ) + \
     monotonic_c
+irqtop_manadocs = files('irqtop.1.adoc')
 
 hwclock_sources = [
   'sys-utils/hwclock.c',
@@ -230,6 +280,11 @@ if LINUX
     monotonic_c,
   ]
 endif
+
+hwclock_manadocs = files(
+  'adjtime_config.5.adoc',
+  'hwclock.8.adoc',
+)
 
 if systemd.found()
   fstrim_service = configure_file(

--- a/term-utils/meson.build
+++ b/term-utils/meson.build
@@ -3,6 +3,7 @@ script_sources = files(
 ) + \
   pty_session_c + \
   monotonic_c
+script_manadocs = files('script.1.adoc')
 
 scriptlive_sources = files(
   'scriptlive.c',
@@ -11,31 +12,38 @@ scriptlive_sources = files(
 ) + \
   pty_session_c + \
   monotonic_c
+scriptlive_manadocs = files('scriptlive.1.adoc')
 
 scriptreplay_sources = files(
   'scriptreplay.c',
   'script-playutils.c',
   'script-playutils.h',
 )
+scriptreplay_manadocs = files('scriptreplay.1.adoc')
 
 agetty_sources = files(
   'agetty.c',
 )
+agetty_manadocs = files('agetty.8.adoc')
 
 setterm_sources = files(
   'setterm.c',
 )
+setterm_manadocs = files('setterm.1.adoc')
 
 mesg_sources = files(
   'mesg.c',
 )
+mesg_manadocs = files('mesg.1.adoc')
 
 wall_sources = files(
   'wall.c',
   'ttymsg.c',
   'ttymsg.h',
 )
+wall_manadocs = files('wall.1.adoc')
 
 write_sources = files(
   'write.c',
 )
+write_manadocs = files('write.1.adoc')

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,0 @@
-diff
-output

--- a/text-utils/meson.build
+++ b/text-utils/meson.build
@@ -1,42 +1,52 @@
 bits_sources = files(
   'bits.c',
 )
+bits_manadocs = files('bits.1.adoc')
 
 col_sources = files(
   'col.c',
 )
+col_manadocs = files('col.1.adoc')
 
 colcrt_sources = files(
   'colcrt.c',
 )
+colcrt_manadocs = files('colcrt.1.adoc')
 
 colrm_sources = files(
   'colrm.c',
 )
+colrm_manadocs = files('colrm.1.adoc')
 
 rev_sources = files(
   'rev.c',
 )
+rev_manadocs = files('rev.1.adoc')
 
 column_sources = files(
   'column.c',
 )
+column_manadocs = files('column.1.adoc')
 
 line_sources = files(
   'line.c',
 )
+line_manadocs = files('line.1.adoc')
 
 pg_sources = files(
   'pg.c',
 )
+pg_manadocs = files('pg.1.adoc')
 
 ul_sources = files(
   'ul.c',
 )
+ul_manadocs = files('ul.1.adoc')
 
 more_sources = files(
   'more.c',
 )
+more_manadocs = files('more.1.adoc')
 
 hexdump_sources = files(
   'hexdump.c',
@@ -45,3 +55,4 @@ hexdump_sources = files(
   'hexdump-display.c',
   'hexdump-parse.c',
 )
+hexdump_manadocs = files('hexdump.1.adoc')


### PR DESCRIPTION
Fixes #2842.

Let me know if I should add an option for building the translations. Right now, it will automatically as part of the default target if `po4a` and `asciidoctor` are found.