### PR TITLE
libmount: exec mount helpers with posixly correct argument order

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -451,10 +451,10 @@ static int exec_helper(struct libmnt_context *cxt)
 			args[i++] = type;		/* 11 */
 		}
 		if (namespace) {
-			args[i++] = "-N";		/* 11 */
-			args[i++] = namespace;		/* 12 */
+			args[i++] = "-N";		/* 12 */
+			args[i++] = namespace;		/* 13 */
 		}
-		args[i] = NULL;				/* 13 */
+		args[i] = NULL;				/* 14 */
 		for (i = 0; args[i]; i++)
 			DBG(CXT, ul_debugobj(cxt, "argv[%d] = \"%s\"",
 							i, args[i]));

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -429,31 +429,33 @@ static int exec_helper(struct libmnt_context *cxt)
 		type = mnt_fs_get_fstype(cxt->fs);
 
 		args[i++] = cxt->helper;		/* 1 */
-		args[i++] = mnt_fs_get_srcpath(cxt->fs);/* 2 */
-		args[i++] = mnt_fs_get_target(cxt->fs);	/* 3 */
 
 		if (mnt_context_is_sloppy(cxt))
-			args[i++] = "-s";		/* 4 */
+			args[i++] = "-s";		/* 2 */
 		if (mnt_context_is_fake(cxt))
-			args[i++] = "-f";		/* 5 */
+			args[i++] = "-f";		/* 3 */
 		if (mnt_context_is_nomtab(cxt))
-			args[i++] = "-n";		/* 6 */
+			args[i++] = "-n";		/* 4 */
 		if (mnt_context_is_verbose(cxt))
-			args[i++] = "-v";		/* 7 */
+			args[i++] = "-v";		/* 5 */
 		if (o) {
-			args[i++] = "-o";		/* 8 */
-			args[i++] = o;			/* 9 */
+			args[i++] = "-o";		/* 6 */
+			args[i++] = o;			/* 7 */
 		}
 		if (type
 		    && strchr(type, '.')
 		    && !endswith(cxt->helper, type)) {
-			args[i++] = "-t";		/* 10 */
-			args[i++] = type;		/* 11 */
+			args[i++] = "-t";		/* 8 */
+			args[i++] = type;		/* 9 */
 		}
 		if (namespace) {
-			args[i++] = "-N";		/* 12 */
-			args[i++] = namespace;		/* 13 */
+			args[i++] = "-N";		/* 10 */
+			args[i++] = namespace;		/* 11 */
 		}
+
+		args[i++] = mnt_fs_get_srcpath(cxt->fs);/* 12 */
+		args[i++] = mnt_fs_get_target(cxt->fs);	/* 13 */
+
 		args[i] = NULL;				/* 14 */
 		for (i = 0; args[i]; i++)
 			DBG(CXT, ul_debugobj(cxt, "argv[%d] = \"%s\"",

--- a/libmount/src/context_umount.c
+++ b/libmount/src/context_umount.c
@@ -711,28 +711,29 @@ static int exec_helper(struct libmnt_context *cxt)
 		type = mnt_fs_get_fstype(cxt->fs);
 
 		args[i++] = cxt->helper;			/* 1 */
-		args[i++] = mnt_fs_get_target(cxt->fs);		/* 2 */
 
 		if (mnt_context_is_nomtab(cxt))
-			args[i++] = "-n";			/* 3 */
+			args[i++] = "-n";			/* 2 */
 		if (mnt_context_is_lazy(cxt))
-			args[i++] = "-l";			/* 4 */
+			args[i++] = "-l";			/* 3 */
 		if (mnt_context_is_force(cxt))
-			args[i++] = "-f";			/* 5 */
+			args[i++] = "-f";			/* 4 */
 		if (mnt_context_is_verbose(cxt))
-			args[i++] = "-v";			/* 6 */
+			args[i++] = "-v";			/* 5 */
 		if (mnt_context_is_rdonly_umount(cxt))
-			args[i++] = "-r";			/* 7 */
+			args[i++] = "-r";			/* 6 */
 		if (type
 		    && strchr(type, '.')
 		    && !endswith(cxt->helper, type)) {
-			args[i++] = "-t";			/* 8 */
-			args[i++] = type;			/* 9 */
+			args[i++] = "-t";			/* 7 */
+			args[i++] = type;			/* 8 */
 		}
 		if (namespace) {
-			args[i++] = "-N";			/* 10 */
-			args[i++] = namespace;			/* 11 */
+			args[i++] = "-N";			/* 9 */
+			args[i++] = namespace;			/* 10 */
 		}
+
+		args[i++] = mnt_fs_get_target(cxt->fs);		/* 11 */
 
 		args[i] = NULL;					/* 12 */
 		for (i = 0; args[i]; i++)

--- a/tests/expected/mount/special-basic
+++ b/tests/expected/mount/special-basic
@@ -1,1 +1,1 @@
-/sbin/mount.mytest called with "/foo /bar -o rw"
+/sbin/mount.mytest called with "-o rw /foo /bar"

--- a/tests/expected/mount/special-multi-types
+++ b/tests/expected/mount/special-multi-types
@@ -1,1 +1,1 @@
-/sbin/mount.mytest called with "/foo /bar -o rw"
+/sbin/mount.mytest called with "-o rw /foo /bar"

--- a/tests/expected/mount/special-options
+++ b/tests/expected/mount/special-options
@@ -1,1 +1,1 @@
-/sbin/mount.mytest called with "/foo /bar -o rw,foo"
+/sbin/mount.mytest called with "-o rw,foo /foo /bar"

--- a/tests/expected/mount/special-user
+++ b/tests/expected/mount/special-user
@@ -1,1 +1,1 @@
-/sbin/mount.mytest called with "/foo /bar -o rw,user,noexec,nosuid,nodev,abc"
+/sbin/mount.mytest called with "-o rw,user,noexec,nosuid,nodev,abc /foo /bar"

--- a/tests/expected/mount/special-username
+++ b/tests/expected/mount/special-username
@@ -1,1 +1,1 @@
-/sbin/mount.mytest called with "/foo /bar -o rw,user=name,abc"
+/sbin/mount.mytest called with "-o rw,user=name,abc /foo /bar"


### PR DESCRIPTION
libmount: exec mount helpers with posixly correct argument order

This improves compatibility with non-gnu userspaces.

On distributions such as Chimera Linux and Void Linux Musl where the libc provides posix getopt instead of gnu getopt, mount helpers which use getopt to parse arguments will not parse options which appear after non-option arguments. In particular, mount.nilfs2 from nilfs-utils is affected by this and on such systems, mounting NILFS filesystems fails in some situations when the mount utility is from util-linux and the nilfs mount helper is present. This patch ensures mount/unmount work as expected on such systems with no negative effects or compromises for ordinary GNU/linux.

Fixes [https://github.com/nilfs-dev/nilfs-utils/issues/12](https://github.com/nilfs-dev/nilfs-utils/issues/12) and [https://github.com/chimera-linux/cports/issues/3214](https://github.com/chimera-linux/cports/issues/3214)