### PR TITLE
Clarification on the meaning of "bright %s" in setterm

### DIFF
--- a/term-utils/setterm.c
+++ b/term-utils/setterm.c
@@ -235,6 +235,7 @@ static int parse_ulhb_color(char **av, int *oi)
 	if (!is_valid_color(color) || color == DEFAULT)
 		errx(EXIT_FAILURE, "%s: %s", _("argument error"), color_name);
 	if (bright && (color == BLACK || color == GREY))
+		/* TRANSLATORS: "bright" is an adjective and is mutually exclusive with the color %s. Do not translate it as "brightness". */
 		errx(EXIT_FAILURE, _("argument error: bright %s is not supported"), color_name);
 
 	if (bright)


### PR DESCRIPTION
I am the Japanese translator for util-linux.
Let me confirm the meaning of the following message in term-utils/setterm.c:237:
```
	if (bright && (color == BLACK || color == GREY))
		errx(EXIT_FAILURE, _("argument error: bright %s is not supported"), color_name);
```
The word "bright" in this message seems to be translated as "brightness" in Chinese, French, German, and Japanese.
```
msgstr "参数错误：不支持亮度 %s"
```
```
msgstr "erreur d'argument : luminosité %s non prise en charge"
```
```
msgstr "Argumentfehler: Helligkeitswert %s wird nicht unterstützt"
```
```
msgstr "引数エラー: 明るさ %s はサポートされていません"
```
Is it correct to understand that %s stands for a color, not brightness, and that "bright" is used as an adjective for %s?
If this understanding is correct, I will correct the Japanese translation (->"明るい").

Also, would it be possible to include a comment like this pull request, for example, to encourage other translators to make corrections as well?
Another option might be to change the message itself to something like "argument error: 'bright' and %s are mutually exclusive".
