### PR TITLE
hwclock: Support GNU Hurd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -263,16 +263,20 @@ AC_PATH_PROG([XSLTPROC], [xsltproc])
 
 linux_os=no
 bsd_os=no
+gnu_os=no
 AS_CASE([${host_os}],
   [*linux*],
      [linux_os=yes],
   [*darwin*],
      [darwin_os=yes],
   [*bsd*],
-     [bsd_os=yes])
+     [bsd_os=yes],
+  [gnu*],
+     [gnu_os=yes])
 AM_CONDITIONAL([LINUX], [test "x$linux_os" = xyes])
 AM_CONDITIONAL([DARWIN], [test "x$darwin_os" = xyes])
 AM_CONDITIONAL([BSD], [test "x$bsd_os" = xyes])
+AM_CONDITIONAL([HURD], [test "x$gnu_os" = xyes])
 
 AS_IF([test  "x$darwin_os" = xyes], [
   AC_DEFINE([_DARWIN_C_SOURCE], [1], [Enable MAP_ANON in sys/mman.h on Mac OS X])

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -570,6 +570,11 @@ hwclock_SOURCES += \
 	lib/monotonic.c
 hwclock_LDADD += $(REALTIME_LIBS)
 endif
+if HURD
+hwclock_SOURCES += \
+	sys-utils/hwclock-rtc.c \
+	lib/monotonic.c
+endif
 if HAVE_AUDIT
 hwclock_LDADD += -laudit
 endif

--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -8,10 +8,15 @@
  *
  * rtc.c - Use /dev/rtc for clock access
  */
+#ifdef __GNU__
+#include <sys/ioctl.h>
+#include <hurd/rtc.h>
+#else
 #include <asm/ioctl.h>
-#include <errno.h>
 #include <linux/rtc.h>
 #include <linux/types.h>
+#endif /* __GNU__ */
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -28,6 +33,7 @@
 
 #include "hwclock.h"
 
+#ifndef __GNU__
 #ifndef RTC_PARAM_GET
 struct rtc_param {
 	__u64 param;
@@ -60,6 +66,7 @@ const struct hwclock_param *get_hwclock_params(void)
 {
 	return hwclock_params;
 }
+#endif /* __GNU__ */
 
 /*
  * /dev/rtc is conventionally chardev 10/135
@@ -99,12 +106,20 @@ static int open_rtc(const struct hwclock_control *ctl)
 	/* --rtc option has been given */
 	if (ctl->rtc_dev_name) {
 		rtc_dev_name = ctl->rtc_dev_name;
+#ifdef __GNU__
+		rtc_dev_fd = open(rtc_dev_name, O_RDWR);
+#else
 		rtc_dev_fd = open(rtc_dev_name, O_RDONLY);
+#endif
 	} else {
 		for (i = 0; i < ARRAY_SIZE(fls); i++) {
 			if (ctl->verbose)
 				printf(_("Trying to open: %s\n"), fls[i]);
+#ifdef __GNU__
+			rtc_dev_fd = open(fls[i], O_RDWR);
+#else
 			rtc_dev_fd = open(fls[i], O_RDONLY);
+#endif
 
 			if (rtc_dev_fd < 0) {
 				if (errno == ENOENT || errno == ENODEV)
@@ -411,6 +426,7 @@ int set_epoch_rtc(const struct hwclock_control *ctl)
 
 
 
+#ifndef __GNU__
 static int resolve_rtc_param_alias(const char *alias, __u64 *value)
 {
 	const struct hwclock_param *param = &hwclock_params[0];
@@ -609,3 +625,4 @@ int rtc_vl_clear(const struct hwclock_control *ctl)
 
 	return 0;
 }
+#endif /* __GNU__ */

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -989,7 +989,7 @@ static void determine_clock_access_method(const struct hwclock_control *ctl)
 	if (ctl->directisa)
 		ur = probe_for_cmos_clock();
 #endif
-#ifdef __linux__
+#if defined(__linux__) || defined(__GNU__)
 	if (!ur)
 		ur = probe_for_rtc_clock(ctl);
 #endif

--- a/sys-utils/hwclock.h
+++ b/sys-utils/hwclock.h
@@ -36,8 +36,10 @@ struct hwclock_control {
 #if defined(__linux__) && defined(__alpha__)
 	char *epoch_option;
 #endif
-#ifdef __linux__
+#if defined(__linux__) || defined(__GNU__)
 	char *rtc_dev_name;
+#endif
+#ifdef __linux__
 	uint32_t param_idx;	/* --param-index <n> */
 #endif
 	char *param_get_option;


### PR DESCRIPTION
**[patch from mailing list]**

* configure.ac: add HURD so it can be used in conditional in am files
* sys-utils/Makemodule.am: compile hwclock for GNU Hurd
* sys-utils/hwclock-rtc.c: compile for GNU Hurd
* sys-utils/hwclock.c: compile for GNU Hurd
* sys-utils/hwclock.h: compile for GNU Hurd