### PR TITLE
gitignore: ignore `tests/failures`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ stamp-h1
 syscalls.h
 tags
 test-suite.log
+tests/failures
 tests/run.sh.log
 tests/run.sh.trs
 update.log


### PR DESCRIPTION
This file is generated by test runner and shouldn't be tracked.