### PR TITLE
lsfd: *early* file path filter

### DIFF
--- a/lsfd-cmd/Makemodule.am
+++ b/lsfd-cmd/Makemodule.am
@@ -8,6 +8,7 @@ dist_noinst_DATA += lsfd-cmd/lsfd.1.adoc
 lsfd_SOURCES = \
 	lsfd-cmd/lsfd.c \
 	lsfd-cmd/lsfd.h \
+	lsfd-cmd/early-filter.c \
 	lsfd-cmd/decode-file-flags.c \
 	lsfd-cmd/decode-file-flags.h \
 	lsfd-cmd/file.c \

--- a/lsfd-cmd/early-filter.c
+++ b/lsfd-cmd/early-filter.c
@@ -1,0 +1,67 @@
+/*
+ * early-filter.c - filter mechanism working when collecting fd informations
+ *
+ * Copyright (C) 2024 Red Hat, Inc. All rights reserved.
+ * Written by Masatake YAMATO <yamato@redhat.com>
+ *
+ * Very generally based on lsof(8) by Victor A. Abell <abe@purdue.edu>
+ * It supports multiple OSes. lsfd specializes to Linux.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "lsfd.h"
+
+#include "list.h"
+
+enum early_filter_type {
+	ef_pid,
+};
+
+struct early_filters {
+	struct list_head filters;
+};
+
+struct early_filter {
+	enum early_filter_type type;
+	union {
+		pid_t pid;
+	};
+	struct list_head filters;
+};
+
+struct early_filters *new_early_filters(void)
+{
+	struct early_filters *early_filters = xmalloc(sizeof(*early_filters));
+	INIT_LIST_HEAD(&early_filters->filters);
+	return early_filters;
+}
+
+static void free_early_filter(struct early_filter *ef)
+{
+	free(ef);
+}
+
+void free_early_filters(struct early_filters *early_filters)
+{
+	list_free(&early_filters->filters, struct early_filter, filters,
+		  free_early_filter);
+	free(early_filters);
+}
+
+void early_filters_optimize(struct early_filters *early_filters)
+{
+	/* STUB */
+}

--- a/lsfd-cmd/early-filter.c
+++ b/lsfd-cmd/early-filter.c
@@ -43,7 +43,10 @@ struct early_filter {
 	enum early_filter_type type;
 	union {
 		pid_t pid;
-		const char *file_path;
+		struct {
+			const char *file_path;
+			size_t file_path_len;
+		};
 	};
 	struct list_head filters;
 };
@@ -165,6 +168,7 @@ static struct early_filter *new_early_filter_file_path(const char *file_path)
 	ef->type = ef_file_path;
 	INIT_LIST_HEAD(&ef->filters);
 	ef->file_path = file_path;
+	ef->file_path_len = strlen(file_path);
 	return ef;
 }
 
@@ -187,7 +191,17 @@ static bool file_path_equal(struct early_filter *early_filter, const void *data)
 	if (early_filter->type != ef_file_path)
 		return false;
 
-	return strcmp(early_filter->file_path, file_path) == 0;
+	if (strncmp(early_filter->file_path, file_path, early_filter->file_path_len) == 0) {
+		const char *rest;
+		if (file_path[early_filter->file_path_len] == '\0')
+			return true;
+
+		rest = file_path + early_filter->file_path_len;
+		if (strcmp(rest, " (deleted)") == 0)
+			return true;
+	}
+
+	return false;
 }
 
 bool early_filters_apply_file_path(struct early_filters *early_filters, const char *file_path)

--- a/lsfd-cmd/early-filter.c
+++ b/lsfd-cmd/early-filter.c
@@ -32,6 +32,9 @@ enum early_filter_type {
 
 struct early_filters {
 	struct list_head filters;
+	unsigned int n_pid_filters;
+
+	pid_t *pids;
 };
 
 struct early_filter {
@@ -46,6 +49,8 @@ struct early_filters *new_early_filters(void)
 {
 	struct early_filters *early_filters = xmalloc(sizeof(*early_filters));
 	INIT_LIST_HEAD(&early_filters->filters);
+	early_filters->n_pid_filters = 0;
+	early_filters->pids = NULL;
 	return early_filters;
 }
 
@@ -58,10 +63,78 @@ void free_early_filters(struct early_filters *early_filters)
 {
 	list_free(&early_filters->filters, struct early_filter, filters,
 		  free_early_filter);
+	if (early_filters->pids != NULL)
+		free(early_filters->pids);
+
 	free(early_filters);
+}
+
+static int pidcmp(const void *a, const void *b)
+{
+	pid_t pa = *(pid_t *)a;
+	pid_t pb = *(pid_t *)b;
+
+	if (pa < pb)
+		return -1;
+	else if (pa == pb)
+		return 0;
+	else
+		return 1;
+}
+
+static void sort_pids(pid_t pids[], const int count)
+{
+	qsort(pids, count, sizeof(pid_t), pidcmp);
 }
 
 void early_filters_optimize(struct early_filters *early_filters)
 {
-	/* STUB */
+	if (early_filters->n_pid_filters > 0) {
+		int i = 0;
+		struct list_head *ef;
+
+		early_filters->pids = xmalloc(sizeof(early_filters->pids[0]) *
+					      early_filters->n_pid_filters);
+
+
+		list_for_each(ef, &early_filters->filters) {
+			struct early_filter *early_filter = list_entry(ef,
+								       struct early_filter,
+								       filters);
+			if (early_filter->type == ef_pid)
+				early_filters->pids[i++] = early_filter->pid;
+		}
+		sort_pids(early_filters->pids, early_filters->n_pid_filters);
+	}
+}
+
+static struct early_filter *new_early_filter_pid(pid_t pid)
+{
+	struct early_filter *ef = xmalloc(sizeof(*ef));
+	ef->type = ef_pid;
+	INIT_LIST_HEAD(&ef->filters);
+	ef->pid = pid;
+	return ef;
+}
+
+void early_filters_add_pid(struct early_filters *early_filters, pid_t pid)
+{
+	struct early_filter *ef = new_early_filter_pid(pid);
+	list_add_tail(&ef->filters, &early_filters->filters);
+	early_filters->n_pid_filters++;
+}
+
+bool early_filters_has_pid_filter(struct early_filters *early_filters)
+{
+	return early_filters->n_pid_filters > 0;
+}
+
+bool early_filters_apply_pid(struct early_filters *early_filters, pid_t pid)
+{
+	if (!early_filters_has_pid_filter(early_filters))
+		return true;
+
+	return bsearch(&pid, early_filters->pids, early_filters->n_pid_filters, sizeof(pid_t), pidcmp)
+		? true
+		: false;
 }

--- a/lsfd-cmd/early-filter.c
+++ b/lsfd-cmd/early-filter.c
@@ -28,11 +28,13 @@
 
 enum early_filter_type {
 	ef_pid,
+	ef_file_path,
 };
 
 struct early_filters {
 	struct list_head filters;
 	unsigned int n_pid_filters;
+	unsigned int n_file_path_filters;
 
 	pid_t *pids;
 };
@@ -41,6 +43,7 @@ struct early_filter {
 	enum early_filter_type type;
 	union {
 		pid_t pid;
+		const char *file_path;
 	};
 	struct list_head filters;
 };
@@ -50,6 +53,7 @@ struct early_filters *new_early_filters(void)
 	struct early_filters *early_filters = xmalloc(sizeof(*early_filters));
 	INIT_LIST_HEAD(&early_filters->filters);
 	early_filters->n_pid_filters = 0;
+	early_filters->n_file_path_filters = 0;
 	early_filters->pids = NULL;
 	return early_filters;
 }
@@ -108,6 +112,22 @@ void early_filters_optimize(struct early_filters *early_filters)
 	}
 }
 
+static bool early_filters_apply (struct early_filters *early_filters,
+				 bool (*predicate)(struct early_filter *, const void *), const void *data)
+{
+	struct list_head *ef;
+
+	list_for_each(ef, &early_filters->filters) {
+		struct early_filter *early_filter = list_entry(ef,
+							       struct early_filter,
+							       filters);
+		if (predicate(early_filter, data))
+			return true;
+	}
+
+	return false;
+}
+
 static struct early_filter *new_early_filter_pid(pid_t pid)
 {
 	struct early_filter *ef = xmalloc(sizeof(*ef));
@@ -137,4 +157,43 @@ bool early_filters_apply_pid(struct early_filters *early_filters, pid_t pid)
 	return bsearch(&pid, early_filters->pids, early_filters->n_pid_filters, sizeof(pid_t), pidcmp)
 		? true
 		: false;
+}
+
+static struct early_filter *new_early_filter_file_path(const char *file_path)
+{
+	struct early_filter *ef = xmalloc(sizeof(*ef));
+	ef->type = ef_file_path;
+	INIT_LIST_HEAD(&ef->filters);
+	ef->file_path = file_path;
+	return ef;
+}
+
+void early_filters_add_file_path(struct early_filters *early_filters, const char *file_path)
+{
+	struct early_filter *ef = new_early_filter_file_path(file_path);
+	list_add_tail(&ef->filters, &early_filters->filters);
+	early_filters->n_file_path_filters++;
+}
+
+bool early_filters_has_file_path(struct early_filters *early_filters)
+{
+	return early_filters->n_file_path_filters > 0;
+}
+
+static bool file_path_equal(struct early_filter *early_filter, const void *data)
+{
+	const char *file_path = data;
+
+	if (early_filter->type != ef_file_path)
+		return false;
+
+	return strcmp(early_filter->file_path, file_path) == 0;
+}
+
+bool early_filters_apply_file_path(struct early_filters *early_filters, const char *file_path)
+{
+	if (!early_filters_has_file_path(early_filters))
+		return true;
+
+	return early_filters_apply(early_filters, file_path_equal, file_path);
 }

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -561,6 +561,8 @@ struct lsfd_control {
 
 	struct libscols_filter *filter;		/* filter */
 	struct libscols_filter **ct_filters;	/* counters (NULL terminated array) */
+
+	struct early_filters *early_filters;
 };
 
 static void *proc_tree;			/* for tsearch/tfind */
@@ -2494,7 +2496,7 @@ int main(int argc, char *argv[])
 	struct lsfd_control ctl = {
 		.show_main = 1
 	};
-
+	ctl.early_filters = new_early_filters();
 	INIT_LIST_HEAD(&counter_specs);
 
 	enum {
@@ -2693,6 +2695,8 @@ int main(int argc, char *argv[])
 	if (n_pids > 0)
 		sort_pids(pids, n_pids);
 
+	early_filters_optimize(ctl.early_filters);
+
 	if (scols_table_get_column_by_name(ctl.tb, "XMODE"))
 		ctl.show_xmode = 1;
 
@@ -2736,6 +2740,8 @@ int main(int argc, char *argv[])
 	finalize_classes();
 	finalize_ipc_table();
 	finalize_nodevs();
+
+	free_early_filters(ctl.early_filters);
 
 	return 0;
 }

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -840,37 +840,46 @@ static struct file *collect_file_symlink(struct path_cxt *pc,
 					 struct proc *proc,
 					 const char *name,
 					 int assoc,
-					 bool sockets_only)
+					 bool sockets_only,
+					 struct early_filters *early_filters)
 {
 	char sym[PATH_MAX] = { '\0' };
 	struct stat sb;
 	struct file *f, *prev;
 
-	if (ul_path_readlink(pc, sym, sizeof(sym), name) < 0)
+	if (ul_path_readlink(pc, sym, sizeof(sym), name) < 0) {
+		if (early_filters_has_file_path(early_filters))
+			return NULL;
 		f = new_readlink_error_file(proc, errno, assoc);
+	}
 	/* The /proc/#/{fd,ns} often contains the same file (e.g. /dev/tty)
 	 * more than once. Let's try to reuse the previous file if the real
 	 * path is the same to save stat() call.
 	 */
-	else if ((prev = list_last_entry(&proc->files, struct file, files))
-		 && (!prev->is_error)
-		 && prev->name && strcmp(prev->name, sym) == 0) {
-		f = copy_file(prev, assoc);
-		sb = prev->stat;
-	} else if (ul_path_stat(pc, &sb, 0, name) < 0)
-		f = new_stat_error_file(proc, sym, errno, assoc);
 	else {
-		const struct file_class *class = stat2class(&sb);
-
-		if (sockets_only
-		    /* A nsfs file is not a socket but the nsfs file can
-		     * be used as a entry point to collect information from
-		     * other network namespaces. Based on the information,
-		     * various columns of sockets can be filled.
-		     */
-		    && (class != &sock_class) && (class != &nsfs_file_class))
+		if (!early_filters_apply_file_path(early_filters, sym))
 			return NULL;
-		f = new_file(proc, class, &sb, sym, assoc);
+
+		if ((prev = list_last_entry(&proc->files, struct file, files))
+		    && (!prev->is_error)
+		    && prev->name && strcmp(prev->name, sym) == 0) {
+			f = copy_file(prev, assoc);
+			sb = prev->stat;
+		} else if (ul_path_stat(pc, &sb, 0, name) < 0)
+			f = new_stat_error_file(proc, sym, errno, assoc);
+		else {
+			const struct file_class *class = stat2class(&sb);
+
+			if (sockets_only
+			    /* A nsfs file is not a socket but the nsfs file can
+			     * be used as a entry point to collect information from
+			     * other network namespaces. Based on the information,
+			     * various columns of sockets can be filled.
+			     */
+			    && (class != &sock_class) && (class != &nsfs_file_class))
+				return NULL;
+			f = new_file(proc, class, &sb, sym, assoc);
+		}
 	}
 
 	file_init_content(f);
@@ -912,7 +921,7 @@ static struct file *collect_file_symlink(struct path_cxt *pc,
 /* read symlinks from /proc/#/fd
  */
 static void collect_fd_files(struct path_cxt *pc, struct proc *proc,
-			     bool sockets_only)
+			     bool sockets_only, struct early_filters *early_filters)
 {
 	DIR *sub = NULL;
 	struct dirent *d = NULL;
@@ -925,11 +934,12 @@ static void collect_fd_files(struct path_cxt *pc, struct proc *proc,
 			continue;
 
 		snprintf(path, sizeof(path), "fd/%ju", (uintmax_t) num);
-		collect_file_symlink(pc, proc, path, num, sockets_only);
+		collect_file_symlink(pc, proc, path, num, sockets_only, early_filters);
 	}
 }
 
-static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
+static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc,
+			    struct early_filters *early_filters)
 {
 	uint64_t start, end, offset, ino;
 	unsigned long major, minor;
@@ -970,6 +980,8 @@ static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
 		f = copy_file(prev, -assoc);
 	else if ((path = strchr(buf, '/'))) {
 		rtrim_whitespace((unsigned char *) path);
+		if (!early_filters_apply_file_path(early_filters, path))
+			return;
 		if (stat(path, &sb) < 0)
 			/* If a file is mapped but deleted from the file system,
 			 * "stat by the file name" may not work. In that case,
@@ -982,13 +994,20 @@ static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
 
 	try_map_files:
 		if (ul_path_readlinkf(pc, sym, sizeof(sym),
-				      "map_files/%"PRIx64"-%"PRIx64, start, end) < 0)
+				      "map_files/%"PRIx64"-%"PRIx64, start, end) < 0) {
+			if (early_filters_has_file_path(early_filters))
+				return;
 			f = new_readlink_error_file(proc, errno, -assoc);
-		else if (ul_path_statf(pc, &sb, 0,
-				       "map_files/%"PRIx64"-%"PRIx64, start, end) < 0)
+		} else if (ul_path_statf(pc, &sb, 0,
+					 "map_files/%"PRIx64"-%"PRIx64, start, end) < 0) {
+			if (early_filters_has_file_path(early_filters))
+				return;
 			f = new_stat_error_file(proc, sym, errno, -assoc);
-		else
+		} else {
+			if (!early_filters_apply_file_path(early_filters, sym))
+				return;
 			f = new_file(proc, stat2class(&sb), &sb, sym, -assoc);
+		}
 	}
 
 	if (modestr[0] == 'r')
@@ -1005,7 +1024,8 @@ static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
 	file_init_content(f);
 }
 
-static void collect_mem_files(struct path_cxt *pc, struct proc *proc)
+static void collect_mem_files(struct path_cxt *pc, struct proc *proc,
+			      struct early_filters *early_filters)
 {
 	FILE *fp;
 	char buf[BUFSIZ];
@@ -1015,7 +1035,7 @@ static void collect_mem_files(struct path_cxt *pc, struct proc *proc)
 		return;
 
 	while (fgets(buf, sizeof(buf), fp))
-		parse_maps_line(pc, buf, proc);
+		parse_maps_line(pc, buf, proc, early_filters);
 
 	fclose(fp);
 }
@@ -1025,28 +1045,29 @@ static void collect_outofbox_files(struct path_cxt *pc,
 				   enum association assocs[],
 				   const char *names[],
 				   size_t count,
-				   bool sockets_only)
+				   bool sockets_only,
+				   struct early_filters *early_filters)
 {
 	size_t i;
 
 	for (i = 0; i < count; i++)
 		collect_file_symlink(pc, proc, names[assocs[i]], assocs[i] * -1,
-				     sockets_only);
+				     sockets_only, early_filters);
 }
 
 static void collect_execve_file(struct path_cxt *pc, struct proc *proc,
-				bool sockets_only)
+				bool sockets_only, struct early_filters *early_filters)
 {
 	enum association assocs[] = { ASSOC_EXE };
 	const char *names[] = {
 		[ASSOC_EXE]  = "exe",
 	};
 	collect_outofbox_files(pc, proc, assocs, names, ARRAY_SIZE(assocs),
-			       sockets_only);
+			       sockets_only, early_filters);
 }
 
 static void collect_fs_files(struct path_cxt *pc, struct proc *proc,
-			     bool sockets_only)
+			     bool sockets_only, struct early_filters *early_filters)
 {
 	enum association assocs[] = { ASSOC_CWD, ASSOC_ROOT };
 	const char *names[] = {
@@ -1054,10 +1075,11 @@ static void collect_fs_files(struct path_cxt *pc, struct proc *proc,
 		[ASSOC_ROOT] = "root",
 	};
 	collect_outofbox_files(pc, proc, assocs, names, ARRAY_SIZE(assocs),
-			       sockets_only);
+			       sockets_only, early_filters);
 }
 
-static void collect_namespace_files_tophalf(struct path_cxt *pc, struct proc *proc)
+static void collect_namespace_files_tophalf(struct path_cxt *pc, struct proc *proc,
+					    struct early_filters *early_filters)
 {
 	enum association assocs[] = {
 		ASSOC_NS_CGROUP,
@@ -1071,10 +1093,12 @@ static void collect_namespace_files_tophalf(struct path_cxt *pc, struct proc *pr
 	};
 	collect_outofbox_files(pc, proc, assocs, names, ARRAY_SIZE(assocs),
 			       /* Namespace information is always needed. */
-			       false);
+			       false,
+			       early_filters);
 }
 
-static void collect_namespace_files_bottomhalf(struct path_cxt *pc, struct proc *proc)
+static void collect_namespace_files_bottomhalf(struct path_cxt *pc, struct proc *proc,
+					       struct early_filters *early_filters)
 {
 	enum association assocs[] = {
 		ASSOC_NS_NET,
@@ -1096,7 +1120,7 @@ static void collect_namespace_files_bottomhalf(struct path_cxt *pc, struct proc 
 	};
 	collect_outofbox_files(pc, proc, assocs, names, ARRAY_SIZE(assocs),
 			       /* Namespace information is always needed. */
-			       false);
+			       false, early_filters);
 }
 
 static void reset_cooked_bdev(struct cooked_bdev *bdev, dev_t raw, const char *filesystem)
@@ -1947,11 +1971,11 @@ static void read_process(struct lsfd_control *ctl, struct path_cxt *pc,
 		goto out;
 	}
 
-	collect_execve_file(pc, proc, ctl->sockets_only);
+	collect_execve_file(pc, proc, ctl->sockets_only, ctl->early_filters);
 
 	if (proc->pid == proc->leader->pid
 	    || kcmp(proc->leader->pid, proc->pid, KCMP_FS, 0, 0) != 0)
-		collect_fs_files(pc, proc, ctl->sockets_only);
+		collect_fs_files(pc, proc, ctl->sockets_only, ctl->early_filters);
 
 	/* Reading /proc/$pid/mountinfo is expensive.
 	 * mnt_namespaces is a table for avoiding reading mountinfo files
@@ -1972,7 +1996,7 @@ static void read_process(struct lsfd_control *ctl, struct path_cxt *pc,
 
 	/* 1/3. Read /proc/$pid/ns/mnt */
 	if (proc->mnt_ns == NULL)
-		collect_namespace_files_tophalf(pc, proc);
+		collect_namespace_files_tophalf(pc, proc, ctl->early_filters);
 
 	/* 2/3. read /proc/$pid/mountinfo unless we have read it already.
 	 * The backing device for "nsfs" is solved here.
@@ -1996,7 +2020,7 @@ static void read_process(struct lsfd_control *ctl, struct path_cxt *pc,
 	 * When reading the information about the net namespace,
 	 * backing device for "nsfs" must be solved.
 	 */
-	collect_namespace_files_bottomhalf(pc, proc);
+	collect_namespace_files_bottomhalf(pc, proc, ctl->early_filters);
 
 	/* If kcmp is not available,
 	 * there is no way to know whether threads share resources.
@@ -2006,11 +2030,11 @@ static void read_process(struct lsfd_control *ctl, struct path_cxt *pc,
 	if ((!ctl->sockets_only)
 	    && (proc->pid == proc->leader->pid
 		|| kcmp(proc->leader->pid, proc->pid, KCMP_VM, 0, 0) != 0))
-		collect_mem_files(pc, proc);
+		collect_mem_files(pc, proc, ctl->early_filters);
 
 	if (proc->pid == proc->leader->pid
 	    || kcmp(proc->leader->pid, proc->pid, KCMP_FILES, 0, 0) != 0)
-		collect_fd_files(pc, proc, ctl->sockets_only);
+		collect_fd_files(pc, proc, ctl->sockets_only, ctl->early_filters);
 
 	list_add_tail(&proc->procs, &ctl->procs);
 	if (tsearch(proc, &proc_tree, proc_tree_compare) == NULL)
@@ -2120,7 +2144,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	FILE *out = stdout;
 
 	fputs(USAGE_HEADER, out);
-	fprintf(out, _(" %s [options]\n"), program_invocation_short_name);
+	fprintf(out, _(" %s [options] [--] names\n"), program_invocation_short_name);
 
 	fputs(USAGE_OPTIONS, out);
 	fputs(_(" -l, --threads                list in threads level\n"), out);
@@ -2594,8 +2618,8 @@ int main(int argc, char *argv[])
 	if (collist)
 		list_colunms("lsfd-columns", stdout, ctl.raw, ctl.json); /* print and exit */
 
-	if (argv[optind])
-		errtryhelp(EXIT_FAILURE);
+	for (int n = optind; n < argc; n++)
+		early_filters_add_file_path(ctl.early_filters, argv[n]);
 
 #define INITIALIZE_COLUMNS(COLUMN_SPEC)				\
 	for (i = 0; i < ARRAY_SIZE(COLUMN_SPEC); i++)	\

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -2032,7 +2032,7 @@ static void read_process(struct lsfd_control *ctl, struct path_cxt *pc,
 	ul_path_close_dirfd(pc);
 }
 
-static void parse_pids(const char *str, pid_t **pids, int *count)
+static void add_pids_to_early_filters(const char *str, struct early_filters *early_filters)
 {
 	long v;
 	char *next = NULL;
@@ -2049,41 +2049,16 @@ static void parse_pids(const char *str, pid_t **pids, int *count)
 	if (v < 0)
 		errx(EXIT_FAILURE, _("out of range value for pid specification: %ld"), v);
 
-	(*count)++;
-	*pids = xreallocarray(*pids, *count, sizeof(**pids));
-	(*pids)[*count - 1] = (pid_t)v;
+	early_filters_add_pid(early_filters, v);
 
 	while (next && *next != '\0'
 	       && (isspace((unsigned char)*next) || *next == ','))
 		next++;
 	if (*next != '\0')
-		parse_pids(next, pids, count);
+		add_pids_to_early_filters(next, early_filters);
 }
 
-static int pidcmp(const void *a, const void *b)
-{
-	pid_t pa = *(pid_t *)a;
-	pid_t pb = *(pid_t *)b;
-
-	if (pa < pb)
-		return -1;
-	else if (pa == pb)
-		return 0;
-	else
-		return 1;
-}
-
-static void sort_pids(pid_t pids[], const int count)
-{
-	qsort(pids, count, sizeof(pid_t), pidcmp);
-}
-
-static bool member_pids(const pid_t pid, const pid_t pids[], const int count)
-{
-	return bsearch(&pid, pids, count, sizeof(pid_t), pidcmp)? true: false;
-}
-
-static void collect_processes(struct lsfd_control *ctl, const pid_t pids[], int n_pids)
+static void collect_processes(struct lsfd_control *ctl)
 {
 	DIR *dir;
 	struct dirent *d;
@@ -2102,7 +2077,8 @@ static void collect_processes(struct lsfd_control *ctl, const pid_t pids[], int 
 
 		if (procfs_dirent_get_pid(d, &pid) != 0)
 			continue;
-		if (n_pids == 0 || member_pids(pid, pids, n_pids))
+		if (early_filters_has_pid_filter(ctl->early_filters) == false
+		    || early_filters_apply_pid(ctl->early_filters, pid))
 			read_process(ctl, pc, pid, 0);
 	}
 
@@ -2489,8 +2465,6 @@ int main(int argc, char *argv[])
 	char  *filter_expr = NULL;
 	bool debug_filter = false;
 	bool dump_counters = false;
-	pid_t *pids = NULL;
-	int n_pids = 0;
 	struct list_head counter_specs;
 
 	struct lsfd_control ctl = {
@@ -2554,7 +2528,7 @@ int main(int argc, char *argv[])
 			ctl.notrunc = 1;
 			break;
 		case 'p':
-			parse_pids(optarg, &pids, &n_pids);
+			add_pids_to_early_filters(optarg, ctl.early_filters);
 			break;
 		case 'i': {
 			const char *subexpr = NULL;
@@ -2692,9 +2666,6 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (n_pids > 0)
-		sort_pids(pids, n_pids);
-
 	early_filters_optimize(ctl.early_filters);
 
 	if (scols_table_get_column_by_name(ctl.tb, "XMODE"))
@@ -2716,8 +2687,7 @@ int main(int argc, char *argv[])
 	initialize_classes();
 	initialize_devdrvs();
 
-	collect_processes(&ctl, pids, n_pids);
-	free(pids);
+	collect_processes(&ctl);
 
 	attach_xinfos(&ctl.procs);
 	if (ctl.show_xmode)

--- a/lsfd-cmd/lsfd.h
+++ b/lsfd-cmd/lsfd.h
@@ -65,9 +65,12 @@ void early_filters_optimize(struct early_filters *early_filters);
 void early_filters_add_pid(struct early_filters *early_filters, pid_t pid);
 bool early_filters_has_pid_filter(struct early_filters *early_filters);
 
+void early_filters_add_file_path(struct early_filters *early_filters, const char *file_path);
+bool early_filters_has_file_path(struct early_filters *early_filters);
+
 /* Return: true => accept, false => reject */
 bool early_filters_apply_pid(struct early_filters *early_filters, pid_t pid);
-
+bool early_filters_apply_file_path(struct early_filters *early_filters, const char *file_path);
 /*
  * column IDs
  */

--- a/lsfd-cmd/lsfd.h
+++ b/lsfd-cmd/lsfd.h
@@ -62,6 +62,12 @@ void free_early_filters(struct early_filters *early_filters);
 
 void early_filters_optimize(struct early_filters *early_filters);
 
+void early_filters_add_pid(struct early_filters *early_filters, pid_t pid);
+bool early_filters_has_pid_filter(struct early_filters *early_filters);
+
+/* Return: true => accept, false => reject */
+bool early_filters_apply_pid(struct early_filters *early_filters, pid_t pid);
+
 /*
  * column IDs
  */

--- a/lsfd-cmd/lsfd.h
+++ b/lsfd-cmd/lsfd.h
@@ -52,6 +52,17 @@ UL_DEBUG_DECLARE_MASK(lsfd);
 #define DBG(m, x)       __UL_DBG(lsfd, LSFD_DEBUG_, m, x)
 
 /*
+ * Early filter
+ *
+ * early_filter works when collecting information.
+ */
+struct early_filters;
+struct early_filters *new_early_filters(void);
+void free_early_filters(struct early_filters *early_filters);
+
+void early_filters_optimize(struct early_filters *early_filters);
+
+/*
  * column IDs
  */
 enum {

--- a/lsfd-cmd/meson.build
+++ b/lsfd-cmd/meson.build
@@ -1,6 +1,7 @@
 lsfd_sources = files (
   'lsfd.c',
   'lsfd.h',
+  'early-filter.c',
   'decode-file-flags.c',
   'file.c',
   'cdev.c',


### PR DESCRIPTION
Partial solves #2567.

```
$  ./lsfd /dev/null | head -3
COMMAND             PID   USER ASSOC  XMODE TYPE SOURCE MNTID INODE NAME
pipewire          12620 yamato     0 r-----  CHR  mem:3    34     4 /dev/null
wireplumber       12621 yamato     0 r-----  CHR  mem:3    34     4 /dev/null
$  ./lsfd -- /dev/null | head -3
COMMAND             PID   USER ASSOC  XMODE TYPE SOURCE MNTID INODE NAME
pipewire          12620 yamato     0 r-----  CHR  mem:3    34     4 /dev/null
wireplumber       12621 yamato     0 r-----  CHR  mem:3    34     4 /dev/null
$  ./lsfd -- /dev/zero | head -3
COMMAND     PID   USER ASSOC  XMODE TYPE SOURCE MNTID INODE NAME
dd      2434997 yamato     0 r-----  CHR  mem:5    34     6 /dev/zero
```

This feature is not implemented as a syntax-sugar for `-Q`.
The early filter works in the "collecting"-information stage.
I expected the early filter to work much faster than `-Q 'NAME == "/dev/zero"`, a filter working in the "post-collecting" information stage.

```
# time ./lsfd | wc -l
216088

real	0m4.811s
user	0m3.638s
sys	0m1.196s
# time ./lsfd -Q 'NAME == "/dev/zero"' | wc -l
5

real	0m1.605s
user	0m0.702s
sys	0m0.893s
# time ./lsfd -- /dev/zero | wc -l
5

real	0m0.977s
user	0m0.439s
sys	0m0.539s
```

However, the difference between `-Q` and `--` was much smaller than I expected.

Is the early filter mechanism a way to go?