### PR TITLE
lscpu: Add FUJITSU aarch64 MONAKA cpupart

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -250,6 +250,7 @@ static const struct id_part intel_part[] = {
 
 static const struct id_part fujitsu_part[] = {
     { 0x001, "A64FX" },
+    { 0x003, "MONAKA" },
     { -1, "unknown" },
 };
 


### PR DESCRIPTION
Add an entry for FUJITSU aarch64 part MONAKA.

Dear lscpu development team,

This commit adds present support for FUJITSU-MONAKA.
Also update lscpu-arm.c to show the model name in lscpu command.

FUJITSU-MONAKA Specification URL:
https://github.com/fujitsu/FUJITSU-MONAKA

Please review and merge these patches

Best regards.
Emi, Kisanuki
