### PR TITLE
fincore: Use correct syscall number for cachestat on alpha

### DIFF
--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -46,7 +46,11 @@
 #ifndef HAVE_CACHESTAT
 
 #ifndef SYS_cachestat
+#if defined (__alpha__)
+#define SYS_cachestat 561
+#else
 #define SYS_cachestat 451
+#endif
 #endif
 
 struct cachestat_range {


### PR DESCRIPTION
Fixes #3331, #3333