### PR TITLE
fstab.5 mount.8: add note about field separator

### DIFF
--- a/sys-utils/fstab.5.adoc
+++ b/sys-utils/fstab.5.adoc
@@ -54,7 +54,9 @@ The file *fstab* contains descriptive information about the filesystems the syst
 
 The file is not read by *mount*(8) only but often is used by many other tools and daemons, and proper functionality may require additional steps. For example, on systemd-based systems, it's recommended to use *systemctl daemon-reload* after *fstab* modification.
 
-Each filesystem is described on a separate line. Fields on each line are separated by tabs or spaces. Lines starting with '#' are comments. Blank lines are ignored.
+Each filesystem is described on a separate line, with fields separated by tabs or spaces. The line is split into fields before being parsed. This means that any spaces or tabs within the fields must be escaped using \040 or \011, even within quoted strings (e.g. LABEL="foo\040bar").
+
+Lines starting with '#' are comments. Blank lines are ignored.
 
 The following is a typical example of an *fstab* entry:
 

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -790,7 +790,8 @@ The __id-mount__ parameter indicates the starting ID in the new mount.
 The __id-host__ parameter indicates the starting ID in the filesystem.
 The __id-range__ parameter indicates how many IDs are to be mapped.
 It is possible to specify multiple ID-mappings.
-The individual ID-mappings must be separated by spaces.
++
+The individual ID mappings must be separated by spaces. Please note that in the __/etc/fstab__ file, spaces are interpreted as separators between fields. To avoid this, you must escape them using \040. For example, X-mount.idmap=0:0:1\040500:1000:1.
 +
 For example, the ID-mapping *X-mount.idmap=u:1000:0:1 g:1001:1:2 5000:1000:2* creates an idmapped mount where
 UID 0 is mapped to UID 1000, GID 1 is mapped to GUID 1001, GID 2 is mapped to GID 1002, UID and GID 1000 are mapped to 5000, and UID and GID 1001 are mapped to 5001 in the mount.


### PR DESCRIPTION
The value of the mount option X-mount.idmap= can contain spaces as separators between mappings. Unfortunately, this conflicts with the fstab format where fields are separated by spaces. Using quotes does not solve this issue because fields are separated before they are parsed.

This limitation of the fstab parser within libmount is due to backward compatibility. The fstab format is a de-facto standard and is parsed by many tools and libraries, including third-party shell scripts. It would not be practical to introduce any improvements in libmount that would make fstabs unparseable in other places.

Users must understand that in-field spaces must be escaped by \040. For example, X-mount.idmap="0:0:1\040500:1000:1".

Addresses: https://github.com/util-linux/util-linux/issues/2829