### PR TITLE
hardlink: fix memory corruption (size calculation)

### DIFF
--- a/lib/fileeq.c
+++ b/lib/fileeq.c
@@ -272,12 +272,12 @@ size_t ul_fileeq_set_size(struct ul_fileeq *eq, uint64_t filesiz,
 		nreads = filesiz / readsiz;
 		/* enlarge readsize for large files */
 		if (nreads > maxdigs)
-			readsiz = filesiz / maxdigs;
+			readsiz = (filesiz + maxdigs - 1) / maxdigs;
 		break;
 	}
 
 	eq->readsiz = readsiz;
-	eq->blocksmax = filesiz / readsiz;
+	eq->blocksmax = (filesiz + readsiz - 1) / readsiz;
 
 	DBG(EQ, ul_debugobj(eq, "set sizes: filesiz=%ju, maxblocks=%" PRIu64 ", readsiz=%zu",
 				eq->filesiz, eq->blocksmax, eq->readsiz));


### PR DESCRIPTION
The current code rounds down the values for readsiz and blocksmax, which is incorrect. The sizes must be large enough to match the files.

Addresses: https://github.com/util-linux/util-linux/issues/3330