### PR TITLE
po-man: Fix table formatting in romanian translation

### DIFF
--- a/po-man/ro.po
+++ b/po-man/ro.po
@@ -2941,7 +2941,7 @@ msgstr ""
 "|/dev/hda[1-63] |Discul IDE 1\n"
 "|/dev/hdb[1-63] |Discul IDE 2\n"
 "|/dev/sda[1-15] |Discul SCSI 1\n"
-"|/dev/sdb[1-15] ||Discul SCSI 2\n"
+"|/dev/sdb[1-15] |Discul SCSI 2\n"
 
 #. type: delimited block _
 #: ../disk-utils/fsck.minix.8.adoc:40


### PR DESCRIPTION
asciidoctor-2.0.23 was giving an error:

    asciidoctor: ERROR: fsck.minix.8.adoc: line 29: dropping cells from incomplete row detected end of table