### PR TITLE
revise test cases (lsns::filter and lsfd::mkfds-vsock)

### DIFF
--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -3091,7 +3091,7 @@ static void map_root_user(uid_t uid, uid_t gid)
 		    "failed to open /proc/self/uid_map");
 	r = write (mapfd, buf, n);
 	if (r < 0)
-		err(EXIT_FAILURE,
+		err((errno == EPERM? EXIT_EPERM: EXIT_FAILURE),
 		    "failed to write to /proc/self/uid_map");
 	if (r != n)
 		errx(EXIT_FAILURE,

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -38,6 +38,7 @@
 # include <linux/unix_diag.h> /* for UNIX domain sockets */
 #include <linux/sockios.h>  /* SIOCGSKNS */
 #include <linux/vm_sockets.h>
+#include <linux/vm_sockets_diag.h> /* vsock_diag_req/vsock_diag_msg */
 #include <mqueue.h>
 #include <net/if.h>
 #include <netinet/in.h>
@@ -3224,22 +3225,37 @@ static void *make_sockdiag(const struct factory *factory, struct fdesc fdescs[],
 	struct arg family = decode_arg("family", factory->params, argc, argv);
 	const char *sfamily = ARG_STRING(family);
 	int ifamily;
+	struct arg type = decode_arg("type", factory->params, argc, argv);
+	const char *stype = ARG_STRING(type);
+	int itype;
 	int diagsd;
 	void *req = NULL;
 	size_t reqlen = 0;
 	int e;
 	struct unix_diag_req udr;
+	struct vsock_diag_req vdr;
 
 	if (strcmp(sfamily, "unix") == 0)
 		ifamily = AF_UNIX;
+	else if (strcmp(sfamily, "vsock") == 0)
+		ifamily = AF_VSOCK;
 	else
 		errx(EXIT_FAILURE, "unknown/unsupported family: %s", sfamily);
-	free_arg(&family);
 
-	diagsd = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_SOCK_DIAG);
+	if (strcmp(stype, "dgram") == 0)
+		itype = SOCK_DGRAM;
+	else if (strcmp(stype, "raw") == 0)
+		itype = SOCK_RAW;
+	else
+		errx(EXIT_FAILURE, "unknown/unsupported type: %s", stype);
+
+
+	diagsd = socket(AF_NETLINK, itype, NETLINK_SOCK_DIAG);
 	if (diagsd < 0)
 		err(errno == EPROTONOSUPPORT? EXIT_EPROTONOSUPPORT: EXIT_FAILURE,
-		    "failed in sendmsg()");
+		    "failed in socket(AF_NETLINK, %s, NETLINK_SOCK_DIAG)", stype);
+	free_arg(&family);
+	free_arg(&type);
 
 	if (ifamily == AF_UNIX) {
 		udr = (struct unix_diag_req) {
@@ -3249,6 +3265,13 @@ static void *make_sockdiag(const struct factory *factory, struct fdesc fdescs[],
 		};
 		req = &udr;
 		reqlen = sizeof(udr);
+	} else if (ifamily == AF_VSOCK) {
+		vdr = (struct vsock_diag_req) {
+			.sdiag_family = AF_VSOCK,
+			.vdiag_states = ~(uint32_t)0,
+		};
+		req = &vdr;
+		reqlen = sizeof(vdr);
 	}
 
 	e = send_diag_request(diagsd, req, reqlen);
@@ -4271,10 +4294,16 @@ static const struct factory factories[] = {
 		.make = make_sockdiag,
 		.params = (struct parameter []) {
 			{
+				.name = "type",
+				.type = PTYPE_STRING,
+				.desc = "dgram or raw",
+				.defv.string = "dgram",
+			},
+			{
 				.name = "family",
 				.type = PTYPE_STRING,
 				/* TODO: inet, inet6 */
-				.desc = "name of a protocol family ([unix])",
+				.desc = "name of a protocol family ([unix]|vsock)",
 				.defv.string = "unix",
 			},
 			PARAM_END

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -105,13 +105,14 @@ function lsfd_check_mkfds_factory
 function lsfd_check_sockdiag
 {
 	local family=$1
+	local type=${2:-dgram}
 
 	ts_check_test_command "$TS_HELPER_MKFDS"
 
 	local msg
 	local err
 
-	msg=$("$TS_HELPER_MKFDS" -c sockdiag 9 family=$family 2>&1)
+	msg=$("$TS_HELPER_MKFDS" -c sockdiag 9 family=$family type=$type 2>&1)
 	err=$?
 
 	case $err in

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -149,3 +149,23 @@ function lsfd_check_vsock
 		ts_failed "failed to use a AF_VSOCK socket: $msg [$err]";;
 	esac
 }
+
+function lsfd_check_userns
+{
+	ts_check_test_command "$TS_HELPER_MKFDS"
+
+	local msg
+	local err
+
+	msg=$("$TS_HELPER_MKFDS" -c userns 3 2>&1)
+	err=$?
+
+	case $err in
+	    0)
+		return;;
+	    "$EPERM")
+		ts_skip "maybe /proc/self/uid_map it not writable";;
+	    *)
+		ts_failed "failed to use a AF_VSOCK socket: $msg [$err]";;
+	esac
+}

--- a/tests/ts/lsfd/mkfds-vsock
+++ b/tests/ts/lsfd/mkfds-vsock
@@ -48,7 +48,10 @@ modprobe --quiet hv_vsock ||:
 # VMADDR_CID_LOCAL requires this.
 modprobe --quiet vsock_loopback	||:
 
+modprobe --quiet vsock_diag || :
+
 lsfd_check_vsock
+lsfd_check_sockdiag vsock raw
 
 {
 

--- a/tests/ts/lsns/filter
+++ b/tests/ts/lsns/filter
@@ -31,6 +31,8 @@ ts_check_test_command "$TS_HELPER_MKFDS"
 # unshare(2) used in userns factory of test_mkfds reports "Invalid argument".
 ts_skip_qemu_user
 
+lsfd_check_userns
+
 ts_cd "$TS_OUTDIR"
 PID=
 FD=4


### PR DESCRIPTION
On some platforms, lsns::filter test failed with the following message:
    
       +test_mkfds: failed to write to /proc/self/uid_map: -1: Operation
       not permitted
    
The first commit in this pull request is to skip the test case on such platforms.

The second and the third commits are for skipping the lsfd::mkfds-sock test case where the diag socket for AF_VSOCK is unavailable.