### PR TITLE
ci: bump coveralls compiler version to gcc 13

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -60,7 +60,7 @@ jobs:
       cancel-in-progress: true
     env:
       COMPILER: gcc
-      COMPILER_VERSION: 10
+      COMPILER_VERSION: 13
       SANITIZE: no
       COVERAGE: yes
     steps:


### PR DESCRIPTION
coverall CI output:

COMPILER=gcc
COMPILER_VERSION=10
...
Found gcov version: 13.2.0
...
geninfo: ERROR: Incompatible GCC/GCOV version found