### PR TITLE
Fix non-Linux build

### DIFF
--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -1370,6 +1370,7 @@ static int command_partattrs(struct sfdisk *sf, int argc, char **argv)
 	return write_changes(sf);
 }
 
+#ifdef BLKDISCARD
 /*
  * sfdisk --discard-free <device>
  */
@@ -1432,6 +1433,12 @@ done:
 	fdisk_unref_table(tb);
 	return rc;
 }
+#else /* BLKDISCARD */
+static int command_discard_free(struct sfdisk *sf, int argc, char **argv)
+{
+	fdisk_warnx(sf->cxt, _("Discard unsupported on your system."));
+}
+#endif /* BLKDISCARD */
 
 /*
  * sfdisk --disk-id <device> [<str>]

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -791,6 +791,7 @@ const unsigned char *blkid_probe_get_buffer(blkid_probe pr, uint64_t off, uint64
 	return real_off ? bf->data + (real_off - bf->off + bias) : bf->data + bias;
 }
 
+#ifdef O_DIRECT
 /*
  * This is blkid_probe_get_buffer with the read done as an O_DIRECT operation.
  * Note that @off is offset within probing area, the probing area is defined by
@@ -817,6 +818,7 @@ const unsigned char *blkid_probe_get_buffer_direct(blkid_probe pr, uint64_t off,
 	}
 	return ret;
 }
+#endif
 
 /**
  * blkid_probe_reset_buffers:

--- a/libblkid/src/superblocks/ext.c
+++ b/libblkid/src/superblocks/ext.c
@@ -164,6 +164,7 @@ static struct ext2_super_block *ext_get_super(
 		 * then declare a checksum mismatch.
 		 */
 		if (!blkid_probe_verify_csum(pr, csum, le32_to_cpu(es->s_checksum))) {
+#ifdef O_DIRECT
 			if (blkid_probe_reset_buffers(pr))
 				return NULL;
 
@@ -175,6 +176,9 @@ static struct ext2_super_block *ext_get_super(
 			csum = crc32c(~0, es, offsetof(struct ext2_super_block, s_checksum));
 			if (!blkid_probe_verify_csum(pr, csum, le32_to_cpu(es->s_checksum)))
 				return NULL;
+#else
+			return NULL;
+#endif
 		}
 	}
 	if (fc)

--- a/libmount/meson.build
+++ b/libmount/meson.build
@@ -24,6 +24,7 @@ lib_mount_sources = '''
   src/mountP.h
   src/cache.c
   src/fs.c
+  src/fs_statmount.c
   src/init.c
   src/iter.c
   src/lock.c
@@ -31,6 +32,7 @@ lib_mount_sources = '''
   src/optstr.c
   src/tab.c
   src/tab_diff.c
+  src/tab_listmount.c
   src/tab_parse.c
   src/tab_update.c
   src/test.c
@@ -43,8 +45,6 @@ lib_mount_sources = '''
 
 if LINUX
   lib_mount_sources += '''
-    src/fs_statmount.c
-    src/tab_listmount.c
     src/hooks.c
     src/monitor.c
     src/optlist.c

--- a/libmount/src/Makemodule.am
+++ b/libmount/src/Makemodule.am
@@ -11,6 +11,7 @@ libmount_la_SOURCES = \
 	libmount/src/mountP.h \
 	libmount/src/cache.c \
 	libmount/src/fs.c \
+	libmount/src/fs_statmount.c \
 	libmount/src/init.c \
 	libmount/src/iter.c \
 	libmount/src/lock.c \
@@ -19,6 +20,7 @@ libmount_la_SOURCES = \
 	libmount/src/optstr.c \
 	libmount/src/tab.c \
 	libmount/src/tab_diff.c \
+	libmount/src/tab_listmount.c \
 	libmount/src/tab_parse.c \
 	libmount/src/tab_update.c \
 	libmount/src/test.c \
@@ -30,8 +32,6 @@ libmount_la_SOURCES += \
 	libmount/src/context.c \
 	libmount/src/context_mount.c \
 	libmount/src/context_umount.c \
-	libmount/src/fs_statmount.c \
-	libmount/src/tab_listmount.c \
 	libmount/src/hooks.c \
 	libmount/src/hook_mount.c \
 	libmount/src/hook_mount_legacy.c \


### PR DESCRIPTION
This fixes non-Linux builds, by:

- making sfdisk discard option conditioned by availability of BLKDISCARD
- defining and using blkid_probe_get_buffer only if O_DIRECT is available
- always building src/fs_statmount.c and src/tab_listmount.c, they already contain proper conditions to make them void if support is not available.