### PR TITLE
Include errno.h within lsfd.c

### DIFF
--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -37,6 +37,7 @@
 #include <sys/uio.h>
 #include <linux/sched.h>
 #include <sys/syscall.h>
+#include <errno.h>
 
 #ifdef HAVE_LINUX_KCMP_H
 #  include <linux/kcmp.h>


### PR DESCRIPTION
This is needed for ENOSYS to be defined

libgcc:           14.2.0

```
2025-01-13T22:59:57.1752408Z misc-utils/lsfd.c: In function 'kcmp':
2025-01-13T22:59:57.1762407Z misc-utils/lsfd.c:66:9: error: 'errno' undeclared (first use in this function)
2025-01-13T22:59:57.1762947Z    66 |         errno = ENOSYS;
2025-01-13T22:59:57.1770931Z       |         ^~~~~
2025-01-13T22:59:57.1771263Z misc-utils/lsfd.c:40:1: note: 'errno' is defined in header '<errno.h>'; did you forget to '#include <errno.h>'?
2025-01-13T22:59:57.1771555Z    39 | #include <sys/syscall.h>
2025-01-13T22:59:57.1771767Z   +++ |+#include <errno.h>
2025-01-13T22:59:57.1771955Z    40 | 
2025-01-13T22:59:57.1772231Z misc-utils/lsfd.c:66:9: note: each undeclared identifier is reported only once for each function it appears in
2025-01-13T22:59:57.1772507Z    66 |         errno = ENOSYS;
2025-01-13T22:59:57.1772684Z       |         ^~~~~
2025-01-13T22:59:57.1779860Z misc-utils/lsfd.c:66:17: error: 'ENOSYS' undeclared (first use in this function)
2025-01-13T22:59:57.1780285Z    66 |         errno = ENOSYS;
2025-01-13T22:59:57.1780499Z       |                 ^~~~~~
2025-01-13T22:59:57.2204441Z   CC       misc-utils/lsfd-lsfd-decode-file-flags.o
2025-01-13T22:59:57.2803898Z make[2]: *** [Makefile:13624: misc-utils/lsfd-lsfd.o]
```