### PR TITLE
sys-utils: fix add NULL check for mnt_fs_get_target return value

### DIFF
--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -1132,6 +1132,9 @@ static int nsfs_xasputs(char **str,
 
 		const char *tgt = mnt_fs_get_target(fs);
 
+		if(!tgt)
+			continue;
+
 		if (!*str)
 			xasprintf(str, "%s", tgt);
 


### PR DESCRIPTION
Report of the static analyzer:
Return value of a function 'mnt_fs_get_target' is dereferenced at lsns.c:694 without checking for NULL, but it is usually checked for this function (24/26).

Corrections explained:
Added a NULL check before using the tgt pointer. If tgt is NULL, the current iteration is skipped.
- Added if (!tgt) check before using tgt.

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov <[ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)>