### PR TITLE
Add fuse.portal to list of pseudo file systems

### DIFF
--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -396,6 +396,7 @@ int mnt_fstype_is_pseudofs(const char *type)
 		"fuse.gvfs-fuse-daemon", /* Old name, not used by gvfs any more. */
 		"fuse.gvfsd-fuse",
 		"fuse.lxcfs",
+		"fuse.portal",
 		"fuse.rofiles-fuse",
 		"fuse.vmware-vmblock",
 		"fuse.xwmfs",


### PR DESCRIPTION
Fixes output of findmnt --real (opensuse#1234736).