### PR TITLE
uuidd: add sysusers file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -919,6 +919,11 @@ if systemd.found()
   systemdsystemunitdir = systemd.get_variable(pkgconfig : 'systemdsystemunitdir')
 endif
 
+systemd_sysusers_dir = ''
+if systemd.found()
+  systemd_sysusers_dir = systemd.get_variable(pkgconfig : 'sysusers_dir')
+endif
+
 sysvinit = get_option('sysvinit').enabled()
 sysvinitrcdir = sysconfdir + '/init.d'
 

--- a/misc-utils/meson.build
+++ b/misc-utils/meson.build
@@ -69,7 +69,8 @@ if build_liblastlog2 and systemd.found()
     configuration : conf)
   install_data(
     lastlog2_tmpfiles,
-    install_dir : '/usr/lib/tmpfiles.d')
+    install_dir : '/usr/lib/tmpfiles.d',
+    rename : 'lastlog2.conf')
 
   lastlog2_service = configure_file(
     input : 'lastlog2-import.service.in',
@@ -87,7 +88,8 @@ if build_uuidd and systemd.found()
     configuration : conf)
   install_data(
     uuidd_tmpfiles,
-    install_dir : '/usr/lib/tmpfiles.d')
+    install_dir : '/usr/lib/tmpfiles.d',
+    rename : 'uuidd.conf')
 
   uuidd_service = configure_file(
     input : 'uuidd.service.in',

--- a/misc-utils/meson.build
+++ b/misc-utils/meson.build
@@ -104,6 +104,11 @@ if build_uuidd and systemd.found()
   install_data(
     uuidd_socket,
     install_dir : systemdsystemunitdir)
+
+  install_data(
+    'uuidd-sysusers.conf',
+    install_dir: systemd_sysusers_dir,
+    rename : 'uuidd.conf')
 endif
 if build_uuidd and sysvinit
   uuidd_rc = configure_file(

--- a/misc-utils/uuidd-sysusers.conf
+++ b/misc-utils/uuidd-sysusers.conf
@@ -1,0 +1,1 @@
+u uuidd - "UUID generator helper daemon" /var/lib/libuuid


### PR DESCRIPTION
This will allow the user to be created automatically and the scriptlets to create the user and group dropped from the spec file: https://fedoraproject.org/wiki/Changes/RPMSuportForSystemdSysusers

The config is equivalent to what the Fedora package does, i.e. a dynamically-allocated uid and gid, and an account with nologin as the shell.