### PR TITLE
Revert "hwclock-rtc.c: try the 'new' rtc class first"

### DIFF
--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -176,7 +176,7 @@
 #ifdef __ia64__
 # define _PATH_RTC_DEV		"/dev/efirtc"
 #else
-# define _PATH_RTC_DEV		"/dev/rtc0"
+# define _PATH_RTC_DEV		"/dev/rtc"
 #endif
 
 /* raw paths*/

--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -94,8 +94,8 @@ static int open_rtc(const struct hwclock_control *ctl)
 		"/dev/efirtc",
 		"/dev/misc/efirtc",
 #endif
-		"/dev/rtc0",
 		"/dev/rtc",
+		"/dev/rtc0",
 		"/dev/misc/rtc"
 	};
 	size_t i;

--- a/sys-utils/hwclock.8.adoc
+++ b/sys-utils/hwclock.8.adoc
@@ -137,7 +137,7 @@ This option is meaningful for ISA compatible machines in the x86 and x86_64 fami
 This option is required when using the *--setepoch* function. The minimum _year_ value is 1900. The maximum is system dependent (*ULONG_MAX - 1*).
 
 *-f*, **--rtc=**__filename__::
-Override *hwclock*'s default rtc device file name. Otherwise it will use the first one found in this order: _/dev/rtc0_, _/dev/rtc_, _/dev/misc/rtc_. For *IA-64:* _/dev/efirtc_ _/dev/misc/efirtc_
+Override *hwclock*'s default rtc device file name. Otherwise it will use the first one found in this order: _/dev/rtc_, _/dev/rtc0_, _/dev/misc/rtc_. For *IA-64:* _/dev/efirtc_ _/dev/misc/efirtc_
 
 *-l*, *--localtime*; *-u*, *--utc*::
 Indicate which timescale the Hardware Clock is set to.
@@ -373,7 +373,7 @@ The system timezone file.
 _/usr/share/zoneinfo/_::
 The system timezone database directory.
 
-Device files *hwclock* may try for Hardware Clock access: _/dev/rtc0_ _/dev/rtc_ _/dev/misc/rtc_ _/dev/efirtc_ _/dev/misc/efirtc_
+Device files *hwclock* may try for Hardware Clock access: _/dev/rtc_ _/dev/rtc0_ _/dev/misc/rtc_ _/dev/efirtc_ _/dev/misc/efirtc_
 
 == SEE ALSO
 


### PR DESCRIPTION
This (effectively) reverts commit
1811900a91be856e794005511eac7859adb8e383.

There was no real motivation given, and it certainly makes the default behaviour of hwclock on current linux systems counter-intuitive: udev has a standard rule so that whichever rtc device is designated as the CONFIG_RTC_HCTOSYS_DEVICE one in the kernel configuration also becomes the target of the /dev/rtc symlink. People may have some other way of setting that symlink, but regardless, that must be considered the primary or default rtc for the system.

Also, busybox's implementation of hwclock still uses the original /dev/rtc, /dev/rtc0 order, meaning that installing util-linux's version on a board previously using busybox leads to unexpected regressions - it's not at all clear that one must go around and stick --rtc /dev/rtc on every hwclock invocation in all scripts.

While it's usually busybox that should align with the full-fledged implementation, in this case, I do believe that util-linux is wrong.

There is no change in behaviour on systems that for some reason do not have a /dev/rtc symlink, or for which it is a symlink to rtc0 (such as on any board with only a single RTC device). However, I do understand that reverting this after 8 years can itself lead to regressions, and I can understand if it would be rejected for that reason. However, in that case I'd appreciate a config option so that one can choose the primary rtc device at build time.