### PR TITLE
setpriv.c: fix memory leak in parse_groups function

### DIFF
--- a/sys-utils/setpriv.c
+++ b/sys-utils/setpriv.c
@@ -448,7 +448,7 @@ static void parse_groups(struct privctx *opts, const char *str)
 	while ((c = strsep(&groups, ",")))
 		opts->groups[i++] = get_group(c, _("Invalid supplementary group id"));
 
-	free(groups);
+	free(buf);
 }
 
 static void parse_pdeathsig(struct privctx *opts, const char *str)


### PR DESCRIPTION
The static analyzer flagged a memory leak in the parse_groups function. The memory allocated for 'buf' (via xstrdup) was not freed at the end of the function, leading to a memory leak.

Changes:
- Added free(buf) at the end of the function to release allocated memory.

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
