### PR TITLE
fallocate: forbid --posix with special options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -882,6 +882,7 @@ have = cc.links(code, name : 'fallocate() function')
 conf.set('HAVE_FALLOCATE', have ? 1 : false)
 
 code = '''
+#define _POSIX_C_SOURCE 200112L
 #include <unistd.h>
 #include <fcntl.h>
 

--- a/sys-utils/fallocate.1.adoc
+++ b/sys-utils/fallocate.1.adoc
@@ -28,7 +28,7 @@ The exit status returned by *fallocate* is 0 on success and 1 on failure.
 
 The _length_ and _offset_ arguments may be followed by the multiplicative suffixes KiB (=1024), MiB (=1024*1024), and so on for GiB, TiB, PiB, EiB, ZiB, and YiB (the "iB" is optional, e.g., "K" has the same meaning as "KiB") or the suffixes KB (=1000), MB (=1000*1000), and so on for GB, TB, PB, EB, ZB, and YB.
 
-The options *--collapse-range*, *--dig-holes*, *--punch-hole*, and *--zero-range* are mutually exclusive.
+The options *--collapse-range*, *--dig-holes*, *--punch-hole*, *--zero-range* and *--posix* are mutually exclusive.
 
 *-c*, *--collapse-range*::
 Removes a byte range from a file, without leaving a hole. The byte range to be collapsed starts at _offset_ and continues for _length_ bytes. At the completion of the operation, the contents of the file starting at the location __offset__+_length_ will be appended at the location _offset_, and the file will be _length_ bytes smaller. The option *--keep-size* may not be specified for the collapse-range operation.

--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -315,7 +315,7 @@ int main(int argc, char **argv)
 	static const ul_excl_t excl[] = {	/* rows and cols in ASCII order */
 		{ 'c', 'd', 'p', 'z' },
 		{ 'c', 'n' },
-		{ 'x', 'c', 'd', 'i', 'n', 'p', 'z'},
+		{ 'c', 'd', 'i', 'n', 'p', 'x', 'z'},
 		{ 0 }
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;


### PR DESCRIPTION
Option --posix picks posix_fallocate, which does not have a
mode flag. Forbid using any options that set mode flags when
also giving --posix.

Addresses: https://lore.kernel.org/util-linux/173703231441.1463009.14898093986088300384@localhost/

Obviously it would be better if the modes were supported, but that means writing a lot more code.