### PR TITLE
libuuid: remove pthread_atfork() usage to clear uuidd cache at fork()

### DIFF
--- a/libuuid/meson.build
+++ b/libuuid/meson.build
@@ -29,8 +29,6 @@ if cc.has_link_argument('-Wl,--version-script=@0@'.format(libuuid_sym_path))
 	libuuid_link_args += ['-Wl,--version-script=@0@'.format(libuuid_sym_path)]
 endif
 
-thread_dep = dependency('threads')
-
 lib_uuid = both_libraries(
   'uuid',
   list_h,
@@ -45,7 +43,7 @@ lib_uuid = both_libraries(
   link_depends : libuuid_link_depends,
   version : libuuid_version,
   link_args : libuuid_link_args,
-  dependencies : [socket_libs, thread_dep,
+  dependencies : [socket_libs,
                   build_libuuid ? [] : disabler()],
   install : build_libuuid)
 uuid_dep = declare_dependency(link_with: lib_uuid, include_directories: dir_libuuid)

--- a/libuuid/src/Makemodule.am
+++ b/libuuid/src/Makemodule.am
@@ -7,7 +7,7 @@ test_uuid_parser_CFLAGS = $(AM_CFLAGS) -I$(ul_libuuid_incdir)
 check_PROGRAMS += test_uuid_time
 test_uuid_time_SOURCES = libuuid/src/gen_uuid.c \
 	libuuid/src/pack.c libuuid/src/unpack.c lib/randutils.c lib/md5.c lib/sha1.c
-test_uuid_time_LDADD = libuuid.la $(SOCKET_LIBS) $(LDADD) -lpthread
+test_uuid_time_LDADD = libuuid.la $(SOCKET_LIBS) $(LDADD)
 test_uuid_time_CFLAGS = $(AM_CFLAGS) -I$(ul_libuuid_incdir) -DTEST_PROGRAM
 
 # includes
@@ -37,7 +37,7 @@ libuuid_la_SOURCES = \
 EXTRA_libuuid_la_DEPENDENCIES = \
 	libuuid/src/libuuid.sym
 
-libuuid_la_LIBADD       = $(LDADD) $(SOCKET_LIBS) -lpthread
+libuuid_la_LIBADD       = $(LDADD) $(SOCKET_LIBS)
 
 libuuid_la_CFLAGS = \
 	$(AM_CFLAGS) \

--- a/libuuid/uuid.pc.in
+++ b/libuuid/uuid.pc.in
@@ -7,5 +7,5 @@ Name: uuid
 Description: Universally unique id library
 Version: @LIBUUID_VERSION@
 Cflags: -I${includedir}/uuid
-Libs.private: @SOCKET_LIBS@ -lpthread
+Libs.private: @SOCKET_LIBS@
 Libs: -L${libdir} -luuid


### PR DESCRIPTION
libuuid had an issue [1] in which it was returning duplicated (non-unique) uuids after a fork(). This was due to a reuse of cached values.

The commit [2] fixed this issue by registering a cache reset function with pthread_atfork(), which is one of the rare possible standard call to do that.

Before commit [2], libuuid was not depending on the pthread library. Many packages (also not strongly requiring a pthread library) are using libuuid. Example of those libuuid users still working without pthread are: e2fsprogs, erofs-utils, f2fs-tools, mtd, parted, ... Commit [2] is now propagating this dependency on all those packages.

While this is not an issue on most mainstream Linux distributions (which are all including a pthread library), this introduced many failures in Buildroot Linux. See [3] and [4]. In this case, Buildroot Linux includes several configurations without pthread support. Those are based on the uClibc-ng. See [5]. Those configurations can still be useful in specific cases (very low resource systems, debug sessions, bring-ups, ...). Most of the packages using libuuid are low level system tools. Bringing a pthread requirement on them would reduce the number of cases in which they can be used.

This commit proposes an alternate implementation of the uuidd cache cleanup, without relying on pthread_atfork(). Instead, it records the PID of the owner process which initialized the cache, and invalidate it if is about to be used by another PID. Since the pthread library is no longer needed, build system files are also updated accordingly.

[1] https://github.com/util-linux/util-linux/issues/3009
[2] https://github.com/t-8ch/util-linux/commit/25bd5396ab700623134b491f42a3280556cb674c
[3] https://buildroot.org/
[4] https://autobuild.buildroot.org/?reason=util-linux-2.40.2
[5] https://uclibc-ng.org/