### PR TITLE
whereis: avoid accessing uninitialized memory

### DIFF
--- a/misc-utils/whereis.c
+++ b/misc-utils/whereis.c
@@ -471,7 +471,7 @@ static void findin(const char *dir, const char *pattern, int *count,
 
 static void lookup(const char *pattern, struct wh_dirlist *ls, int want)
 {
-	char patbuf[PATH_MAX];
+	char patbuf[PATH_MAX] = { 0 };
 	int count = 0;
 	char *wait = NULL, *p;
 


### PR DESCRIPTION
See https://github.com/util-linux/util-linux/issues/3239

Perhaps it would be better to fix xstrncpy to always add a terminating NUL to `dest`, even when `src` is an empty string (like `strncpy` does), but I'm not sure whether it would be safe.

The output it produces is still bogus, though:

```
# before
root@974aed1734e0:/src# ./whereis /
`:

# after
root@974aed1734e0:/src# ./whereis /
: /usr/share/man/cs/. /usr/share/man/da/. [ ... snip ... ] /usr/share/info/.
```

It's not clear what is the expected output in this case.
