### PR TITLE
lslogins: don't ignore stat error

### DIFF
--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -498,10 +498,14 @@ static int parse_utmpx(const char *path, size_t *nrecords, struct utmpx **record
 
 	/* optimize allocation according to file size, the realloc() below is
 	 * just fallback only */
-	if (stat(path, &st) == 0 && (size_t) st.st_size >= sizeof(struct utmpx)) {
-		imax = st.st_size / sizeof(struct utmpx);
-		ary = xreallocarray(NULL, imax, sizeof(struct utmpx));
-	}
+	if (stat(path, &st) == 0) {
+		if ((size_t) st.st_size >= sizeof(struct utmpx)) {
+			imax = st.st_size / sizeof(struct utmpx);
+			ary = xreallocarray(NULL, imax, sizeof(struct utmpx));
+		} else
+			return -ENODATA;
+	} else
+		return -errno;
 
 	for (i = 0; ; i++) {
 		struct utmpx *u;


### PR DESCRIPTION
In the parse_utmpx function, errors of the stat() call are ignored. As result is imax=1 and ary=NULL.
In best case will getutxent() fail, too. In worst case, lslogins will crash in ary[i] = *u; since ary is NULL and the if (i == imax) failed, since i=0 and imax=1.

Since we replaced wtmp with wtmpdb, there is no /var/log/wtmp on openSUSE/SUSE anymore. So we run quite frequently now into this.
My first idea was to add wtmpdb support, but since we have lastlog which provides all needed values, too, I see this as overkill.