### PR TITLE
sys-utils: added POSIX IPC support to lsipc, ipcrm and ipcmk

### DIFF
--- a/bash-completion/ipcmk
+++ b/bash-completion/ipcmk
@@ -9,19 +9,30 @@ _ipcmk_module()
 			COMPREPLY=( $(compgen -W "size" -- $cur) )
 			return 0
 			;;
+		'-m'|'--posix-shmem')
+			COMPREPLY=( $(compgen -W "size" -- $cur) )
+			return 0
+			;;
 		'-S'|'--semaphore')
 			COMPREPLY=( $(compgen -W "number" -- $cur) )
+			return 0
+			;;
+		'-s'|'--posix-semaphore'|'-Q'|'--queue'|'-q'|'--posix-mqueue')
 			return 0
 			;;
 		'-p'|'--mode')
 			COMPREPLY=( $(compgen -W "mode" -- $cur) )
 			return 0
 			;;
+		'-n'|'--name')
+			COMPREPLY=( $(compgen -W "name" -- $cur) )
+			return 0
+			;;
 		'-h'|'--help'|'-V'|'--version')
 			return 0
 			;;
 	esac
-	COMPREPLY=( $(compgen -W "--shmem --semaphore --queue --mode --help --version" -- $cur) )
+	COMPREPLY=( $(compgen -W "--shmem --posix-shmem --semaphore --posix-semaphore --queue --posix-mqueue --mode --name --help --version" -- $cur) )
 	return 0
 }
 complete -F _ipcmk_module ipcmk

--- a/bash-completion/ipcrm
+++ b/bash-completion/ipcrm
@@ -6,32 +6,47 @@ _ipcrm_module()
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 	case $prev in
 		'-m'|'--shmem-id')
-			KEYIDS="$(ipcs -m | awk '{if (3 < NR) {print $2}}')"
+			KEYIDS="$(lsipc -m | awk 'NR>1 {print $2}')"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-M'|'--shmem-key')
-			KEYIDS="$(ipcs -m | awk '{if (3 < NR) {print $1}}')"
+			KEYIDS="$(lsipc -m | awk 'NR>1 {print $1}')"
+			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
+			return 0
+			;;
+		'--posix-shmem')
+			KEYIDS="$(lsipc -M | awk 'NR>1 {print $1}')"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-q'|'--queue-id')
-			KEYIDS="$(ipcs -q | awk '{if (3 < NR) {print $2}}')"
+			KEYIDS="$(lsipc -q | awk 'NR>1 {print $2}')"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-Q'|'--queue-key')
-			KEYIDS="$(ipcs -q | awk '{if (3 < NR) {print $1}}')"
+			KEYIDS="$(lsipc -q | awk 'NR>1 {print $1}')"
+			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
+			return 0
+			;;
+		'--posix-mqueue')
+			KEYIDS="$(lsipc -Q | awk 'NR>1 {print $1}')"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-s'|'--semaphore-id')
-			KEYIDS="$(ipcs -s | awk '{if (3 < NR) {print $2}}')"
+			KEYIDS="$(lsipc -s | awk '{if (3 < NR) {print $2}}')"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-S'|'--semaphore-key')
-			KEYIDS="$(ipcs -s | awk '{if (3 < NR) {print $1}}')"
+			KEYIDS="$(lsipc -s | awk '{if (3 < NR) {print $1}}')"
+			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
+			return 0
+			;;
+		'--posix-semaphore')
+			KEYIDS="$(lsipc -S | awk 'NR>1 {print $1}')"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
@@ -42,16 +57,19 @@ _ipcrm_module()
 	case $cur in
 		'=')
 			cur=${cur#=}
-			COMPREPLY=( $(compgen -W "shm msg sem" -- $cur) )
+			COMPREPLY=( $(compgen -W "shm pshm msg pmsg sem psem" -- $cur) )
 			return 0
 			;;
 	esac
 	OPTS="	--shmem-id
 		--shmem-key
+		--posix-shmem
 		--queue-id
 		--queue-key
+		--posix-mqueue
 		--semaphore-id
 		--semaphore-key
+		--posix-semaphore
 		--all=
 		--verbose
 		--help

--- a/bash-completion/ipcrm
+++ b/bash-completion/ipcrm
@@ -6,47 +6,47 @@ _ipcrm_module()
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 	case $prev in
 		'-m'|'--shmem-id')
-			KEYIDS="$(lsipc -m | awk 'NR>1 {print $2}')"
+			KEYIDS="$(lsipc -m --noheadings -o ID)"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-M'|'--shmem-key')
-			KEYIDS="$(lsipc -m | awk 'NR>1 {print $1}')"
+			KEYIDS="$(lsipc -m --noheadings -o KEY)"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'--posix-shmem')
-			KEYIDS="$(lsipc -M | awk 'NR>1 {print $1}')"
+			KEYIDS="$(lsipc -M --noheadings -o NAME)"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-q'|'--queue-id')
-			KEYIDS="$(lsipc -q | awk 'NR>1 {print $2}')"
+			KEYIDS="$(lsipc -q --noheadings -o ID)"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-Q'|'--queue-key')
-			KEYIDS="$(lsipc -q | awk 'NR>1 {print $1}')"
+			KEYIDS="$(lsipc -q --noheadings -o KEY)"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'--posix-mqueue')
-			KEYIDS="$(lsipc -Q | awk 'NR>1 {print $1}')"
+			KEYIDS="$(lsipc -Q --noheadings -o NAME)"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-s'|'--semaphore-id')
-			KEYIDS="$(lsipc -s | awk '{if (3 < NR) {print $2}}')"
+			KEYIDS="$(lsipc -s --noheadings -o ID)"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'-S'|'--semaphore-key')
-			KEYIDS="$(lsipc -s | awk '{if (3 < NR) {print $1}}')"
+			KEYIDS="$(lsipc -s --noheadings -o KEY)"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;
 		'--posix-semaphore')
-			KEYIDS="$(lsipc -S | awk 'NR>1 {print $1}')"
+			KEYIDS="$(lsipc -S --noheadings -o NAME)"
 			COMPREPLY=( $(compgen -W "$KEYIDS" -- $cur) )
 			return 0
 			;;

--- a/bash-completion/lsipc
+++ b/bash-completion/lsipc
@@ -9,6 +9,10 @@ _lsipc_module()
 			COMPREPLY=( $(compgen -W "id" -- $cur) )
 			return 0
 			;;
+		'-N'|'--name')
+			COMPREPLY=( $(compgen -W "name" -- $cur) )
+			return 0
+			;;
 		'-h'|'--help'|'-V'|'--version')
 			return 0
 			;;
@@ -45,10 +49,14 @@ _lsipc_module()
 	esac
 	OPTS="
 		--shmems
+		--posix-shmems
 		--queues
+		--posix-mqueues
 		--semaphores
+		--posix-semaphores
 		--global
 		--id
+		--name
 		--noheadings
 		--notruncate
 		--time-format
@@ -62,6 +70,7 @@ _lsipc_module()
 		--numeric-perms
 		--raw
 		--time
+		--shell
 		--help
 		--version
 	"

--- a/configure.ac
+++ b/configure.ac
@@ -356,6 +356,7 @@ AC_CHECK_HEADERS([ \
 	linux/if_alg.h \
 	locale.h \
 	mntent.h \
+  mqueue.h \
 	net/if_dl.h \
 	net/if.h \
 	netinet/in.h \
@@ -363,6 +364,7 @@ AC_CHECK_HEADERS([ \
 	pty.h \
 	security/pam_appl.h \
 	security/pam_modules.h \
+  semaphore.h \
 	shadow.h \
 	stdint.h \
 	stdio_ext.h \
@@ -375,6 +377,7 @@ AC_CHECK_HEADERS([ \
 	sys/ioctl.h \
 	sys/io.h \
 	sys/mkdev.h \
+  sys/mman.h \
 	sys/mount.h \
 	sys/param.h \
 	sys/pidfd.h \

--- a/configure.ac
+++ b/configure.ac
@@ -2102,6 +2102,13 @@ UL_BUILD_INIT([chmem])
 UL_REQUIRES_LINUX([chmem])
 AM_CONDITIONAL([BUILD_CHMEM], [test "x$build_chmem" = xyes])
 
+AC_CHECK_FUNCS([shm_open], [], [
+  AC_CHECK_LIB([rt], [shm_open], [POSIXIPC_LIBS="-lrt"])
+])
+AC_CHECK_FUNCS([sem_close], [], [
+  AC_CHECK_LIB([pthread], [sem_close], [POSIXIPC_LIBS="$POSIXIPC_LIBS -lpthread"])
+])
+AC_SUBST([POSIXIPC_LIBS])
 
 AC_ARG_ENABLE([ipcmk],
   AS_HELP_STRING([--disable-ipcmk], [do not build ipcmk]),

--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -187,7 +187,7 @@
 
 #define _PATH_PROC_KERNEL	"/proc/sys/kernel"
 
-/* ipc paths */
+/* System V ipc paths */
 #define _PATH_PROC_SYSV_MSG	"/proc/sysvipc/msg"
 #define _PATH_PROC_SYSV_SEM	"/proc/sysvipc/sem"
 #define _PATH_PROC_SYSV_SHM	"/proc/sysvipc/shm"
@@ -207,6 +207,13 @@
 #define _PATH_PROC_SYS_FS	"/proc/sys/fs"
 #define _PATH_PROC_PIPE_MAX_SIZE	_PATH_PROC_SYS_FS "/pipe-max-size"
 #define _PATH_PROC_BINFMT_MISC	_PATH_PROC_SYS_FS "/binfmt_misc"
+
+/* Posix ipc paths */
+#define _PATH_DEV_MQUEUE	"/dev/mqueue"
+#define _PATH_PROC_POSIX_IPC_MSGMAX _PATH_PROC_SYS_FS "/mqueue/msgsize_max"
+#define _PATH_PROC_POSIX_IPC_MSGMNB _PATH_PROC_SYS_FS "/mqueue/msg_max"
+#define _PATH_PROC_POSIX_IPC_MSGMNI _PATH_PROC_SYS_FS "/mqueue/queues_max"
+#define _PATH_DEV_SHM	"/dev/shm"
 
 /* irqtop paths */
 #define _PATH_PROC_INTERRUPTS	"/proc/interrupts"

--- a/meson.build
+++ b/meson.build
@@ -1484,6 +1484,7 @@ exe = executable(
   ipcrm_sources,
   include_directories : includes,
   link_with : [lib_common],
+  dependencies : [mount_dep],
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -1499,6 +1500,7 @@ exe = executable(
   ipcs_sources,
   include_directories : includes,
   link_with : [lib_common],
+  dependencies : [mount_dep],
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -2204,6 +2206,7 @@ exe = executable(
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols],
+  dependencies : [mount_dep],
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)

--- a/meson.build
+++ b/meson.build
@@ -1463,12 +1463,22 @@ endif
 
 has_seminfo_type = cc.has_type('struct seminfo', args : '-D_GNU_SOURCE', prefix : '#include <sys/sem.h>')
 
+posixipc_libs = []
+if not cc.has_function('shm_open')
+  posixipc_libs = cc.find_library('rt', required : true)
+endif
+
+if not cc.has_function('sem_close')
+  posixipc_libs += cc.find_library('pthread', required : true)
+endif
+
 opt = get_option('build-ipcmk').require(has_seminfo_type).allowed()
 exe = executable(
   'ipcmk',
   ipcmk_sources,
   include_directories : includes,
   link_with : [lib_common],
+  dependencies : posixipc_libs,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -1484,7 +1494,7 @@ exe = executable(
   ipcrm_sources,
   include_directories : includes,
   link_with : [lib_common],
-  dependencies : [mount_dep],
+  dependencies : [mount_dep] + posixipc_libs,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -1500,7 +1510,7 @@ exe = executable(
   ipcs_sources,
   include_directories : includes,
   link_with : [lib_common],
-  dependencies : [mount_dep],
+  dependencies : [mount_dep] + posixipc_libs,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -2206,7 +2216,7 @@ exe = executable(
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols],
-  dependencies : [mount_dep],
+  dependencies : [mount_dep] + posixipc_libs,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)

--- a/meson.build
+++ b/meson.build
@@ -1494,7 +1494,7 @@ exe = executable(
   ipcrm_sources,
   include_directories : includes,
   link_with : [lib_common],
-  dependencies : [mount_dep] + posixipc_libs,
+  dependencies : posixipc_libs,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -1510,7 +1510,7 @@ exe = executable(
   ipcs_sources,
   include_directories : includes,
   link_with : [lib_common],
-  dependencies : [mount_dep] + posixipc_libs,
+  dependencies : posixipc_libs,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -2216,7 +2216,7 @@ exe = executable(
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols],
-  dependencies : [mount_dep] + posixipc_libs,
+  dependencies : posixipc_libs,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)

--- a/meson.build
+++ b/meson.build
@@ -199,6 +199,7 @@ headers = '''
         mntent.h
         paths.h
         pty.h
+        semaphore.h
         shadow.h
         stdint.h
         stdio_ext.h
@@ -229,6 +230,7 @@ headers = '''
         linux/tiocl.h
         linux/version.h
         linux/watchdog.h
+        mqueue.h
         net/if.h
         net/if_dl.h
         netinet/in.h
@@ -244,6 +246,7 @@ headers = '''
         sys/ioccom.h
         sys/ioctl.h
         sys/mkdev.h
+        sys/mman.h
         sys/mount.h
         sys/param.h
         sys/pidfd.h
@@ -1464,11 +1467,11 @@ endif
 has_seminfo_type = cc.has_type('struct seminfo', args : '-D_GNU_SOURCE', prefix : '#include <sys/sem.h>')
 
 posixipc_libs = []
-if not cc.has_function('shm_open')
+if not cc.has_function('shm_open') and conf.get('HAVE_SYS_MMAN_H').to_string() == '1'
   posixipc_libs = cc.find_library('rt', required : true)
 endif
 
-if not cc.has_function('sem_close')
+if not cc.has_function('sem_close') and conf.get('HAVE_SEMAPHORE_H').to_string() == '1'
   posixipc_libs += cc.find_library('pthread', required : true)
 endif
 

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -36,7 +36,7 @@ usrbin_exec_PROGRAMS += ipcmk
 MANPAGES += sys-utils/ipcmk.1
 dist_noinst_DATA += sys-utils/ipcmk.1.adoc
 ipcmk_SOURCES = sys-utils/ipcmk.c
-ipcmk_LDADD = $(LDADD) libcommon.la
+ipcmk_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la
 endif
 
 if BUILD_IPCRM
@@ -46,7 +46,7 @@ dist_noinst_DATA += sys-utils/ipcrm.1.adoc
 ipcrm_SOURCES = sys-utils/ipcrm.c \
 		sys-utils/ipcutils.c \
 		sys-utils/ipcutils.h
-ipcrm_LDADD = $(LDADD) libcommon.la libmount.la
+ipcrm_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la libmount.la
 ipcrm_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 endif
 
@@ -57,7 +57,7 @@ dist_noinst_DATA += sys-utils/ipcs.1.adoc
 ipcs_SOURCES =	sys-utils/ipcs.c \
 		sys-utils/ipcutils.c \
 		sys-utils/ipcutils.h
-ipcs_LDADD = $(LDADD) libcommon.la libmount.la
+ipcs_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la libmount.la
 ipcs_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 endif
 
@@ -97,7 +97,7 @@ dist_noinst_DATA += sys-utils/lsipc.1.adoc
 lsipc_SOURCES =	sys-utils/lsipc.c \
 		sys-utils/ipcutils.c \
 		sys-utils/ipcutils.h
-lsipc_LDADD = $(LDADD) libcommon.la libsmartcols.la libmount.la
+lsipc_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la libsmartcols.la libmount.la
 lsipc_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir) -I$(ul_libmount_incdir)
 endif
 

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -46,8 +46,7 @@ dist_noinst_DATA += sys-utils/ipcrm.1.adoc
 ipcrm_SOURCES = sys-utils/ipcrm.c \
 		sys-utils/ipcutils.c \
 		sys-utils/ipcutils.h
-ipcrm_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la libmount.la
-ipcrm_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
+ipcrm_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la
 endif
 
 if BUILD_IPCS
@@ -57,8 +56,7 @@ dist_noinst_DATA += sys-utils/ipcs.1.adoc
 ipcs_SOURCES =	sys-utils/ipcs.c \
 		sys-utils/ipcutils.c \
 		sys-utils/ipcutils.h
-ipcs_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la libmount.la
-ipcs_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
+ipcs_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la
 endif
 
 if BUILD_IRQTOP
@@ -97,8 +95,8 @@ dist_noinst_DATA += sys-utils/lsipc.1.adoc
 lsipc_SOURCES =	sys-utils/lsipc.c \
 		sys-utils/ipcutils.c \
 		sys-utils/ipcutils.h
-lsipc_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la libsmartcols.la libmount.la
-lsipc_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir) -I$(ul_libmount_incdir)
+lsipc_LDADD = $(LDADD) $(POSIXIPC_LIBS) libcommon.la libsmartcols.la
+lsipc_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
 endif
 
 if BUILD_RENICE

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -43,8 +43,11 @@ if BUILD_IPCRM
 usrbin_exec_PROGRAMS += ipcrm
 MANPAGES += sys-utils/ipcrm.1
 dist_noinst_DATA += sys-utils/ipcrm.1.adoc
-ipcrm_SOURCES = sys-utils/ipcrm.c
-ipcrm_LDADD = $(LDADD) libcommon.la
+ipcrm_SOURCES = sys-utils/ipcrm.c \
+		sys-utils/ipcutils.c \
+		sys-utils/ipcutils.h
+ipcrm_LDADD = $(LDADD) libcommon.la libmount.la
+ipcrm_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 endif
 
 if BUILD_IPCS
@@ -54,7 +57,8 @@ dist_noinst_DATA += sys-utils/ipcs.1.adoc
 ipcs_SOURCES =	sys-utils/ipcs.c \
 		sys-utils/ipcutils.c \
 		sys-utils/ipcutils.h
-ipcs_LDADD = $(LDADD) libcommon.la
+ipcs_LDADD = $(LDADD) libcommon.la libmount.la
+ipcs_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 endif
 
 if BUILD_IRQTOP
@@ -93,8 +97,8 @@ dist_noinst_DATA += sys-utils/lsipc.1.adoc
 lsipc_SOURCES =	sys-utils/lsipc.c \
 		sys-utils/ipcutils.c \
 		sys-utils/ipcutils.h
-lsipc_LDADD = $(LDADD) libcommon.la libsmartcols.la
-lsipc_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
+lsipc_LDADD = $(LDADD) libcommon.la libsmartcols.la libmount.la
+lsipc_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir) -I$(ul_libmount_incdir)
 endif
 
 if BUILD_RENICE

--- a/sys-utils/ipcmk.1.adoc
+++ b/sys-utils/ipcmk.1.adoc
@@ -56,7 +56,8 @@ include::man-common/help-version.adoc[]
 
 == AUTHORS
 
-mailto:hayden.james@gmail.com[Hayden A. James]
+mailto:hayden.james@gmail.com[Hayden A. James],
+mailto:paithankarprasanna@gmail.com[Prasanna Paithankar]
 
 == SEE ALSO
 

--- a/sys-utils/ipcmk.1.adoc
+++ b/sys-utils/ipcmk.1.adoc
@@ -20,7 +20,7 @@ ipcmk - make various IPC resources
 
 == DESCRIPTION
 
-*ipcmk* allows you to create System V inter-process communication (IPC) objects: shared memory segments, message queues, and semaphore arrays.
+*ipcmk* allows you to create POSIX and System V inter-process communication (IPC) objects: shared memory segments, message queues, and semaphore (arrays for System V).
 
 == OPTIONS
 
@@ -29,11 +29,23 @@ Resources can be specified with these options:
 *-M*, *--shmem* _size_::
 Create a shared memory segment of _size_ bytes. The _size_ argument may be followed by the multiplicative suffixes KiB (=1024), MiB (=1024*1024), and so on for GiB, etc. (the "iB" is optional, e.g., "K" has the same meaning as "KiB") or the suffixes KB (=1000), MB (=1000*1000), and so on for GB, etc.
 
+*-m*, *--posix-shmem* _size_::
+Create a POSIX shared memory segment of _size_ bytes. The _size_ argument may be followed by the multiplicative suffixes KiB (=1024), MiB (=1024*1024), and so on for GiB, etc. (the "iB" is optional, e.g., "K" has the same meaning as "KiB") or the suffixes KB (=1000), MB (=1000*1000), and so on for GB, etc.
+
 *-Q*, *--queue*::
 Create a message queue.
 
+*-q*, *--posix-mqueue*::
+Create a POSIX message queue.
+
 *-S*, *--semaphore* _number_::
 Create a semaphore array with _number_ of elements.
+
+*-s*, *--posix-semaphore*::
+Create a POSIX named semaphore.
+
+*-n*, *--name* _name_::
+Name of the POSIX IPC object. This option is mandatory for POSIX IPC objects.
 
 Other options are:
 
@@ -50,6 +62,7 @@ mailto:hayden.james@gmail.com[Hayden A. James]
 
 *ipcrm*(1),
 *ipcs*(1),
+*lsipc*(1),
 *sysvipc*(7)
 
 include::man-common/bugreports.adoc[]

--- a/sys-utils/ipcmk.c
+++ b/sys-utils/ipcmk.c
@@ -14,9 +14,9 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <errno.h>
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
 		{"shmem", required_argument, NULL, 'M'},
 		{"posix-shmem", required_argument, NULL, 'm'},
 		{"semaphore", required_argument, NULL, 'S'},
-		{"posix-semaphore", required_argument, NULL, 's'},
+		{"posix-semaphore", no_argument, NULL, 's'},
 		{"queue", no_argument, NULL, 'Q'},
 		{"posix-mqueue", no_argument, NULL, 'q'},
 		{"mode", required_argument, NULL, 'p'},

--- a/sys-utils/ipcrm.1.adoc
+++ b/sys-utils/ipcrm.1.adoc
@@ -23,19 +23,19 @@ ipcrm - remove certain IPC resources
 
 == DESCRIPTION
 
-*ipcrm* removes System V inter-process communication (IPC) objects and associated data structures from the system. In order to delete such objects, you must be superuser, or the creator or owner of the object.
+*ipcrm* removes POSIX and System V inter-process communication (IPC) objects and associated data structures from the system. In order to delete such objects, you must be superuser, or the creator or owner of the object.
 
-System V IPC objects are of three types: shared memory, message queues, and semaphores. Deletion of a message queue or semaphore object is immediate (regardless of whether any process still holds an IPC identifier for the object). A shared memory object is only removed after all currently attached processes have detached (*shmdt*(2)) the object from their virtual address space.
+POSIX and System V IPC objects are of three types: shared memory, message queues, and semaphores. Deletion of a message queue or semaphore object is immediate (regardless of whether any process still holds an IPC identifier for the object). A shared memory object is only removed after all currently attached processes have detached (*shmdt*(2)) the object from their virtual address space.
 
 Two syntax styles are supported. The old Linux historical syntax specifies a three-letter keyword indicating which class of object is to be deleted, followed by one or more IPC identifiers for objects of this type.
 
 The SUS-compliant syntax allows the specification of zero or more objects of all three types in a single command line, with objects specified either by key or by identifier (see below). Both keys and identifiers may be specified in decimal, hexadecimal (specified with an initial '0x' or '0X'), or octal (specified with an initial '0').
 
-The details of the removes are described in *shmctl*(2), *msgctl*(2), and *semctl*(2). The identifiers and keys can be found by using *ipcs*(1).
+The details of the removes are described in *shmctl*(2), *shm_unlink*(3), *msgctl*(2), *mq_unlink*(3), *semctl*(2), and *sem_unlink*(3). The identifiers and keys can be found by using *lsipc*(1) or *ipcs*(1).
 
 == OPTIONS
 
-*-a*, *--all* [*shm*] [*msg*] [*sem*]::
+*-a*, *--all* [*shm*] [*pshm*] [*msg*] [*pmsg*] [*sem*] [*psem*]::
 Remove all resources. When an option argument is provided, the removal is performed only for the specified resource types.
 +
 _Warning!_ Do not use *-a* if you are unsure how the software using the resources might react to missing objects. Some programs create these resources at startup and may not have any code to deal with an unexpected disappearance.
@@ -46,17 +46,26 @@ Remove the shared memory segment created with _shmkey_ after the last detach is 
 *-m*, *--shmem-id* _shmid_::
 Remove the shared memory segment identified by _shmid_ after the last detach is performed.
 
+*-x*, *--posix-shmem* _name_::
+Remove the POSIX shared memory segment created with _name_.
+
 *-Q*, *--queue-key* _msgkey_::
 Remove the message queue created with _msgkey_.
 
 *-q*, *--queue-id* _msgid_::
 Remove the message queue identified by _msgid_.
 
+*-y*, *--posix-mqueue* _name_::
+Remove the POSIX message queue created with _name_.
+
 *-S*, *--semaphore-key* _semkey_::
 Remove the semaphore created with _semkey_.
 
 *-s*, *--semaphore-id* _semid_::
 Remove the semaphore identified by _semid_.
+
+*-z*, *--posix-semaphore* _name_::
+Remove the POSIX named semaphore created with _name_.
 
 include::man-common/help-version.adoc[]
 
@@ -69,13 +78,17 @@ In its first Linux implementation, *ipcrm* used the deprecated syntax shown in t
 
 *ipcmk*(1),
 *ipcs*(1),
+*lsipc*(1),
 *msgctl*(2),
+*mq_unlink*(3),
 *msgget*(2),
 *semctl*(2),
 *semget*(2),
+*sem_unlink*(3),
 *shmctl*(2),
 *shmdt*(2),
 *shmget*(2),
+*shm_unlink*(3),
 *ftok*(3),
 *sysvipc*(7)
 

--- a/sys-utils/ipcrm.c
+++ b/sys-utils/ipcrm.c
@@ -20,6 +20,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
 #include "c.h"
 #include "nls.h"
 #include "strutils.h"
@@ -29,8 +31,11 @@
 
 typedef enum type_id {
 	SHM,
+	PSHM,
 	SEM,
+	PSEM,
 	MSG,
+	PMSG,
 	ALL
 } type_id;
 
@@ -48,14 +53,17 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Remove certain IPC resources.\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
-	fputs(_(" -m, --shmem-id <id>        remove shared memory segment by id\n"), out);
-	fputs(_(" -M, --shmem-key <key>      remove shared memory segment by key\n"), out);
-	fputs(_(" -q, --queue-id <id>        remove message queue by id\n"), out);
-	fputs(_(" -Q, --queue-key <key>      remove message queue by key\n"), out);
-	fputs(_(" -s, --semaphore-id <id>    remove semaphore by id\n"), out);
-	fputs(_(" -S, --semaphore-key <key>  remove semaphore by key\n"), out);
-	fputs(_(" -a, --all[=shm|msg|sem]    remove all (in the specified category)\n"), out);
-	fputs(_(" -v, --verbose              explain what is being done\n"), out);
+	fputs(_(" -m, --shmem-id <id>        				remove shared memory segment by id\n"), out);
+	fputs(_(" -M, --shmem-key <key>      				remove shared memory segment by key\n"), out);
+	fputs(_("     --posix-shmem <name>   				remove POSIX shared memory segment by name\n"), out);
+	fputs(_(" -q, --queue-id <id>        				remove message queue by id\n"), out);
+	fputs(_(" -Q, --queue-key <key>      				remove message queue by key\n"), out);
+	fputs(_("     --posix-mqueue <name>  				remove POSIX message queue by name\n"), out);
+	fputs(_(" -s, --semaphore-id <id>    				remove semaphore by id\n"), out);
+	fputs(_(" -S, --semaphore-key <key>  				remove semaphore by key\n"), out);
+	fputs(_("     --posix-semaphore <name> 				remove POSIX semaphore by name\n"), out);
+	fputs(_(" -a, --all[=shm|pshm|msg|pmsg|sem|psem]	remove all (in the specified category)\n"), out);
+	fputs(_(" -v, --verbose              				explain what is being done\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
 	fprintf(out, USAGE_HELP_OPTIONS(28));
@@ -229,6 +237,50 @@ static int key_to_id(type_id type, char *s)
 	return id;
 }
 
+static int remove_name(type_id type, char *name)
+{
+	int ret;
+	
+	switch (type) {
+		case PSHM:
+			if (verbose)
+				printf(_("removing POSIX shared memory `%s'\n"), name);
+			ret = shm_unlink(name);
+			break;
+		case PMSG:
+			if (verbose)
+				printf(_("removing POSIX message queue `%s'\n"), name);
+			ret = mq_unlink(name);
+			break;
+		case PSEM:
+			if (verbose)
+				printf(_("removing POSIX semaphore `%s'\n"), name);
+			ret = sem_unlink(name);
+			break;
+		default:
+			errx(EXIT_FAILURE, "impossible occurred");
+	}
+
+	if (ret < 0) {
+		switch (errno) {
+		case EACCES:
+		case EPERM:
+			warnx(_("permission denied for name `%s'"), name);
+			break;
+		case ENOENT:
+			warnx(_("name `%s' not found"), name);
+			break;
+		case ENAMETOOLONG:
+			warnx(_("name `%s' too long"), name);
+			break;
+		default:
+			err(EXIT_FAILURE, _("name failed"));
+		}
+		return 1;
+	}
+	return 0;
+}		
+
 static int remove_all(type_id type)
 {
 	int ret = 0;
@@ -236,12 +288,18 @@ static int remove_all(type_id type)
 
 	struct shmid_ds shmseg;
 
+	struct posix_shm_data *shmds, *shmdsp;
+
 	struct semid_ds semary;
 	struct seminfo seminfo;
 	union semun arg;
 
+	struct posix_sem_data *semds, *semdsp;
+
 	struct msqid_ds msgque;
 	struct msginfo msginfo;
+
+	struct posix_msg_data *msgds, *msgdsp;
 
 	if (type == SHM || type == ALL) {
 		maxid = shmctl(0, SHM_INFO, &shmseg);
@@ -253,6 +311,16 @@ static int remove_all(type_id type)
 			if (rm_me < 0)
 				continue;
 			ret |= remove_id(SHM, 0, rm_me);
+		}
+	}
+	if (type == PSHM || type == ALL) {
+		if (posix_ipc_shm_get_info(NULL, &shmds) > 0) {
+			for (shmdsp = shmds; shmdsp->next != NULL; shmdsp = shmdsp->next) {
+				if (verbose)
+					printf(_("removing POSIX shared memory `%s'\n"), shmdsp->name);
+				ret |= remove_name(PSHM, shmdsp->name);
+			}
+			posix_ipc_shm_free_info(shmds);
 		}
 	}
 	if (type == SEM || type == ALL) {
@@ -269,6 +337,16 @@ static int remove_all(type_id type)
 			ret |= remove_id(SEM, 0, rm_me);
 		}
 	}
+	if (type == PSEM || type == ALL) {
+		if (posix_ipc_sem_get_info(NULL, &semds) > 0) {
+			for (semdsp = semds; semdsp->next != NULL; semdsp = semdsp->next) {
+				if (verbose)
+					printf(_("removing POSIX semaphore `%s'\n"), semdsp->sname);
+				ret |= remove_name(PSEM, semdsp->sname);
+			}
+			posix_ipc_sem_free_info(semds);
+		}
+	}
 	if (type == MSG || type == ALL) {
 		maxid =
 		    msgctl(0, MSG_INFO, (struct msqid_ds *)(void *)&msginfo);
@@ -280,6 +358,16 @@ static int remove_all(type_id type)
 			if (rm_me < 0)
 				continue;
 			ret |= remove_id(MSG, 0, rm_me);
+		}
+	}
+	if (type == PMSG || type == ALL) {
+		if (posix_ipc_msg_get_info(NULL, &msgds) > 0) {
+			for (msgdsp = msgds; msgdsp->next != NULL; msgdsp = msgdsp->next) {
+				if (verbose)
+					printf(_("removing POSIX message queue `%s'\n"), msgdsp->mname);
+				ret |= remove_name(PMSG, msgdsp->mname);
+			}
+			posix_ipc_msg_free_info(msgds);
 		}
 	}
 	return ret;
@@ -294,13 +382,22 @@ int main(int argc, char **argv)
 	int rm_all = 0;
 	type_id what_all = ALL;
 
+	enum {
+		OPT_PSHM = CHAR_MAX + 1,
+		OPT_PMSG,
+		OPT_PSEM
+	};
+
 	static const struct option longopts[] = {
 		{"shmem-id", required_argument, NULL, 'm'},
 		{"shmem-key", required_argument, NULL, 'M'},
+		{"posix-shmem", required_argument, NULL, OPT_PSHM},
 		{"queue-id", required_argument, NULL, 'q'},
 		{"queue-key", required_argument, NULL, 'Q'},
+		{"posix-mqueue", required_argument, NULL, OPT_PMSG},
 		{"semaphore-id", required_argument, NULL, 's'},
 		{"semaphore-key", required_argument, NULL, 'S'},
+		{"posix-semaphore", required_argument, NULL, OPT_PSEM},
 		{"all", optional_argument, NULL, 'a'},
 		{"verbose", no_argument, NULL, 'v'},
 		{"version", no_argument, NULL, 'V'},
@@ -309,8 +406,10 @@ int main(int argc, char **argv)
 	};
 
 	/* if the command is executed without parameters, do nothing */
-	if (argc == 1)
-		return 0;
+	if (argc == 1) {
+		warnx(_("bad usage"));
+		errtryhelp(EXIT_FAILURE);
+	}
 
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
@@ -368,15 +467,33 @@ int main(int argc, char **argv)
 			if (remove_id(SEM, iskey, id))
 				ret++;
 			break;
+		case OPT_PSHM:
+			if (remove_name(PSHM, optarg))
+				ret++;
+			break;
+		case OPT_PMSG:
+			if (remove_name(PMSG, optarg))
+				ret++;
+			break;
+		case OPT_PSEM:
+			if (remove_name(PSEM, optarg))
+				ret++;
+			break;
 		case 'a':
 			rm_all = 1;
 			if (optarg) {
 				if (!strcmp(optarg, "shm"))
 					what_all = SHM;
+				else if (!strcmp(optarg, "pshm"))
+					what_all = PSHM;
 				else if (!strcmp(optarg, "msg"))
 					what_all = MSG;
+				else if (!strcmp(optarg, "pmsg"))
+					what_all = PMSG;
 				else if (!strcmp(optarg, "sem"))
 					what_all = SEM;
+				else if (!strcmp(optarg, "psem"))
+					what_all = PSEM;
 				else
 					errx(EXIT_FAILURE,
 					     _("unknown argument: %s"), optarg);

--- a/sys-utils/ipcrm.c
+++ b/sys-utils/ipcrm.c
@@ -242,23 +242,35 @@ static int key_to_id(type_id type, char *s)
 
 static int remove_name(type_id type, char *name)
 {
-	int ret;
+	int ret = 0;
 	
 	switch (type) {
 		case PSHM:
+			#ifndef HAVE_SYS_MMAN_H
+			warnx(_("POSIX shared memory is not supported"));
+			#else
 			if (verbose)
 				printf(_("removing POSIX shared memory `%s'\n"), name);
 			ret = shm_unlink(name);
+			#endif
 			break;
 		case PMSG:
+			#ifndef HAVE_MQUEUE_H
+			warnx(_("POSIX message queues are not supported"));
+			#else
 			if (verbose)
 				printf(_("removing POSIX message queue `%s'\n"), name);
 			ret = mq_unlink(name);
+			#endif
 			break;
 		case PSEM:
+			#ifndef HAVE_SEMAPHORE_H
+			warnx(_("POSIX semaphores are not supported"));
+			#else
 			if (verbose)
 				printf(_("removing POSIX semaphore `%s'\n"), name);
 			ret = sem_unlink(name);
+			#endif
 			break;
 		default:
 			errx(EXIT_FAILURE, "impossible occurred");
@@ -282,7 +294,7 @@ static int remove_name(type_id type, char *name)
 		return 1;
 	}
 	return 0;
-}		
+}
 
 static int remove_all(type_id type)
 {

--- a/sys-utils/ipcrm.c
+++ b/sys-utils/ipcrm.c
@@ -13,6 +13,9 @@
  *
  * 1999-04-02 frank zago
  * - can now remove several id's in the same call
+ * 
+ * 2025 Prasanna Paithankar <paithankarprasanna@gmail.com>
+ * - Added POSIX IPC support
  */
 #include <errno.h>
 #include <getopt.h>

--- a/sys-utils/ipcutils.h
+++ b/sys-utils/ipcutils.h
@@ -18,14 +18,20 @@
 #include <sys/msg.h>
 #include <sys/sem.h>
 #include <sys/shm.h>
-#include <mqueue.h>
-#include <semaphore.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 #include <grp.h>
 #include <pwd.h>
 #include <stdint.h>
+
+#ifdef HAVE_MQUEUE_H
+#include <mqueue.h>
+#endif
+
+#ifdef HAVE_SEMAPHORE_H
+#include <semaphore.h>
+#endif
 
 /*
  * SHM_DEST and SHM_LOCKED are defined in kernel headers, but inside

--- a/sys-utils/ipcutils.h
+++ b/sys-utils/ipcutils.h
@@ -18,12 +18,15 @@
 #include <sys/msg.h>
 #include <sys/sem.h>
 #include <sys/shm.h>
+#include <mqueue.h>
+#include <semaphore.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 #include <grp.h>
 #include <pwd.h>
 #include <stdint.h>
+#include <libmount.h>
 
 /*
  * SHM_DEST and SHM_LOCKED are defined in kernel headers, but inside
@@ -99,6 +102,7 @@ enum {
 };
 
 struct ipc_limits {
+	/* System V IPC */
 	uint64_t	shmmni;		/* max number of segments */
 	uint64_t	shmmax;		/* max segment size */
 	uint64_t	shmall;		/* max total shared memory */
@@ -113,6 +117,11 @@ struct ipc_limits {
 	int		msgmni;		/* max queues system wide */
 	uint64_t	msgmax;		/* max size of message */
 	int		msgmnb;		/* default max size of queue */
+
+	/* POSIX IPC */
+	uint64_t	msgmax_posix;	/* max size of message */
+	uint64_t	msgmni_posix;	/* max queues system wide */
+	uint64_t	msgmnb_posix;	/* default max number of messages in a queue */
 };
 
 extern int ipc_msg_get_limits(struct ipc_limits *lim);
@@ -153,6 +162,20 @@ struct shm_data {
 extern int ipc_shm_get_info(int id, struct shm_data **shmds);
 extern void ipc_shm_free_info(struct shm_data *shmds);
 
+struct posix_shm_data {
+	char			*name;
+	int64_t			mtime;	/* last change time */
+	uid_t			cuid;
+	gid_t			cgid;
+	off_t			size;
+	unsigned int	mode;
+
+	struct posix_shm_data *next;
+};
+
+extern int posix_ipc_shm_get_info(const char *name, struct posix_shm_data **shmds);
+extern void posix_ipc_shm_free_info(struct posix_shm_data *shmds);
+
 /* See 'struct sem_array' in kernel sources
  */
 struct sem_elem {
@@ -175,6 +198,20 @@ struct sem_data {
 extern int ipc_sem_get_info(int id, struct sem_data **semds);
 extern void ipc_sem_free_info(struct sem_data *semds);
 
+struct posix_sem_data {
+	char			*sname;
+	int64_t			mtime;	/* last change time */
+	uid_t			cuid;
+	gid_t			cgid;
+	unsigned int	mode;
+	int				sval;	/* semaphore value */
+
+	struct posix_sem_data *next;
+};
+
+extern int posix_ipc_sem_get_info(const char *name, struct posix_sem_data **semds);
+extern void posix_ipc_sem_free_info(struct posix_sem_data *semds);
+
 /* See 'struct msg_queue' in kernel sources
  */
 struct msg_data {
@@ -194,5 +231,20 @@ struct msg_data {
 
 extern int ipc_msg_get_info(int id, struct msg_data **msgds);
 extern void ipc_msg_free_info(struct msg_data *msgds);
+
+struct posix_msg_data {
+	char			*mname;
+	int64_t			mtime;
+	uid_t			cuid;
+	gid_t			cgid;
+	unsigned int	mode;
+	uint64_t		q_cbytes;	/* current number of bytes on the queue */
+	long			q_qnum;		/* number of messages on the queue */
+
+	struct posix_msg_data *next;
+};
+
+extern int posix_ipc_msg_get_info(const char *name, struct posix_msg_data **msgds);
+extern void posix_ipc_msg_free_info(struct posix_msg_data *msgds);
 
 #endif /* UTIL_LINUX_IPCUTILS_H */

--- a/sys-utils/ipcutils.h
+++ b/sys-utils/ipcutils.h
@@ -26,7 +26,6 @@
 #include <grp.h>
 #include <pwd.h>
 #include <stdint.h>
-#include <libmount.h>
 
 /*
  * SHM_DEST and SHM_LOCKED are defined in kernel headers, but inside

--- a/sys-utils/lsipc.1.adoc
+++ b/sys-utils/lsipc.1.adoc
@@ -16,12 +16,15 @@ lsipc - show information on IPC facilities currently employed in the system
 
 == DESCRIPTION
 
-*lsipc* shows information on the System V inter-process communication facilities for which the calling process has read access.
+*lsipc* shows information on the POSIX and System V inter-process communication facilities for which the calling process has read access.
 
 == OPTIONS
 
 *-i*, *--id* _id_::
-Show full details on just the one resource element identified by _id_. This option needs to be combined with one of the three resource options: *-m*, *-q* or *-s*. It is possible to override the default output format for this option with the *--list*, *--raw*, *--json* or *--export* option.
+Show full details on just the one resource element (System V) identified by _id_. This option needs to be combined with one of the three resource options: *-m*, *-q* or *-s*. It is possible to override the default output format for this option with the *--list*, *--raw*, *--json* or *--export* option.
+
+*-N*, *--name* _name_::
+Show full details on just the one resource element (POSIX) identified by _name_. This option needs to be combined with one of the three resource options: *-M*, *-Q* or *-S*. It is possible to override the default output format for this option with the *--list*, *--raw*, *--json* or *--export* option.
 
 *-g*, *--global*::
 Show system-wide usage and limits of IPC resources. This option may be combined with one of the three resource options: *-m*, *-q* or *-s*. The default is to show information about all resources.
@@ -31,13 +34,22 @@ include::man-common/help-version.adoc[]
 === Resource options
 
 *-m*, *--shmems*::
-Write information about active shared memory segments.
+Write information about active System V shared memory segments.
+
+*-M*, *--posix-shmems*::
+Write information about active POSIX shared memory segments.
 
 *-q*, *--queues*::
-Write information about active message queues.
+Write information about active System V message queues.
+
+*-Q*, *--posix-mqueues*::
+Write information about active POSIX message queues. Mounts /dev/mqueue if not already mounted.
 
 *-s*, *--semaphores*::
-Write information about active semaphore sets.
+Write information about active System V semaphore sets.
+
+*-S*, *--posix-semaphores*::
+Write information about active POSIX named semaphores.
 
 === Output formatting
 

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -992,11 +992,11 @@ static void do_posix_msg(const char *name, struct lsipc_control *ctl, struct lib
 	struct posix_msg_data *msgds, *p;
 	char *arg = NULL;
 
-	int rc = posix_ipc_msg_get_info(name, &msgds);
-	if (rc == -1)
+	int retval = posix_ipc_msg_get_info(name, &msgds);
+	if (retval == -1)
 		return;
 
-	if (rc < 1) {
+	if (retval < 1) {
 		if (name != NULL)
 			warnx(_("mqueue %s not found"), name);
 		return;

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -178,7 +178,7 @@ static const struct lsipc_coldesc coldescs[] =
 	[COL_CTIME]	= { "CTIME",	N_("Time of the last change"), N_("Last change"), 1, SCOLS_FL_RIGHT},
 
 	/* posix-common */
-	[COL_NAME] 		= { "NAME",     N_("Resource name"), N_("Name"), 1 },
+	[COL_NAME] 		= { "NAME",     N_("POSIX resource name"), N_("Name"), 1 },
 	[COL_MTIME]	= { "MTIME",   N_("Time of last action"), N_("Last action"), 1, SCOLS_FL_RIGHT},
 
 	/* msgq-specific */

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -1067,7 +1067,7 @@ static void do_posix_msg(const char *name, struct lsipc_control *ctl, struct lib
 				rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_MSGS:
-				rc = scols_line_sprintf(ln, n, "%ju", p->q_qnum);
+				rc = scols_line_sprintf(ln, n, "%ld", p->q_qnum);
 				break;
 			}
 			if (rc != 0)

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -59,18 +59,29 @@ enum {
 	COLDESC_IDX_GEN_FIRST = 0,
 		COL_KEY = COLDESC_IDX_GEN_FIRST,
 		COL_ID,
-		COL_OWNER,
-		COL_PERMS,
-		COL_CUID,
-		COL_CUSER,
-		COL_CGID,
-		COL_CGROUP,
+
+		/* generic and posix */
+		COLDESC_IDX_GEN_POSIX_FIRST,
+			COL_OWNER = COLDESC_IDX_GEN_POSIX_FIRST,
+			COL_PERMS,
+			COL_CUID,
+			COL_CUSER,
+			COL_CGID,
+			COL_CGROUP,
+		COLDSEC_IDX_GEN_POSIX_LAST = COL_CGROUP,
+
 		COL_UID,
 		COL_USER,
 		COL_GID,
 		COL_GROUP,
 		COL_CTIME,
 	COLDESC_IDX_GEN_LAST = COL_CTIME,
+
+	/* posix-specific */
+	COLDESC_IDX_POSIX_FIRST,
+		COL_NAME = COLDESC_IDX_POSIX_FIRST,
+		COL_MTIME,
+	COLDESC_IDX_POSIX_LAST = COL_MTIME,
 
 	/* msgq-specific */
 	COLDESC_IDX_MSG_FIRST,
@@ -107,7 +118,12 @@ enum {
 		COL_LIMIT,
 		COL_USED,
 		COL_USEPERC,
-	COLDESC_IDX_SUM_LAST = COL_USEPERC
+	COLDESC_IDX_SUM_LAST = COL_USEPERC,
+
+	/* posix-sem-specific */
+	COLDESC_IDX_POSIX_SEM_FIRST,
+		COL_SVAL = COLDESC_IDX_POSIX_SEM_FIRST,
+	COLDESC_IDX_POSIX_SEM_LAST = COL_SVAL
 };
 
 /* not all columns apply to all options, so we specify a legal range for each */
@@ -161,6 +177,10 @@ static const struct lsipc_coldesc coldescs[] =
 	[COL_GROUP]	= { "GROUP",	N_("Group name"), N_("Group name"), 1},
 	[COL_CTIME]	= { "CTIME",	N_("Time of the last change"), N_("Last change"), 1, SCOLS_FL_RIGHT},
 
+	/* posix-common */
+	[COL_NAME] 		= { "NAME",     N_("Resource name"), N_("Name"), 1 },
+	[COL_MTIME]	= { "MTIME",   N_("Time of last action"), N_("Last action"), 1, SCOLS_FL_RIGHT},
+
 	/* msgq-specific */
 	[COL_USEDBYTES]	= { "USEDBYTES",N_("Bytes used"), N_("Bytes used"), 1, SCOLS_FL_RIGHT},
 	[COL_MSGS]	= { "MSGS",	N_("Number of messages"), N_("Messages"), 1},
@@ -189,6 +209,9 @@ static const struct lsipc_coldesc coldescs[] =
 	[COL_USED]      = { "USED",     N_("Currently used"), N_("Used"), 1, SCOLS_FL_RIGHT },
 	[COL_USEPERC]	= { "USE%",     N_("Currently use percentage"), N_("Use"), 1, SCOLS_FL_RIGHT },
 	[COL_LIMIT]     = { "LIMIT",    N_("System-wide limit"), N_("Limit"), 1, SCOLS_FL_RIGHT },
+
+	/* posix-sem-specific */
+	[COL_SVAL]	= { "SVAL",	N_("Semaphore value"), N_("Value"), 1, SCOLS_FL_RIGHT}
 };
 
 
@@ -296,11 +319,15 @@ static void __attribute__((__noreturn__)) usage(void)
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Resource options:\n"), out);
-	fputs(_(" -m, --shmems      shared memory segments\n"), out);
-	fputs(_(" -q, --queues      message queues\n"), out);
-	fputs(_(" -s, --semaphores  semaphores\n"), out);
-	fputs(_(" -g, --global      info about system-wide usage (may be used with -m, -q and -s)\n"), out);
-	fputs(_(" -i, --id <id>     print details on resource identified by <id>\n"), out);
+	fputs(_(" -m, --shmems           shared memory segments\n"), out);
+	fputs(_(" -M, --posix-shmems     POSIX shared memory segments\n"), out);
+	fputs(_(" -q, --queues        	 message queues\n"), out);
+	fputs(_(" -Q, --posix-mqueues 	 POSIX message queues\n"), out);
+	fputs(_(" -s, --semaphores    	 semaphores\n"), out);
+	fputs(_(" -S, --posix-semaphores POSIX semaphores\n"), out);
+	fputs(_(" -g, --global      	 info about system-wide usage (may be used with -m, -q and -s)\n"), out);
+	fputs(_(" -i, --id <id>          print details on resource identified by <id>\n"), out);
+	fputs(_(" -N, --name <name>      print details on posix resource identified by <name>\n"), out);
 
 	fputs(USAGE_OPTIONS, out);
 	fputs(_("     --noheadings         don't print headings\n"), out);
@@ -322,20 +349,30 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_SEPARATOR, out);
 	fprintf(out, USAGE_HELP_OPTIONS(26));
 
-	fprintf(out, _("\nGeneric columns:\n"));
+	fprintf(out, _("\nGeneric System V columns:\n"));
 	for (i = COLDESC_IDX_GEN_FIRST; i <= COLDESC_IDX_GEN_LAST; i++)
 		fprintf(out, " %14s  %s\n", coldescs[i].name, _(coldescs[i].help));
+	
+	fprintf(out, _("\nGeneric POSIX columns:\n"));
+	fprintf(out, " %14s  %s\n", coldescs[COL_NAME].name, _(coldescs[COL_NAME].help));
+	for (i = COLDESC_IDX_GEN_POSIX_FIRST; i <= COLDSEC_IDX_GEN_POSIX_LAST; i++)
+		fprintf(out, " %14s  %s\n", coldescs[i].name, _(coldescs[i].help));
+	fprintf(out, " %14s  %s\n", coldescs[COL_MTIME].name, _(coldescs[COL_MTIME].help));
 
-	fprintf(out, _("\nShared-memory columns (--shmems):\n"));
+	fprintf(out, _("\nSystem V Shared-memory columns (--shmems):\n"));
 	for (i = COLDESC_IDX_SHM_FIRST; i <= COLDESC_IDX_SHM_LAST; i++)
 		fprintf(out, " %14s  %s\n", coldescs[i].name, _(coldescs[i].help));
 
-	fprintf(out, _("\nMessage-queue columns (--queues):\n"));
+	fprintf(out, _("\nSystem V Message-queue columns (--queues):\n"));
 	for (i = COLDESC_IDX_MSG_FIRST; i <= COLDESC_IDX_MSG_LAST; i++)
 		fprintf(out, " %14s  %s\n", coldescs[i].name, _(coldescs[i].help));
 
-	fprintf(out, _("\nSemaphore columns (--semaphores):\n"));
+	fprintf(out, _("\nSystem V Semaphore columns (--semaphores):\n"));
 	for (i = COLDESC_IDX_SEM_FIRST; i <= COLDESC_IDX_SEM_LAST; i++)
+		fprintf(out, " %14s  %s\n", coldescs[i].name, _(coldescs[i].help));
+
+	fprintf(out, _("\nPOSIX Semaphore columns (--posix-semaphores):\n"));
+	for (i = COLDESC_IDX_POSIX_SEM_FIRST; i <= COLDESC_IDX_POSIX_SEM_LAST; i++)
 		fprintf(out, " %14s  %s\n", coldescs[i].name, _(coldescs[i].help));
 
 	fprintf(out, _("\nSummary columns (--global):\n"));
@@ -728,6 +765,92 @@ static void do_sem_global(struct lsipc_control *ctl, struct libscols_table *tb)
 	global_set_data(ctl, tb, "SEMVMX", _("Semaphore max value"), 0, lim.semvmx, 0, 0);
 }
 
+static void do_posix_sem(const char *name, struct lsipc_control *ctl, struct libscols_table *tb)
+{
+	struct libscols_line *ln;
+	struct passwd *pw = NULL;
+	struct group *gr = NULL;
+	struct posix_sem_data *semds, *p;
+	char *arg = NULL;
+
+	scols_table_set_name(tb, "posix-semaphores");
+	if (posix_ipc_sem_get_info(name, &semds) < 1) {
+		if (name)
+			warnx(_("name %s not found"), name);
+		return;
+	}
+	for (p = semds; p->next != NULL || name != NULL; p = p->next) {
+		size_t n;
+
+		ln = scols_table_new_line(tb, NULL);
+		if (!ln)
+			err(EXIT_FAILURE, _("failed to allocate output line"));
+
+		/* no need to call getpwuid() for the same user */
+		if (!(pw && pw->pw_uid == p->cuid))
+			pw = getpwuid(p->cuid);
+
+		/* no need to call getgrgid() for the same user */
+		if (!(gr && gr->gr_gid == p->cgid))
+			gr = getgrgid(p->cgid);
+
+		for (n = 0; n < ncolumns; n++) {
+			int rc = 0;
+			switch (get_column_id(n)) {
+			case COL_NAME:
+				rc = scols_line_set_data(ln, n, p->sname);
+				break;
+			case COL_OWNER:
+				arg = get_username(&pw, p->cuid);
+				if (!arg)
+					xasprintf(&arg, "%u", p->cuid);
+				rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_PERMS:
+				if (ctl->numperms)
+					xasprintf(&arg, "%#o", p->mode & 0777);
+				else {
+					arg = xmalloc(11);
+					xstrmode(p->mode & 0777, arg);
+				}
+				rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_MTIME:
+				if (p->mtime != 0)
+					rc = scols_line_refer_data(ln, n,
+						make_time(ctl->time_mode,
+							  (time_t) p->mtime));
+				break;
+			case COL_CUID:
+				rc = scols_line_sprintf(ln, n, "%u", p->cuid);
+				break;
+			case COL_CUSER:
+				arg = get_username(&pw, p->cuid);
+				if (arg)
+					rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_CGID:
+				rc = scols_line_sprintf(ln, n, "%u", p->cgid);
+				break;
+			case COL_CGROUP:
+				arg = get_groupname(&gr, p->cgid);
+				if (arg)
+					rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_SVAL:
+				rc = scols_line_sprintf(ln, n, "%d", p->sval);
+				break;
+			}
+			if (rc != 0)
+				err(EXIT_FAILURE, _("failed to add output data"));
+			arg = NULL;
+		}
+		if (name != NULL)
+			break;		
+	}
+	posix_ipc_sem_free_info(semds);
+}
+
 static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 {
 	struct libscols_line *ln;
@@ -861,6 +984,101 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 	ipc_msg_free_info(msgds);
 }
 
+static void do_posix_msg(const char *name, struct lsipc_control *ctl, struct libscols_table *tb)
+{
+    struct libscols_line *ln;
+	struct passwd *pw = NULL;
+	struct group *gr = NULL;
+	struct posix_msg_data *msgds, *p;
+	char *arg = NULL;
+
+	if (posix_ipc_msg_get_info(name, &msgds) < 1) {
+		if (name != NULL)
+			warnx(_("mqueue %s not found"), name);
+		return;
+	}
+	scols_table_set_name(tb, "posix-messages");
+
+	for (p = msgds; p->next != NULL || name != NULL; p = p->next) {
+		size_t n;
+		ln = scols_table_new_line(tb, NULL);
+
+		if (!ln)
+			err(EXIT_FAILURE, _("failed to allocate output line"));
+
+		/* no need to call getpwuid() for the same user */
+		if (!(pw && pw->pw_uid == p->cuid))
+			pw = getpwuid(p->cuid);
+
+		/* no need to call getgrgid() for the same user */
+		if (!(gr && gr->gr_gid == p->cgid))
+			gr = getgrgid(p->cgid);
+
+		for (n = 0; n < ncolumns; n++) {
+			int rc = 0;
+
+			switch (get_column_id(n)) {
+			case COL_NAME:
+				rc = scols_line_refer_data(ln, n, p->mname);
+				break;
+			case COL_OWNER:
+				arg = get_username(&pw, p->cuid);
+				if (!arg)
+					xasprintf(&arg, "%u", p->cuid);
+				rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_PERMS:
+				if (ctl->numperms)
+					xasprintf(&arg, "%#o", p->mode & 0777);
+				else {
+					arg = xmalloc(11);
+					xstrmode(p->mode & 0777, arg);
+					rc = scols_line_refer_data(ln, n, arg);
+				}
+				break;
+			case COL_CUID:
+				rc = scols_line_sprintf(ln, n, "%u", p->cuid);
+				break;
+			case COL_CUSER:
+				arg = get_username(&pw, p->cuid);
+				if (arg)
+					rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_CGID:
+				rc = scols_line_sprintf(ln, n, "%u", p->cgid);
+				break;
+			case COL_CGROUP:
+				arg = get_groupname(&gr, p->cgid);
+				if (arg)
+					rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_MTIME:
+				if (p->mtime != 0)
+					rc = scols_line_refer_data(ln, n,
+						make_time(ctl->time_mode,
+							  (time_t) p->mtime));
+				break;
+			case COL_USEDBYTES:
+				if (ctl->bytes)
+					xasprintf(&arg, "%ju", p->q_cbytes);
+				else
+					arg = size_to_human_string(SIZE_SUFFIX_1LETTER,
+							p->q_cbytes);
+				rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_MSGS:
+				rc = scols_line_sprintf(ln, n, "%ju", p->q_qnum);
+				break;
+			}
+			if (rc != 0)
+				err(EXIT_FAILURE, _("failed to set data"));
+			arg = NULL;
+		}
+		if (name != NULL)
+			break;
+	}
+	posix_ipc_msg_free_info(msgds);
+} 
 
 static void do_msg_global(struct lsipc_control *ctl, struct libscols_table *tb)
 {
@@ -879,9 +1097,31 @@ static void do_msg_global(struct lsipc_control *ctl, struct libscols_table *tb)
 		ipc_msg_free_info(msgds);
 	}
 
-	global_set_data(ctl, tb, "MSGMNI", _("Number of message queues"), msgqs, lim.msgmni, 1, 0);
-	global_set_data(ctl, tb, "MSGMAX", _("Max size of message (bytes)"),	0, lim.msgmax, 0, 1);
-	global_set_data(ctl, tb, "MSGMNB", _("Default max size of queue (bytes)"), 0, lim.msgmnb, 0, 1);
+	global_set_data(ctl, tb, "MSGMNI", _("Number of System V message queues"), msgqs, lim.msgmni, 1, 0);
+	global_set_data(ctl, tb, "MSGMAX", _("Max size of System V message (bytes)"),	0, lim.msgmax, 0, 1);
+	global_set_data(ctl, tb, "MSGMNB", _("Default max size of System V queue (bytes)"), 0, lim.msgmnb, 0, 1);
+}
+
+static void do_posix_msg_global(struct lsipc_control *ctl, struct libscols_table *tb)
+{
+	struct posix_msg_data *pmsgds;
+	struct ipc_limits lim;
+	int pmsgqs = 0;
+
+	ipc_msg_get_limits(&lim);
+
+	/* count number of used posix queues */
+	if (posix_ipc_msg_get_info(NULL, &pmsgds) > 0) {
+		struct posix_msg_data *p;
+
+		for (p = pmsgds; p->next != NULL; p = p->next)
+			++pmsgqs;
+		posix_ipc_msg_free_info(pmsgds);
+	}
+
+	global_set_data(ctl, tb, "MQUMNI", _("Number of POSIX message queues"), pmsgqs, lim.msgmni_posix, 1, 0);
+	global_set_data(ctl, tb, "MQUMAX", _("Max size of POSIX message (bytes)"), 0, lim.msgmax_posix, 0, 1);
+	global_set_data(ctl, tb, "MQUMNB", _("Number of messages in POSIX message queue"), 0, lim.msgmnb_posix, 0, 0);
 }
 
 
@@ -1054,6 +1294,100 @@ static void do_shm(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 	ipc_shm_free_info(shmds);
 }
 
+static void do_posix_shm(const char *name, struct lsipc_control *ctl, struct libscols_table *tb)
+{
+	struct libscols_line *ln;
+	struct passwd *pw = NULL;
+	struct group *gr = NULL;
+	struct posix_shm_data *shmds, *p;
+	char *arg = NULL;
+
+	if (posix_ipc_shm_get_info(name, &shmds) < 1) {
+		if (name != NULL)
+			warnx(_("shm %s not found"), name);
+		return;
+	}
+
+	scols_table_set_name(tb, "posix-sharedmemory");
+
+	for (p = shmds; p->next != NULL || name != NULL ; p = p->next) {
+		size_t n;
+		ln = scols_table_new_line(tb, NULL);
+
+		if (!ln)
+			err(EXIT_FAILURE, _("failed to allocate output line"));
+
+		/* no need to call getpwuid() for the same user */
+		if (!(pw && pw->pw_uid == p->cuid))
+			pw = getpwuid(p->cuid);
+
+		/* no need to call getgrgid() for the same user */
+		if (!(gr && gr->gr_gid == p->cgid))
+			gr = getgrgid(p->cgid);
+
+		for (n = 0; n < ncolumns; n++) {
+			int rc = 0;
+
+			switch (get_column_id(n)) {
+			case COL_NAME:
+				rc = scols_line_refer_data(ln, n, p->name);
+				break;
+			case COL_OWNER:
+				arg = get_username(&pw, p->cuid);
+				if (!arg)
+					xasprintf(&arg, "%u", p->cuid);
+				rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_PERMS:
+				if (ctl->numperms)
+					xasprintf(&arg, "%#o", p->mode & 0777);
+				else {
+					arg = xmalloc(11);
+					xstrmode(p->mode & 0777, arg);
+				}
+				rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_CUID:
+				rc = scols_line_sprintf(ln, n, "%u", p->cuid);
+				break;
+			case COL_CUSER:
+				arg = get_username(&pw, p->cuid);
+				if (arg)
+					rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_CGID:
+				rc = scols_line_sprintf(ln, n, "%u", p->cgid);
+				break;
+			case COL_CGROUP:
+				arg = get_groupname(&gr, p->cgid);
+				if (arg)
+					rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_SIZE:
+				if (ctl->bytes)
+					xasprintf(&arg, "%ju", p->size);
+				else
+					arg = size_to_human_string(SIZE_SUFFIX_1LETTER,
+							p->size);
+				rc = scols_line_refer_data(ln, n, arg);
+				break;
+			case COL_MTIME:
+				if (p->mtime != 0)
+					rc = scols_line_refer_data(ln, n,
+						make_time(ctl->time_mode,
+							  (time_t) p->mtime));
+				break;
+			}
+			if (rc != 0)
+				err(EXIT_FAILURE, _("failed to set data"));
+			arg = NULL;
+		}
+		if (name != NULL)
+			break;
+	}
+	posix_ipc_shm_free_info(shmds);
+}
+
 static void do_shm_global(struct lsipc_control *ctl, struct libscols_table *tb)
 {
 	struct shm_data *shmds;
@@ -1081,11 +1415,13 @@ static void do_shm_global(struct lsipc_control *ctl, struct libscols_table *tb)
 int main(int argc, char *argv[])
 {
 	int opt, msg = 0, sem = 0, shm = 0, id = -1;
+	int pmsg = 0, pshm = 0, psem = 0;
 	int show_time = 0, show_creat = 0, global = 0;
 	size_t i;
 	struct lsipc_control *ctl = xcalloc(1, sizeof(struct lsipc_control));
 	static struct libscols_table *tb;
 	char *outarg = NULL;
+	char *name = NULL;
 
 	/* long only options. */
 	enum {
@@ -1103,11 +1439,15 @@ int main(int argc, char *argv[])
 		{ "id",             required_argument,	NULL, 'i' },
 		{ "json",           no_argument,	NULL, 'J' },
 		{ "list",           no_argument,        NULL, 'l' },
+		{ "name",           required_argument,	NULL, 'N' },
 		{ "newline",        no_argument,	NULL, 'n' },
 		{ "noheadings",     no_argument,	NULL, OPT_NOHEAD },
 		{ "notruncate",     no_argument,	NULL, OPT_NOTRUNC },
 		{ "numeric-perms",  no_argument,	NULL, 'P' },
 		{ "output",         required_argument,	NULL, 'o' },
+		{ "posix-mqueues",  no_argument,	NULL, 'Q' },
+		{ "posix-semaphores", no_argument,	NULL, 'S' },
+		{ "posix-shmems",   no_argument,	NULL, 'M' },
 		{ "queues",         no_argument,	NULL, 'q' },
 		{ "raw",            no_argument,	NULL, 'r' },
 		{ "semaphores",     no_argument,	NULL, 's' },
@@ -1121,9 +1461,9 @@ int main(int argc, char *argv[])
 
 	static const ul_excl_t excl[] = {	/* rows and cols in ASCII order */
 		{ 'J', 'e', 'l', 'n', 'r' },
-		{ 'g', 'i' },
+		{ 'N', 'g', 'i' },
 		{ 'c', 'o', 't' },
-		{ 'm', 'q', 's' },
+		{ 'M', 'Q', 'S', 'm', 'q', 's' },	
 		{ 0 }
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;
@@ -1137,7 +1477,7 @@ int main(int argc, char *argv[])
 
 	scols_init_debug(0);
 
-	while ((opt = getopt_long(argc, argv, "bceghi:Jlmno:PqrstVy", longopts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "bceghi:JlMmN:no:PQqrSstVy", longopts, NULL)) != -1) {
 
 		err_exclusive_options(opt, longopts, excl, excl_st);
 
@@ -1147,6 +1487,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'i':
 			id = strtos32_or_err(optarg, _("failed to parse IPC identifier"));
+			break;
+		case 'N':
+			name = optarg;
 			break;
 		case 'e':
 			ctl->outmode = OUT_EXPORT;
@@ -1173,6 +1516,17 @@ int main(int argc, char *argv[])
 			LOWER = COLDESC_IDX_MSG_FIRST;
 			UPPER = COLDESC_IDX_MSG_LAST;
 			break;
+		case 'Q':
+			pmsg = 1;
+			add_column(columns, ncolumns++, COL_NAME);
+			add_column(columns, ncolumns++, COL_PERMS);
+			add_column(columns, ncolumns++, COL_OWNER);
+			add_column(columns, ncolumns++, COL_MTIME);
+			add_column(columns, ncolumns++, COL_USEDBYTES);
+			add_column(columns, ncolumns++, COL_MSGS);
+			LOWER = COLDESC_IDX_POSIX_FIRST;
+			UPPER = COLDESC_IDX_POSIX_LAST;
+			break;
 		case 'l':
 			ctl->outmode = OUT_LIST;
 			break;
@@ -1192,6 +1546,16 @@ int main(int argc, char *argv[])
 			LOWER = COLDESC_IDX_SHM_FIRST;
 			UPPER = COLDESC_IDX_SHM_LAST;
 			break;
+		case 'M':
+			pshm = 1;
+			add_column(columns, ncolumns++, COL_NAME);
+			add_column(columns, ncolumns++, COL_PERMS);
+			add_column(columns, ncolumns++, COL_OWNER);
+			add_column(columns, ncolumns++, COL_SIZE);
+			add_column(columns, ncolumns++, COL_MTIME);
+			LOWER = COLDESC_IDX_POSIX_FIRST;
+			UPPER = COLDESC_IDX_POSIX_LAST;
+			break;
 		case 'n':
 			ctl->outmode = OUT_NEWLINE;
 			break;
@@ -1207,6 +1571,16 @@ int main(int argc, char *argv[])
 			add_column(columns, ncolumns++, COL_NSEMS);
 			LOWER = COLDESC_IDX_SEM_FIRST;
 			UPPER = COLDESC_IDX_SEM_LAST;
+			break;
+		case 'S':
+			psem = 1;
+			add_column(columns, ncolumns++, COL_NAME);
+			add_column(columns, ncolumns++, COL_PERMS);
+			add_column(columns, ncolumns++, COL_OWNER);
+			add_column(columns, ncolumns++, COL_MTIME);
+			add_column(columns, ncolumns++, COL_SVAL);
+			LOWER = COLDESC_IDX_POSIX_FIRST;
+			UPPER = COLDESC_IDX_POSIX_LAST;
 			break;
 		case OPT_NOTRUNC:
 			ctl->notrunc = 1;
@@ -1240,10 +1614,10 @@ int main(int argc, char *argv[])
 	}
 
 	/* default is global */
-	if (msg + shm + sem == 0) {
-		msg = shm = sem = global = 1;
-		if (show_time || show_creat || id != -1)
-			errx(EXIT_FAILURE, _("--global is mutually exclusive with --creator, --id and --time"));
+	if (msg + shm + sem + pmsg + pshm + psem == 0) {
+		msg = shm = sem = pmsg = pshm = psem = global = 1;
+		if (show_time || show_creat || id != -1 || name != NULL)
+			errx(EXIT_FAILURE, _("--global is mutually exclusive with --creator, --id, --name and --time"));
 	}
 	if (global) {
 		add_column(columns, ncolumns++, COL_RESOURCE);
@@ -1256,7 +1630,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* default to pretty-print if --id specified */
-	if (id != -1 && !ctl->outmode)
+	if ((id != -1 || name != NULL) && !ctl->outmode)
 		ctl->outmode = OUT_PRETTY;
 
 	if (!ctl->time_mode)
@@ -1270,8 +1644,10 @@ int main(int argc, char *argv[])
 		if (show_creat) {
 			add_column(columns, ncolumns++, COL_CUID);
 			add_column(columns, ncolumns++, COL_CGID);
-			add_column(columns, ncolumns++, COL_UID);
-			add_column(columns, ncolumns++, COL_GID);
+			if (!(pmsg || pshm || psem)) {
+				add_column(columns, ncolumns++, COL_UID);
+				add_column(columns, ncolumns++, COL_GID);
+			}
 		}
 		if (msg && show_time) {
 			add_column(columns, ncolumns++, COL_SEND);
@@ -1312,17 +1688,31 @@ int main(int argc, char *argv[])
 		else
 			do_msg(id, ctl, tb);
 	}
+	if (pmsg) {
+		if (global)
+			do_posix_msg_global(ctl, tb);
+		else
+			do_posix_msg(name, ctl, tb);
+	}
 	if (shm) {
 		if (global)
 			do_shm_global(ctl ,tb);
 		else
 			do_shm(id, ctl, tb);
 	}
+	if (pshm) {
+		if (!global)
+			do_posix_shm(name, ctl, tb);
+	}
 	if (sem) {
 		if (global)
 			do_sem_global(ctl, tb);
 		else
 			do_sem(id, ctl, tb);
+	}
+	if (psem) {
+		if (!global)
+			do_posix_sem(name, ctl, tb);
 	}
 
 	print_table(ctl, tb);

--- a/sys-utils/meson.build
+++ b/sys-utils/meson.build
@@ -20,6 +20,8 @@ ipcmk_sources = files(
 
 ipcrm_sources = files(
   'ipcrm.c',
+  'ipcutils.c',
+  'ipcutils.h',
 )
 
 ipcs_sources = files(


### PR DESCRIPTION
The lsipc, ipcrm and ipcmk tools currently support on the listing, removal and creation of System V IPCs. The additions include support for POSIX IPCs (shm, mqueue and sem).

- lsipc
    a. Global view now also shows POSIX mqueue resource limits.
    b. Command line options -M (--posix-shmems), -Q (--posix-mqueues), -S (--posix-semaphores) added.
    c. Mounts `/dev/mqueue` if not already mounted for POSIX mqueue operations.
- ipcrm
    a. Unlinks POSIX IPCs
- ipcmk
    a. Opens POSIX IPCs
