### PR TITLE
github: enable verbose output, don't generate docs default

### DIFF
--- a/.github/workflows/cibuild.sh
+++ b/.github/workflows/cibuild.sh
@@ -77,9 +77,18 @@ function run_coverity {
 }
 
 for phase in "${PHASES[@]}"; do
+    opts=()
     case $phase in
+    CONFIGUREFAST)
+	opts+=(
+	     --disable-poman
+	     --disable-asciidoc
+	     --disable-gtk-doc
+	)
+	# fallthrough
+	;&
     CONFIGURE)
-        opts=(
+        opts+=(
             --disable-use-tty-group
             --disable-makeinstall-chown
             --enable-all-programs
@@ -118,8 +127,8 @@ for phase in "${PHASES[@]}"; do
         CC="$CC" CXX="$CXX" CFLAGS="${CFLAGS[@]}" CXXFLAGS="${CXXFLAGS[@]}" LDFLAGS="${LDFLAGS[@]}" ./configure "${opts[@]}"
         ;;
     MAKE)
-        make -j"$(nproc)"
-        make -j"$(nproc)" check-programs
+        make -j"$(nproc)" V=1
+        make -j"$(nproc)" V=1 check-programs
 
         untracked_files="$(git ls-files --others --exclude-standard)"
         if [ -n "$untracked_files" ]; then

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Ubuntu setup
         run: sudo -E .github/workflows/cibuild-setup-ubuntu.sh
       - name: Configure
-        run: .github/workflows/cibuild.sh CONFIGURE
+        run: .github/workflows/cibuild.sh CONFIGUREFAST
       - name: Code checks
         run: .github/workflows/cibuild.sh CODECHECK
       - name: Configure & Make
@@ -69,7 +69,7 @@ jobs:
       - name: Ubuntu setup
         run: sudo -E .github/workflows/cibuild-setup-ubuntu.sh
       - name: Configure & Make
-        run: .github/workflows/cibuild.sh CONFIGURE MAKE
+        run: .github/workflows/cibuild.sh CONFIGUREFAST MAKE
       - name: Check
         run: sudo -E .github/workflows/cibuild.sh CHECK
       - name: Coveralls
@@ -140,7 +140,7 @@ jobs:
       - name: Ubuntu setup
         run: .github/workflows/cibuild-setup-ubuntu.sh
       - name: Configure
-        run: .github/workflows/cibuild.sh CONFIGURE
+        run: .github/workflows/cibuild.sh CONFIGUREFAST
       - name: Code checks
         run: .github/workflows/cibuild.sh CODECHECK
       - name: Configure & Make
@@ -179,7 +179,7 @@ jobs:
             .github/workflows/cibuild-setup-ubuntu.sh
             git config --global --add safe.directory "$PWD"
             # Configure & Make
-            .github/workflows/cibuild.sh CONFIGURE MAKE
+            .github/workflows/cibuild.sh CONFIGUREFAST MAKE
             # Check
             .github/workflows/cibuild.sh CHECK
 
@@ -237,7 +237,7 @@ jobs:
       - name: Configure
         run: |
           source .github/workflows/openwrt-sdk-env.sh  ~/${{ env.OPENWRT_SDK }}
-          .github/workflows/cibuild.sh CONFIGURE
+          .github/workflows/cibuild.sh CONFIGUREFAST
       - name: Make
         run: |
           source .github/workflows/openwrt-sdk-env.sh  ~/${{ env.OPENWRT_SDK }}


### PR DESCRIPTION
Generating all documentation (man pages, man page translations, and library API docs) is a very time-consuming task. It is also architecture-independent, as it involves text conversions using Python, Ruby, etc. It would be better to only do this once in CI and only when all other tasks have been successfully completed.

This commit also enables verbose output for autotools to make the compiler command line visible in logs.

* Add V=1 (verbose) for "make" command.

* Add CONFIGUREFAST phase with disabled po-man, asciidoc, and gtk-doc.

* Use full version CONFIGURE phase only for the distcheck CI job.