### PR TITLE
mkswap: improve --file to be usable on btrfs

### DIFF
--- a/disk-utils/mkswap.8.adoc
+++ b/disk-utils/mkswap.8.adoc
@@ -114,6 +114,8 @@ If you don't know the page size that your machine uses, you can look it up with 
 
 Aside from *mkswap --file*, it is also possible to create the swapfile manually before initializing it with *mkswap*, e.g. using a command like
 
+Since version 2.41, *mkswap --file* sets the nocow attribute for newly created files to support swapfiles on Btrfs.
+
 ....
 # dd if=/dev/zero of=swapfile bs=1MiB count=$((8*1024))
 ....

--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -62,6 +62,10 @@
 # include <blkid.h>
 #endif
 
+#if defined(FS_IOC_FIEMAP) && defined(FIEMAP_EXTENT_LAST)
+# define USE_EXTENDS_CHECK 1
+#endif
+
 #define MIN_GOODPAGES	10
 
 #define SELINUX_SWAPFILE_TYPE	"swapfile_t"
@@ -264,7 +268,7 @@ static void check_blocks(struct mkswap_control *ctl)
 }
 
 
-#ifdef HAVE_LINUX_FIEMAP_H
+#ifdef USE_EXTENDS_CHECK
 static void warn_extent(struct mkswap_control *ctl, const char *msg, uint64_t off)
 {
 	if (ctl->nbad_extents == 0) {
@@ -351,7 +355,7 @@ done:
 	if (ctl->nbad_extents)
 		fputc('\n', stderr);
 }
-#endif /* HAVE_LINUX_FIEMAP_H */
+#endif /* USE_EXTENDS_CHECK */
 
 /* return size in pages */
 static unsigned long long get_size(const struct mkswap_control *ctl)
@@ -740,7 +744,7 @@ int main(int argc, char **argv)
 
 	if (ctl.check)
 		check_blocks(&ctl);
-#ifdef HAVE_LINUX_FIEMAP_H
+#ifdef USE_EXTENDS_CHECK
 	if (!ctl.quiet && S_ISREG(ctl.devstat.st_mode))
 		check_extents(&ctl);
 #endif

--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -417,11 +417,11 @@ static void open_device(struct mkswap_control *ctl)
 		err(EXIT_FAILURE, _("cannot open %s"), ctl->devname);
 
 	if (ctl->file && ctl->filesz) {
-		int attr = 0;
-
+#ifdef USE_NOCOW
 		/* Let's attempt to set the "nocow" attribute for Btrfs, etc.
 		 * Ignore if unsupported. */
-#ifdef USE_NOCOW
+		int attr = 0;
+
 		if (ioctl(ctl->fd, FS_IOC_GETFLAGS, &attr) == 0) {
 			attr |= FS_NOCOW_FL;
 			if (ioctl(ctl->fd, FS_IOC_SETFLAGS, &attr) < 0 &&
@@ -429,7 +429,6 @@ static void open_device(struct mkswap_control *ctl)
 				warn(_("failed to set 'nocow' attribute"));
 		}
 #endif
-
 		if (ftruncate(ctl->fd, ctl->filesz) < 0)
 			err(EXIT_FAILURE, _("couldn't allocate swap file %s"), ctl->devname);
 #ifdef HAVE_POSIX_FALLOCATE

--- a/sys-utils/swapon.8.adoc
+++ b/sys-utils/swapon.8.adoc
@@ -152,6 +152,8 @@ The most portable solution to create a swap file is to use *dd*(1) and _/dev/zer
 
 Swap files on Btrfs are supported since Linux 5.0 on files with *nocow* attribute. See the *btrfs*(5) manual page for more details.
 
+Since version 2.41, the command *mkswap --file* can create a new swap file with the *nocow* attribute.
+
 === NFS
 
 Swap over *NFS* may not work.


### PR DESCRIPTION
Let's attempt to set the "nonow" attribute; ignore it if unsupported.
