### PR TITLE
Fix --disable-widechar compile warnings

### DIFF
--- a/lib/mbsedit.c
+++ b/lib/mbsedit.c
@@ -174,8 +174,8 @@ static size_t mbs_insert(char *str, wint_t c, size_t *ncells)
 	memmove(str + n, str, bytes);
 	memcpy(str, in, n);
 	str[bytes + n] = '\0';
-out:
 #ifdef HAVE_WIDECHAR
+out:
 	free(in);
 #endif
 	return n;

--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -146,7 +146,9 @@ static long startline;			/* start line from argv[] */
 static int nextfile = 1;		/* files to advance */
 static jmp_buf jmpenv;			/* jump from signal handlers */
 static int canjump;			/* jmpenv is valid */
+#ifdef HAVE_WIDECHAR
 static wchar_t wbuf[READBUF];		/* used in several widechar routines */
+#endif
 
 static char *copyright;
 static const char *helpscreen = N_("\


### PR DESCRIPTION
**[from Mailing list]**

Fix warnings when compiling without wide char support.

Marc.