### PR TITLE
lscpu: skip frequencies of 0 MHz when getting minmhz

### DIFF
--- a/sys-utils/lscpu-topology.c
+++ b/sys-utils/lscpu-topology.c
@@ -660,6 +660,8 @@ float lsblk_cputype_get_minmhz(struct lscpu_cxt *cxt, struct lscpu_cputype *ct)
 
 		if (!cpu || cpu->type != ct || !is_cpu_present(cxt, cpu))
 			continue;
+		if (!cpu->mhz_min_freq)
+			continue;
 		if (res < 0.0 || cpu->mhz_min_freq < res)
 			res = cpu->mhz_min_freq;
 	}


### PR DESCRIPTION
read_mhz() sets cpu->mhz_min_freq from /sys/devices/system/cpu/cpuN/ cpufreq/cpuinfo_min_freq. The file read fails if cpuN is offline and cpu->mhz_min_freq is left as 0. 0 MHz is treated as invalid frequency.

lsblk_cputype_get_minmhz() iterates through all possible CPUs to find the minimum frequency. If one or more CPUs are offline, the minimum frequency will be 0. This is reflected in the output of lscpu:

	$ ./lscpu | grep min
	CPU min MHz:                        0.0000

Ignore 0-MHz frequencies to find the actual minimum frequency:

	$ ./lscpu | grep min
	CPU min MHz:                     1200.0000

Reported-by: Thangamani Krishnan <thangamani.krishnan@intel.com>