### PR TITLE
lib/colors: fix fallback to system directory

### DIFF
--- a/lib/colors.c
+++ b/lib/colors.c
@@ -246,7 +246,7 @@ static int filename_to_tokens(const char *str,
 static int colors_readdir(struct ul_color_ctl *cc, const char *dirname)
 {
 	DIR *dir;
-	int rc = 0;
+	int rc = -ENOENT;
 	struct dirent *d;
 	char sfile[PATH_MAX] = { '\0' };
 	size_t namesz, termsz;
@@ -312,6 +312,7 @@ static int colors_readdir(struct ul_color_ctl *cc, const char *dirname)
 					type == UL_COLORFILE_ENABLE ? "enable" : "???",
 					cc->scores[type], score));
 		cc->scores[type] = score;
+		rc = 0;
 		if (type == UL_COLORFILE_SCHEME)
 			strncpy(sfile, d->d_name, sizeof(sfile));
 	}
@@ -320,8 +321,6 @@ static int colors_readdir(struct ul_color_ctl *cc, const char *dirname)
 		sfile[sizeof(sfile) - 1] = '\0';
 		if (asprintf(&cc->sfile, "%s/%s", dirname, sfile) <= 0)
 			rc = -ENOMEM;
-	} else {
-		rc = -ENOENT;
 	}
 
 	closedir(dir);


### PR DESCRIPTION
The current check relies on "*sfile" to recognize if a configuration has been found in the current directory. However this condition is only true for "type == UL_COLORFILE_SCHEME", breaking the .enable and .disable configurations.
Instead reorder the logic a bit so that any valid configuration returns rc == 0.

Reported-by: Chris Hofstaedtler <zeha@debian.org>
Link: https://lore.kernel.org/util-linux/Z5a08yD10L1J8AIa@per.namespace.at/
Fixes: 4bdf22803f9a ("lib/colors: ensure fallback to system directory")