### PR TITLE
sys-utils: remove redundant comparison in read_hypervisor_dmi in lscpu-virt.c

### DIFF
--- a/sys-utils/lscpu-virt.c
+++ b/sys-utils/lscpu-virt.c
@@ -258,8 +258,7 @@ static int read_hypervisor_dmi(void)
 
 	if (sizeof(uint8_t) != 1
 	    || sizeof(uint16_t) != 2
-	    || sizeof(uint32_t) != 4
-	    || '\0' != 0)
+	    || sizeof(uint32_t) != 4)
 		return VIRT_VENDOR_NONE;
 
 	/* -1 : no DMI in /sys,


### PR DESCRIPTION
The comparison `'\0' != 0` always evaluates to false, as `'\0'` is
equivalent to 0. This check is redundant and triggers a warning from
the static analyzer (Svace). Remove it to avoid confusion and improve
code clarity.

Additionally, the check for sizeof(uint8_t), sizeof(uint16_t), and
sizeof(uint32_t) remains intact to ensure cross-platform compatibility.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>