### PR TITLE
ci: temporarily switch the alt-arch job worker to Ubuntu 22.04

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -150,7 +150,11 @@ jobs:
 
   build-arch:
     name: build (qemu-user, ${{ matrix.arch }})
-    runs-on: ubuntu-latest
+    # FIXME: using Ubuntu 24.04 on the worker causes random segfaults in s390x containers
+    #        using qemu-user-static. Let's switch this, temporarily, to Ubuntu 22.04 which
+    #        doesn't seem to have this issue. Note: the coverage shouldn't change, since
+    #        the "inner" alt-arch containers still use "ubuntu-latest" (24.04 ATTOW).
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ toJSON(matrix) }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
Using Ubuntu 24.04 on the worker causes random segfaults in s390x containers using qemu-user-static. Let's switch this, temporarily, to Ubuntu 22.04 which doesn't seem to have this issue.

Note: the coverage shouldn't change, since the "inner" alt-arch containers still use "ubuntu-latest" (24.04 ATTOW).