### PR TITLE
chrt: Add --sched_runtime support for SCHED_{OTHER,BATCH}

### DIFF
--- a/schedutils/chrt.1.adoc
+++ b/schedutils/chrt.1.adoc
@@ -68,7 +68,7 @@ Set scheduling policy to *SCHED_DEADLINE* (sporadic task model deadline scheduli
 == SCHEDULING OPTIONS
 
 *-T*, *--sched-runtime* _nanoseconds_::
-Specifies runtime parameter for *SCHED_DEADLINE* policy (Linux-specific).
+Specifies runtime parameter for *SCHED_DEADLINE* and custom slice length for *SCHED_OTHER* and *SCHED_BATCH* policies (Linux-specific). Note that custom slice length via the runtime parameter is supported since Linux 6.12.
 
 *-P*, *--sched-period* _nanoseconds_::
 Specifies period parameter for *SCHED_DEADLINE* policy (Linux-specific). Note that the kernel's lower limit is 100 milliseconds.

--- a/tests/expected/schedutils/chrt-batch-custom-slice
+++ b/tests/expected/schedutils/chrt-batch-custom-slice
@@ -1,0 +1,3 @@
+SCHED_BATCH
+0
+<removed>'s current runtime parameter: 100000

--- a/tests/expected/schedutils/chrt-other-custom-slice
+++ b/tests/expected/schedutils/chrt-other-custom-slice
@@ -1,0 +1,3 @@
+SCHED_OTHER
+0
+<removed>'s current runtime parameter: 100000

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -312,8 +312,13 @@ function ts_init_env {
 	CHARSET="UTF-8"
 	ASAN_OPTIONS="detect_leaks=0"
 	UBSAN_OPTIONS="print_stacktrace=1:print_summary=1:halt_on_error=1"
+	KERNEL_VERSION_XYZ=$(uname -r | awk -F- '{print $1}')
+	KERNEL_VERSION_MAJOR=$(echo "$KERNEL_VERSION_XYZ" | awk -F. '{print $1}')
+	KERNEL_VERSION_MINOR=$(echo "$KERNEL_VERSION_XYZ" | awk -F. '{print $2}')
+	KERNEL_RELEASE=$(echo "$KERNEL_VERSION_XYZ" | awk -F. '{print $3}')
 
-	export LANG LANGUAGE LC_ALL CHARSET ASAN_OPTIONS UBSAN_OPTIONS
+	export LANG LANGUAGE LC_ALL CHARSET ASAN_OPTIONS UBSAN_OPTIONS \
+	       KERNEL_VERSION_XYZ KERNEL_VERSION_MAJOR KERNEL_VERSION_MINOR KERNEL_RELEASE
 
 	mydir=$(ts_canonicalize "$mydir")
 
@@ -639,6 +644,27 @@ function ts_skip_subtest {
 	# reset environment back to parental test
 	ts_init_core_env
 
+}
+
+# Specify the kernel version X.Y.Z you wish to compare against like:
+#
+#	ts_kernel_ver_lt X Y Z
+#
+function ts_kernel_ver_lt {
+	if [ $KERNEL_VERSION_MAJOR -lt $1 ]; then
+		return 0
+	elif [ $KERNEL_VERSION_MAJOR -eq $1 ]; then
+		if [ $KERNEL_VERSION_MINOR -lt $2 ]; then
+			return 0
+		elif [ $KERNEL_VERSION_MINOR -eq $2 ]; then
+			if [ $KERNEL_RELEASE -lt $3 ]; then
+				return 0
+			fi
+		fi
+
+	fi
+
+	return 1
 }
 
 function ts_finalize {

--- a/tests/ts/schedutils/chrt
+++ b/tests/ts/schedutils/chrt
@@ -37,6 +37,26 @@ function skip_policy {
 	return 0
 }
 
+function skip_kernel_lt {
+	ts_kernel_ver_lt $1 $2 $3
+	if [ $? == 0 ]; then
+		ts_skip_subtest "kernel version must be >= $1.$2.$3"
+		return 1
+	fi
+
+	return 0
+}
+
+function skip_kernel_ge {
+	ts_kernel_ver_lt $1 $2 $3
+	if [ $? == 1 ]; then
+		ts_skip_subtest "kernel version must be < $1.$2.$3"
+		return 1
+	fi
+
+	return 0
+}
+
 function cleanup_output {
 	sed -i -e 's/pid [0-9]*/<removed>/' $TS_OUTPUT
 }
@@ -53,7 +73,7 @@ fi
 
 
 ts_init_subtest "batch"
-skip_policy SCHED_BATCH
+skip_policy SCHED_BATCH && skip_kernel_ge 6 12 0
 if [ $? == 0 ]; then
 	do_chrt --batch 0
 	cleanup_output
@@ -61,10 +81,28 @@ if [ $? == 0 ]; then
 fi
 
 
+ts_init_subtest "batch-custom-slice"
+skip_policy SCHED_BATCH && skip_kernel_lt 6 12 0
+if [ $? == 0 ]; then
+	do_chrt --batch --sched-runtime 100000 0
+	cleanup_output
+	ts_finalize_subtest
+fi
+
+
 ts_init_subtest "other"
-skip_policy SCHED_OTHER
+skip_policy SCHED_OTHER && skip_kernel_ge 6 12 0
 if [ $? == 0 ]; then
 	do_chrt --other 0
+	cleanup_output
+	ts_finalize_subtest
+fi
+
+
+ts_init_subtest "other-custom-slice"
+skip_policy SCHED_OTHER && skip_kernel_lt 6 12 0
+if [ $? == 0 ]; then
+	do_chrt --other --sched-runtime 100000 0
 	cleanup_output
 	ts_finalize_subtest
 fi


### PR DESCRIPTION
Kernels starting with 6.12 have a new feature which allows requesting a custom slice length on a task while using one of **SCHED_OTHER**, **SCHED_BATCH** or **SCHED_EXT**. The interface was created by repurposing the **_sched_attr::sched_runtime_** parameter. Similarly, this patch series uses the existing chrt interface to take advantage of this new feature.

With these changes, for **SCHED_{OTHER,BATCH}**, the current/new value of **_sched_runtime_** is reported even if the custom slice feature is not present and also, **SCHED_DEADLINE** output is now on two lines (see differences in expected test output). This may or may not be desirable.

Test output (kernel 6.13.0-rc1-00060-g7d9da040575b):
```
   schedutils: chrt                           ...
                : fifo                        ... OK
                : batch                       ... SKIPPED (kernel version must be < 6.12.0)
                : batch-custom-slice          ... OK
                : other                       ... SKIPPED (kernel version must be < 6.12.0)
                : other-custom-slice          ... OK
                : rr                          ... OK
                : idle                        ... OK
                : deadline                    ... OK
           ... OK (all 8 sub-tests PASSED)
   schedutils: chrt-non-user                  ...
                : batch-vs-nice               ... KNOWN FAILED (schedutils/chrt-non-root-batch-vs-nice)
Supported policies:
SCHED_OTHER min/max priority    : 0/0
SCHED_FIFO min/max priority     : 1/99
SCHED_RR min/max priority       : 1/99
SCHED_BATCH min/max priority    : 0/0
SCHED_IDLE min/max priority     : 0/0
SCHED_DEADLINE min/max priority : 0/0
           ... KNOWN FAILED (1 from 1 sub-tests)
```
