### PR TITLE
fallocate: keep-size and zero-range are compatible

### DIFF
--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -315,7 +315,7 @@ int main(int argc, char **argv)
 	static const ul_excl_t excl[] = {	/* rows and cols in ASCII order */
 		{ 'c', 'd', 'p', 'z' },
 		{ 'c', 'n' },
-		{ 'c', 'd', 'i', 'n', 'p', 'x', 'z'},
+		{ 'c', 'd', 'i', 'p', 'x', 'z'},
 		{ 0 }
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;


### PR DESCRIPTION
As far as I can tell, `--keep-size` is only incompatible with `--collapse-range` (as specified in the man pages).

This behavior was relied on before b85feb999c505222d4815638344c8883d5e4ab58, which reordered the mutually exclusive options in `fallocate.c`'s `excl` parameter to match the documented ascii-ordering requirement.

This was done with the express goal of making `--posix` incompatible with other options.  Presumably, the "incorrect" ordering of the options before that patch resulted in behavior that was mostly-acceptable.

This patch does something much simpler: it removes `n` from the list.  If `--keep-size` is indeed incompatible with `--zero-range`, then at a minimum, the following statement should be removed from the manual page, under the `--zero-range` option:

```
Option --keep-size can be specified to prevent file length modification.
```

I am assuming this was just a typo in 833f9a7aae713278eec5f85266597482f18c7370 that slipped by.