### PR TITLE
zramctl: wait for device being initialized and unlocked by udevd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2718,6 +2718,8 @@ AS_IF([test "x$with_systemd" != xno], [
        AC_DEFINE([HAVE_LIBSYSTEMD], [1], [Define if libsystemd is available])
        AC_DEFINE([USE_SYSTEMD], [1], [Define if systemd support is wanted ])
        AC_CHECK_DECLS([sd_session_get_username], [], [], [#include <systemd/sd-login.h>])
+       AC_CHECK_DECLS([sd_device_new_from_syspath], [], [], [#include <systemd/sd-device.h>])
+       AC_CHECK_DECLS([sd_device_open], [], [], [#include <systemd/sd-device.h>])
   )
 ])
 AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$have_systemd" = xyes])

--- a/meson.build
+++ b/meson.build
@@ -373,6 +373,19 @@ lib_systemd = dependency(
   required : get_option('systemd'))
 conf.set('HAVE_LIBSYSTEMD', lib_systemd.found() ? 1 : false)
 conf.set('USE_SYSTEMD', lib_systemd.found() ? 1 : false)
+summary('libsystemd', lib_systemd.found() ? 'enabled' : 'disabled', section : 'components')
+
+# Since systemd-240, which provides basic functions in sd-device.
+have = cc.has_function(
+  'sd_device_new_from_syspath',
+  dependencies : lib_systemd)
+conf.set('HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH', have ? 1 : false)
+
+# Since systemd-251, which also newly provides sd_device_new_from_devname().
+have = cc.has_function(
+  'sd_device_open',
+  dependencies : lib_systemd)
+conf.set('HAVE_DECL_SD_DEVICE_OPEN', have ? 1 : false)
 
 have = cc.has_function(
   'sd_session_get_username',
@@ -1858,6 +1871,8 @@ exe = executable(
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols],
+  # requires systemd v240 or newer
+  dependencies : [conf.get('HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH') == 1 ? lib_systemd : [] ],
   install_dir : sbindir,
   install : opt,
   build_by_default : opt)

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -332,7 +332,11 @@ zramctl_SOURCES = sys-utils/zramctl.c \
 		  lib/ismounted.c
 zramctl_LDADD = $(LDADD) libcommon.la libsmartcols.la
 zramctl_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
+if HAVE_SYSTEMD
+zramctl_LDADD += $(SYSTEMD_LIBS)
+zramctl_CFLAGS += $(SYSTEMD_CFLAGS)
 endif
+endif # BUILD_ZRAMCTL
 
 
 if BUILD_PRLIMIT


### PR DESCRIPTION
systemd-udevd takes a lock during processing the uevent for a block device. The kernel refuses 'reset' attribute for zram device is written when the device node is opened. Hence, during systemd-udevd processes a uevent for zram device, we cannot write 'reset' attribute. Let's wait for the device being initialized and unlocked by udevd.

Note, there still exists a race window, as we need to release the lock before writing 'reset' attribute. But, the situation should be better now.