### PR TITLE
lsipc: doesn't mount /dev/mqueue

### DIFF
--- a/sys-utils/lsipc.1.adoc
+++ b/sys-utils/lsipc.1.adoc
@@ -45,7 +45,7 @@ Write information about active POSIX shared memory segments.
 Write information about active System V message queues.
 
 *-Q*, *--posix-mqueues*::
-Write information about active POSIX message queues. Mounts /dev/mqueue if not already mounted.
+Write information about active POSIX message queues.
 
 *-s*, *--semaphores*::
 Write information about active System V semaphore sets.


### PR DESCRIPTION
Missed updating man for lsipc. 