### PR TITLE
libmount: Fix removal of "owner" option when executed as root

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -203,10 +203,6 @@ static int evaluate_permissions(struct libmnt_context *cxt)
 		 *
 		 * The old deprecated way is to use mnt_optstr_get_flags().
 		 */
-		if (user_flags & (MNT_MS_OWNER | MNT_MS_GROUP))
-			rc = mnt_optlist_remove_flags(ol,
-					MNT_MS_OWNER | MNT_MS_GROUP, cxt->map_userspace);
-
 		if (!rc && (user_flags & MNT_MS_OWNER))
 			rc = mnt_optlist_insert_flags(ol,
 					MS_OWNERSECURE, cxt->map_linux,
@@ -226,6 +222,10 @@ static int evaluate_permissions(struct libmnt_context *cxt)
 		if (!rc && (user_flags & MNT_MS_USERS))
 			rc = mnt_optlist_insert_flags(ol, MS_SECURE, cxt->map_linux,
 					MNT_MS_USERS, cxt->map_userspace);
+
+		if (user_flags & (MNT_MS_OWNER | MNT_MS_GROUP))
+			rc = mnt_optlist_remove_flags(ol,
+					MNT_MS_OWNER | MNT_MS_GROUP, cxt->map_userspace);
 
 		DBG(CXT, ul_debugobj(cxt, "perms: superuser [rc=%d]", rc));
 		if (rc)


### PR DESCRIPTION
When executed as root, libmount replaces the "owner" and "group" mount options with "nosuid, nodev, ..." However, this can result in an "invalid argument" error because libmount removes the unwanted options first and then tries to address the location for the new options using the already removed options. To fix this, we need to reverse the order of operations.