### PR TITLE
libmount: add support for STATMOUNT_SB_SOURCE

### DIFF
--- a/include/mount-api-utils.h
+++ b/include/mount-api-utils.h
@@ -266,7 +266,13 @@ struct ul_statmount {
 	uint32_t mnt_root;		/* [str] Root of mount relative to root of fs */
 	uint32_t mnt_point;	/* [str] Mountpoint relative to current root */
 	uint64_t mnt_ns_id;	 /* ID of the mount namespace */
-	uint64_t __spare2[49];
+	uint32_t fs_subtype;	/* [str] Subtype of fs_type (if any) */
+	uint32_t sb_source;	/* [str] Source string of the mount */
+	uint32_t opt_num;	/* Number of fs options */
+	uint32_t opt_array;	/* [str] Array of nul terminated fs options */
+	uint32_t opt_sec_num;	/* Number of security options */
+	uint32_t opt_sec_array;	/* [str] Array of nul terminated security options */
+	uint64_t __spare2[46];
 	char str[];		/* Variable size part containing strings */
 };
 
@@ -316,6 +322,19 @@ struct ul_statmount {
 #ifndef STATMOUNT_MNT_OPTS
 # define STATMOUNT_MNT_OPTS		0x00000080U     /* Want/got mnt_opts */
 #endif
+#ifndef STATMOUNT_FS_SUBTYPE
+# define STATMOUNT_FS_SUBTYPE		0x00000100U	/* Want/got fs_subtype */
+#endif
+#ifndef STATMOUNT_SB_SOURCE
+# define STATMOUNT_SB_SOURCE		0x00000200U	/* Want/got sb_source */
+#endif
+#ifndef STATMOUNT_OPT_ARRAY
+# define STATMOUNT_OPT_ARRAY		0x00000400U	/* Want/got opt_... */
+#endif
+#ifndef STATMOUNT_OPT_SEC_ARRAY
+# define STATMOUNT_OPT_SEC_ARRAY	0x00000800U	/* Want/got opt_sec... */
+#endif
+
 
 /*
  * Special @mnt_id values that can be passed to listmount

--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -427,7 +427,8 @@ const char *mnt_fs_get_srcpath(struct libmnt_fs *fs)
 	/* fstab-like fs */
 	if (fs->tagname)
 		return NULL;	/* the source contains a "NAME=value" */
-	return fs->source;
+
+	return mnt_fs_get_source(fs);
 }
 
 /**
@@ -439,7 +440,13 @@ const char *mnt_fs_get_srcpath(struct libmnt_fs *fs)
  */
 const char *mnt_fs_get_source(struct libmnt_fs *fs)
 {
-	return fs ? fs->source : NULL;
+	if (!fs)
+		return NULL;
+
+#ifdef HAVE_STATMOUNT_API
+	mnt_fs_try_statmount(fs, source, STATMOUNT_SB_SOURCE);
+#endif
+	return fs->source;
 }
 
 /*

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -195,6 +195,9 @@ static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 	if (!rc && (sm->mask & STATMOUNT_MNT_ROOT) && !fs->root)
 		rc = mnt_fs_set_root(fs, sm_str(sm, sm->mnt_root));
 
+	if (!rc && (sm->mask & STATMOUNT_SB_SOURCE) && !fs->source)
+		rc = mnt_fs_set_source(fs, sm_str(sm, sm->sb_source));
+
 	if (!rc && (sm->mask & STATMOUNT_MNT_BASIC)) {
 		if (!fs->propagation)
 			fs->propagation = sm->mnt_propagation;
@@ -348,6 +351,8 @@ int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask)
 			mask |= STATMOUNT_MNT_OPTS;
 		if (!fs->ns_id)
 			mask |= STATMOUNT_MNT_NS_ID;
+		if (!fs->source)
+			mask |= STATMOUNT_SB_SOURCE;
 	}
 
 	if (fs->ns_id)
@@ -364,14 +369,15 @@ int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask)
 		DBG(FS, ul_debugobj(fs, " use private buffer"));
 		rc = sys_statmount(fs->uniq_id, 0, mask, &buf, &bufsiz, 0);
 	}
-	DBG(FS, ul_debugobj(fs, " statmount [rc=%d bufsiz=%zu ns=%" PRIu64 " mask: %s%s%s%s%s%s]",
+	DBG(FS, ul_debugobj(fs, " statmount [rc=%d bufsiz=%zu ns=%" PRIu64 " mask: %s%s%s%s%s%s%s]",
 				rc, bufsiz, ns,
 				mask & STATMOUNT_SB_BASIC ? "sb-basic " : "",
 				mask & STATMOUNT_MNT_BASIC ? "mnt-basic " : "",
 				mask & STATMOUNT_MNT_ROOT ? "mnt-root " : "",
 				mask & STATMOUNT_MNT_POINT ? "mnt-point " : "",
 				mask & STATMOUNT_FS_TYPE ? "fs-type " : "",
-				mask & STATMOUNT_MNT_OPTS ? "mnt-opts " : ""));
+				mask & STATMOUNT_MNT_OPTS ? "mnt-opts " : "",
+				mask & STATMOUNT_SB_SOURCE ? "sb-source " : ""));
 
 	if (!rc)
 		rc = apply_statmount(fs, buf);


### PR DESCRIPTION
* read mount source by statmount() 9requires kernel >=6.14
* add new STATMOUNT_* masks