### PR TITLE
fallocate: rework incompatible options

### DIFF
--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -313,9 +313,8 @@ int main(int argc, char **argv)
 	};
 
 	static const ul_excl_t excl[] = {	/* rows and cols in ASCII order */
-		{ 'c', 'd', 'p', 'z' },
-		{ 'c', 'n' },
 		{ 'c', 'd', 'i', 'p', 'x', 'z'},
+		{ 'c', 'i', 'n', 'x' },
 		{ 0 }
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;


### PR DESCRIPTION
Follow up to [d95f9a6](https://github.com/aerusso/util-linux/commit/d95f9a6a7242bdcd2081c88caa34785cacd88d3e) and [util-linux#3410](https://github.com/util-linux/util-linux/pull/3410) addressing ordering requirements, natural incompatibilities between various options, and limitations of `posix_fallocate`.

@karelzak Hopefully I didn't fat-finger this PR yet again.
