### PR TITLE
include/pidfd-utils: improve robustness

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -889,7 +889,7 @@ int main(int argc, char *argv[])
 	pid_t pid_bind = 0, pid_idmap = 0;
 	const char *newinterp = NULL;
 	pid_t pid = 0;
-#ifdef UL_HAVE_PIDFD
+#ifdef HAVE_PIDFD_OPEN
 	int fd_parent_pid = -1;
 #endif
 	int fd_idmap, fd_bind = -1;
@@ -1116,7 +1116,7 @@ int main(int argc, char *argv[])
 			sigaddset(&sigset, SIGTERM) != 0 ||
 			sigprocmask(SIG_BLOCK, &sigset, &oldsigset) != 0)
 			err(EXIT_FAILURE, _("sigprocmask block failed"));
-#ifdef UL_HAVE_PIDFD
+#ifdef HAVE_PIDFD_OPEN
 		if (kill_child_signo != 0) {
 			/* make a connection to the original process (parent) */
 			fd_parent_pid = pidfd_open(getpid(), 0);
@@ -1182,7 +1182,7 @@ int main(int argc, char *argv[])
 	if (kill_child_signo != 0) {
 		if (prctl(PR_SET_PDEATHSIG, kill_child_signo) < 0)
 			err(EXIT_FAILURE, "prctl failed");
-#ifdef UL_HAVE_PIDFD
+#ifdef HAVE_PIDFD_OPEN
 		/* Use poll() to check that there is still the original parent. */
 		if (fd_parent_pid != -1) {
 			struct pollfd pollfds[1] = {

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -21,6 +21,7 @@
 #include "xalloc.h"
 #include "test_mkfds.h"
 #include "exitcodes.h"
+#include "pidfd-utils.h"
 
 #include <arpa/inet.h>
 #include <ctype.h>
@@ -81,7 +82,6 @@
 
 #define _U_ __attribute__((__unused__))
 
-static int pidfd_open(pid_t pid, unsigned int flags);
 static void do_nothing(int signum _U_);
 
 static void __attribute__((__noreturn__)) usage(FILE *out, int status)
@@ -4409,22 +4409,6 @@ static void rename_self(const char *comm)
 static void do_nothing(int signum _U_)
 {
 }
-
-#ifdef __NR_pidfd_open
-
-static int
-pidfd_open(pid_t pid, unsigned int flags)
-{
-	return syscall(__NR_pidfd_open, pid, flags);
-}
-#else
-static int
-pidfd_open(pid_t pid _U_, unsigned int flags _U_)
-{
-	errno = ENOSYS;
-	return -1;
-}
-#endif
 
 /*
  * Multiplexers


### PR DESCRIPTION
* Check for all SYS_* macros
* Define UL_HAVE_PIDFD only if all syscalls are available

Fixes: https://github.com/util-linux/util-linux/issues/3437