### PR TITLE
test_mkfds: disable ppoll multiplexer if sigset_t is not defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -987,6 +987,15 @@ AC_CHECK_TYPES([sighandler_t], [], [], [[
 #include <signal.h>
 ]])
 
+# checking sigset_t defined in the kernel header in
+# asm/signal.h. tests/helpers/test_mkfds_ppoll.c expects the RAW sigset_t
+# is defined in the header file.
+# However, a slightly older arch/parisc doesn't export the type.
+# See https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=487fa28fa8b60417642ac58e8beda6e2509d18f9
+AC_CHECK_TYPES([sigset_t], [], [], [[
+#include <asm/signal.h>
+]])
+
 AC_CHECK_DECLS([CPU_ALLOC], [], [], [[
 #include <sched.h>
 ]])

--- a/meson.build
+++ b/meson.build
@@ -515,6 +515,10 @@ conf.set('HAVE_ENVIRON_DECL', have ? 1 : false)
 have = cc.has_header_symbol('signal.h', 'sighandler_t', args : '-D_GNU_SOURCE')
 conf.set('HAVE_SIGHANDLER_T', have ? 1 : false)
 
+# checking sigset_t defined in the kernel header
+have = cc.has_header_symbol('asm/signal.h', 'sigset_t', args : '-D_GNU_SOURCE')
+conf.set('HAVE_SIGSET_T', have ? 1 : false)
+
 have = cc.has_function('strsignal')
 conf.set10('HAVE_STRSIGNAL_DECL', have)
 

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -4536,12 +4536,14 @@ static struct multiplexer multiplexers [] = {
 		.fn = wait_event_poll,
 	},
 #endif
+#ifdef HAVE_SIGSET_T
 #ifdef __NR_ppoll
 	{
 		.name = "ppoll",
 		.fn = wait_event_ppoll,
 	},
 #endif
+#endif	/* HAVE_SIGSET_T */
 };
 
 static struct multiplexer *lookup_multiplexer(const char *name)

--- a/tests/helpers/test_mkfds_ppoll.c
+++ b/tests/helpers/test_mkfds_ppoll.c
@@ -35,6 +35,8 @@
  * This file is for defining the poll multiplexer only with <asm/poll.h>.
  *
  */
+#ifdef HAVE_SIGSET_T		/* defined in config.h */
+
 #include "test_mkfds.h"
 
 #include <string.h>		/* memset */
@@ -77,3 +79,5 @@ DEFUN_WAIT_EVENT_POLL(ppoll,
 		      clear_sigset(&sigset);,
 		      syscall(__NR_ppoll, pfds, n, NULL, &sigset, sizeof(sigset)))
 #endif
+
+#endif	/* HAVE_SIGSET_T */


### PR DESCRIPTION
Fixes #3432

The ppoll multiplexer requires RAW sigset_t type generally defined in asm/linux.h. However, the parisc arch of the kernel older than 487fa28fa8b60417642ac58e8beda6e2509d18f9 didn't export the type to the user space.