### PR TITLE
ci: bump uraimo/run-on-arch-action to v3

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -150,11 +150,7 @@ jobs:
 
   build-arch:
     name: build (qemu-user, ${{ matrix.arch }})
-    # FIXME: using Ubuntu 24.04 on the worker causes random segfaults in s390x containers
-    #        using qemu-user-static. Let's switch this, temporarily, to Ubuntu 22.04 which
-    #        doesn't seem to have this issue. Note: the coverage shouldn't change, since
-    #        the "inner" alt-arch containers still use "ubuntu-latest" (24.04 ATTOW).
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ toJSON(matrix) }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -164,7 +164,7 @@ jobs:
     steps:
       - name: Repository checkout
         uses: actions/checkout@v4
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.arch }}
           dockerRunArgs: --privileged -v /dev:/dev


### PR DESCRIPTION
The latest v3 version should address the sporadic segfaults we've been
seeing (mainly on s390x).