### PR TITLE
tests: (lsns/nsfs) consider the cases that lsns returns multiple paths

### DIFF
--- a/tests/ts/lsns/nsfs
+++ b/tests/ts/lsns/nsfs
@@ -27,6 +27,7 @@ ts_check_enotty
 ts_check_test_command "$TS_CMD_LSNS"
 ts_check_test_command "$TS_CMD_MOUNT"
 ts_check_test_command "$TS_CMD_UMOUNT"
+ts_check_test_command "$TS_HELPER_SYSINFO"
 ts_check_prog "ip"
 ts_check_prog "dd"
 ts_check_prog "touch"

--- a/tests/ts/lsns/nsfs
+++ b/tests/ts/lsns/nsfs
@@ -79,8 +79,22 @@ fi
     dd if=/dev/zero bs=1 count=1 2> $NULL
 } > $FIFO
 
-test "$NSFS_NAMES_MLINES" = "$PATH1
-$PATH2" && test "$NSFS_NAMES_1LINE" = "$PATH1,$PATH2"
+
+does_combination_include()
+{
+    local p1 p2
+    for p1 in "$@"; do
+	for p2 in "$@"; do
+	    if [ "$p1" = "$PATH1" ] && [ "$p2" = "$PATH2" ]; then
+		return 0
+	    fi
+	done
+    done
+    return 1
+}
+
+does_combination_include $NSFS_NAMES_MLINES &&
+    does_combination_include ${NSFS_NAMES_1LINE//,/ }
 
 RESULT=$?
 echo $RESULT >> $TS_OUTPUT


### PR DESCRIPTION
Fixes #3442

If a target directory is bind-mount'ed, lsns returns multiple paths as the value for NSFS column. This change considers this case.
