### PR TITLE
Use `ipc_stat::cgid` for the column `COL_CGID`.

### DIFF
--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -926,7 +926,7 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 					rc = scols_line_refer_data(ln, n, arg);
 				break;
 			case COL_CGID:
-				rc = scols_line_sprintf(ln, n, "%u", p->msg_perm.cuid);
+				rc = scols_line_sprintf(ln, n, "%u", p->msg_perm.cgid);
 				break;
 			case COL_CGROUP:
 				arg = get_groupname(&gr, p->msg_perm.cgid);


### PR DESCRIPTION
Use `ipc_stat::cgid` for the column `COL_CGID`.