### PR TITLE
lscpu: RISC-V: Print ISA information in summary

### DIFF
--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -461,6 +461,7 @@ lscpu_SOURCES = sys-utils/lscpu.c \
 		sys-utils/lscpu-virt.c \
 		sys-utils/lscpu-arm.c \
 		sys-utils/lscpu-dmi.c \
+		sys-utils/lscpu-riscv.c \
 		sys-utils/lscpu.h
 lscpu_LDADD = $(LDADD) libcommon.la libsmartcols.la $(RTAS_LIBS)
 lscpu_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)

--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -233,6 +233,7 @@ static const struct cpuinfo_pattern type_patterns[] =
 	DEF_PAT_CPUTYPE( "family",		PAT_FAMILY,	family),
 	DEF_PAT_CPUTYPE( "features",		PAT_FEATURES,	flags),		/* s390 */
 	DEF_PAT_CPUTYPE( "flags",		PAT_FLAGS,	flags),		/* x86 */
+	DEF_PAT_CPUTYPE( "isa",			PAT_ISA,	isa),		/* riscv */
 	DEF_PAT_CPUTYPE( "marchid",		PAT_FAMILY,	family),	/* riscv */
 	DEF_PAT_CPUTYPE( "max thread id",	PAT_MAX_THREAD_ID, mtid),	/* s390 */
 	DEF_PAT_CPUTYPE( "mimpid",		PAT_MODEL,	model),		/* riscv */

--- a/sys-utils/lscpu-riscv.c
+++ b/sys-utils/lscpu-riscv.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright (C) 2025 Ventana Micro Systems Inc.
+ *
+ */
+#include "lscpu.h"
+#include "strutils.h"
+#include "strv.h"
+
+static int riscv_cmp_func(const void *a, const void *b)
+{
+	return strcmp(*(const char **)a, *(const char **)b);
+}
+
+bool is_riscv(struct lscpu_cputype *ct)
+{
+	const char *base_isa[] = {"rv32", "rv64", "rv128"};
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(base_isa); i++) {
+		if (!strncasecmp(ct->isa, base_isa[i], strlen(base_isa[i])))
+			return true;
+	}
+
+	return false;
+}
+
+/*
+ * Reformat the isa string, but the length stays the same.
+ */
+void lscpu_format_isa_riscv(struct lscpu_cputype *ct)
+{
+	char **split;
+	size_t i;
+
+	split = strv_split(ct->isa, "_");
+
+	/* Sort multi-letter extensions alphabetically */
+	if (strv_length(split) > 1)
+		qsort(&split[1], strv_length(split) - 1, sizeof(char *), riscv_cmp_func);
+
+	/* Keep Base ISA and single-letter extensions at the start */
+	strcpy(ct->isa, split[0]);
+
+	for (i = 1; i < strv_length(split); i++) {
+		strcat(ct->isa, " ");
+		strcat(ct->isa, split[i]);
+	}
+
+	strv_free(split);
+}

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -954,6 +954,11 @@ print_summary_cputype(struct lscpu_cxt *cxt,
 
 	if (ct->flags)
 		add_summary_s(tb, sec, _("Flags:"), ct->flags);
+
+	if (ct->isa && is_riscv(ct)) {
+		lscpu_format_isa_riscv(ct);
+		add_summary_s(tb, sec, _("ISA:"), ct->isa);
+	}
 }
 
 /*

--- a/sys-utils/lscpu.h
+++ b/sys-utils/lscpu.h
@@ -278,6 +278,7 @@ struct lscpu_cxt {
 		 CPU_ISSET_S((_cpu)->logical_id, (_cxt)->setsize, (_cxt)->present))
 
 int is_arm(struct lscpu_cxt *cxt);
+bool is_riscv(struct lscpu_cputype *ct);
 
 struct lscpu_cputype *lscpu_new_cputype(void);
 void lscpu_ref_cputype(struct lscpu_cputype *ct);
@@ -320,6 +321,7 @@ int lscpu_create_cpus(struct lscpu_cxt *cxt, cpu_set_t *cpuset, size_t setsize);
 struct lscpu_cpu *lscpu_cpus_loopup_by_type(struct lscpu_cxt *cxt, struct lscpu_cputype *ct);
 
 void lscpu_decode_arm(struct lscpu_cxt *cxt);
+void lscpu_format_isa_riscv(struct lscpu_cputype *ct);
 
 int lookup(char *line, char *pattern, char **value);
 

--- a/sys-utils/meson.build
+++ b/sys-utils/meson.build
@@ -184,6 +184,7 @@ lscpu_sources = files(
   'lscpu-virt.c',
   'lscpu-arm.c',
   'lscpu-dmi.c',
+  'lscpu-riscv.c',
 )
 lscpu_manadocs = files('lscpu.1.adoc')
 

--- a/tests/expected/lscpu/lscpu-rv64-linux
+++ b/tests/expected/lscpu/lscpu-rv64-linux
@@ -4,6 +4,7 @@ Model name:          sifive,u74-mc
 Thread(s) per core:  2
 Core(s) per socket:  1
 Socket(s):           1
+ISA:                 rv64imafdc
 L1d cache:           64 KiB (2 instances)
 L1i cache:           64 KiB (2 instances)
 L2 cache:            2 MiB (1 instance)

--- a/tests/expected/lscpu/lscpu-rv64-milkvpioneer
+++ b/tests/expected/lscpu/lscpu-rv64-milkvpioneer
@@ -7,6 +7,7 @@ Model:               0x0
 Thread(s) per core:  1
 Core(s) per socket:  64
 Socket(s):           1
+ISA:                 rv64imafdcv
 NUMA node(s):        4
 NUMA node0 CPU(s):   0-7,16-23
 NUMA node1 CPU(s):   8-15,24-31

--- a/tests/expected/lscpu/lscpu-rv64-visionfive2
+++ b/tests/expected/lscpu/lscpu-rv64-visionfive2
@@ -8,6 +8,7 @@ Model:               0x4210427
 Thread(s) per core:  1
 Core(s) per socket:  4
 Socket(s):           1
+ISA:                 rv64imafdc zba zbb zicntr zicsr zifencei zihpm
 L1d cache:           128 KiB (4 instances)
 L1i cache:           128 KiB (4 instances)
 L2 cache:            2 MiB (1 instance)


### PR DESCRIPTION
[**from mailling list**]

The ISA information for RISC-V is important for understanding the different extensions supported by the CPU. Print the ISA information in the summary, with the Base ISA and single-letter extensions at the beginning, followed by multi-letter extensions sorted in alphabetical order. The information is the same as the cpuinfo information, except that underscores are replaced by spaces and multi-letter extensions are simply sorted instead of following any ISA string ordering rule.

The sample output below shows the difference between cpuinfo and lscpu.

cpuinfo output:
isa             : rv64imafdch_zicbom_zicboz_zicntr_zicsr_zifencei_zihintntl_zihintpause_zihpm_zawrs_zfa_zba_zbb_zbc_zbs_smaia_ssaia_sstc

lscpu output:
ISA:                rv64imafdch smaia ssaia sstc zawrs zba zbb zbc zbs zfa zicbom zicboz zicntr zicsr zifencei zihintntl zihintpause zihpm