### PR TITLE
terminal-colors.d: support NO_COLOR

### DIFF
--- a/lib/colors.c
+++ b/lib/colors.c
@@ -600,7 +600,9 @@ int colors_init(int mode, const char *name)
 		cc->mode = mode;
 
 	if (cc->mode == UL_COLORMODE_UNDEF
+	    && getenv("NO_COLOR") == NULL
 	    && (ready = colors_terminal_is_ready())) {
+
 		int rc = colors_read_configuration(cc);
 		if (rc)
 			cc->mode = UL_COLORMODE_DEFAULT;

--- a/lib/terminal-colors.d.5.adoc
+++ b/lib/terminal-colors.d.5.adoc
@@ -33,8 +33,7 @@ The _term_ is a terminal identifier (the *TERM* environment variable). The termi
 The _type_ is a file type. Supported file types are:
 
 *disable*::
-Turns off output colorization for all compatible utilities.
-
+Turns off output colorization for all compatible utilities. See also the NO_COLOR environment variable below.
 *enable*::
 Turns on output colorization; any matching *disable* files are ignored.
 
@@ -130,6 +129,11 @@ Lines where the first non-blank character is a # (hash) are ignored. Any other u
 
 *TERMINAL_COLORS_DEBUG*=all::
 enables debug output.
+
+*NO_COLOR*::
+if defined, this disables output colorization unless explicitly enabled by a
+command-line option. See https://no-color.org/ for more details. Supported
+since util-linux version 2.41.
 
 == FILES
 

--- a/man-common/colors.adoc
+++ b/man-common/colors.adoc
@@ -9,6 +9,9 @@ for the *{command}* command or for all tools by
 ____
 _/etc/terminal-colors.d/disable_
 ____
+Since version 2.41, the $NO_COLOR environment variable is also supported to
+disable output colorization unless explicitly enabled by a command-line option.
+
 The user-specific _$XDG_CONFIG_HOME/terminal-colors.d_
 or _$HOME/.config/terminal-colors.d_ overrides the global setting. 
 


### PR DESCRIPTION
We already provide the ability to easily disable output colorization, but there is also the https://no-color.org initiative based on the NO_COLOR environment variable. Let's support this method to disable colors. Let's be friendly :-)

Addresses: https://github.com/util-linux/util-linux/issues/3463