### PR TITLE
su: (man) fix duplicate asterisk

### DIFF
--- a/login-utils/runuser.1.adoc
+++ b/login-utils/runuser.1.adoc
@@ -73,7 +73,7 @@ If the target user has a restricted shell (i.e., not listed in _/etc/shells_), t
 **--session-command=**__command__::
 Same as *-c*, but do not create a new session. (Discouraged.)
 
-*-T*, *--no-pty**::
+*-T*, *--no-pty*::
 Do not create a pseudo-terminal, opposite of *--pty* and *-P*.
 Note that running without a pseudo-terminal opens the security risk of privilege escalation through TIOCSTI/TIOCLINUX ioctl command injection.
 

--- a/login-utils/su.1.adoc
+++ b/login-utils/su.1.adoc
@@ -81,7 +81,7 @@ The shell to run is selected according to the following rules, in order:
 **--session-command=**__command__::
 Same as *-c*, but do not create a new session. (Discouraged.)
 
-*-T*, *--no-pty**::
+*-T*, *--no-pty*::
 Do not create a pseudo-terminal, opposite of *--pty* and *-P*.
 Note that running without a pseudo-terminal opens the security risk of privilege escalation through TIOCSTI/TIOCLINUX ioctl command injection.
 

--- a/po-man/cs.po
+++ b/po-man/cs.po
@@ -11040,7 +11040,7 @@ msgstr "Stejné jako *-c*, ale nevytvoří novou relaci. (Nedoporučuje se.)"
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, fuzzy, no-wrap
 #| msgid "*-P*, *--pty*"
-msgid "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
 msgstr "*-P*, *--pty*"
 
 #. type: Plain text

--- a/po-man/de.po
+++ b/po-man/de.po
@@ -12696,8 +12696,8 @@ msgstr ""
 #. type: Labeled list
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, no-wrap
-msgid "*-T*, *--no-pty**"
-msgstr "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
+msgstr "*-T*, *--no-pty*"
 
 #. type: Plain text
 #: ../login-utils/runuser.1.adoc:79 ../login-utils/su.1.adoc:87

--- a/po-man/es.po
+++ b/po-man/es.po
@@ -11813,7 +11813,7 @@ msgstr ""
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, fuzzy, no-wrap
 #| msgid "*-n*, *--noparity*"
-msgid "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
 msgstr "*-n*, *--noparity*"
 
 #. type: Plain text

--- a/po-man/fr.po
+++ b/po-man/fr.po
@@ -12693,7 +12693,7 @@ msgstr "Comme *-c*, mais sans créer de nouvelle session (à éviter)."
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, fuzzy, no-wrap
 #| msgid "*-n*, *--noparity*"
-msgid "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
 msgstr "*-n*, *--noparity*"
 
 #. type: Plain text

--- a/po-man/ko.po
+++ b/po-man/ko.po
@@ -10746,8 +10746,8 @@ msgstr ""
 #. type: Labeled list
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, no-wrap
-msgid "*-T*, *--no-pty**"
-msgstr "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
+msgstr "*-T*, *--no-pty*"
 
 #. type: Plain text
 #: ../login-utils/runuser.1.adoc:79 ../login-utils/su.1.adoc:87

--- a/po-man/pt_BR.po
+++ b/po-man/pt_BR.po
@@ -12501,7 +12501,7 @@ msgstr ""
 #. type: Labeled list
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, fuzzy, no-wrap
-msgid "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
 msgstr " -P, --pty                       cria um novo pseudoterminal\n"
 
 #. type: Plain text

--- a/po-man/ro.po
+++ b/po-man/ro.po
@@ -12702,8 +12702,8 @@ msgstr "La fel ca *-c*, dar nu creează o sesiune nouă. (Neindicată.)"
 #. type: Labeled list
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, no-wrap
-msgid "*-T*, *--no-pty**"
-msgstr "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
+msgstr "*-T*, *--no-pty"
 
 #. type: Plain text
 #: ../login-utils/runuser.1.adoc:79 ../login-utils/su.1.adoc:87

--- a/po-man/sr.po
+++ b/po-man/sr.po
@@ -12353,8 +12353,8 @@ msgstr "Исто као *-c*, али не прави нову сесију. (Н�
 #. type: Labeled list
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, no-wrap
-msgid "*-T*, *--no-pty**"
-msgstr "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
+msgstr "*-T*, *--no-pty*"
 
 #. type: Plain text
 #: ../login-utils/runuser.1.adoc:79 ../login-utils/su.1.adoc:87

--- a/po-man/uk.po
+++ b/po-man/uk.po
@@ -13383,8 +13383,8 @@ msgstr "Те саме, що і *-c*, але без створення сеанс
 #. type: Labeled list
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, no-wrap
-msgid "*-T*, *--no-pty**"
-msgstr "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
+msgstr "*-T*, *--no-pty*"
 
 #. type: Plain text
 #: ../login-utils/runuser.1.adoc:79 ../login-utils/su.1.adoc:87

--- a/po-man/util-linux-man.pot
+++ b/po-man/util-linux-man.pot
@@ -10507,7 +10507,7 @@ msgstr ""
 #. type: Labeled list
 #: ../login-utils/runuser.1.adoc:76 ../login-utils/su.1.adoc:84
 #, no-wrap
-msgid "*-T*, *--no-pty**"
+msgid "*-T*, *--no-pty*"
 msgstr ""
 
 #. type: Plain text


### PR DESCRIPTION
This fixes a trailing asterix:

```
       -T, --no-pty*
           Do not create a pseudo-terminal, opposite of --pty and -P.
           Note that running without a pseudo-terminal opens the security
           risk of privilege escalation through TIOCSTI/TIOCLINUX ioctl
           command injection.
```

See [su(1)](https://man7.org/linux/man-pages/man1/su.1.html)