### PR TITLE
sysusers: create fully locked system account

### DIFF
--- a/misc-utils/uuidd-sysusers.conf.in
+++ b/misc-utils/uuidd-sysusers.conf.in
@@ -1,1 +1,1 @@
-u uuidd - "UUID generator helper daemon" @localstatedir@/lib/libuuid
+u! uuidd - "UUID generator helper daemon" @localstatedir@/lib/libuuid


### PR DESCRIPTION
... for some extra security. The account is marked locked as a whole, not just created with an invalid password.

https://github.com/systemd/systemd/blob/v257/NEWS#L767-L777
https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html#u