### PR TITLE
meson: fix po-man installation

### DIFF
--- a/po-man/meson.build
+++ b/po-man/meson.build
@@ -33,6 +33,7 @@ foreach adoc : manadocs
 endforeach
 
 meson.add_install_script(meson.project_source_root() / 'tools/poman-install.sh',
-  '--mandir', get_option('mandir'),
+  '--force-destdir',
+  '--mandir', mandir,
   '--mansrcdir', meson.current_build_dir() / 'translations/man',
   manpages)


### PR DESCRIPTION
* in po-man/meson.build use already defined mandir
* make sure $DESTDIR is used in the install script

Addresses: https://github.com/util-linux/util-linux/pull/3378