### PR TITLE
include/list,lsfd: remove LIST_HEAD macro again

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -35,9 +35,6 @@ struct list_head {
 	struct list_head *next, *prev;
 };
 
-#define LIST_HEAD(name) \
-	struct list_head name = { .next = &(name), .prev = &(name) }
-
 #define INIT_LIST_HEAD(ptr) do { \
 	(ptr)->next = (ptr); (ptr)->prev = (ptr); \
 } while (0)

--- a/lsfd-cmd/sock-xinfo.c
+++ b/lsfd-cmd/sock-xinfo.c
@@ -74,7 +74,7 @@ static struct stat self_netns_sb;
 static void *xinfo_tree;	/* for tsearch/tfind */
 static void *netns_tree;
 
-static LIST_HEAD(unix_ipcs);
+static struct list_head unix_ipcs;
 static void *unix_oneway_ipc_tree;	/* for tsearch/tfind */
 
 struct iface {
@@ -269,6 +269,8 @@ void initialize_sock_xinfos(void)
 	struct path_cxt *pc;
 	DIR *dir;
 	struct dirent *d;
+
+	INIT_LIST_HEAD(&unix_ipcs);
 
 	self_netns_fd = open("/proc/self/ns/net", O_RDONLY);
 


### PR DESCRIPTION
This reverts commit cafae2d19742ad56a05a51bb23b798dbbd5c62a8. See 5d74cf0092b132bf224024548e46566033c84937 about the reason.