### PR TITLE
fix mkfs.bfs memory leak

### DIFF
--- a/disk-utils/mkfs.bfs.c
+++ b/disk-utils/mkfs.bfs.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
 	if (argc == 2 && !strcmp(argv[1], "-V"))
 		print_version(EXIT_SUCCESS);
 
-	volume = fsname = "      ";	/* is there a default? */
+	volume = fsname = NULL;
 	inodes = 0;
 
 	while ((c = getopt_long(argc, argv, "N:V:F:vhcl", longopts, NULL)) != -1) {
@@ -260,13 +260,29 @@ int main(int argc, char **argv)
 	sb.s_start = cpu_to_le32(ino_bytes + sizeof(struct bfssb));
 	sb.s_end = cpu_to_le32(total_blocks * BFS_BLOCKSIZE - 1);
 	sb.s_from = sb.s_to = sb.s_backup_from = sb.s_backup_to = -1;
-	memcpy(sb.s_fsname, fsname, 6);
-	memcpy(sb.s_volume, volume, 6);
+
+	if (fsname == NULL){
+		fsname = "      ";
+		memcpy(sb.s_fsname, fsname, 6);
+	}
+	else{
+		memcpy(sb.s_fsname, fsname, 6);
+		free(fsname);
+	}
+	if (volume == NULL){
+		volume = "      ";
+		memcpy(sb.s_volume, volume, 6);
+	}
+	else{
+		memcpy(sb.s_volume, volume, 6);
+		free(volume);
+	}
+	volume = fsname = NULL;
 
 	if (verbose) {
 		fprintf(stderr, _("Device: %s\n"), device);
-		fprintf(stderr, _("Volume: <%-6s>\n"), volume);
-		fprintf(stderr, _("FSname: <%-6s>\n"), fsname);
+		fprintf(stderr, _("Volume: <%-6s>\n"), sb.s_volume);
+		fprintf(stderr, _("FSname: <%-6s>\n"), sb.s_fsname);
 		fprintf(stderr, _("BlockSize: %d\n"), BFS_BLOCKSIZE);
 		if (ino_blocks == 1)
 			fprintf(stderr, _("Inodes: %ld (in 1 block)\n"),

--- a/disk-utils/mkfs.bfs.c
+++ b/disk-utils/mkfs.bfs.c
@@ -158,6 +158,8 @@ int main(int argc, char **argv)
 			len = strlen(optarg);
 			if (len <= 0 || len > 6)
 				errx(EXIT_FAILURE, _("volume name too long"));
+			if (volume != NULL)
+				errx(EXIT_FAILURE, _("more than one volume"));
 			volume = xstrdup(optarg);
 			break;
 
@@ -165,6 +167,8 @@ int main(int argc, char **argv)
 			len = strlen(optarg);
 			if (len <= 0 || len > 6)
 				errx(EXIT_FAILURE, _("fsname name too long"));
+			if (fsname != NULL)
+				errx(EXIT_FAILURE, _("more than one fsname"));
 			fsname = xstrdup(optarg);
 			break;
 


### PR DESCRIPTION
In the main function of disk-utils/mkfs.bfs.c, memory is allocated using xstrdup (a wrapper for strdup), but it is not freed, resulting in a memory leak.

The content of the xstrdup function is as follows:
```
// in util-linux/include/xalloc.h
char *xstrdup(const char *str)
{
        char *ret;

        assert(str);
        ret = strdup(str);
        if (!ret)
                err(XALLOC_EXIT_CODE, "cannot duplicate string");
        return ret;
}

```
The content of the main function is as follows:
```
// in disk-utils/mkfs.bfs.c
int main(int argc, char **argv)
{
        char *device, *volume, *fsname;
        //====cut====
        volume = fsname = "      ";     /* is there a default? */
        //====cut====
                case 'V':
                        len = strlen(optarg);
                        if (len <= 0 || len > 6)
                                errx(EXIT_FAILURE, _("volume name too long"));
                        volume = xstrdup(optarg);
                        break;

                case 'F':
                        len = strlen(optarg);
                        if (len <= 0 || len > 6)
                                errx(EXIT_FAILURE, _("fsname name too long"));
                        fsname = xstrdup(optarg);
                        break;
                //====cut====
        memcpy(sb.s_fsname, fsname, 6);
        memcpy(sb.s_volume, volume, 6);
        if (verbose) {
                fprintf(stderr, _("Device: %s\n"), device);
                fprintf(stderr, _("Volume: <%-6s>\n"), volume);
                fprintf(stderr, _("FSname: <%-6s>\n"), fsname);
     //====cut====
     //fsname and volume was not freeed  
```

The memory allocated by strdup was not freed after use.