### PR TITLE
Use the 'fallthrough' attribute

### DIFF
--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -1580,7 +1580,7 @@ static int ui_menu_move(struct cfdisk *cf, int key)
 				ui_menu_goto(cf, (int) m->idx - m->page_sz);
 				return 0;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		case KEY_HOME:
 			ui_menu_goto(cf, 0);
 			return 0;
@@ -1589,7 +1589,7 @@ static int ui_menu_move(struct cfdisk *cf, int key)
 				ui_menu_goto(cf, m->idx + m->page_sz);
 				return 0;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		case KEY_END:
 			ui_menu_goto(cf, m->nitems);
 			return 0;
@@ -2671,7 +2671,7 @@ static int ui_run(struct cfdisk *cf)
 				ui_table_goto(cf, (int) cf->lines_idx - cf->page_sz);
 				break;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		case KEY_HOME:
 			ui_table_goto(cf, 0);
 			break;
@@ -2680,7 +2680,7 @@ static int ui_run(struct cfdisk *cf)
 				ui_table_goto(cf, cf->lines_idx + cf->page_sz);
 				break;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		case KEY_END:
 			ui_table_goto(cf, (int) cf->nlines - 1);
 			break;

--- a/disk-utils/fdisk-menu.c
+++ b/disk-utils/fdisk-menu.c
@@ -620,7 +620,7 @@ static int generic_menu_cb(struct fdisk_context **cxt0,
 			rc = fdisk_reread_partition_table(cxt);
 		if (!rc)
 			rc = fdisk_deassign_device(cxt, 0);
-		/* fallthrough */
+		FALLTHROUGH;
 	case 'q':
 		fdisk_unref_context(cxt);
 		fputc('\n', stdout);

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -780,7 +780,7 @@ int main(int argc, char ** argv)
 			break;
 		case 'v': /* kept for backwards compatibility */
 			warnx(_("-v is ambiguous, use '-2' instead"));
-			/* fallthrough */
+			FALLTHROUGH;
 		case '2':
 			fs_version = 2;
 			break;

--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -2095,7 +2095,7 @@ static int command_fdisk(struct sfdisk *sf, int argc, char **argv)
 				break;
 			}
 		}
-		/* fallthrough */
+		FALLTHROUGH;
 	case SFDISK_DONE_WRITE:
 		rc = write_changes(sf);
 		break;
@@ -2334,7 +2334,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'J':
 			sf->json = 1;
-			/* fallthrough */
+			FALLTHROUGH;
 		case 'd':
 			sf->act = ACT_DUMP;
 			break;
@@ -2346,7 +2346,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'G':
 			warnx(_("--show-pt-geometry is no more implemented. Using --show-geometry."));
-			/* fallthrough */
+			FALLTHROUGH;
 		case 'g':
 			sf->act = ACT_SHOW_GEOM;
 			break;

--- a/include/c.h
+++ b/include/c.h
@@ -82,6 +82,39 @@
 # endif
 #endif
 
+#ifdef __has_attribute
+# define UL_HAS_ATTRIBUTE(x) __has_attribute(x)
+#else
+# define UL_HAS_ATTRIBUTE(x) 0
+#endif
+
+/* C-language Attributes are added in C23. */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ > 201710L) && defined(__has_c_attribute)
+# define UL_HAS_C_ATTRIBUTE(x) __has_c_attribute(x)
+#else
+# define UL_HAS_C_ATTRIBUTE(x) 0
+#endif
+
+#if defined(__cplusplus) && defined(__has_cpp_attribute)
+# define UL_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+# define UL_HAS_CPP_ATTRIBUTE(x) 0
+#endif
+
+/*
+Define FALLTHROUGH macro for annotating switch case with the 'fallthrough' attribute
+introduced in CPP17 and C23.
+CPP17 : https://en.cppreference.com/w/cpp/language/attributes/fallthrough
+C23   : https://en.cppreference.com/w/c/language/attributes/fallthrough
+*/
+#if UL_HAS_C_ATTRIBUTE(fallthrough) || UL_HAS_CPP_ATTRIBUTE(fallthrough)
+# define FALLTHROUGH [[fallthrough]]
+#elif UL_HAS_ATTRIBUTE(__fallthrough__)
+# define FALLTHROUGH __attribute__ ((__fallthrough__))
+#else
+# define FALLTHROUGH /* fallthrough */
+#endif
+
 
 /*
  * It evaluates to 1 if the attribute/feature is supported by the current

--- a/include/xxhash.h
+++ b/include/xxhash.h
@@ -631,14 +631,12 @@ introduced in CPP17 and C23.
 CPP17 : https://en.cppreference.com/w/cpp/language/attributes/fallthrough
 C23   : https://en.cppreference.com/w/c/language/attributes/fallthrough
 */
-#if XXH_HAS_C_ATTRIBUTE(x)
-# define XXH_FALLTHROUGH [[fallthrough]]
-#elif XXH_HAS_CPP_ATTRIBUTE(x)
+#if XXH_HAS_C_ATTRIBUTE(fallthrough) || XXH_HAS_CPP_ATTRIBUTE(fallthrough)
 # define XXH_FALLTHROUGH [[fallthrough]]
 #elif XXH_HAS_ATTRIBUTE(__fallthrough__)
-# define XXH_FALLTHROUGH __attribute__ ((fallthrough))
+# define XXH_FALLTHROUGH __attribute__ ((__fallthrough__))
 #else
-# define XXH_FALLTHROUGH
+# define XXH_FALLTHROUGH /* fallthrough */
 #endif
 
 /*!

--- a/include/xxhash.h
+++ b/include/xxhash.h
@@ -605,39 +605,10 @@ XXH_PUBLIC_API void XXH32_canonicalFromHash(XXH32_canonical_t* dst, XXH32_hash_t
  */
 XXH_PUBLIC_API XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canonical_t* src);
 
+/* Reuse FALLTHROUGH macro from c.h */
+#include "c.h"
 
-#ifdef __has_attribute
-# define XXH_HAS_ATTRIBUTE(x) __has_attribute(x)
-#else
-# define XXH_HAS_ATTRIBUTE(x) 0
-#endif
-
-/* C-language Attributes are added in C23. */
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ > 201710L) && defined(__has_c_attribute)
-# define XXH_HAS_C_ATTRIBUTE(x) __has_c_attribute(x)
-#else
-# define XXH_HAS_C_ATTRIBUTE(x) 0
-#endif
-
-#if defined(__cplusplus) && defined(__has_cpp_attribute)
-# define XXH_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
-#else
-# define XXH_HAS_CPP_ATTRIBUTE(x) 0
-#endif
-
-/*
-Define XXH_FALLTHROUGH macro for annotating switch case with the 'fallthrough' attribute
-introduced in CPP17 and C23.
-CPP17 : https://en.cppreference.com/w/cpp/language/attributes/fallthrough
-C23   : https://en.cppreference.com/w/c/language/attributes/fallthrough
-*/
-#if XXH_HAS_C_ATTRIBUTE(fallthrough) || XXH_HAS_CPP_ATTRIBUTE(fallthrough)
-# define XXH_FALLTHROUGH [[fallthrough]]
-#elif XXH_HAS_ATTRIBUTE(__fallthrough__)
-# define XXH_FALLTHROUGH __attribute__ ((__fallthrough__))
-#else
-# define XXH_FALLTHROUGH /* fallthrough */
-#endif
+#define XXH_FALLTHROUGH FALLTHROUGH
 
 /*!
  * @}

--- a/lib/pty-session.c
+++ b/lib/pty-session.c
@@ -586,11 +586,11 @@ static int handle_signal(struct ul_pty *pty, int fd)
 		}
 		break;
 	case SIGHUP:
-		/* fallthrough */
+		FALLTHROUGH;
 	case SIGTERM:
-		/* fallthrough */
+		FALLTHROUGH;
 	case SIGINT:
-		/* fallthrough */
+		FALLTHROUGH;
 	case SIGQUIT:
 		DBG(SIG, ul_debugobj(pty, " get signal SIG{TERM,INT,QUIT}"));
 		pty->delivered_signal = info.ssi_signo;

--- a/libblkid/src/topology/md.c
+++ b/libblkid/src/topology/md.c
@@ -121,11 +121,11 @@ static int probe_md_tp(blkid_probe pr,
 	switch (md.level) {
 	case 6:
 		md.raid_disks--;
-		/* fallthrough */
+		FALLTHROUGH;
 	case 5:
 	case 4:
 		md.raid_disks--;
-		/* fallthrough */
+		FALLTHROUGH;
 	case 1:
 	case 0:
 	case 10:

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1833,7 +1833,7 @@ int mnt_context_get_mount_excode(
 			snprintf(buf, bufsz, _("cannot mount; probably corrupted filesystem on %s"), src);
 			break;
 		}
-		/* fallthrough */
+		FALLTHROUGH;
 
 	default:
 	generic_error:

--- a/libsmartcols/src/calculate.c
+++ b/libsmartcols/src/calculate.c
@@ -344,7 +344,7 @@ static int reduce_column(struct libscols_table *tb,
 		/* reduce extreme columns with large width deviation */
 		if (st->width_deviation < st->width_avg / 2.0)
 			break;
-		/* fallthrough */
+		FALLTHROUGH;
 	case 2:
 		/* reduce extreme columns */
 		if (!scols_column_is_noextremes(cl))
@@ -356,7 +356,7 @@ static int reduce_column(struct libscols_table *tb,
 		/* reduce columns with trunc flag and relative whint and large width deviation */
 		if (st->width_deviation < st->width_avg / 2.0)
 			break;
-		/* fallthrough */
+		FALLTHROUGH;
 	case 4:
 		/* reduce columns with trunc flag and relative whint */
 		if (!is_trunc)
@@ -372,7 +372,7 @@ static int reduce_column(struct libscols_table *tb,
 		/* reduce all columns with trunc flag large width deviation */
 		if (st->width_deviation < st->width_avg / 2.2)
 			break;
-		/* fallthrough */
+		FALLTHROUGH;
 	case 6:
 		/* reduce all columns with trunc flag */
 		if (!is_trunc && !scols_column_is_noextremes(cl))

--- a/libsmartcols/src/print.c
+++ b/libsmartcols/src/print.c
@@ -1281,7 +1281,7 @@ int __scols_initialize_printing(struct libscols_table *tb, struct ul_buffer *buf
 	case SCOLS_FMT_JSON:
 		ul_jsonwrt_init(&tb->json, tb->out, 0);
 		extra_bufsz += tb->nlines * 3;		/* indentation */
-		/* fallthrough */
+		FALLTHROUGH;
 	case SCOLS_FMT_EXPORT:
 	{
 		struct libscols_column *cl;

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -866,7 +866,7 @@ static void process_wtmp_file(const struct last_control *ctl,
 					c = whydown;
 				quit = list(ctl, &ut, lastboot, c);
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 
 		case DEAD_PROCESS:
 			/*

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -1208,13 +1208,13 @@ static struct libscols_table *setup_table(struct lslogins_control *ctl)
 		break;
 	case OUT_NEWLINE:
 		scols_table_set_column_separator(table, "\n");
-		/* fallthrough */
+		FALLTHROUGH;
 	case OUT_EXPORT:
 		scols_table_enable_export(table, 1);
 		break;
 	case OUT_NUL:
 		scols_table_set_line_separator(table, "\0");
-		/* fallthrough */
+		FALLTHROUGH;
 	case OUT_RAW:
 		scols_table_enable_raw(table, 1);
 		break;

--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -1154,7 +1154,7 @@ int su_main(int argc, char **argv, int mode)
 				errx(EXIT_FAILURE, _("no command was specified"));
 			break;
 		}
-		/* fallthrough */
+		FALLTHROUGH;
 	case SU_MODE:
 		if (optind < argc)
 			su->new_user = argv[optind++];

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -401,11 +401,11 @@ static void tcfinal(struct console *con)
 		break;
 	case 1:				/* odd parity */
 		tio->c_cflag |= PARODD;
-		/* fallthrough */
+		FALLTHROUGH;
 	case 2:				/* even parity */
 		tio->c_cflag |= PARENB;
 		tio->c_iflag |= (INPCK | ISTRIP);
-		/* fallthrough */
+		FALLTHROUGH;
 	case (1 | 2):			/* no parity bit */
 		tio->c_cflag &= ~CSIZE;
 		tio->c_cflag |= CS7;
@@ -796,7 +796,7 @@ static char *getpasswd(struct console *con)
 			switch (errno) {
 			case EIO:
 				con->flags |= CON_EIO;
-				/* fallthrough */
+				FALLTHROUGH;
 			default:
 				warn(_("cannot read %s"), con->tty);
 				break;
@@ -1241,7 +1241,7 @@ int main(int argc, char **argv)
 			exit(0);
 		case -1:
 			warn(_("fork failed"));
-			/* fallthrough */
+			FALLTHROUGH;
 		default:
 			break;
 		}

--- a/lsfd-cmd/bdev.c
+++ b/lsfd-cmd/bdev.c
@@ -70,7 +70,7 @@ static bool bdev_fill_column(struct proc *proc __attribute__((__unused__)),
 				  minor(file->stat.st_rdev));
 			break;
 		}
-		/* FALL THROUGH */
+		FALLTHROUGH;
 	case COL_MAJMIN:
 		xasprintf(&str, "%u:%u",
 			  major(file->stat.st_rdev),

--- a/lsfd-cmd/cdev.c
+++ b/lsfd-cmd/cdev.c
@@ -307,7 +307,7 @@ static bool cdev_generic_fill_column(struct proc *proc  __attribute__((__unused_
 				  minor(file->stat.st_rdev));
 			return true;
 		}
-		/* FALL THROUGH */
+		FALLTHROUGH;
 	case COL_MAJMIN:
 		xasprintf(str, "%u:%u",
 			  major(file->stat.st_rdev),

--- a/lsfd-cmd/file.c
+++ b/lsfd-cmd/file.c
@@ -148,7 +148,7 @@ static bool abst_fill_column(struct proc *proc,
 	case COL_FD:
 		if (!is_opened_file(file))
 			return false;
-		/* FALL THROUGH */
+		FALLTHROUGH;
 	case COL_ASSOC:
 		if (is_opened_file(file))
 			xasprintf(&str, "%d", file->association);
@@ -432,7 +432,7 @@ static bool file_fill_column(struct proc *proc __attribute__((__unused__)),
 				return true;
 			}
 		}
-		/* FALL THROUGH */
+		FALLTHROUGH;
 	case COL_KNAME:
 		if (file->name
 		    && scols_line_set_data(ln, column_index, file->name))

--- a/lsfd-cmd/sock-xinfo.c
+++ b/lsfd-cmd/sock-xinfo.c
@@ -1157,7 +1157,7 @@ static bool tcp_get_listening(struct sock_xinfo *sock_xinfo,
 			n = class->get_addr(l4, L4_LOCAL);		\
 			has_laddr = true;				\
 			p = tcp->local_port;				\
-			/* FALL THROUGH */				\
+			FALLTHROUGH;					\
 		case COL_##L4##_RADDR:					\
 			if (!has_laddr) {				\
 				n = class->get_addr(l4, L4_REMOTE);	\
@@ -1173,7 +1173,7 @@ static bool tcp_get_listening(struct sock_xinfo *sock_xinfo,
 		case COL_##L4##_LPORT:					\
 			p = tcp->local_port;				\
 			has_lport = true;				\
-			/* FALL THROUGH */				\
+			FALLTHROUGH;					\
 		case COL_##L4##_RPORT:					\
 			if (!has_lport)					\
 				p = tcp->remote_port;			\

--- a/lsfd-cmd/sock.c
+++ b/lsfd-cmd/sock.c
@@ -69,7 +69,7 @@ static bool sock_fill_column(struct proc *proc __attribute__((__unused__)),
 	case COL_TYPE:
 		if (!sock->protoname)
 			return false;
-		/* FALL THROUGH */
+		FALLTHROUGH;
 	case COL_SOCK_PROTONAME:
 		if (sock->protoname)
 			if (scols_line_set_data(ln, column_index, sock->protoname))

--- a/lsfd-cmd/unkn.c
+++ b/lsfd-cmd/unkn.c
@@ -99,7 +99,7 @@ static bool unkn_fill_column(struct proc *proc,
 	case COL_TYPE:
 		if (!unkn->anon_ops)
 			return false;
-		/* FALL THROUGH */
+		FALLTHROUGH;
 	case COL_AINODECLASS:
 		if (unkn->anon_ops) {
 			str = anon_get_class(unkn);

--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -485,7 +485,7 @@ int main(int argc, char **argv)
 		ctl.req.day = strtos32_or_err(*argv++, _("illegal day value"));
 		if (ctl.req.day < 1 || DAYS_IN_MONTH < ctl.req.day)
 			errx(EXIT_FAILURE, _("illegal day value: use 1-%d"), DAYS_IN_MONTH);
-		/* fallthrough */
+		FALLTHROUGH;
 	case 2:
 		if (isdigit(**argv))
 			ctl.req.month = strtos32_or_err(*argv++, _("illegal month value: use 1-12"));
@@ -497,7 +497,7 @@ int main(int argc, char **argv)
 		}
 		if (ctl.req.month < 1 || MONTHS_IN_YEAR < ctl.req.month)
 			errx(EXIT_FAILURE, _("illegal month value: use 1-12"));
-		/* fallthrough */
+		FALLTHROUGH;
 	case 1:
 		ctl.req.year = strtos32_or_err(*argv++, _("illegal year value"));
 		if (ctl.req.year < SMALLEST_YEAR)

--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -529,7 +529,7 @@ int main(int argc, char ** argv)
 			case COL_RES:
 				if (!ctl.bytes)
 					break;
-				/* fallthrough */
+				FALLTHROUGH;
 			default:
 				scols_column_set_json_type(cl, SCOLS_JSON_NUMBER);
 				break;

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -638,7 +638,7 @@ static char *get_data(struct libmnt_fs *fs, int num, size_t *datasiz, struct fin
 		if (str)
 			break;
 
-		/* fallthrough */
+		FALLTHROUGH;
 	case COL_SOURCE:
 	{
 		const char *root = mnt_fs_get_root(fs);
@@ -1493,7 +1493,7 @@ static int get_column_json_type(int id, int scols_flags, int *multi, unsigned in
 			*multi = 1;
 		if (!(findmnt_flags & FL_BYTES))
 			break;
-		/* fallthrough */
+		FALLTHROUGH;
 	case COL_ID:
 	case COL_UNIQ_ID:
 	case COL_PARENT:
@@ -1982,7 +1982,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'M':
 			findmnt.flags |= FL_STRICTTARGET;
-			/* fallthrough */
+			FALLTHROUGH;
 		case 'T':
 			set_match(COL_TARGET, optarg);
 			findmnt.flags |= FL_NOSWAPMATCH;

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -2224,7 +2224,7 @@ static void set_column_type(const struct colinfo *ci, struct libscols_column *cl
 		/* See init_scols_filter(), it may overwrite the type */
 		if (!lsblk->bytes)
 			break;
-		/* fallthrough */
+		FALLTHROUGH;
 	case COLTYPE_NUM:
 		scols_column_set_json_type(cl, SCOLS_JSON_NUMBER);
 		scols_column_set_data_type(cl, SCOLS_DATA_U64);

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -722,7 +722,7 @@ static int get_json_type_for_column(int column_id, int representing_in_bytes)
 	case COL_SIZE:
 		if (!representing_in_bytes)
 			return SCOLS_JSON_STRING;
-		/* fallthrough */
+		FALLTHROUGH;
 	case COL_PID:
 	case COL_START:
 	case COL_END:

--- a/schedutils/uclampset.c
+++ b/schedutils/uclampset.c
@@ -268,7 +268,7 @@ int main(int argc, char **argv)
 			break;
 		case 'V':
 			print_version(EXIT_SUCCESS);
-			/* fallthrough */
+			FALLTHROUGH;
 		case 'h':
 			usage();
 		default:

--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -1928,7 +1928,7 @@ int main(int argc, char *argv[])
 			;
 		else
 			break;
-		/* fallthrough */
+		FALLTHROUGH;
 	case SYSLOG_ACTION_CLEAR:
 		if (klogctl(SYSLOG_ACTION_CLEAR, NULL, 0) < 0)
 			err(EXIT_FAILURE, _("clear kernel buffer failed"));

--- a/sys-utils/flock.c
+++ b/sys-utils/flock.c
@@ -405,7 +405,7 @@ int main(int argc, char *argv[])
 				if (open_flags & O_RDWR)
 					break;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		default:
 			/* Other errors */
 			if (filename)

--- a/sys-utils/ipcrm.c
+++ b/sys-utils/ipcrm.c
@@ -448,7 +448,7 @@ int main(int argc, char **argv)
 				ret++;
 				break;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		case 'm':
 			if (!iskey)
 				id = strtos32_or_err(optarg, _("failed to parse argument"));
@@ -462,7 +462,7 @@ int main(int argc, char **argv)
 				ret++;
 				break;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		case 'q':
 			if (!iskey)
 				id = strtos32_or_err(optarg, _("failed to parse argument"));
@@ -476,7 +476,7 @@ int main(int argc, char **argv)
 				ret++;
 				break;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		case 's':
 			if (!iskey)
 				id = strtos32_or_err(optarg, _("failed to parse argument"));

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -403,7 +403,7 @@ static struct libscols_table *new_table(struct lsipc_control *ctl)
 	switch(ctl->outmode) {
 	case OUT_NEWLINE:
 		scols_table_set_column_separator(table, "\n");
-		/* fallthrough */
+		FALLTHROUGH;
 	case OUT_EXPORT:
 		scols_table_enable_export(table, 1);
 		break;

--- a/sys-utils/lsmem.c
+++ b/sys-utils/lsmem.c
@@ -725,7 +725,7 @@ int main(int argc, char **argv)
 			case COL_SIZE:
 				if (!lsmem->bytes)
 					break;
-				/* fallthrough */
+				FALLTHROUGH;
 			case COL_NODE:
 				scols_column_set_json_type(cl, SCOLS_JSON_NUMBER);
 				break;

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -2265,7 +2265,7 @@ static char *get_logname(struct issue *ie, struct options *op, struct termios *t
 				break;
 			case CTL('U'):
 				cp->kill = ascval;		/* set kill character */
-				/* fallthrough */
+				FALLTHROUGH;
 			case CTL('C'):
 				if (key == CTL('C') && !(op->flags & F_VCONSOLE))
 					/* Ignore CTRL+C on serial line */
@@ -2375,12 +2375,12 @@ static void termio_final(struct options *op, struct termios *tp, struct chardata
 	case 1:
 		/* odd parity */
 		tp->c_cflag |= PARODD;
-		/* fallthrough */
+		FALLTHROUGH;
 	case 2:
 		/* even parity */
 		tp->c_cflag |= PARENB;
 		tp->c_iflag |= INPCK | ISTRIP;
-		/* fallthrough */
+		FALLTHROUGH;
 	case (1 | 2):
 		/* no parity bit */
 		tp->c_cflag &= ~CSIZE;

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -712,9 +712,9 @@ static int callback_log_signal(void *data, struct signalfd_siginfo *info, void *
 		break;
 	}
 	case SIGTERM:
-		/* fallthrough */
+		FALLTHROUGH;
 	case SIGINT:
-		/* fallthrough */
+		FALLTHROUGH;
 	case SIGQUIT:
 		ssz = log_signal(ctl, info->ssi_signo, NULL);
 		break;

--- a/text-utils/hexdump-parse.c
+++ b/text-utils/hexdump-parse.c
@@ -355,7 +355,7 @@ isint:				cs[3] = '\0';
 					case 'A':
 						endfu = fu;
 						fu->flags |= F_IGNORE;
-						/* fallthrough */
+						FALLTHROUGH;
 					case 'a':
 						pr->flags = F_ADDRESS;
 						++p2;

--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -1037,7 +1037,7 @@ static void ttyin(struct more_control *ctl, char buf[], int nmax, char pchar)
 						case (size_t)-2:
 						case (size_t)-1:
 							state = state_bak;
-							/* fallthrough */
+							FALLTHROUGH;
 						case 0:
 							mblength = 1;
 						}
@@ -1172,7 +1172,7 @@ static void expand(struct more_control *ctl, char *inbuf)
 				*outstr++ = *inpstr++;
 				break;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		default:
 			*outstr++ = c;
 		}
@@ -1793,7 +1793,7 @@ static int more_key_command(struct more_control *ctl, char *filename)
 				break;
 			}
 			search_again = 1;
-			/* fallthrough */
+			FALLTHROUGH;
 		case more_kc_search:
 			if (cmd.number == 0)
 				cmd.number++;
@@ -1860,7 +1860,7 @@ static int more_key_command(struct more_control *ctl, char *filename)
 				execute_editor(ctl, cmdbuf, sizeof(cmdbuf), filename);
 				break;
 			}
-			/* fallthrough */
+			FALLTHROUGH;
 		default:
 			if (ctl->suppress_bell) {
 				erase_to_col(ctl, 0);

--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -658,7 +658,7 @@ static void prompt(long long pageno)
 					break;
 				case SEARCH_FIN:
 					state = SEARCH;
-					/* fallthrough */
+					FALLTHROUGH;
 				case SEARCH:
 					if (cmd.cmdline[cmd.cmdlen - 1] == '\\') {
 						escape = 1;
@@ -737,7 +737,7 @@ static void prompt(long long pageno)
 					continue;
 				}
 				state = COUNT;
-				/* fallthrough */
+				FALLTHROUGH;
 			case COUNT:
 				break;
 			case ADDON_FIN:

--- a/text-utils/ul.c
+++ b/text-utils/ul.c
@@ -516,7 +516,7 @@ static void filter(struct ul_ctl *ctl, struct term_caps const *const tcs, FILE *
 			}
 			ctl->buf[ctl->column].c_char = '_';
 			ctl->buf[ctl->column].c_width = 1;
-			/* fallthrough */
+			FALLTHROUGH;
 		case ' ':
 			set_column(ctl, ctl->column + 1);
 			continue;
@@ -617,7 +617,7 @@ int main(int argc, char **argv)
 		break;
 	default:
 		warnx(_("trouble reading terminfo"));
-		/* fallthrough */
+		FALLTHROUGH;
 	case 0:
 		if (opt_terminal)
 			warnx(_("terminal `%s' is not known, defaulting to `dumb'"),


### PR DESCRIPTION
C23[1] and CPP17[2] introduced the 'fallthrough' attribute to let the compiler know that we're intentionally falling through a case statement. This suppress a warning with new compilers when doing an implicit fallthrough.

[1] https://en.cppreference.com/w/c/language/attributes/fallthrough
[2] https://en.cppreference.com/w/cpp/language/attributes/fallthrough