### PR TITLE
lsfd: scan the protocol field of /proc/net/packet as a hex number

### DIFF
--- a/lsfd-cmd/lsfd.1.adoc
+++ b/lsfd-cmd/lsfd.1.adoc
@@ -396,7 +396,7 @@ PACKET.IFACE <``string``>::
 Interface name associated with the packet socket.
 
 PACKET.PROTOCOL <``string``>::
-L3 protocol associated with the packet socket.
+L2 protocol associated with the packet socket.
 
 PARTITION <``string``>::
 Block device name resolved by `/proc/partition`.

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -311,7 +311,7 @@ static const struct colinfo infos[] = {
 				   N_("net interface associated with the packet socket") },
 	[COL_PACKET_PROTOCOL]  = { "PACKET.PROTOCOL",
 				   0,   SCOLS_FL_RIGHT,SCOLS_JSON_STRING,
-				   N_("L3 protocol associated with the packet socket") },
+				   N_("L2 protocol associated with the packet socket") },
 	[COL_PARTITION]        = { "PARTITION",
 				   0,   SCOLS_FL_RIGHT, SCOLS_JSON_STRING,
 				   N_("block device name resolved by /proc/partition") },

--- a/lsfd-cmd/sock-xinfo.c
+++ b/lsfd-cmd/sock-xinfo.c
@@ -2477,7 +2477,7 @@ static void load_xinfo_from_proc_packet(ino_t netns_inode)
 		unsigned long inode;
 		struct packet_xinfo *pkt;
 
-		if (sscanf(line, "%*x %*d %" SCNu16 " %" SCNu16 " %u %*d %*d %*d %lu",
+		if (sscanf(line, "%*x %*d %" SCNu16 " %" SCNx16 " %u %*d %*d %*d %lu",
 			   &type, &protocol, &iface, &inode) < 4)
 			continue;
 

--- a/tests/expected/lsfd/mkfds-mapped-packet-socket
+++ b/tests/expected/lsfd/mkfds-mapped-packet-socket
@@ -1,8 +1,8 @@
 PACKET
 SOCK.PROTONAME: 0
-type=raw protocol=all iface=lo raw PACKET lo all
+type=raw protocol=ppptalk iface=lo raw PACKET lo ppptalk
 NAME,SOCK.TYPE,SOCK.PROTONAME,PACKET.IFACE,PACKET.PROTOCOL: 0
 PACKET
 SOCK.PROTONAME: 0
-type=dgram protocol=all iface=lo dgram PACKET lo all
+type=dgram protocol=ppptalk iface=lo dgram PACKET lo ppptalk
 NAME,SOCK.TYPE,SOCK.PROTONAME,PACKET.IFACE,PACKET.PROTOCOL: 0

--- a/tests/ts/lsfd/mkfds-mapped-packet-socket
+++ b/tests/ts/lsfd/mkfds-mapped-packet-socket
@@ -35,11 +35,12 @@ FD=3
 EXPR=
 INTERFACE=lo
 SOCKTYPE=
+PROTOCOL=$(printf "%d" 0x10)
 ERR=
 
 for SOCKTYPE in RAW DGRAM; do
     coproc MKFDS { "$TS_HELPER_MKFDS" mapped-packet-socket $FD \
-				      interface=${INTERFACE} socktype=${SOCKTYPE}; }
+				      interface=${INTERFACE} socktype=${SOCKTYPE} protocol=${PROTOCOL}; }
     if read -u ${MKFDS[0]} PID; then
 	EXPR='(ASSOC == "shm") and (STTYPE == "SOCK") and (MODE == "-w-")'
 	${TS_CMD_LSFD} -p "$PID" -n -o SOCK.PROTONAME -Q "${EXPR}"


### PR DESCRIPTION
The original code read the protocol field of /proc/net/packet as a decimal number.