### PR TITLE
treewide: avoid strcasecmp() for ASCII-only strings

### DIFF
--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -53,6 +53,7 @@
 #endif
 
 #include "c.h"
+#include "cctype.h"
 #include "closestream.h"
 #include "nls.h"
 #include "widechar.h"
@@ -2507,7 +2508,7 @@ static int main_menu_action(struct cfdisk *cf, int key)
 			  buf, sizeof(buf));
 
 		ref = 1;
-		if (rc <= 0 || (strcasecmp(buf, "yes") != 0 &&
+		if (rc <= 0 || (c_strcasecmp(buf, "yes") != 0 &&
 				strcasecmp(buf, _("yes")) != 0)) {
 			info = _("Did not write partition table to disk.");
 			break;

--- a/disk-utils/fdisk-list.h
+++ b/disk-utils/fdisk-list.h
@@ -11,6 +11,8 @@
 #ifndef UTIL_LINUX_FDISK_LIST_H
 #define UTIL_LINUX_FDISK_LIST_H
 
+#include "cctype.h"
+
 extern void list_disklabel(struct fdisk_context *cxt);
 extern void list_disk_identifier(struct fdisk_context *cxt);
 extern void list_disk_geometry(struct fdisk_context *cxt);
@@ -51,7 +53,7 @@ static inline int wipemode_from_string(const char *str)
 		return -EINVAL;
 
 	for (i = 0; i < ARRAY_SIZE(modes); i++) {
-		if (strcasecmp(str, modes[i]) == 0)
+		if (c_strcasecmp(str, modes[i]) == 0)
 			return i;
 	}
 

--- a/disk-utils/partx.c
+++ b/disk-utils/partx.c
@@ -162,7 +162,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < NCOLS; i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/include/cctype.h
+++ b/include/cctype.h
@@ -23,6 +23,9 @@
 #ifndef UTIL_LINUX_CCTYPE_H
 #define UTIL_LINUX_CCTYPE_H
 
+#include <stddef.h>
+#include <limits.h>
+
 /**
  * The functions defined in this file assume the "C" locale and a character
  * set without diacritics (ASCII-US or EBCDIC-US or something like that).
@@ -317,38 +320,54 @@ static inline int c_toupper (int c)
 	}
 }
 
+#define C_CTYPE_CMP(c1, c2)	(((c1) > (c2)) - ((c1) < (c2)))
+
 static inline int c_strncasecmp(const char *a, const char *b, size_t n)
 {
-	int res = 0;
+	const unsigned char *p1 = (const unsigned char *) a;
+	const unsigned char *p2 = (const unsigned char *) b;
+	unsigned char x, y;
 
-        for (; n > 0; a++, b++, n--) {
-		unsigned int x = (unsigned int) *a;
-		unsigned int y = (unsigned int) *b;
+	if (n == 0 || p1 == p2)
+		return 0;
 
-		res = c_tolower(x) - c_tolower(y);
-                if (res)
-                        break;
-        }
-        return res;
+	do {
+		x = c_tolower(*p1);
+		y = c_tolower(*p2);
+
+		if (--n == 0 || x == '\0')
+			break;
+		++p1, ++p2;
+	} while (x == y);
+
+	if (UCHAR_MAX <= INT_MAX)
+		return x - y;
+
+	return C_CTYPE_CMP(x, y);
 }
 
 static inline int c_strcasecmp(const char *a, const char *b)
 {
-	int res = 0;
+	const unsigned char *p1 = (const unsigned char *) a;
+	const unsigned char *p2 = (const unsigned char *) b;
+	unsigned char x, y;
 
-	if (a == b)
+	if (p1 == p2)
 		return 0;
 
-	for (; *a != '\0'; a++, b++) {
-		unsigned int x = (unsigned int) *a;
-		unsigned int y = (unsigned int) *b;
+	do {
+		x = c_tolower(*p1);
+		y = c_tolower(*p2);
 
-		res = c_tolower(x) - c_tolower(y);
-		if (res)
+		if (x == '\0')
 			break;
-	}
+		++p1, ++p2;
+	} while (x == y);
 
-	return res;
+	if (UCHAR_MAX <= INT_MAX)
+		return x - y;
+
+	return C_CTYPE_CMP(x, y);
 }
 
 #endif /* UTIL_LINUX_CCTYPE_H */

--- a/lib/blkdev.c
+++ b/lib/blkdev.c
@@ -35,6 +35,7 @@
 #include "all-io.h"
 #include "blkdev.h"
 #include "c.h"
+#include "cctype.h"
 #include "linux_version.h"
 #include "fileutils.h"
 #include "nls.h"
@@ -384,14 +385,14 @@ int blkdev_lock(int fd, const char *devname, const char *lockmode)
 	if (!lockmode)
 		return 0;
 
-	if (strcasecmp(lockmode, "yes") == 0 ||
+	if (c_strcasecmp(lockmode, "yes") == 0 ||
 	    strcmp(lockmode, "1") == 0)
 		oper = LOCK_EX;
 
-	else if (strcasecmp(lockmode, "nonblock") == 0)
+	else if (c_strcasecmp(lockmode, "nonblock") == 0)
 		oper = LOCK_EX | LOCK_NB;
 
-	else if (strcasecmp(lockmode, "no") == 0 ||
+	else if (c_strcasecmp(lockmode, "no") == 0 ||
 		 strcmp(lockmode, "0") == 0)
 		return 0;
 	else {

--- a/lib/colors.c
+++ b/lib/colors.c
@@ -32,6 +32,7 @@
 #endif
 
 #include "c.h"
+#include "cctype.h"
 #include "colors.h"
 #include "pathnames.h"
 #include "strutils.h"
@@ -744,7 +745,7 @@ int colormode_from_string(const char *str)
 	assert(ARRAY_SIZE(modes) == __UL_NCOLORMODES);
 
 	for (i = 0; i < ARRAY_SIZE(modes); i++) {
-		if (strcasecmp(str, modes[i]) == 0)
+		if (c_strcasecmp(str, modes[i]) == 0)
 			return i;
 	}
 

--- a/lib/logindefs.c
+++ b/lib/logindefs.c
@@ -32,6 +32,7 @@
 #include <pwd.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "closestream.h"
 #include "logindefs.h"
 #include "nls.h"
@@ -171,7 +172,7 @@ static struct item *search(const char *name)
 
 	ptr = list;
 	while (ptr != NULL) {
-		if (strcasecmp(name, ptr->name) == 0)
+		if (c_strcasecmp(name, ptr->name) == 0)
 			return ptr;
 		ptr = ptr->next;
 	}
@@ -185,7 +186,7 @@ static const char *search_config(const char *name)
 
 	ptr = list;
 	while (ptr != NULL) {
-		if (strcasecmp(name, ptr->name) == 0)
+		if (c_strcasecmp(name, ptr->name) == 0)
 			return ptr->path;
 		ptr = ptr->next;
 	}
@@ -196,7 +197,7 @@ static const char *search_config(const char *name)
 int getlogindefs_bool(const char *name, int dflt)
 {
 	struct item *ptr = search(name);
-	return ptr && ptr->value ? (strcasecmp(ptr->value, "yes") == 0) : dflt;
+	return ptr && ptr->value ? (c_strcasecmp(ptr->value, "yes") == 0) : dflt;
 }
 
 unsigned long getlogindefs_num(const char *name, unsigned long dflt)

--- a/lib/match.c
+++ b/lib/match.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "match.h"
+#include "cctype.h"
 
 /*
  * match_fstype:
@@ -39,10 +40,10 @@ int match_fstype(const char *type, const char *pattern)
 	len = strlen(type);
 	p = pattern;
 	while(1) {
-		if (!strncmp(p, "no", 2) && !strncasecmp(p+2, type, len) &&
+		if (!strncmp(p, "no", 2) && !c_strncasecmp(p+2, type, len) &&
 		    (p[len+2] == 0 || p[len+2] == ','))
 			return 0;
-		if (strncasecmp(p, type, len) == 0 && (p[len] == 0 || p[len] == ','))
+		if (c_strncasecmp(p, type, len) == 0 && (p[len] == 0 || p[len] == ','))
 			return !no;
 		p = strchr(p,',');
 		if (!p)

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "pathnames.h"
 #include "sysfs.h"
 #include "fileutils.h"
@@ -576,7 +577,7 @@ int sysfs_blkdev_get_wholedisk(	struct path_cxt *pc,
 	tmp = uuid;
 	prefix = uuid ? strsep(&tmp, "-") : NULL;
 
-        if (prefix && strncasecmp(prefix, "part", 4) == 0)
+        if (prefix && c_strncasecmp(prefix, "part", 4) == 0)
             is_part = 1;
         free(uuid);
 

--- a/libblkid/src/config.c
+++ b/libblkid/src/config.c
@@ -29,6 +29,7 @@
 
 #include "blkidP.h"
 #include "env.h"
+#include "cctype.h"
 
 static int parse_evaluate(struct blkid_config *conf, char *s)
 {
@@ -94,7 +95,7 @@ static int parse_next(FILE *fd, struct blkid_config *conf)
 
 	if (!strncmp(s, "SEND_UEVENT=", 12)) {
 		s += 12;
-		if (*s && !strcasecmp(s, "yes"))
+		if (*s && !c_strcasecmp(s, "yes"))
 			conf->uevent = TRUE;
 		else if (*s)
 			conf->uevent = FALSE;

--- a/libblkid/src/partitions/partitions.c
+++ b/libblkid/src/partitions/partitions.c
@@ -23,6 +23,7 @@
 #include "partitions.h"
 #include "sysfs.h"
 #include "strutils.h"
+#include "cctype.h"
 
 /**
  * SECTION: partitions
@@ -1044,7 +1045,7 @@ blkid_partition blkid_partlist_devno_to_partition(blkid_partlist ls, dev_t devno
 			tmp = uuid;
 			prefix = uuid ? strsep(&tmp, "-") : NULL;
 
-			if (prefix && strncasecmp(prefix, "part", 4) == 0) {
+			if (prefix && c_strncasecmp(prefix, "part", 4) == 0) {
 				char *end = NULL;
 
 				errno = 0;

--- a/libfdisk/src/context.c
+++ b/libfdisk/src/context.c
@@ -2,6 +2,7 @@
 # include <blkid.h>
 #endif
 
+#include "cctype.h"
 #include "blkdev.h"
 #ifdef __linux__
 # include "partx.h"
@@ -168,9 +169,9 @@ struct fdisk_context *fdisk_new_nested_context(struct fdisk_context *parent,
 	}
 
 	if (name) {
-		if (strcasecmp(name, "bsd") == 0)
+		if (c_strcasecmp(name, "bsd") == 0)
 			lb = cxt->labels[ cxt->nlabels++ ] = fdisk_new_bsd_label(cxt);
-		else if (strcasecmp(name, "dos") == 0 || strcasecmp(name, "mbr") == 0)
+		else if (c_strcasecmp(name, "dos") == 0 || c_strcasecmp(name, "mbr") == 0)
 			lb = cxt->labels[ cxt->nlabels++ ] = fdisk_new_dos_label(cxt);
 	}
 
@@ -227,12 +228,12 @@ struct fdisk_label *fdisk_get_label(struct fdisk_context *cxt, const char *name)
 	if (!name)
 		return cxt->label;
 
-	if (strcasecmp(name, "mbr") == 0)
+	if (c_strcasecmp(name, "mbr") == 0)
 		name = "dos";
 
 	for (i = 0; i < cxt->nlabels; i++)
 		if (cxt->labels[i]
-		    && strcasecmp(cxt->labels[i]->name, name) == 0)
+		    && c_strcasecmp(cxt->labels[i]->name, name) == 0)
 			return cxt->labels[i];
 
 	DBG(CXT, ul_debugobj(cxt, "failed to found %s label driver", name));

--- a/libfdisk/src/label.c
+++ b/libfdisk/src/label.c
@@ -1,5 +1,6 @@
 
 #include "fdiskP.h"
+#include "cctype.h"
 
 
 /**
@@ -236,7 +237,7 @@ const struct fdisk_field *fdisk_label_get_field_by_name(
 	assert(name);
 
 	for (i = 0; i < lb->nfields; i++) {
-		if (lb->fields[i].name && strcasecmp(lb->fields[i].name, name) == 0)
+		if (lb->fields[i].name && c_strcasecmp(lb->fields[i].name, name) == 0)
 			return &lb->fields[i];
 	}
 

--- a/libfdisk/src/parttype.c
+++ b/libfdisk/src/parttype.c
@@ -2,6 +2,7 @@
 #include <ctype.h>
 
 #include "fdiskP.h"
+#include "cctype.h"
 #include "strutils.h"
 
 /**
@@ -264,7 +265,7 @@ struct fdisk_parttype *fdisk_label_get_parttype_from_string(
 
 	for (i = 0; i < lb->nparttypes; i++)
 		if (lb->parttypes[i].typestr
-		    && strcasecmp(lb->parttypes[i].typestr, str) == 0)
+		    && c_strcasecmp(lb->parttypes[i].typestr, str) == 0)
 			return (struct fdisk_parttype *)&lb->parttypes[i];
 
 	return NULL;

--- a/libfdisk/src/script.c
+++ b/libfdisk/src/script.c
@@ -1,4 +1,5 @@
 
+#include "cctype.h"
 #include "fdiskP.h"
 #include "strutils.h"
 #include "carefulputc.h"
@@ -239,7 +240,7 @@ static struct fdisk_scriptheader *script_get_header(struct fdisk_script *dp,
 	list_for_each(p, &dp->headers) {
 		struct fdisk_scriptheader *fi = list_entry(p, struct fdisk_scriptheader, headers);
 
-		if (strcasecmp(fi->name, name) == 0)
+		if (c_strcasecmp(fi->name, name) == 0)
 			return fi;
 	}
 
@@ -1165,41 +1166,41 @@ static int parse_line_nameval(struct fdisk_script *dp, char *s)
 		DBG(SCRIPT, ul_debugobj(dp, " parsing '%s'", p));
 		p = (char *) skip_blank(p);
 
-		if (!strncasecmp(p, "start=", 6)) {
+		if (!c_strncasecmp(p, "start=", 6)) {
 			p += 6;
 			rc = parse_start_value(dp, pa, &p);
 
-		} else if (!strncasecmp(p, "size=", 5)) {
+		} else if (!c_strncasecmp(p, "size=", 5)) {
 			p += 5;
 			rc = parse_size_value(dp, pa, &p);
 
-		} else if (!strncasecmp(p, "bootable", 8)) {
+		} else if (!c_strncasecmp(p, "bootable", 8)) {
 			/* we use next_token() to skip possible extra space */
 			char *tk = next_token(&p);
-			if (tk && strcasecmp(tk, "bootable") == 0)
+			if (tk && c_strcasecmp(tk, "bootable") == 0)
 				pa->boot = 1;
 			else
 				rc = -EINVAL;
 
-		} else if (!strncasecmp(p, "attrs=", 6)) {
+		} else if (!c_strncasecmp(p, "attrs=", 6)) {
 			p += 6;
 			free(pa->attrs);
 			rc = next_string(&p, &pa->attrs);
 
-		} else if (!strncasecmp(p, "uuid=", 5)) {
+		} else if (!c_strncasecmp(p, "uuid=", 5)) {
 			p += 5;
 			free(pa->uuid);
 			rc = next_string(&p, &pa->uuid);
 
-		} else if (!strncasecmp(p, "name=", 5)) {
+		} else if (!c_strncasecmp(p, "name=", 5)) {
 			p += 5;
 			free(pa->name);
 			rc = next_string(&p, &pa->name);
 			if (!rc)
 				unhexmangle_string(pa->name);
 
-		} else if (!strncasecmp(p, "type=", 5) ||
-			   !strncasecmp(p, "Id=", 3)) {		/* backward compatibility */
+		} else if (!c_strncasecmp(p, "type=", 5) ||
+			   !c_strncasecmp(p, "Id=", 3)) {		/* backward compatibility */
 			char *type = NULL;
 
 			fdisk_unref_parttype(pa->type);

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -2054,6 +2054,7 @@ int mnt_table_is_fs_mounted(struct libmnt_table *tb, struct libmnt_fs *fstab_fs)
 
 #ifdef TEST_PROGRAM
 #include "pathnames.h"
+#include "cctype.h"
 
 static int parser_errcb(struct libmnt_table *tb __attribute__((unused)),
 			const char *filename, int line)
@@ -2229,9 +2230,9 @@ static int test_find(struct libmnt_test *ts __attribute__((unused)),
 	mnt_table_set_cache(tb, mpc);
 	mnt_unref_cache(mpc);
 
-	if (strcasecmp(find, "source") == 0)
+	if (c_strcasecmp(find, "source") == 0)
 		fs = mnt_table_find_source(tb, what, dr);
-	else if (strcasecmp(find, "target") == 0)
+	else if (c_strcasecmp(find, "target") == 0)
 		fs = mnt_table_find_target(tb, what, dr);
 
 	if (!fs)

--- a/libsmartcols/src/filter-param.c
+++ b/libsmartcols/src/filter-param.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <regex.h>
 
+#include "cctype.h"
 #include "rpmatch.h"
 #include "smartcolsP.h"
 
@@ -627,8 +628,8 @@ static int string_cast(int type, struct filter_param *n)
 	case SCOLS_DATA_BOOLEAN:
 	{
 		bool x = str && *str
-			     && (strcasecmp(str, "1") == 0
-				 || strcasecmp(str, "true") == 0
+			     && (strcmp(str, "1") == 0
+				 || c_strcasecmp(str, "true") == 0
 				 || rpmatch(str) == RPMATCH_YES);
 		n->val.boolean = x;
 		break;

--- a/login-utils/chfn.c
+++ b/login-utils/chfn.c
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "env.h"
 #include "closestream.h"
 #include "islocal.h"
@@ -245,7 +246,7 @@ static char *ask_new_field(struct chfn_control *ctl, const char *question,
 			free(buf);
 			return xstrdup(def_val);
 		}
-		if (!strcasecmp(buf, "none")) {
+		if (!c_strcasecmp(buf, "none")) {
 			free(buf);
 			ctl->changed = 1;
 			return xstrdup("");

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -52,6 +52,7 @@
 #endif
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "closestream.h"
 #include "xalloc.h"
@@ -324,7 +325,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(coldescs); i++) {
 		const char *cn = coldescs[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -46,6 +46,7 @@
 #define PF_KTHREAD		0x00200000	/* I am a kernel thread */
 
 #include "c.h"
+#include "cctype.h"
 #include "list.h"
 #include "closestream.h"
 #include "column-list-table.h"
@@ -614,7 +615,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "closestream.h"
 #include "xalloc.h"
@@ -149,7 +150,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -44,6 +44,7 @@
 #include "nls.h"
 #include "closestream.h"
 #include "c.h"
+#include "cctype.h"
 #include "strutils.h"
 #include "xalloc.h"
 #include "optutils.h"
@@ -344,13 +345,13 @@ static int poll_action_name_to_id(const char *name, size_t namesz)
 {
 	int id = -1;
 
-	if (strncasecmp(name, "move", namesz) == 0 && namesz == 4)
+	if (c_strncasecmp(name, "move", namesz) == 0 && namesz == 4)
 		id = MNT_TABDIFF_MOVE;
-	else if (strncasecmp(name, "mount", namesz) == 0 && namesz == 5)
+	else if (c_strncasecmp(name, "mount", namesz) == 0 && namesz == 5)
 		id = MNT_TABDIFF_MOUNT;
-	else if (strncasecmp(name, "umount", namesz) == 0 && namesz == 6)
+	else if (c_strncasecmp(name, "umount", namesz) == 0 && namesz == 6)
 		id = MNT_TABDIFF_UMOUNT;
-	else if (strncasecmp(name, "remount", namesz) == 0 && namesz == 7)
+	else if (c_strncasecmp(name, "remount", namesz) == 0 && namesz == 7)
 		id = MNT_TABDIFF_REMOUNT;
 	else
 		warnx(_("unknown action: %s"), name);
@@ -396,7 +397,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = column_id_to_name(i);
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -56,6 +56,7 @@
 
 #include "all-io.h"
 #include "c.h"
+#include "cctype.h"
 #include "closestream.h"
 #include "nls.h"
 #include "pathnames.h"
@@ -220,7 +221,7 @@ static int decode(const char *name, const CODE *codetab)
 		return -1;
 	}
 	for (c = codetab; c->c_name; c++)
-		if (!strcasecmp(name, c->c_name))
+		if (!c_strcasecmp(name, c->c_name))
 			return (c->c_val);
 
 	return -1;

--- a/misc-utils/lsblk-properties.c
+++ b/misc-utils/lsblk-properties.c
@@ -6,6 +6,7 @@
 #endif
 
 #include "c.h"
+#include "cctype.h"
 #include "xalloc.h"
 #include "mangle.h"
 #include "path.h"
@@ -352,13 +353,13 @@ done:
 
 static int name2method(const char *name, size_t namesz)
 {
-	if (namesz == 4 && strncasecmp(name, "none", namesz) == 0)
+	if (namesz == 4 && c_strncasecmp(name, "none", namesz) == 0)
 		return LSBLK_METHOD_NONE;
-	if (namesz == 4 && strncasecmp(name, "udev", namesz) == 0)
+	if (namesz == 4 && c_strncasecmp(name, "udev", namesz) == 0)
 		return LSBLK_METHOD_UDEV;
-	if (namesz == 5 && strncasecmp(name, "blkid", namesz) == 0)
+	if (namesz == 5 && c_strncasecmp(name, "blkid", namesz) == 0)
 		return LSBLK_METHOD_BLKID;
-	if (namesz == 4 && strncasecmp(name, "file", namesz) == 0)
+	if (namesz == 4 && c_strncasecmp(name, "file", namesz) == 0)
 		return LSBLK_METHOD_FILE;
 
 	warnx(_("unknown properties probing method: %s"), name);
@@ -472,7 +473,7 @@ const char *lsblk_parttype_code_to_string(const char *code, const char *pttype)
 			const struct lsblk_parttype *t = &gpt_types[i];
 
 			if (t->name && t->typestr &&
-			    strcasecmp(code, t->typestr) == 0)
+			    c_strcasecmp(code, t->typestr) == 0)
 				return t->name;
 		}
 	}

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -40,6 +40,7 @@
 #include <blkid.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "pathnames.h"
 #include "blkdev.h"
 #include "canonicalize.h"
@@ -350,7 +351,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 
@@ -362,7 +363,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 		for (i = 0; i < ARRAY_SIZE(infos); i++) {
 			if (scols_shellvar_name(infos[i].name, &buf, &bufsz) != 0)
 				continue;
-			if (!strncasecmp(name, buf, namesz) && !*(buf + namesz)) {
+			if (!c_strncasecmp(name, buf, namesz) && !*(buf + namesz)) {
 				free(buf);
 				return i;
 			}
@@ -463,7 +464,7 @@ static char *get_type(struct lsblk_device *dev)
 
 			if (dm_uuid_prefix) {
 				/* kpartx hack to remove partition number */
-				if (strncasecmp(dm_uuid_prefix, "part", 4) == 0)
+				if (c_strncasecmp(dm_uuid_prefix, "part", 4) == 0)
 					dm_uuid_prefix[4] = '\0';
 
 				res = xstrdup(dm_uuid_prefix);

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -31,6 +31,7 @@
 #include <linux/rtc.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "strutils.h"
 #include "timeutils.h"
@@ -172,7 +173,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -43,6 +43,7 @@
 #include "xalloc.h"
 #include "strutils.h"
 #include "c.h"
+#include "cctype.h"
 #include "list.h"
 #include "closestream.h"
 #include "optutils.h"
@@ -552,7 +553,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/misc-utils/uuidparse.c
+++ b/misc-utils/uuidparse.c
@@ -48,6 +48,7 @@
 #include <uuid.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "closestream.h"
 #include "nls.h"
 #include "optutils.h"
@@ -118,7 +119,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/misc-utils/wipefs.c
+++ b/misc-utils/wipefs.c
@@ -40,6 +40,7 @@
 #include "all-io.h"
 #include "match.h"
 #include "c.h"
+#include "cctype.h"
 #include "closestream.h"
 #include "optutils.h"
 #include "blkdev.h"
@@ -126,7 +127,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/schedutils/ionice.c
+++ b/schedutils/ionice.c
@@ -19,6 +19,7 @@
 #include "nls.h"
 #include "strutils.h"
 #include "c.h"
+#include "cctype.h"
 #include "closestream.h"
 
 static int tolerant;
@@ -65,7 +66,7 @@ static int parse_ioclass(const char *str)
 	size_t i;
 
 	for (i = 0; i < ARRAY_SIZE(to_prio); i++)
-		if (!strcasecmp(str, to_prio[i]))
+		if (!c_strcasecmp(str, to_prio[i]))
 			return i;
 	return -1;
 }

--- a/sys-utils/chmem.c
+++ b/sys-utils/chmem.c
@@ -25,6 +25,7 @@
 #include <dirent.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "path.h"
 #include "strutils.h"
@@ -84,7 +85,7 @@ static int zone_name_to_id(const char *name)
 	size_t i;
 
 	for (i = 0; i < ARRAY_SIZE(zone_names); i++) {
-		if (!strcasecmp(name, zone_names[i]))
+		if (!c_strcasecmp(name, zone_names[i]))
 			return i;
 	}
 	return -1;
@@ -133,7 +134,7 @@ static int chmem_size(struct chmem_desc *desc, int enable, int zone_id)
 				zn = zone_names[zone_id];
 				if (enable && !strcasestr(line, zn))
 					continue;
-				if (!enable && strncasecmp(line, zn, strlen(zn)) != 0)
+				if (!enable && c_strncasecmp(line, zn, strlen(zn)) != 0)
 					continue;
 			} else if (enable) {
 				/* By default, use zone Movable for online, if valid */
@@ -218,7 +219,7 @@ static int chmem_range(struct chmem_desc *desc, int enable, int zone_id)
 					warnx(_("%s enable failed: Zone mismatch"), str);
 					continue;
 				}
-				if (!enable && strncasecmp(line, zn, strlen(zn)) != 0) {
+				if (!enable && c_strncasecmp(line, zn, strlen(zn)) != 0) {
 					warnx(_("%s disable failed: Zone mismatch"), str);
 					continue;
 				}

--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "colors.h"
 #include "nls.h"
 #include "strutils.h"
@@ -460,7 +461,7 @@ static int parse_level(const char *str, size_t len)
 		for (i = 0; i < ARRAY_SIZE(level_names); i++) {
 			const char *n = level_names[i].name;
 
-			if (strncasecmp(str, n, len) == 0 && *(n + len) == '\0')
+			if (c_strncasecmp(str, n, len) == 0 && *(n + len) == '\0')
 				return i + offset;
 		}
 	}
@@ -498,7 +499,7 @@ static int parse_facility(const char *str, size_t len)
 		for (i = 0; i < ARRAY_SIZE(facility_names); i++) {
 			const char *n = facility_names[i].name;
 
-			if (strncasecmp(str, n, len) == 0 && *(n + len) == '\0')
+			if (c_strncasecmp(str, n, len) == 0 && *(n + len) == '\0')
 				return i;
 		}
 	}

--- a/sys-utils/irq-common.c
+++ b/sys-utils/irq-common.c
@@ -25,6 +25,7 @@
 #include <libsmartcols.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "pathnames.h"
 #include "strutils.h"
@@ -89,7 +90,7 @@ int irq_column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);
@@ -405,13 +406,13 @@ static void sort_result(struct irq_output *out,
 
 void set_sort_func_by_name(struct irq_output *out, const char *name)
 {
-	if (strcasecmp(name, "IRQ") == 0)
+	if (c_strcasecmp(name, "IRQ") == 0)
 		out->sort_cmp_func = cmp_interrupts;
-	else if (strcasecmp(name, "TOTAL") == 0)
+	else if (c_strcasecmp(name, "TOTAL") == 0)
 		out->sort_cmp_func = cmp_total;
-	else if (strcasecmp(name, "DELTA") == 0)
+	else if (c_strcasecmp(name, "DELTA") == 0)
 		out->sort_cmp_func = cmp_delta;
-	else if (strcasecmp(name, "NAME") == 0)
+	else if (c_strcasecmp(name, "NAME") == 0)
 		out->sort_cmp_func = cmp_name;
 	else
 		errx(EXIT_FAILURE, _("unsupported column name to sort output"));

--- a/sys-utils/ldattach.c
+++ b/sys-utils/ldattach.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "all-io.h"
 #include "nls.h"
 #include "strutils.h"
@@ -152,7 +153,7 @@ static int lookup_table(const struct ld_table *tab, const char *str)
 	const struct ld_table *t;
 
 	for (t = tab; t && t->name; t++)
-		if (!strcasecmp(t->name, str))
+		if (!c_strcasecmp(t->name, str))
 			return t->value;
 	return -1;
 }

--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -26,6 +26,7 @@
 #include <libsmartcols.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "strutils.h"
 #include "loopdev.h"
@@ -124,7 +125,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/sys-utils/lscpu-riscv.c
+++ b/sys-utils/lscpu-riscv.c
@@ -12,6 +12,7 @@
 #include "lscpu.h"
 #include "strutils.h"
 #include "strv.h"
+#include "cctype.h"
 
 static int riscv_cmp_func(const void *a, const void *b)
 {
@@ -24,7 +25,7 @@ bool is_riscv(struct lscpu_cputype *ct)
 	size_t i;
 
 	for (i = 0; i < ARRAY_SIZE(base_isa); i++) {
-		if (!strncasecmp(ct->isa, base_isa[i], strlen(base_isa[i])))
+		if (!c_strncasecmp(ct->isa, base_isa[i], strlen(base_isa[i])))
 			return true;
 	}
 

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -29,6 +29,7 @@
 
 #include <libsmartcols.h>
 
+#include "cctype.h"
 #include "closestream.h"
 #include "optutils.h"
 #include "c_strtod.h"
@@ -186,7 +187,7 @@ cpu_column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(coldescs_cpu); i++) {
 		const char *cn = coldescs_cpu[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);
@@ -201,7 +202,7 @@ cache_column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(coldescs_cache); i++) {
 		const char *cn = coldescs_cache[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -35,6 +35,7 @@
 #include <libsmartcols.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "closestream.h"
 #include "strutils.h"
@@ -244,7 +245,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(coldescs); i++) {
 		const char *cn = coldescs[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz)) {
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz)) {
 			if (i > COL_CTIME) {
 				if (i >= LOWER && i <= UPPER)
 					return i;

--- a/sys-utils/lsmem.c
+++ b/sys-utils/lsmem.c
@@ -11,22 +11,25 @@
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  */
-#include <c.h>
-#include <nls.h>
-#include <path.h>
-#include <strutils.h>
-#include <closestream.h>
-#include <xalloc.h>
-#include <getopt.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <getopt.h>
+#include <stdbool.h>
 #include <dirent.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <assert.h>
-#include <optutils.h>
+
 #include <libsmartcols.h>
+
+#include "c.h"
+#include "cctype.h"
+#include "nls.h"
+#include "path.h"
+#include "strutils.h"
+#include "closestream.h"
+#include "xalloc.h"
+#include "optutils.h"
 
 #define _PATH_SYS_MEMORY		"/sys/devices/system/memory"
 
@@ -150,7 +153,7 @@ static int zone_name_to_id(const char *name)
 	size_t i;
 
 	for (i = 0; i < ARRAY_SIZE(zone_names); i++) {
-		if (!strcasecmp(name, zone_names[i]))
+		if (!c_strcasecmp(name, zone_names[i]))
 			return i;
 	}
 	return ZONE_UNKNOWN;
@@ -166,7 +169,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(coldescs); i++) {
 		const char *cn = coldescs[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);
@@ -737,7 +740,7 @@ int main(int argc, char **argv)
 		int split[ARRAY_SIZE(coldescs)] = { 0 };
 		static size_t nsplits = 0;
 
-		if (strcasecmp(splitarg, "none") == 0)
+		if (c_strcasecmp(splitarg, "none") == 0)
 			;
 		else if (string_add_to_idarray(splitarg, split, ARRAY_SIZE(split),
 					&nsplits, column_name_to_id) < 0)

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -42,6 +42,7 @@
 #include "nls.h"
 #include "xalloc.h"
 #include "c.h"
+#include "cctype.h"
 #include "widechar.h"
 #include "list.h"
 #include "closestream.h"
@@ -271,7 +272,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/sys-utils/prlimit.c
+++ b/sys-utils/prlimit.c
@@ -24,6 +24,7 @@
 #include <libsmartcols.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "xalloc.h"
 #include "strutils.h"
@@ -277,7 +278,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/sys-utils/rfkill.c
+++ b/sys-utils/rfkill.c
@@ -30,6 +30,7 @@
 #include <sys/time.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "closestream.h"
 #include "nls.h"
 #include "optutils.h"
@@ -156,7 +157,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/sys-utils/swapon.c
+++ b/sys-utils/swapon.c
@@ -29,6 +29,7 @@
 #include <libsmartcols.h>
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "bitops.h"
 #include "blkdev.h"
@@ -158,7 +159,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/sys-utils/wdctl.c
+++ b/sys-utils/wdctl.c
@@ -32,6 +32,7 @@
 
 #include "nls.h"
 #include "c.h"
+#include "cctype.h"
 #include "xalloc.h"
 #include "closestream.h"
 #include "optutils.h"
@@ -165,7 +166,7 @@ static long name2bit(const char *name, size_t namesz)
 
 	for (i = 0; i < ARRAY_SIZE(wdflags); i++) {
 		const char *cn = wdflags[i].name;
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return wdflags[i].flag;
 	}
 	warnx(_("unknown flag: %s"), name);
@@ -178,7 +179,7 @@ static int column2id(const char *name, size_t namesz)
 
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/sys-utils/zramctl.c
+++ b/sys-utils/zramctl.c
@@ -34,6 +34,7 @@
 #endif
 
 #include "c.h"
+#include "cctype.h"
 #include "nls.h"
 #include "closestream.h"
 #include "strutils.h"
@@ -155,7 +156,7 @@ static int column_name_to_id(const char *name, size_t namesz)
 	for (i = 0; i < ARRAY_SIZE(infos); i++) {
 		const char *cn = infos[i].name;
 
-		if (!strncasecmp(name, cn, namesz) && !*(cn + namesz))
+		if (!c_strncasecmp(name, cn, namesz) && !*(cn + namesz))
 			return i;
 	}
 	warnx(_("unknown column: %s"), name);

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -58,6 +58,7 @@
 #include "closestream.h"
 #include "nls.h"
 #include "c.h"
+#include "cctype.h"
 #include "ttyutils.h"
 #include "all-io.h"
 #include "monotonic.h"
@@ -864,9 +865,9 @@ int main(int argc, char **argv)
 			ctl.quiet = 1;
 			break;
 		case 'm':
-			if (strcasecmp(optarg, "classic") == 0)
+			if (c_strcasecmp(optarg, "classic") == 0)
 				format = SCRIPT_FMT_TIMING_SIMPLE;
-			else if (strcasecmp(optarg, "advanced") == 0)
+			else if (c_strcasecmp(optarg, "advanced") == 0)
 				format = SCRIPT_FMT_TIMING_MULTI;
 			else
 				errx(EXIT_FAILURE, _("unsupported logging format: '%s'"), optarg);

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -18,6 +18,7 @@
  */
 
 #include "c.h"
+#include "cctype.h"
 #include "xalloc.h"
 #include "test_mkfds.h"
 #include "exitcodes.h"
@@ -242,10 +243,10 @@ static union value boolean_read(const char *arg, const union value *defv)
 	if (!arg)
 		return *defv;
 
-	if (strcasecmp(arg, "true") == 0
+	if (c_strcasecmp(arg, "true") == 0
 	    || strcmp(arg, "1") == 0
-	    || strcasecmp(arg, "yes") == 0
-	    || strcasecmp(arg, "y") == 0)
+	    || c_strcasecmp(arg, "yes") == 0
+	    || c_strcasecmp(arg, "y") == 0)
 		r.boolean = true;
 	else
 		r.boolean = false;


### PR DESCRIPTION
See also https://github.com/util-linux/util-linux/issues/3490