### PR TITLE
treewide: fix optional arguments usage

### DIFF
--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -2600,6 +2600,8 @@ int main(int argc, char *argv[])
 			const char *subexpr = NULL;
 
 			ctl.sockets_only = 1;
+			if (optarg && *optarg == '=')
+				optarg++;
 			if (optarg == NULL)
 				subexpr = inet46_subexpr;
 			else if (strcmp(optarg, "4") == 0)

--- a/misc-utils/enosys.c
+++ b/misc-utils/enosys.c
@@ -207,6 +207,8 @@ int main(int argc, char **argv)
 			return EXIT_SUCCESS;
 		case 'd':
 			if (optarg) {
+				if (*optarg == '=')
+					optarg++;
 				dump = fopen(optarg, "w");
 				if (!dump)
 					err(EXIT_FAILURE, _("Could not open %s"), optarg);

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -627,9 +627,11 @@ static void parse_options(int argc, char **argv, struct uuidd_cxt_t *uuidd_cxt,
 		err_exclusive_options(c, longopts, excl, excl_st);
 		switch (c) {
 		case 'C':
-			if (optarg != NULL)
+			if (optarg) {
+				if (*optarg == '=')
+					optarg++;
 				uuidd_cxt->cont_clock_offset = parse_cont_clock(optarg);
-			else
+			} else
 				uuidd_cxt->cont_clock_offset = 7200; /* default 2h */
 			break;
 		case 'd':

--- a/misc-utils/wipefs.c
+++ b/misc-utils/wipefs.c
@@ -711,6 +711,8 @@ main(int argc, char **argv)
 			break;
 		case 'b':
 			if (optarg) {
+				if (*optarg == '=')
+					optarg++;
 				ctl.backup = optarg;
 			} else {
 				ctl.backup = getenv("HOME");

--- a/sys-utils/ipcrm.c
+++ b/sys-utils/ipcrm.c
@@ -498,6 +498,8 @@ int main(int argc, char **argv)
 		case 'a':
 			rm_all = 1;
 			if (optarg) {
+				if (*optarg == '=')
+					optarg++;
 				if (!strcmp(optarg, "shm"))
 					what_all = SHM;
 				else if (!strcmp(optarg, "pshm"))

--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -196,9 +196,11 @@ static void enable_namespace(int nstype, const char *path)
 {
 	struct namespace_file *nsfile = get_nsfile(nstype);
 
-	if (nsfile)
+	if (nsfile) {
+		if (path && *path == '=')	/* used in getopt_long() block */
+			path++;
 		enable_nsfile(nsfile, path);
-	else
+	} else
 		assert(nsfile);
 }
 
@@ -620,12 +622,16 @@ int main(int argc, char *argv[])
 				do_rd = true;
 			break;
 		case 'w':
-			if (optarg)
+			if (optarg) {
+				if (*optarg == '=')
+					optarg++;
 				open_target_fd(&wd_fd, "cwd", optarg);
-			else
+			} else
 				do_wd = true;
 			break;
 		case 'W':
+			if (optarg && *optarg == '=')
+				optarg++;
 			wdns = optarg;
 			break;
 		case 'e':


### PR DESCRIPTION
In some parts of the code, the optional argument handling is missing for cases where the argument starts with '='. This is particularly important for short options with optional arguments, as suggested by our man pages. The libc getopt_long() handles this for long options, but for short options, it's our responsibility.

Note that some argument parsing functions (mostly colormode_or_err()) already implement this, as they are usually used with optional arguments.