### PR TITLE
swapoff: fix memory_leak in do_swapoff

### DIFF
--- a/sys-utils/swapoff.c
+++ b/sys-utils/swapoff.c
@@ -110,7 +110,8 @@ static int do_swapoff(const char *orig_special, int quiet, int canonic)
 
 	if (!canonic) {
 		char *n, *v;
-
+		/* The mntcache is always used; see the main().
+		 * There is no need to free the memory allocated by mnt_resolve_spec.*/
 		special = mnt_resolve_spec(orig_special, mntcache);
 		if (!special && blkid_parse_tag_string(orig_special, &n, &v) == 0) {
 			special = swapoff_resolve_tag(n, v, mntcache);


### PR DESCRIPTION
A memory leak exists in the do_swapoff function. 
The mnt_resolve_spec function allocates memory for special (a pointer), but this memory is never freed afterward.
```
		special = mnt_resolve_spec(orig_special, mntcache);
```