### PR TITLE
disk-utils: add attribute nonstring to bfs byte arrays

### DIFF
--- a/disk-utils/mkfs.bfs.c
+++ b/disk-utils/mkfs.bfs.c
@@ -48,8 +48,8 @@ struct bfssb {
 	int32_t s_backup_from, s_backup_to;
 
 	/* labels - may well contain garbage */
-	char s_fsname[6];
-	char s_volume[6];
+	char s_fsname[6] __ul_nonstring;
+	char s_volume[6] __ul_nonstring;
 	char s_pad[472];
 };
 

--- a/include/c.h
+++ b/include/c.h
@@ -153,6 +153,12 @@ C23   : https://en.cppreference.com/w/c/language/attributes/fallthrough
 # define __ul_returns_nonnull
 #endif
 
+#if __has_attribute(__nonstring__)
+# define __ul_nonstring __attribute__((__nonstring__))
+#else
+# define __ul_nonstring
+#endif
+
 /*
  * Force a compilation error if condition is true, but also produce a
  * result (of value 0 and type size_t), so the expression can be used


### PR DESCRIPTION
GCC15 requires to annotate such fields as nonstrings or a warning is now issued that they are missing the ending null.