### PR TITLE
Do not use strerror on shared libraries

### DIFF
--- a/libblkid/src/verify.c
+++ b/libblkid/src/verify.c
@@ -73,8 +73,8 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 	diff = (uintmax_t)now - dev->bid_time;
 
 	if (stat(dev->bid_name, &st) < 0) {
-		DBG(PROBE, ul_debug("blkid_verify: error %s (%d) while "
-			   "trying to stat %s", strerror(errno), errno,
+		DBG(PROBE, ul_debug("blkid_verify: error %m (%d) while "
+			   "trying to stat %s", errno,
 			   dev->bid_name));
 	open_err:
 		if ((errno == EPERM) || (errno == EACCES) || (errno == ENOENT)) {
@@ -128,8 +128,8 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 
 	fd = open(dev->bid_name, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
 	if (fd < 0) {
-		DBG(PROBE, ul_debug("blkid_verify: error %s (%d) while "
-					"opening %s", strerror(errno), errno,
+		DBG(PROBE, ul_debug("blkid_verify: error %m (%d) while "
+					"opening %s", errno,
 					dev->bid_name));
 		goto open_err;
 	}

--- a/liblastlog2/src/lastlog2.c
+++ b/liblastlog2/src/lastlog2.c
@@ -559,8 +559,8 @@ ll2_import_lastlog(struct ll2_context *context, const char *lastlog_file,
 
 	ll_fp = fopen(lastlog_file, "r");
 	if (ll_fp == NULL) {
-		if (error && asprintf(error, "Failed to open '%s': %s",
-				     lastlog_file, strerror(errno)) < 0)
+		if (error && asprintf(error, "Failed to open '%s': %m",
+				     lastlog_file) < 0)
 			return -ENOMEM;
 
 		return -1;
@@ -569,8 +569,8 @@ ll2_import_lastlog(struct ll2_context *context, const char *lastlog_file,
 
 	if (fstat(fileno(ll_fp), &statll) != 0) {
 		retval = -1;
-		if (error && asprintf(error, "Cannot get size of '%s': %s",
-					lastlog_file, strerror(errno)) < 0)
+		if (error && asprintf(error, "Cannot get size of '%s': %m",
+					lastlog_file) < 0)
 			retval = -ENOMEM;
 
 		goto done;


### PR DESCRIPTION
Using strerror is not safe in shared libraries as it is unknown what the calling apps may do with the storage behind the scenes. Using %m is ok, except in contexts that need to be as-safe.