### PR TITLE
lib/loopdev: drop workaround for kernel uevent bug and some cleanups

### DIFF
--- a/include/loopdev.h
+++ b/include/loopdev.h
@@ -179,7 +179,6 @@ extern const char *loopcxt_get_device(struct loopdev_cxt *lc);
 extern struct loop_info64 *loopcxt_get_info(struct loopdev_cxt *lc);
 
 extern int loopcxt_get_fd(struct loopdev_cxt *lc);
-extern int loopcxt_set_fd(struct loopdev_cxt *lc, int fd, mode_t mode);
 
 extern int loopcxt_init_iterator(struct loopdev_cxt *lc, int flags);
 extern int loopcxt_deinit_iterator(struct loopdev_cxt *lc);

--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -1418,11 +1418,7 @@ int loopcxt_setup_device(struct loopdev_cxt *lc)
 	do {
 		errno = 0;
 
-		/* For the ioctls, it's enough to use O_RDONLY for a read-only
-		 * loop device, but udevd monitor devices by inotify, and udevd
-		 * needs IN_CLOSE_WRITE event to trigger probing of the new device.
-		 */
-		dev_fd = __loopcxt_get_fd(lc, O_RDWR);
+		dev_fd = __loopcxt_get_fd(lc, mode);
 		if (dev_fd >= 0 || lc->control_ok == 0)
 			break;
 		if (errno != EACCES && errno != ENOENT)

--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -346,16 +346,6 @@ int loopcxt_get_fd(struct loopdev_cxt *lc)
 	return __loopcxt_get_fd(lc, O_RDONLY);
 }
 
-int loopcxt_set_fd(struct loopdev_cxt *lc, int fd, mode_t mode)
-{
-	if (!lc)
-		return -EINVAL;
-
-	lc->fd = fd;
-	lc->mode = mode;
-	return 0;
-}
-
 /*
  * @lc: context
  * @flags: LOOPITER_FL_* flags

--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -1418,12 +1418,9 @@ int loopcxt_setup_device(struct loopdev_cxt *lc)
 	do {
 		errno = 0;
 
-		/* For the ioctls, it's enough to use O_RDONLY, but udevd
-		 * monitor devices by inotify, and udevd needs IN_CLOSE_WRITE
-		 * event to trigger probing of the new device.
-		 *
-		 * The mode used for the device does not have to match the mode
-		 * used for the backing file.
+		/* For the ioctls, it's enough to use O_RDONLY for a read-only
+		 * loop device, but udevd monitor devices by inotify, and udevd
+		 * needs IN_CLOSE_WRITE event to trigger probing of the new device.
 		 */
 		dev_fd = __loopcxt_get_fd(lc, O_RDWR);
 		if (dev_fd >= 0 || lc->control_ok == 0)


### PR DESCRIPTION
Details in the commit messages.

This is not yet ready to be merged as the kernel fix has not hit mainline yet.