### PR TITLE
include/mount-api-utils: include linux/unistd.h

### DIFF
--- a/include/mount-api-utils.h
+++ b/include/mount-api-utils.h
@@ -8,6 +8,7 @@
 #ifdef HAVE_LINUX_MOUNT_H
 #include <sys/mount.h>
 #include <linux/mount.h>
+#include <linux/unistd.h>
 #include <sys/syscall.h>
 #include <inttypes.h>
 


### PR DESCRIPTION
If SYS_statmount/SYS_listmount is not provided by the libc, util-linux will fall back to __NR_statmount/__NR_listmount from the kernel UAPI headers.
However it is not guaranteed that these symbols are actually visible in mount-api-utils.

Include linux/unistd.h which provides syscall numbers. While this header is specific to Linux, the code is already using linux/mount.h.