### PR TITLE
bits: only build when cpu_set_t is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2319,7 +2319,11 @@ UL_REQUIRES_HAVE([scriptlive], [pty], [openpty function (libutil)])
 AM_CONDITIONAL([BUILD_SCRIPTLIVE], [test "x$build_scriptlive" = xyes])
 
 
-UL_BUILD_INIT([bits], [yes])
+AC_ARG_ENABLE([bits],
+  AS_HELP_STRING([--disable-bits], [do not build bits]),
+  [], [UL_DEFAULT_ENABLE([bits], [check])])
+UL_BUILD_INIT([bits])
+UL_REQUIRES_HAVE([bits], [cpu_set_t], [cpu_set_t type])
 AM_CONDITIONAL([BUILD_BITS], [test "x$build_bits" = xyes])
 
 UL_BUILD_INIT([col], [check])

--- a/meson.build
+++ b/meson.build
@@ -1261,7 +1261,7 @@ endif
 
 ############################################################
 
-opt = not get_option('build-bits').disabled()
+opt = not get_option('build-bits').require(have_cpu_set_t).disabled()
 exe = executable(
   'bits',
   bits_sources,


### PR DESCRIPTION
Doesn't build on macOS.

Fixes: 6e1301d59 ("text-utils: add bits command")