### PR TITLE
Add SCHED_EXT support to chrt

### DIFF
--- a/bash-completion/chrt
+++ b/bash-completion/chrt
@@ -19,6 +19,7 @@ _chrt_module()
 				--all-tasks
 				--batch
 				--deadline
+				--ext
 				--fifo
 				--help
 				--idle

--- a/schedutils/chrt.1.adoc
+++ b/schedutils/chrt.1.adoc
@@ -65,6 +65,9 @@ Set scheduling policy to *SCHED_IDLE* (scheduling very low priority jobs). Linux
 *-d*, *--deadline*::
 Set scheduling policy to *SCHED_DEADLINE* (sporadic task model deadline scheduling). Linux-specific, supported since 3.14. The priority argument has to be set to zero. See also *--sched-runtime*, *--sched-deadline* and *--sched-period*. The relation between the options required by the kernel is runtime <= deadline <= period. *chrt* copies _period_ to _deadline_ if *--sched-deadline* is not specified and _deadline_ to _runtime_ if *--sched-runtime* is not specified. It means that at least *--sched-period* has to be specified. See *sched*(7) for more details.
 
+*-d*, *--ext*::
+Set scheduling policy to *SCHED_EXT* (BPF program-defined scheduling). Linux-specific, supported since 6.12. The priority argument has to be set to zero.
+
 == SCHEDULING OPTIONS
 
 *-T*, *--sched-runtime* _nanoseconds_::

--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -71,6 +71,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("Policy options:\n"), out);
 	fputs(_(" -b, --batch          set policy to SCHED_BATCH\n"), out);
 	fputs(_(" -d, --deadline       set policy to SCHED_DEADLINE\n"), out);
+	fputs(_(" -e, --ext            set policy to SCHED_EXT\n"), out);
 	fputs(_(" -f, --fifo           set policy to SCHED_FIFO\n"), out);
 	fputs(_(" -i, --idle           set policy to SCHED_IDLE\n"), out);
 	fputs(_(" -o, --other          set policy to SCHED_OTHER\n"), out);
@@ -120,6 +121,10 @@ static const char *get_policy_name(int policy)
 #ifdef SCHED_DEADLINE
 	case SCHED_DEADLINE:
 		return "SCHED_DEADLINE";
+#endif
+#ifdef SCHED_EXT
+	case SCHED_EXT:
+		return "SCHED_EXT";
 #endif
 	default:
 		break;
@@ -290,6 +295,9 @@ static void show_min_max(void)
 #ifdef SCHED_DEADLINE
 		SCHED_DEADLINE,
 #endif
+#ifdef SCHED_EXT
+		SCHED_EXT,
+#endif
 	};
 
 	for (i = 0; i < ARRAY_SIZE(policies); i++) {
@@ -397,6 +405,7 @@ int main(int argc, char **argv)
 		{ "all-tasks",  no_argument, NULL, 'a' },
 		{ "batch",	no_argument, NULL, 'b' },
 		{ "deadline",   no_argument, NULL, 'd' },
+		{ "ext",	no_argument, NULL, 'e' },
 		{ "fifo",	no_argument, NULL, 'f' },
 		{ "idle",	no_argument, NULL, 'i' },
 		{ "pid",	no_argument, NULL, 'p' },
@@ -418,7 +427,7 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	close_stdout_atexit();
 
-	while((c = getopt_long(argc, argv, "+abdD:fiphmoP:T:rRvV", longopts, NULL)) != -1)
+	while((c = getopt_long(argc, argv, "+abdD:efiphmoP:T:rRvV", longopts, NULL)) != -1)
 	{
 		switch (c) {
 		case 'a':
@@ -433,6 +442,11 @@ int main(int argc, char **argv)
 		case 'd':
 #ifdef SCHED_DEADLINE
 			ctl->policy = SCHED_DEADLINE;
+#endif
+			break;
+		case 'e':
+#ifdef SCHED_EXT
+			ctl->policy = SCHED_EXT;
 #endif
 			break;
 		case 'f':

--- a/schedutils/sched_attr.h
+++ b/schedutils/sched_attr.h
@@ -124,4 +124,12 @@ static int sched_getattr(pid_t pid, struct sched_attr *attr, unsigned int size, 
 # define SCHED_DEADLINE 6
 #endif
 
+/* the SCHED_EXT is supported since Linux 6.12
+ * commit id f0e1a0643a59bf1f922fa209cec86a170b784f3f
+ * -- temporary workaround for people with old glibc headers
+ */
+#if defined(__linux__) && !defined(SCHED_EXT)
+# define SCHED_EXT 7
+#endif
+
 #endif /* UTIL_LINUX_SCHED_ATTR_H */

--- a/tests/expected/schedutils/chrt-ext
+++ b/tests/expected/schedutils/chrt-ext
@@ -1,0 +1,4 @@
+SCHED_EXT
+0
+SCHED_EXT
+0

--- a/tests/ts/schedutils/chrt
+++ b/tests/ts/schedutils/chrt
@@ -137,6 +137,15 @@ if [ $? == 0 ]; then
 	ts_finalize_subtest
 fi
 
+ts_init_subtest "ext"
+skip_policy SCHED_EXT
+if [ $? == 0 ]; then
+	do_chrt --ext 0
+	do_chrt -e 0
+	cleanup_output
+	ts_finalize_subtest
+fi
+
 # failed -- let's report kernel limits
 #
 if [ $TS_NSUBFAILED -ne 0 ]; then


### PR DESCRIPTION
SCHED_EXT was added in kernel 6.12, which lets processes be scheduled by a BPF-defined scheduler. This PR adds SCHED_EXT support to chrt, updates the tests, the man page, and bash completion.