### PR TITLE
libblkid: Fix crash while parsing config with libeconf

### DIFF
--- a/libblkid/src/config.c
+++ b/libblkid/src/config.c
@@ -154,7 +154,7 @@ struct blkid_config *blkid_read_config(const char *filename)
 
 #else /* !HAVE_LIBECONF */
 
-	static econf_file *file = NULL;
+	econf_file *file = NULL;
 	char *line = NULL;
 	bool uevent = false;
 	econf_err error;


### PR DESCRIPTION
As the whole econf_file structure is freed by econf_free(file) at the end of blkid_read_config(), econf_file structure cannot be defined as static and initialized only once. The econf_free() is not robust enough and keeps a pointer to the garbage after the first call of blkid_read_config(). And if /etc/blkid.conf does not exist, it is called second time.

Link: https://bugzilla.opensuse.org/show_bug.cgi?id=1242705