### PR TITLE
Do not call exit() on code ending in shared libraries

### DIFF
--- a/lib/canonicalize.c
+++ b/lib/canonicalize.c
@@ -192,7 +192,7 @@ char *canonicalize_path_restricted(const char *path)
 		write_all(pipes[1], (char *) &len, sizeof(len));
 		if (canonical)
 			write_all(pipes[1], canonical, len);
-		exit(0);
+		_exit(0);
 	default:
 		break;
 	}

--- a/libblkid/src/topology/dm.c
+++ b/libblkid/src/topology/dm.c
@@ -74,7 +74,7 @@ static int probe_dm_tp(blkid_probe pr,
 			dup2(dmpipe[1], STDOUT_FILENO);
 
 		if (drop_permissions() != 0)
-			 exit(1);
+			 _exit(1);
 
 		snprintf(maj, sizeof(maj), "%d", major(devno));
 		snprintf(min, sizeof(min), "%d", minor(devno));

--- a/libblkid/src/topology/lvm.c
+++ b/libblkid/src/topology/lvm.c
@@ -83,7 +83,7 @@ static int probe_lvm_tp(blkid_probe pr,
 			dup2(lvpipe[1], STDOUT_FILENO);
 
 		if (drop_permissions() != 0)
-			 exit(1);
+			 _exit(1);
 
 		lvargv[0] = cmd;
 		lvargv[1] = devname;
@@ -92,7 +92,7 @@ static int probe_lvm_tp(blkid_probe pr,
 		execv(lvargv[0], lvargv);
 
 		DBG(LOWPROBE, ul_debug("Failed to execute %s: errno=%d", cmd, errno));
-		exit(1);
+		_exit(1);
 	}
 	case -1:
 		DBG(LOWPROBE, ul_debug("Failed to forking: errno=%d", errno));


### PR DESCRIPTION
It is not cool to call atexit() handlers of unknown applications from shared libraries, use _exit instead.