### PR TITLE
fix sectors typos

### DIFF
--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -883,7 +883,7 @@ void discard_sectors(struct fdisk_context *cxt)
 
 	if (fdisk_ask_menu(cxt, _("Type of area to be discarded"),
 			&c, 'p', _("partition sectors"), 'p',
-				 _("free space sectros"), 'f', NULL) != 0)
+				 _("free space sectors"), 'f', NULL) != 0)
 		return;
 
 	switch (c) {

--- a/po/ca.po
+++ b/po/ca.po
@@ -1314,7 +1314,7 @@ msgstr "Nombre de partició"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free Space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Espai lliure"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/cs.po
+++ b/po/cs.po
@@ -1147,7 +1147,7 @@ msgstr "číslo oddílu"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Volný prostor"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/da.po
+++ b/po/da.po
@@ -1197,7 +1197,7 @@ msgstr "partitionsnummer"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Frit område"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/de.po
+++ b/po/de.po
@@ -1167,7 +1167,7 @@ msgstr "Partitionsnummer"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Freier Bereich"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/et.po
+++ b/po/et.po
@@ -1177,7 +1177,7 @@ msgstr "Partitsiooni number"
 
 #: disk-utils/fdisk.c:889
 #, fuzzy
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Vaba ruum"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/eu.po
+++ b/po/eu.po
@@ -1175,7 +1175,7 @@ msgstr "Partizio zenbakia"
 
 #: disk-utils/fdisk.c:889
 #, fuzzy
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Leku librea"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/fi.po
+++ b/po/fi.po
@@ -1160,7 +1160,7 @@ msgstr "osionumero"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Vapaa tila"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/fr.po
+++ b/po/fr.po
@@ -1098,7 +1098,7 @@ msgid "partition sectors"
 msgstr "secteurs de partition"
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "secteurs de l'espace libre"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/gl.po
+++ b/po/gl.po
@@ -1153,7 +1153,7 @@ msgid "partition sectors"
 msgstr "Esta partición non é usábel"
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr ""
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/hr.po
+++ b/po/hr.po
@@ -1096,7 +1096,7 @@ msgid "partition sectors"
 msgstr "sektori particije"
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "sektori slobodnog prostora"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/hu.po
+++ b/po/hu.po
@@ -1176,7 +1176,7 @@ msgstr "Partíciószám"
 
 #: disk-utils/fdisk.c:889
 #, fuzzy
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Szabad terület"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/id.po
+++ b/po/id.po
@@ -1178,7 +1178,7 @@ msgstr "Nomor partisi"
 
 #: disk-utils/fdisk.c:889
 #, fuzzy
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Space kosong"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/it.po
+++ b/po/it.po
@@ -1183,7 +1183,7 @@ msgstr "Numero della partizione"
 
 #: disk-utils/fdisk.c:889
 #, fuzzy
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Spazio disponibile"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/ja.po
+++ b/po/ja.po
@@ -1117,7 +1117,7 @@ msgstr "パーティション番号"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "空き領域"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/ka.po
+++ b/po/ka.po
@@ -1096,7 +1096,7 @@ msgstr "დანაყოფის ნომერი"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "თავისუფალი სივრცე"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/ko.po
+++ b/po/ko.po
@@ -1095,7 +1095,7 @@ msgid "partition sectors"
 msgstr "분할 영역 섹터"
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "여분 공간 섹터"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/nl.po
+++ b/po/nl.po
@@ -1120,7 +1120,7 @@ msgid "partition sectors"
 msgstr "partitie-sectoren"
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "vrijeruimte-sectoren"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/pl.po
+++ b/po/pl.po
@@ -1093,7 +1093,7 @@ msgid "partition sectors"
 msgstr "sektory partycji"
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "sektory wolnego miejsca"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/pt.po
+++ b/po/pt.po
@@ -1123,7 +1123,7 @@ msgstr "número da partição"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Espaço livre"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1132,7 +1132,7 @@ msgstr "número da partição"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Espaço livre"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/ro.po
+++ b/po/ro.po
@@ -1149,7 +1149,7 @@ msgid "partition sectors"
 msgstr "sectoarele partiției"
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "sectoare ale spațiului liber"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/ru.po
+++ b/po/ru.po
@@ -1124,7 +1124,7 @@ msgstr "номер раздела"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Свободное пространство"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/sk.po
+++ b/po/sk.po
@@ -1110,7 +1110,7 @@ msgid "partition sectors"
 msgstr "číslo oddielu"
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr ""
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/sl.po
+++ b/po/sl.po
@@ -1185,7 +1185,7 @@ msgstr "©tevilka razdelka"
 
 #: disk-utils/fdisk.c:889
 #, fuzzy
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Neuporabljen prostor"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/sr.po
+++ b/po/sr.po
@@ -1103,7 +1103,7 @@ msgstr "број партиције"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Слободан простор"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/sv.po
+++ b/po/sv.po
@@ -1135,7 +1135,7 @@ msgstr "partitionsnummer"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Ledigt utrymme"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/tr.po
+++ b/po/tr.po
@@ -1126,7 +1126,7 @@ msgstr "Disk bölümü numarası"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Boş alan"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/uk.po
+++ b/po/uk.po
@@ -1094,7 +1094,7 @@ msgid "partition sectors"
 msgstr "сектори розділу"
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "сектори вільного місця"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/util-linux.pot
+++ b/po/util-linux.pot
@@ -1077,7 +1077,7 @@ msgid "partition sectors"
 msgstr ""
 
 #: disk-utils/fdisk.c:889
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr ""
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/vi.po
+++ b/po/vi.po
@@ -1146,7 +1146,7 @@ msgstr "số của phân vùng"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "Chỗ trống"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1106,7 +1106,7 @@ msgstr "分区号"
 #: disk-utils/fdisk.c:889
 #, fuzzy
 #| msgid "Free space"
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "剩余空间"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1171,7 +1171,7 @@ msgstr "分割區編號"
 
 #: disk-utils/fdisk.c:889
 #, fuzzy
-msgid "free space sectros"
+msgid "free space sectors"
 msgstr "剩餘空間"
 
 #: disk-utils/fdisk.c:905 disk-utils/sfdisk.c:1441


### PR DESCRIPTION
Fixed a typo in the "(T) discard (trim) sectors" function.

The string
> free space sectros

should be
> free space sectors