### PR TITLE
lsfd/mkfds-foreign-sockets: skip when lacking sock_diag ability

### DIFF
--- a/tests/ts/lsfd/mkfds-foreign-sockets
+++ b/tests/ts/lsfd/mkfds-foreign-sockets
@@ -30,6 +30,8 @@ ts_skip_nonroot
 ts_skip_qemu_user
 ts_cd "$TS_OUTDIR"
 
+lsfd_check_sockdiag "unix"
+
 declare -A tcase
 tcase[NAME]="state=connected"
 tcase[SOCK.NETNS]=


### PR DESCRIPTION
The ENDPOINTS will need sock_diag ability. The kernel might not enable related configs. Check and skip in case of lacking such ability.

Fixes: https://github.com/util-linux/util-linux/issues/3590