### PR TITLE
Backport add ul_ prefix to v2.41

### DIFF
--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -1955,7 +1955,7 @@ static int ui_get_size(struct cfdisk *cf,	/* context */
 				insec = 1;
 				buf[len - 1] = '\0';
 			}
-			rc = parse_size(buf, (uintmax_t *)&user, &pwr);	/* parse */
+			rc = ul_parse_size(buf, (uintmax_t *)&user, &pwr);	/* parse */
 		}
 
 		if (rc == 0) {

--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -359,7 +359,7 @@ static int ask_offset(struct fdisk_context *cxt,
 			p++;
 		}
 
-		rc = parse_size(p, &num, &pwr);
+		rc = ul_parse_size(p, &num, &pwr);
 		if (rc)
 			continue;
 		DBG(ASK, ul_debug("parsed size: %ju", num));

--- a/disk-utils/partx.c
+++ b/disk-utils/partx.c
@@ -864,7 +864,7 @@ int main(int argc, char **argv)
 			what = ACT_LIST;
 			break;
 		case 'n':
-			if (parse_range(optarg, &lower, &upper, 0))
+			if (ul_parse_range(optarg, &lower, &upper, 0))
 				errx(EXIT_FAILURE, _("failed to parse --nr <M-N> range"));
 			break;
 		case 'o':

--- a/include/strutils.h
+++ b/include/strutils.h
@@ -21,7 +21,7 @@
 /* initialize a custom exit code for all *_or_err functions */
 extern void strutils_set_exitcode(int exit_code);
 
-extern int parse_size(const char *str, uintmax_t *res, int *power);
+extern int ul_parse_size(const char *str, uintmax_t *res, int *power);
 extern int strtosize(const char *str, uintmax_t *res);
 extern uintmax_t strtosize_or_err(const char *str, const char *errmesg);
 

--- a/include/strutils.h
+++ b/include/strutils.h
@@ -68,7 +68,7 @@ extern int isxdigit_strend(const char *str, const char **end);
 #define isxdigit_string(_s)	isxdigit_strend(_s, NULL)
 
 
-extern int parse_switch(const char *arg, const char *errmesg, ...);
+extern int ul_parse_switch(const char *arg, const char *errmesg, ...);
 
 #ifndef HAVE_MEMPCPY
 extern void *mempcpy(void *restrict dest, const void *restrict src, size_t n);

--- a/include/strutils.h
+++ b/include/strutils.h
@@ -260,7 +260,7 @@ extern int string_to_bitarray(const char *list, char *ary,
 extern int string_to_bitmask(const char *list,
 			     unsigned long *mask,
 			     long (*name2flag)(const char *, size_t));
-extern int parse_range(const char *str, int *lower, int *upper, int def);
+extern int ul_parse_range(const char *str, int *lower, int *upper, int def);
 
 extern int streq_paths(const char *a, const char *b);
 

--- a/include/timeutils.h
+++ b/include/timeutils.h
@@ -47,7 +47,7 @@ typedef uint64_t nsec_t;
 #define FORMAT_TIMESTAMP_RELATIVE_MAX 256
 #define FORMAT_TIMESPAN_MAX 64
 
-int parse_timestamp(const char *t, usec_t *usec);
+int ul_parse_timestamp(const char *t, usec_t *usec);
 int get_gmtoff(const struct tm *tp);
 
 /* flags and masks for strxxx_iso() functions */

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -863,7 +863,7 @@ int string_to_bitmask(const char *list,
  *
  * Returns: 0 on success, <0 on error.
  */
-int parse_range(const char *str, int *lower, int *upper, int def)
+int ul_parse_range(const char *str, int *lower, int *upper, int def)
 {
 	char *end = NULL;
 

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -64,7 +64,7 @@ static int do_scale_by_power (uintmax_t *x, int base, int power)
  * Note that the function does not accept numbers with '-' (negative sign)
  * prefix.
  */
-int parse_size(const char *str, uintmax_t *res, int *power)
+int ul_parse_size(const char *str, uintmax_t *res, int *power)
 {
 	const char *p;
 	char *end;
@@ -220,7 +220,7 @@ err:
 
 int strtosize(const char *str, uintmax_t *res)
 {
-	return parse_size(str, res, NULL);
+	return ul_parse_size(str, res, NULL);
 }
 
 int isdigit_strend(const char *str, const char **end)

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -247,9 +247,9 @@ int isxdigit_strend(const char *str, const char **end)
 }
 
 /*
- *  parse_switch(argv[i], "on", "off",  "yes", "no",  NULL);
+ *  ul_parse_switch(argv[i], "on", "off",  "yes", "no",  NULL);
  */
-int parse_switch(const char *arg, const char *errmesg, ...)
+int ul_parse_switch(const char *arg, const char *errmesg, ...)
 {
 	const char *a, *b;
 	va_list ap;

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -403,7 +403,7 @@ static int parse_timestamp_reference(time_t x, const char *t, usec_t *usec)
 	return 0;
 }
 
-int parse_timestamp(const char *t, usec_t *usec)
+int ul_parse_timestamp(const char *t, usec_t *usec)
 {
 	return parse_timestamp_reference(time(NULL), t, usec);
 }
@@ -872,7 +872,7 @@ int main(int argc, char *argv[])
 	if (strcmp(argv[1], "--timestamp") == 0) {
 		usec_t usec = 0;
 
-		r = parse_timestamp(argv[2], &usec);
+		r = ul_parse_timestamp(argv[2], &usec);
 		if (r)
 			errx(EXIT_FAILURE, "Can not parse '%s': %s", argv[2], strerror(-r));
 		ts.tv_sec = (time_t) (usec / USEC_PER_SEC);

--- a/libfdisk/src/gpt.c
+++ b/libfdisk/src/gpt.c
@@ -735,7 +735,7 @@ static int get_script_u64(struct fdisk_context *cxt, uint64_t *num, const char *
 	if (!str)
 		return 1;
 
-	rc = parse_size(str, (uintmax_t *) num, &pwr);
+	rc = ul_parse_size(str, (uintmax_t *) num, &pwr);
 	if (rc < 0)
 		return rc;
 	if (pwr)

--- a/libfdisk/src/script.c
+++ b/libfdisk/src/script.c
@@ -1024,7 +1024,7 @@ static int parse_start_value(struct fdisk_script *dp, struct fdisk_partition *pa
 		int pow = 0, sign = skip_optional_sign(&tk);
 		uint64_t num;
 
-		rc = parse_size(tk, (uintmax_t *) &num, &pow);
+		rc = ul_parse_size(tk, (uintmax_t *) &num, &pow);
 		if (!rc) {
 			if (pow) {	/* specified as <num><suffix> */
 				if (!dp->cxt->sector_size) {
@@ -1080,7 +1080,7 @@ static int parse_size_value(struct fdisk_script *dp, struct fdisk_partition *pa,
 		int pow = 0, sign = skip_optional_sign(&tk);
 		uint64_t num;
 
-		rc = parse_size(tk, (uintmax_t *) &num, &pow);
+		rc = ul_parse_size(tk, (uintmax_t *) &num, &pow);
 		if (!rc) {
 			if (pow) { /* specified as <size><suffix> */
 				if (!dp->cxt->sector_size) {
@@ -1564,7 +1564,7 @@ int fdisk_apply_script_headers(struct fdisk_context *cxt, struct fdisk_script *d
 	if (str) {
 		uintmax_t sz;
 
-		rc = parse_size(str, &sz, NULL);
+		rc = ul_parse_size(str, &sz, NULL);
 		if (rc == 0)
 			rc = fdisk_save_user_grain(cxt, sz);
 		if (rc)
@@ -1591,7 +1591,7 @@ int fdisk_apply_script_headers(struct fdisk_context *cxt, struct fdisk_script *d
 	if (str) {
 		uintmax_t sz;
 
-		rc = parse_size(str, &sz, NULL);
+		rc = ul_parse_size(str, &sz, NULL);
 		if (rc == 0)
 			rc = fdisk_gpt_set_npartitions(cxt, sz);
 	}

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -1054,17 +1054,17 @@ int main(int argc, char **argv)
 			ctl.time_fmt = LAST_TIMEFTM_CTIME;
 			break;
 		case 'p':
-			if (parse_timestamp(optarg, &p) < 0)
+			if (ul_parse_timestamp(optarg, &p) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
 			ctl.present = (time_t) (p / 1000000);
 			break;
 		case 's':
-			if (parse_timestamp(optarg, &p) < 0)
+			if (ul_parse_timestamp(optarg, &p) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
 			ctl.since = (time_t) (p / 1000000);
 			break;
 		case 't':
-			if (parse_timestamp(optarg, &p) < 0)
+			if (ul_parse_timestamp(optarg, &p) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
 			ctl.until = (time_t) (p / 1000000);
 			break;

--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -467,7 +467,7 @@ int main(int argc, char **argv)
 	if (argc == 1 && !isdigit_string(*argv)) {
 		usec_t x;
 		/* cal <timestamp> */
-		if (parse_timestamp(*argv, &x) == 0)
+		if (ul_parse_timestamp(*argv, &x) == 0)
 			now = (time_t) (x / 1000000);
 		/* cal <monthname> */
 		else if ((ctl.req.month = monthname_to_number(&ctl, *argv)) > 0)

--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -1818,13 +1818,13 @@ int main(int argc, char *argv[])
 			break;
 		case OPT_SINCE:
 		{
-			if (parse_timestamp(optarg, &ctl.since) < 0)
+			if (ul_parse_timestamp(optarg, &ctl.since) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
 			break;
 		}
 		case OPT_UNTIL:
 		{
-			if (parse_timestamp(optarg, &ctl.until) < 0)
+			if (ul_parse_timestamp(optarg, &ctl.until) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
 			break;
 		}

--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -207,7 +207,7 @@ static void parse_args(struct eject_control *ctl, int argc, char **argv)
 		switch (c) {
 		case 'a':
 			ctl->a_option = 1;
-			ctl->a_arg = parse_switch(optarg, _("argument error"),
+			ctl->a_arg = ul_parse_switch(optarg, _("argument error"),
 						"on", "off",  "1", "0",  NULL);
 			break;
 		case 'c':
@@ -229,7 +229,7 @@ static void parse_args(struct eject_control *ctl, int argc, char **argv)
 			break;
 		case 'i':
 			ctl->i_option = 1;
-			ctl->i_arg = parse_switch(optarg, _("argument error"),
+			ctl->i_arg = ul_parse_switch(optarg, _("argument error"),
 						"on", "off",  "1", "0",  NULL);
 			break;
 		case 'm':

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -1561,7 +1561,7 @@ int main(int argc, char **argv)
 		/* minimalistic GPLv2 based parser */
 		usec_t usec;
 
-		if (parse_timestamp(ctl.date_opt, &usec) == 0)
+		if (ul_parse_timestamp(ctl.date_opt, &usec) == 0)
 			set_time = (time_t) (usec / 1000000);
 #endif
 		else {

--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -818,7 +818,7 @@ int main(int argc, char **argv)
 		case OPT_DIO:
 			use_dio = set_dio = 1;
 			if (optarg)
-				use_dio = parse_switch(optarg, _("argument error"), "on", "off", NULL);
+				use_dio = ul_parse_switch(optarg, _("argument error"), "on", "off", NULL);
 			if (use_dio)
 				lo_flags |= LO_FLAGS_DIRECT_IO;
 			break;

--- a/sys-utils/lscpu-topology.c
+++ b/sys-utils/lscpu-topology.c
@@ -509,7 +509,7 @@ static int read_caches(struct lscpu_cxt *cxt, struct lscpu_cpu *cpu)
 			/* cache size */
 			if (ul_path_readf_buffer(sys, buf, sizeof(buf),
 					"cpu%d/cache/index%zu/size", num, i) > 0)
-				parse_size(buf, &ca->size, NULL);
+				ul_parse_size(buf, &ca->size, NULL);
 			else
 				ca->size = 0;
 		}

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -516,7 +516,7 @@ int main(int argc, char **argv)
 		case OPT_DATE:
 		{	/* alarm time, see timestamp format from manual */
 			usec_t p;
-			if (parse_timestamp(optarg, &p) < 0)
+			if (ul_parse_timestamp(optarg, &p) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
 			alarm = (time_t) (p / 1000000);
 			break;

--- a/sys-utils/tunelp.c
+++ b/sys-utils/tunelp.c
@@ -189,24 +189,24 @@ int main(int argc, char **argv)
 			break;
 		case 'a':
 			cmds->op = LPABORT;
-			cmds->val = parse_switch(optarg, _("argument error"), "on", "off", NULL);
+			cmds->val = ul_parse_switch(optarg, _("argument error"), "on", "off", NULL);
 			cmds->next = xmalloc(sizeof(struct command));
 			cmds = cmds->next;
 			cmds->next = NULL;
 			break;
 		case 'q':
-			show_irq = parse_switch(optarg, _("argument error"), "on", "off", NULL);
+			show_irq = ul_parse_switch(optarg, _("argument error"), "on", "off", NULL);
 			break;
 		case 'o':
 			cmds->op = LPABORTOPEN;
-			cmds->val = parse_switch(optarg, _("argument error"), "on", "off", NULL);
+			cmds->val = ul_parse_switch(optarg, _("argument error"), "on", "off", NULL);
 			cmds->next = xmalloc(sizeof(struct command));
 			cmds = cmds->next;
 			cmds->next = NULL;
 			break;
 		case 'C':
 			cmds->op = LPCAREFUL;
-			cmds->val = parse_switch(optarg, _("argument error"), "on", "off", NULL);
+			cmds->val = ul_parse_switch(optarg, _("argument error"), "on", "off", NULL);
 			cmds->next = xmalloc(sizeof(struct command));
 			cmds = cmds->next;
 			cmds->next = NULL;

--- a/term-utils/setterm.c
+++ b/term-utils/setterm.c
@@ -559,22 +559,22 @@ static void parse_option(struct setterm_control *ctl, int ac, char **av)
 			break;
 		case OPT_CURSOR:
 			ctl->opt_cursor = set_opt_flag(ctl->opt_cursor);
-			ctl->opt_cu_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_cu_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_REPEAT:
 			ctl->opt_repeat = set_opt_flag(ctl->opt_repeat);
-			ctl->opt_rep_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_rep_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_APPCURSORKEYS:
 			ctl->opt_appcursorkeys = set_opt_flag(ctl->opt_appcursorkeys);
-			ctl->opt_appck_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_appck_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_LINEWRAP:
 			ctl->opt_linewrap = set_opt_flag(ctl->opt_linewrap);
-			ctl->opt_li_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_li_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_DEFAULT:
@@ -598,32 +598,32 @@ static void parse_option(struct setterm_control *ctl, int ac, char **av)
 			break;
 		case OPT_INVERSESCREEN:
 			ctl->opt_inversescreen = set_opt_flag(ctl->opt_inversescreen);
-			ctl->opt_invsc_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_invsc_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_BOLD:
 			ctl->opt_bold = set_opt_flag(ctl->opt_bold);
-			ctl->opt_bo_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_bo_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_HALF_BRIGHT:
 			ctl->opt_halfbright = set_opt_flag(ctl->opt_halfbright);
-			ctl->opt_hb_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_hb_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_BLINK:
 			ctl->opt_blink = set_opt_flag(ctl->opt_blink);
-			ctl->opt_bl_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_bl_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_REVERSE:
 			ctl->opt_reverse = set_opt_flag(ctl->opt_reverse);
-			ctl->opt_re_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_re_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_UNDERLINE:
 			ctl->opt_underline = set_opt_flag(ctl->opt_underline);
-			ctl->opt_un_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_un_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_STORE:
@@ -632,7 +632,7 @@ static void parse_option(struct setterm_control *ctl, int ac, char **av)
 		case OPT_CLEAR:
 			ctl->opt_clear = set_opt_flag(ctl->opt_clear);
 			if (optarg)
-				ctl->opt_cl_all = parse_switch(optarg, _("argument error"),
+				ctl->opt_cl_all = ul_parse_switch(optarg, _("argument error"),
 						"all", "rest", NULL);
 			else
 				ctl->opt_cl_all = 1;
@@ -667,7 +667,7 @@ static void parse_option(struct setterm_control *ctl, int ac, char **av)
 			break;
 		case OPT_MSG:
 			ctl->opt_msg = set_opt_flag(ctl->opt_msg);
-			ctl->opt_msg_on = parse_switch(optarg, _("argument error"),
+			ctl->opt_msg_on = ul_parse_switch(optarg, _("argument error"),
 						"on", "off", NULL);
 			break;
 		case OPT_MSGLEVEL:

--- a/text-utils/column.c
+++ b/text-utils/column.c
@@ -482,7 +482,7 @@ static void apply_columnflag_from_list(struct column_control *ctl, const char *l
 		}
 
 		/* parse range (N-M) */
-		if (strchr(*one, '-') && parse_range(*one, &low, &up, 0) == 0) {
+		if (strchr(*one, '-') && ul_parse_range(*one, &low, &up, 0) == 0) {
 			for (; low <= up; low++) {
 				if (low < 0)
 					cl = get_last_visible_column(ctl, (low * -1) -1);


### PR DESCRIPTION
This is a backport of add ul_ prefix patches #3569 to v2.41: Patches 1, 2 and 4 are simply applied, patch 3 treewide: (add ul_ to parse_switch() function name) was created again.