### PR TITLE
ts/kill/decode: fix for musl

### DIFF
--- a/tests/ts/kill/decode
+++ b/tests/ts/kill/decode
@@ -53,14 +53,19 @@ ACK=
 	    # Sending one more USR1 is for making the signal pending state.
 	    "$TS_CMD_KILL" -USR1 "$PID"
 	    "$TS_CMD_KILL" -d "$PID" | {
-		if [[ $("$TS_CMD_KILL" --list=34) == RT0 ]]; then
+		SIGRTMIN=$("$TS_CMD_KILL" -L | grep -o '[0-9]\+ RTMIN' | cut -d " " -f 1)
+		if [[ $("$TS_CMD_KILL" --list=$SIGRTMIN) == RT0 ]]; then
 		    # See man signal(7).
 		    #   The  Linux  kernel  supports a range of 33 different real-time signals,
 		    #   numbered 32 to 64.  However, the glibc POSIX threads implementation in‐
 		    #   ternally uses two (for NPTL) or three (for LinuxThreads) real-time sig‐
 		    #   nals (see pthreads(7)), and adjusts the value of SIGRTMIN suitably  (to
 		    #   34 or 35).
-		    sed -e s/' 32 33'// -e s/' 34'//
+		    sed_cmd="sed"
+		    for ((i=32; i<=SIGRTMIN; i++)); do
+			sed_cmd+=" -e s/' $i'//"
+		    done
+		    eval $sed_cmd
 		else
 		    cat
 		fi


### PR DESCRIPTION
glibc uses 34 as the value of SIGRTMIN:
https://sourceware.org/git/?p=glibc.git;a=blob;f=signal/allocrtsig.c;h=8ed8e37dd6c41f94be6eef042ce9db1af1153228;hb=HEAD#l27 """
static int current_rtmin = __SIGRTMIN + RESERVED_SIGRT; """

musl uses 35 as the value of SIGRTMIN:
https://git.musl-libc.org/cgit/musl/tree/src/signal/sigrtmin.c

Adjust the test case to cope with musl. Otherwise, it fails with the following difference:

  -Ignored: HUP QUIT TRAP PIPE ALRM
  +Ignored: HUP QUIT TRAP PIPE ALRM 34