### PR TITLE
libblkid/libmount: ntfs: return filesystem type 'ntfs3'

### DIFF
--- a/libblkid/src/superblocks/ntfs.c
+++ b/libblkid/src/superblocks/ntfs.c
@@ -248,7 +248,7 @@ int blkid_probe_is_ntfs(blkid_probe pr)
 
 const struct blkid_idinfo ntfs_idinfo =
 {
-	.name		= "ntfs",
+	.name		= "ntfs3",
 	.usage		= BLKID_USAGE_FILESYSTEM,
 	.probefunc	= probe_ntfs,
 	.magics		=

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -506,7 +506,7 @@ const char *mnt_statfs_get_fstype(struct statfs *vfs)
 	case STATFS_NCP_MAGIC:		return "ncp";
 	case STATFS_NFS_MAGIC:		return "nfs";
 	case STATFS_NILFS_MAGIC:	return "nilfs2";
-	case STATFS_NTFS_MAGIC:		return "ntfs";
+	case STATFS_NTFS_MAGIC:		return "ntfs3";
 	case STATFS_OCFS2_MAGIC:	return "ocfs2";
 	case STATFS_OMFS_MAGIC:		return "omfs";
 	case STATFS_OPENPROMFS_MAGIC:	return "openpromfs";


### PR DESCRIPTION
Change the returned filesystem type from 'ntfs' to 'ntfs3', to match what the kernel/fs/ntfs3 driver calls register_filesystem on [1][2]. This same driver also registers itself as 'ntfs', but then runs in a "legacy" mode [3] which forces the mount to stay RO.

This change enables all users of libmount/libblkid to correctly auto-detect and auto-mount a NTFS filesystem with the `--type ntfs3`, getting the normal operation mode of the linux kernel driver - having RW etc

```
# e.g. these commands:
mount /dev/sda1 /mnt/usb
systemd-mount /dev/sda1 /mnt/usb
# ... would just work as a user would expect
# And if read-only is required, the usual way would still be to explicitly state it:
mount -o ro /dev/sda1 /mnt/usb 
```

Link: [1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/ntfs3/super.c?h=v6.12#n1794
Link: [2]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/ntfs3/super.c?h=v6.12#n1874
Link: [3]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/ntfs3/super.c?h=v6.12#n412