### PR TITLE
chrt: Make priority optional for policies that don't use it

### DIFF
--- a/schedutils/chrt.1.adoc
+++ b/schedutils/chrt.1.adoc
@@ -49,7 +49,7 @@ chrt - manipulate the real-time attributes of a process
 == POLICIES
 
 *-o*, *--other*::
-Set scheduling policy to *SCHED_OTHER* (time-sharing scheduling). This is the default Linux scheduling policy.
+Set scheduling policy to *SCHED_OTHER* (time-sharing scheduling). This is the default Linux scheduling policy. Since util-linux v2.42, the priority argument is optional; if specified, it must be set to zero.
 
 *-f*, *--fifo*::
 Set scheduling policy to *SCHED_FIFO* (first in-first out).
@@ -58,16 +58,16 @@ Set scheduling policy to *SCHED_FIFO* (first in-first out).
 Set scheduling policy to *SCHED_RR* (round-robin scheduling). When no policy is defined, the *SCHED_RR* is used as the default.
 
 *-b*, *--batch*::
-Set scheduling policy to *SCHED_BATCH* (scheduling batch processes). Linux-specific, supported since 2.6.16. The priority argument has to be set to zero.
+Set scheduling policy to *SCHED_BATCH* (scheduling batch processes). Linux-specific, supported since 2.6.16. Since util-linux v2.42, the priority argument is optional; if specified, it must be set to zero.
 
 *-i*, *--idle*::
-Set scheduling policy to *SCHED_IDLE* (scheduling very low priority jobs). Linux-specific, supported since 2.6.23. The priority argument has to be set to zero.
+Set scheduling policy to *SCHED_IDLE* (scheduling very low priority jobs). Linux-specific, supported since 2.6.23. Since util-linux v2.42, the priority argument is optional; if specified, it must be set to zero.
 
 *-d*, *--deadline*::
-Set scheduling policy to *SCHED_DEADLINE* (sporadic task model deadline scheduling). Linux-specific, supported since 3.14. The priority argument has to be set to zero. See also *--sched-runtime*, *--sched-deadline* and *--sched-period*. The relation between the options required by the kernel is runtime <= deadline <= period. *chrt* copies _period_ to _deadline_ if *--sched-deadline* is not specified and _deadline_ to _runtime_ if *--sched-runtime* is not specified. It means that at least *--sched-period* has to be specified. See *sched*(7) for more details.
+Set scheduling policy to *SCHED_DEADLINE* (sporadic task model deadline scheduling). Linux-specific, supported since 3.14. Since util-linux v2.42, the priority argument is optional; if specified, it must be set to zero. See also *--sched-runtime*, *--sched-deadline* and *--sched-period*. The relation between the options required by the kernel is runtime <= deadline <= period. *chrt* copies _period_ to _deadline_ if *--sched-deadline* is not specified and _deadline_ to _runtime_ if *--sched-runtime* is not specified. It means that at least *--sched-period* has to be specified. See *sched*(7) for more details.
 
 *-d*, *--ext*::
-Set scheduling policy to *SCHED_EXT* (BPF program-defined scheduling). Linux-specific, supported since 6.12. The priority argument has to be set to zero.
+Set scheduling policy to *SCHED_EXT* (BPF program-defined scheduling). Linux-specific, supported since 6.12. Since util-linux v2.42, the priority argument is optional; if specified, it must be set to zero.
 
 == SCHEDULING OPTIONS
 
@@ -131,6 +131,10 @@ ____
 Reset priorities to default for a process{colon}::
 ____
 *chrt -o --pid 0* _PID_
+____
+Set a custom slice of 1 ms for a SCHED_OTHER task (priority is optional for policies other than SCHED_FIFO and SCHED_RR){colon}::
+____
+*chrt -o -T 1000000 --pid* _PID_
 ____
 See *sched*(7) for a detailed discussion of the different scheduler classes and how they interact.
 

--- a/schedutils/chrt.1.adoc
+++ b/schedutils/chrt.1.adoc
@@ -40,7 +40,7 @@ chrt - manipulate the real-time attributes of a process
 
 *chrt* [options] _priority command argument_ ...
 
-*chrt* [options] *-p* [_priority_] _PID_
+*chrt* [options] *--pid* [_priority_] _PID_
 
 == DESCRIPTION
 
@@ -117,20 +117,20 @@ ____
 //TRANSLATORS: Keep {colon} untranslated
 You can also retrieve the real-time attributes of an existing task{colon}::
 ____
-*chrt -p* _PID_
+*chrt --pid* _PID_
 ____
 //TRANSLATORS: Keep {colon} untranslated
 Or set them{colon}::
 ____
-*chrt -r -p* _priority PID_
+*chrt -r --pid* _priority PID_
 ____
 This, for example, sets real-time scheduling to priority _30_ for the process _PID_ with the *SCHED_RR* (round-robin) class{colon}::
 ____
-*chrt -r -p 30* _PID_
+*chrt -r --pid 30* _PID_
 ____
 Reset priorities to default for a process{colon}::
 ____
-*chrt -o -p 0* _PID_
+*chrt -o --pid 0* _PID_
 ____
 See *sched*(7) for a detailed discussion of the different scheduler classes and how they interact.
 

--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -64,7 +64,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	" chrt [options] --pid <priority> <pid>\n"), out);
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Get policy:\n"
-	" chrt [options] -p <pid>\n"), out);
+	" chrt [options] --pid <pid>\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Policy options:\n"), out);
@@ -341,7 +341,7 @@ static int set_sched_one(struct chrt_ctl *ctl, pid_t pid)
 	return set_sched_one_by_setscheduler(ctl, pid);
 }
 
-#else /* !HAVE_SCHED_SETATTR */
+#else /* HAVE_SCHED_SETATTR */
 static int set_sched_one(struct chrt_ctl *ctl, pid_t pid)
 {
 	struct sched_attr sa = { .size = sizeof(struct sched_attr) };
@@ -499,7 +499,7 @@ int main(int argc, char **argv)
 	    ((ctl->pid == -1) && argc - optind < 2)) {
 		warnx(_("bad usage"));
 		errtryhelp(EXIT_FAILURE);
-}
+	}
 
 	if ((ctl->pid > -1) && (ctl->verbose || argc - optind == 1)) {
 		show_sched_info(ctl);

--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -399,7 +399,7 @@ int main(int argc, char **argv)
 {
 	struct chrt_ctl _ctl = { .pid = -1, .policy = SCHED_RR }, *ctl = &_ctl;
 	int c;
-	bool policy_given = false;
+	bool policy_given = false, need_prio = false;
 
 	static const struct option longopts[] = {
 		{ "all-tasks",  no_argument, NULL, 'a' },
@@ -455,6 +455,7 @@ int main(int argc, char **argv)
 		case 'f':
 			ctl->policy = SCHED_FIFO;
 			policy_given = true;
+			need_prio = true;
 			break;
 		case 'R':
 			ctl->reset_on_fork = 1;
@@ -480,6 +481,7 @@ int main(int argc, char **argv)
 		case 'r':
 			ctl->policy = SCHED_RR;
 			policy_given = true;
+			need_prio = true;
 			break;
 		case 'v':
 			ctl->verbose = 1;
@@ -503,29 +505,35 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (((ctl->pid > -1) && argc - optind < 1) ||
-	    ((ctl->pid == -1) && argc - optind < 2)) {
+	if (((ctl->pid > -1) && argc - optind < (need_prio ? 1 : 0)) ||
+	    ((ctl->pid == -1) && argc - optind < (need_prio ? 2 : 1))) {
 		warnx(_("bad usage"));
 		errtryhelp(EXIT_FAILURE);
 	}
 
 	/* pid exists but priority not given */
 	if (ctl->pid > -1 && argc - optind == 1) {
-		/* Error if a policy was specified but no priority given */
-		if (policy_given)
+		/* Error if priority is missing for a policy that requires it */
+		if (policy_given && need_prio)
 			errx(EXIT_FAILURE, ("policy %s requires a priority argument"),
 						get_policy_name(ctl->policy));
 
 		/* If no policy specified, show current settings */
-		show_sched_info(ctl);
-		return EXIT_SUCCESS;
+		if (!policy_given) {
+			show_sched_info(ctl);
+			return EXIT_SUCCESS;
+		}
 	}
 
 	if (ctl->verbose)
 		show_sched_info(ctl);
 
 	errno = 0;
-	ctl->priority = strtos32_or_err(argv[optind], _("invalid priority argument"));
+
+	if (need_prio || argc - optind == 2)
+		ctl->priority = strtos32_or_err(argv[optind], _("invalid priority argument"));
+	else
+		ctl->priority = 0;
 
 	if (ctl->runtime && !supports_runtime_param(ctl->policy))
 		errx(EXIT_FAILURE, _("--sched-runtime option is supported for %s"),


### PR DESCRIPTION
Currently, chrt requires a priority argument even for scheduling policies like SCHED_OTHER and SCHED_BATCH, which ignore it.

This change relaxes that requirement. Now, priority is only expected for SCHED_FIFO and SCHED_RR. For other policies, a default value of 0 is set internally and no argument is required on the command line.

This simplifies usage when modifying runtime parameters like --sched-runtime for non-realtime tasks.

For example, to change the EEVDF tunable base_slice, one currently needs to run:
chrt -v -o -T 1000000 -p 0 $PID

Passing '0' after -p is not intutive and not required as priority is not applicable to SCHED_OTHER tasks. Now with this patch, one can do: chrt -v -o -T 1000000 -p $PID

Passing '0' still works ensuring ABI doesn't break.