### PR TITLE
docs: update mount options for 'ntfs3'

### DIFF
--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1157,23 +1157,48 @@ Just like _nfs_, the _ncpfs_ implementation expects a binary argument (a _struct
 
 === Mount options for ntfs3
 
+The ntfs3 kernel driver provides below mount options - as documented in https://docs.kernel.org/filesystems/ntfs3.html
+
 **iocharset=**__name__::
-Character set to use when returning file names. Unlike VFAT, NTFS suppresses names that contain nonconvertible characters. Deprecated.
+This option informs the driver how to interpret path strings and translate them to Unicode and back. If this option is not set, the default codepage will be used (CONFIG_NLS_DEFAULT).
 
-**nls=**__name__::
-New name for the option earlier called _iocharset_.
+Example: iocharset=utf8
 
-*utf8*::
-Use UTF-8 for converting file names.
+**uid=**|**gid=**|**umask=**::
+Controls the default permissions for files/directories created after the NTFS volume is mounted.
 
-*uni_xlate=*{**0**|**1**|*2*}::
-For 0 (or 'no' or 'false'), do not use escape sequences for unknown Unicode characters. For 1 (or 'yes' or 'true') or 2, use vfat-style 4-byte escape sequences starting with ":". Here 2 gives a little-endian encoding and 1 a byteswapped bigendian encoding.
+**dmask=**|**fmask=**::
+Instead of specifying umask which applies both to files and directories, fmask applies only to files and dmask only to directories.
 
-*posix=[0|1]*::
-If enabled (posix=1), the filesystem distinguishes between upper and lower case. The 8.3 alias names are presented as hard links instead of being suppressed. This option is obsolete.
+**nohidden**::
+Files with the Windows-specific HIDDEN (FILE_ATTRIBUTE_HIDDEN) attribute will not be shown under Linux.
 
-**uid=**__value__, **gid=**__value__ and **umask=**__value__::
-Set the file permission on the filesystem. The umask value is given in octal. By default, the files are owned by root and not readable by somebody else.
+**sys_immutable**::
+Files with the Windows-specific SYSTEM (FILE_ATTRIBUTE_SYSTEM) attribute will be marked as system immutable files.
+
+**hide_dot_files**::
+Updates the Windows-specific HIDDEN (FILE_ATTRIBUTE_HIDDEN) attribute when creating and moving or renaming files. Files whose names start with a dot will have the HIDDEN attribute set and files whose names do not start with a dot will have it unset.
+
+**windows_names**::
+Prevents the creation of files and directories with a name not allowed by Windows, either because it contains some not allowed character (which are the characters “ * / : < > ? \ | and those whose code is less than 0x20), because the name (with or without extension) is a reserved file name (CON, AUX, NUL, PRN, LPT1-9, COM1-9) or because the last character is a space or a dot. Existing such files can still be read and renamed.
+
+**discard**::
+Enable support of the TRIM command for improved performance on delete operations, which is recommended for use with the solid-state drives (SSD).
+
+**force**::
+Forces the driver to mount partitions even if volume is marked dirty. Not recommended for use.
+
+**sparse**::
+Create new files as sparse.
+
+**showmeta**::
+Use this parameter to show all meta-files (System Files) on a mounted NTFS partition. By default, all meta-files are hidden.
+
+**prealloc**::
+Preallocate space for files excessively when file size is increasing on writes. Decreases fragmentation in case of parallel write operations to different files.
+
+**acl**::
+Support POSIX ACLs (Access Control Lists). Effective if supported by Kernel. Not to be confused with NTFS ACLs. The option specified as acl enables support for POSIX ACLs.
 
 === Mount options for overlay
 


### PR DESCRIPTION
Cleanout the mount options, and import the options from the upstream documentation found at https://docs.kernel.org/filesystems/ntfs3.html

Fixes: 847264af6 docs: update mount type to 'ntfs3'