### PR TITLE
script: support non-option argument as command

### DIFF
--- a/term-utils/script.1.adoc
+++ b/term-utils/script.1.adoc
@@ -49,7 +49,7 @@ script - make typescript of terminal session
 
 == SYNOPSIS
 
-*script* [options] [_file_]
+*script* [options] [_file_] [ -- program [arguments]]
 
 == DESCRIPTION
 
@@ -69,7 +69,7 @@ Below, the _size_ argument may be followed by the multiplicative suffixes KiB (=
 Append the output to _file_ or to _typescript_, retaining the prior contents.
 
 *-c*, *--command* _command_::
-Run the _command_ rather than an interactive shell. This makes it easy for a script to capture the output of a program that behaves differently when its stdout is not a tty.
+Run the _command_ rather than an interactive shell. This makes it easy for a script to capture the output of a program that behaves differently when its stdout is not a tty. It's possible to specify the command after '--' too.
 
 *-E*, *--echo* _when_::
 This option controls the *ECHO* flag for the slave end of the session's pseudoterminal. The supported modes are _always_, _never_, or _auto_.


### PR DESCRIPTION
[kzak@redhat.com: - don't use POSIXLY_CORRECT, use "+" in getopt_long(),
                  - use strv_join() rather than local concat function]

Based-on: https://github.com/util-linux/util-linux/pull/3599
Fixes: https://github.com/util-linux/util-linux/issues/3481