### PR TITLE
gitignore: Ignore tests/diff/ and test/output/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,9 @@ stamp-h1
 syscalls.h
 tags
 test-suite.log
+tests/diff/
 tests/failures
+tests/output/
 tests/run.sh.log
 tests/run.sh.trs
 update.log


### PR DESCRIPTION
These are auto-generated and clutter git status.
It's even worse with jj, which will auto-add them.