### PR TITLE
lsblk: use md as fallback TYPE when md/level empty

### DIFF
--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -483,7 +483,7 @@ static char *get_type(struct lsblk_device *dev)
 		char *md_level = NULL;
 
 		ul_path_read_string(dev->sysfs, &md_level, "md/level");
-		res = md_level ? md_level : xstrdup("md");
+		res = (md_level && *md_level) ? md_level : xstrdup("md");
 
 	} else {
 		const char *type = NULL;


### PR DESCRIPTION
Use `"md"` as a fallback for the device type if the sysfs file `md/level` is read but is empty.

Fixes: #3632
