### PR TITLE
man: Replace RETURN VALUE with EXIT STATUS in section 1

### DIFF
--- a/schedutils/coresched.1.adoc
+++ b/schedutils/coresched.1.adoc
@@ -96,7 +96,7 @@ Copy the cookie from a task with pid _123_ to the process group ID _456_{colon}:
 Retrieving or modifying the core scheduling cookie of a process requires *PTRACE_MODE_READ_REALCREDS* ptrace access to that process.
 See the section "Ptrace access mode checking" in *ptrace*(2) for more information.
 
-== RETURN VALUE
+== EXIT STATUS
 On success, *{command}* returns 0.
 If *{command}* fails, it will print an error and return 1.
 

--- a/schedutils/taskset.1.adoc
+++ b/schedutils/taskset.1.adoc
@@ -106,7 +106,7 @@ The *--cpu-list* form is applicable only for launching new commands{colon}::
 
 A user can change the CPU affinity of a process belonging to the same user. A user must possess *CAP_SYS_NICE* to change the CPU affinity of a process belonging to another user. A user can retrieve the affinity mask of any process.
 
-== RETURN VALUE
+== EXIT STATUS
 
 *taskset* returns 0 in its affinity-getting mode as long as the provided PID exists.
 


### PR DESCRIPTION
According to man-pages(7), sections 1 and 8 should normally use EXIT STATUS, while sections 2 and 3 should use RETURN VALUE.

https://man7.org/linux/man-pages/man7/man-pages.7.html