### PR TITLE
bash-completion: fix function name of enosys completion

### DIFF
--- a/bash-completion/enosys
+++ b/bash-completion/enosys
@@ -1,4 +1,4 @@
-_waitpid_module()
+_enosys_module()
 {
 	local cur prev OPTS
 	COMPREPLY=()


### PR DESCRIPTION
The function `_enosys_module` referenced by the completion setting on [the last line of `bash-completion/enosys`](https://github.com/util-linux/util-linux/blob/06419fe95b06c7aa8670081a68dbe43a53bff303/bash-completion/enosys#L50) is not defined in the current master.  As reported in Ref. [1], this causes the following error on an attempt at argument completion for the `enosys` command:

```
bash: _enosys_module: command not found
```

- [1] [linuxbrew error : r/Fedora](https://www.reddit.com/r/Fedora/comments/1llmu0w/comment/n00y98k/)

Also, [the function `_waitpid_module` defined in `bash-completion/enosys`](https://github.com/util-linux/util-linux/blob/06419fe95b06c7aa8670081a68dbe43a53bff303/bash-completion/enosys#L1) overwrites [another completion function of the same name defined in `bash-completion/waitpid`](https://github.com/util-linux/util-linux/blob/06419fe95b06c7aa8670081a68dbe43a53bff303/bash-completion/waitpid#L1).  This patch renames the function in `bash-completion/enosys` to the correct one, `_enosys_module`.