### PR TITLE
column(1) add colors support

### DIFF
--- a/text-utils/column.1.adoc
+++ b/text-utils/column.1.adoc
@@ -136,6 +136,13 @@ Allow using a multi-line cell for long text if necessary. See *--table-wrap* for
 Don't print the column. See *--table-hide* for more details.
 **json=**_type_;;
 Define the column type for JSON output. Supported types are *string*, *number* and *boolean*.
+**color=**_name_;;
+Define the column color for output on the terminal. The _name_ is a color name 
+(black, blink, blue, bold, brown, cyan, darkgray, gray, green, halfbright, 
+lightblue, lightcyan, lightgray, lightgreen, lightmagenta, lightred, magenta, 
+red, reset, reverse, and yellow) or ANSI color sequence number(s) separated by 
+a semicolon, but without the 'ESC[' prefix and 'm' suffix. For example, "37;41" 
+defines sequences for a red background and white foreground.
 
 *-N, --table-columns* _names_::
 Specify column names with a comma-separated list. The names are used for the table header

--- a/text-utils/column.c
+++ b/text-utils/column.c
@@ -346,6 +346,7 @@ static void init_table(struct column_control *ctl)
 		scols_table_enable_noencoding(ctl->tab, 1);
 
 	scols_table_enable_maxout(ctl->tab, ctl->maxout ? 1 : 0);
+	scols_table_enable_colors(ctl->tab, 1);
 
 	if (ctl->tab_columns) {
 		char **opts;


### PR DESCRIPTION
- [x] enable color support 
- [ ]  add `--colors=auto|never|always` to be smart on terminal by default ("auto")
- [ ]  add support for color schemas (logical color names) and enable/disable configuration as implemented in lib/colors.c (aka terminal-colors.d(5))
  - [ ] add callback to libsmartcols to parse additional custom logical color names (e.g. "warning")
  - [ ] add `--table-colorscheme=name` option to column(1) to support terminal-colors.d(5) 
- [ ] update bash-completion
- [ ] update column man page

