### PR TITLE
fsck.cramfs: check buffer size for memcpy()

### DIFF
--- a/disk-utils/cramfs.h
+++ b/disk-utils/cramfs.h
@@ -40,6 +40,15 @@
 #endif
 
 /*
+ * The longest file name component to allow for in the input directory tree.
+ * Ext2fs (and many others) allow up to 255 bytes.  A couple of filesystems
+ * allow longer (e.g. smbfs 1024), but there isn't much use in supporting
+ * >255-byte names in the input directory tree given that such names get
+ * truncated to 255 bytes when written to cramfs.
+ */
+#define MAX_INPUT_NAMELEN 255
+
+/*
  * Reasonably terse representation of the inode data.
  */
 struct cramfs_inode {

--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -244,14 +244,6 @@ identical_file(struct entry *e1, struct entry *e2){
 	return equal;
 }
 
-/*
- * The longest file name component to allow for in the input directory tree.
- * Ext2fs (and many others) allow up to 255 bytes.  A couple of filesystems
- * allow longer (e.g. smbfs 1024), but there isn't much use in supporting
- * >255-byte names in the input directory tree given that such names get
- * truncated to 255 bytes when written to cramfs.
- */
-#define MAX_INPUT_NAMELEN 255
 
 static int find_identical_file(struct entry *orig, struct entry *new, loff_t *fslen_ub)
 {


### PR DESCRIPTION
- reuse MAX_INPUT_NAMELEN
- check path buffer size before memcpy() to the buffer
- check for zero path before use it