### PR TITLE
libblkid: (ext) reduce false positive

### DIFF
--- a/libblkid/src/superblocks/ext.c
+++ b/libblkid/src/superblocks/ext.c
@@ -180,6 +180,15 @@ static struct ext2_super_block *ext_get_super(
 			return NULL;
 #endif
 		}
+	} else {
+		/*
+		 * For legacy fs without checksum, additionally verify the
+		 * block size to reduce false positive. Currently max allowed
+		 * block size is 64KiB (s_log_block_size <= 6), check for 256
+		 * to be more future proof.
+		 */
+		if (le32_to_cpu(es->s_log_block_size) >= 256)
+			return NULL;
 	}
 	if (fc)
 		*fc = le32_to_cpu(es->s_feature_compat);


### PR DESCRIPTION
Currently the false positive rate for ext super block is a little too high, we've hit this several time with random data in encrypted disk from cloud provider. e.g.
```
% xxd -a ./test.ext4.img                                             
00000000: 0000 0000 0000 0000 0000 0000 0000 0000  ................
*
00000430: 0000 0000 0000 0000 53ef 0000 0000 0000  ........S.......
00000440: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000450: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000460: 0800 0000 0000 0000 0000 0000 0000 0000  ................
00000470: 0000 0000 0000 0000 0000 0000 0000 0000  ................
*
% blkid ./test.ext4.img                                              
./test.ext4.img: BLOCK_SIZE="1024" TYPE="jbd"
```
The false positive rate is about 2^(-17) now. This PR should reduce it to 2^(-40)