### PR TITLE
tests/helpers/test_sigstate.c: explicitly reset SIGINT to default action after trapping

### DIFF
--- a/tests/helpers/test_sigstate.c
+++ b/tests/helpers/test_sigstate.c
@@ -68,6 +68,7 @@ int main(int argc _U_, char **argv _U_)
 	sigignore(SIGPIPE);
 	sigignore(SIGALRM);
 
+	signal(SIGINT, SIG_DFL);
 	signal(SIGBUS, SIG_DFL);
 	signal(SIGFPE, SIG_DFL);
 	signal(SIGSEGV, SIG_DFL);


### PR DESCRIPTION
After upgrading bash to 5.3 to contain commit [1], if SIGINT was trapped in asynchronous subshell, bash called set_signal_async_ignored to make sure processes that are created by this asynchronous subshell to ignore SIGINT.

And it caused test case `kill/decode' failed, the signal INT was existed in both of Blocked and Ignored

$ ./tests/run.sh --use-system-commands --parsable --show-diff   kill/decode
...
diff-{{{
|--- /usr/lib/util-linux/ptest/tests/expected/kill/decode        2011-04-05 23:00:00.000000000 +0000
|+++ /usr/lib/util-linux/ptest/tests/output/kill/decode  2025-07-28 12:09:46.279000000 +0000
@@ -16,5 +16,5 @@
 Pending (thread): INT ILL
 Pending (process): USR1
 Blocked: INT ILL ABRT FPE USR1 SEGV TERM
-Ignored: HUP QUIT TRAP PIPE ALRM
+Ignored: HUP INT QUIT TRAP PIPE ALRM
 Caught: ILL USR1
}}}-diff
...

Explicitly reset SIGINT to default action after trapping, then the test case `kill/decode' works on both of old (<5.3) and new (>=5.3) bash

[1] https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?h=devel&id=a5d2617c7a7e602ace1f4149987cdfd075c4e762