### PR TITLE
meson: use curses dep for ncurses

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -290,7 +290,7 @@ if lib_ncursesw.found()
   lib_ncurses = disabler()
 else
   lib_ncurses = dependency(
-    'ncurses',
+    'curses',
     disabler : true,
     required : get_option('ncurses'))
   headers += ['ncurses.h',


### PR DESCRIPTION
curses is special in that it's able to find ncurses in a lot more locations that ncurses, which only looks at pkg-config and cmake. This is somewhat useful with exotic OSes like macOS.