### PR TITLE
setpriv: Add support for LANDLOCK_ACCESS_FS_IOCTL_DEV

### DIFF
--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -79,6 +79,9 @@ static const struct {
 #ifdef LANDLOCK_ACCESS_FS_TRUNCATE
 	{ LANDLOCK_ACCESS_FS_TRUNCATE,    "truncate"    },
 #endif
+#ifdef LANDLOCK_ACCESS_FS_IOCTL_DEV
+	{ LANDLOCK_ACCESS_FS_IOCTL_DEV,   "ioctl-dev"   },
+#endif
 };
 
 static long landlock_access_to_mask(const char *str, size_t len)


### PR DESCRIPTION
The LANDLOCK_ACCESS_FS_IOCTL_DEV access right controls whether the process may use IOCTL on opened device files.  It is available since Linux 6.10.

Compatibility remark:
With this change, using the --landlock-access="fs" shortcut now requires Linux 6.10+, where it previously required Linux 6.2+.