### PR TITLE
logger: fix incorrect warning message when --file and message given

### DIFF
--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -1296,7 +1296,7 @@ int main(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 	if (stdout_reopened && argc)
-		warnx(_("--file <file> and <message> are mutually exclusive, message is ignored"));
+		warnx(_("--file <file> and <message> are mutually exclusive; file is ignored"));
 #ifdef HAVE_LIBSYSTEMD
 	if (jfd) {
 		int ret = journald_entry(&ctl, jfd);


### PR DESCRIPTION
Logger warns that when both --file and a message are given, the message is ignored. It does the opposite. Fix the warning message to conform to the observed behavior.

Example:
echo "You will not see this file in the log" > file.txt

logger -f file.txt "You will see this message in the log, however"

Signed-off-by: Alexander Kappner <agk@godking.net>