### PR TITLE
kill: usage: fix wrapped indent; comments: add 'that'

### DIFF
--- a/misc-utils/kill.c
+++ b/misc-utils/kill.c
@@ -280,7 +280,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -p, --pid              print pids without signaling them\n"), out);
 	fputs(_(" -l, --list[=<signal>|=0x<sigmask>]\n"
 		"                        list signal names, convert a signal number to a name,\n"
-		"                         or convert a signal mask to names\n"), out);
+		"                          or convert a signal mask to names\n"), out);
 	fputs(_(" -L, --table            list signal names and numbers\n"), out);
 	fputs(_(" -r, --require-handler  do not send signal if signal handler is not present\n"), out);
 	fputs(_(" -d, --show-process-state <pid>\n"

--- a/misc-utils/kill.c
+++ b/misc-utils/kill.c
@@ -325,7 +325,7 @@ static char **parse_arguments(int argc, char **argv, struct kill_control *ctl)
 	char *arg;
 
 	/* Loop through the arguments.  Actually, -a is the only option
-	 * can be used with other options.  The 'kill' is basically a
+	 * that can be used with other options.  The 'kill' is basically a
 	 * one-option-at-most program. */
 	for (argc--, argv++; 0 < argc; argc--, argv++) {
 		arg = *argv;


### PR DESCRIPTION
### Summary
Align the wrapped help text indentation in `kill --help` and fix a small
grammar issue in a comment. No functional changes.

### Changes
1) **Help/usage**
- In the `-l, --list` description, increase the leading spaces on the
  wrapped continuation line (“or convert a signal mask to names”) by one,
  so wrapped lines align with the common util-linux help style (see
Documentation/howto-usage-function.txt).

2) **Comments**
- In `parse_arguments()`, insert **“that”** so the sentence reads:
  “-a is the only option **that** can be used with other options.”

### Rationale
- Other util-linux tools (e.g., `fdisk`, `logger`, `last`) indent wrapped
  help lines consistently; this line in `kill` was off by one space.
- The comment fix improves readability.

### Impact
- **No functional impact.**
- The help text change touches a **translatable string** (whitespace-only).

### Testing
- Built successfully (`./autogen.sh && ./configure && make`).
- Verified `kill --help` alignment before/after.
- No test regressions observed.

### Diff highlights
- Usage: one extra leading space on the wrapped “or convert …” line.
- Comment: add “that” in `parse_arguments()`.

### Misc
- Happy to split into separate PRs if preferred, or reword per review.