### PR TITLE
lsclocks: stop using MAX_ClOCKS

### DIFF
--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -84,7 +84,7 @@ static inline clockid_t FD_TO_CLOCKID(int fd)
 #endif
 
 #ifndef CLOCK_AUX
-# define CLOCK_AUX			MAX_CLOCKS
+# define CLOCK_AUX			16
 #endif
 
 #define CLOCK_AUX0			(CLOCK_AUX + 0)


### PR DESCRIPTION
MAX_CLOCKS is only available in the kernel UAPI headers and not libc headers. Switch back to a hardcoded value. This value is a stable ABI anyways and matches the other fallback definitions.

Fixes: d3c49ee062f7 ("lsclocks: use MAX_CLOCKS, improve indention")