### PR TITLE
lscpu: use maximum CPU speed from DMI, avoid duplicate version string

### DIFF
--- a/sys-utils/lscpu.h
+++ b/sys-utils/lscpu.h
@@ -346,6 +346,7 @@ struct dmi_info {
 	char *processor_manufacturer;
 	char *processor_version;
 	uint16_t current_speed;
+	uint16_t max_speed;
 	char *part_num;
 };
 


### PR DESCRIPTION
* Read maximum CPU speed from DMI
* Don't use max speed if nonsensical
* Avoid appending "CPU @ speed" to the version string if it's already included. (This is a code robustness improvement as DMI is currently read for ARMs only, and the issue was detected on Intel.)

Fixes: https://github.com/util-linux/util-linux/commit/a772d7c493afcec32f0123fc947013f74db6e45d