### PR TITLE
getopt: add feature to ignore unknown options

### DIFF
--- a/Documentation/TODO
+++ b/Documentation/TODO
@@ -103,15 +103,6 @@ partx
 
  - support mapping by device-mapper if argv[0] is "kpartx" or --dm option is used.
 
-
-getopt
-------
-  It would be great if getopt could optionally ignore unknown options.
-  Currently, it outputs -- for every option it doesn't recognize but leaving the
-  option as it is could beneficial wrapper scripts which could then pass the
-  options they don't recognize as they are to the command they are wrapping.
-  https://github.com/util-linux/util-linux/issues/701
-
 docs
 ----
 

--- a/misc-utils/getopt.1.adoc
+++ b/misc-utils/getopt.1.adoc
@@ -59,6 +59,9 @@ Test if your *getopt*(1) is this enhanced version or an old version. This genera
 *-u*, *--unquoted*::
 Do not quote the output. Note that whitespace and special (shell-dependent) characters can cause havoc in this mode (like they do with other *getopt*(1) implementations).
 
+*-U*, *--unknown*::
+Leave unknown options as they are and surpress error messages from *getopt(3)*. Since there is no way to know whether an unknown option requires an argument, a non-option argument that follows the unknown option after a whitespace, is considered an option argument, therefore the argument will be left untouched and printed next to the respective unknown option. To prevent unexpected behavior, short options should be specified individually.
+
 include::man-common/help-version.adoc[]
 
 == PARSING

--- a/misc-utils/getopt.c
+++ b/misc-utils/getopt.c
@@ -92,6 +92,7 @@ struct getopt_control {
 	int long_options_nr;		/* number of used elements in array */
 	bool	compatible,		/* compatibility mode for 'difficult' programs */
 		ignore_unknown,		/* leave unknown options as they are */
+		posixly_correct,        /* POSIXLY_CORRECT environmental variable is set */
 		quiet_errors,		/* print errors */
 		quiet_output,		/* print output */
 		quote;			/* quote output */
@@ -205,7 +206,7 @@ static int generate_output(struct getopt_control *ctl, char *argv[], int argc)
 		  (const struct option *)ctl->long_options, &longindex)))
 	       != EOF) {
 
-		if (ctl->ignore_unknown && opt == '?' && !getenv("POSIXLY_CORRECT") && !ctl->quiet_output) {
+		if (ctl->ignore_unknown && opt == '?' && !ctl->posixly_correct && !ctl->quiet_output) {
 			print_normalized(ctl, argv[optind-1]);
 			if ((optind <= argc-1) && !IS_OPT(argv[optind])) {
 				print_normalized(ctl, argv[optind++]);
@@ -292,7 +293,7 @@ static void add_longopt(struct getopt_control *ctl, const char *name, int has_ar
 static void add_short_options(struct getopt_control *ctl, char *options)
 {
 	free(ctl->optstr);
-	if (*options != '+' && getenv("POSIXLY_CORRECT"))
+	if (*options != '+' && ctl->posixly_correct)
 		ctl->optstr = ul_strconcat("+", options);
 	else
 		ctl->optstr = xstrdup(options);
@@ -411,6 +412,8 @@ int main(int argc, char *argv[])
 
 	if (getenv("GETOPT_COMPATIBLE"))
 		ctl.compatible = 1;
+	if (getenv("POSIXLY_CORRECT"))
+		ctl.posixly_correct = 1;
 
 	if (argc == 1) {
 		if (ctl.compatible) {


### PR DESCRIPTION
This feature addition will add the '-U' and '--unknown' options It'll allow getopt to ignore unknown options and leave them untouched. Additionally, it will surpress any error messages generated by getopt(3).

Addresses: #701