### PR TITLE
bash-completion: add fallback to filename expansion for umount

### DIFF
--- a/bash-completion/umount
+++ b/bash-completion/umount
@@ -83,7 +83,13 @@ _umount_module()
 			;;
 	esac
 
-	local IFS=$'\n'
-	COMPREPLY=( $( compgen -W '$( _umount_points_list )'  -- "$cur" ) )
+	if command grep -q "^$cur" <(findmnt -lno TARGET); then
+		local IFS=$'\n'
+		COMPREPLY=( $( compgen -W '$( _umount_points_list )'  -- "$cur" ) )
+	else
+		compopt -o filenames
+		COMPREPLY=( $(compgen -o dirnames -- "$cur") )
+		return 0
+	fi
 }
 complete -F _umount_module -o nospace umount


### PR DESCRIPTION
If the user defined path can not be found in the mount table fallback to simple filename expansion.

Addresses: #1333