### PR TITLE
man: Fixed incorrect ipcrm options

### DIFF
--- a/sys-utils/ipcrm.1.adoc
+++ b/sys-utils/ipcrm.1.adoc
@@ -48,7 +48,7 @@ Remove the shared memory segment created with _shmkey_ after the last detach is 
 *-m*, *--shmem-id* _shmid_::
 Remove the shared memory segment identified by _shmid_ after the last detach is performed.
 
-*-x*, *--posix-shmem* _name_::
+*--posix-shmem* _name_::
 Remove the POSIX shared memory segment created with _name_.
 
 *-Q*, *--queue-key* _msgkey_::
@@ -57,7 +57,7 @@ Remove the message queue created with _msgkey_.
 *-q*, *--queue-id* _msgid_::
 Remove the message queue identified by _msgid_.
 
-*-y*, *--posix-mqueue* _name_::
+*--posix-mqueue* _name_::
 Remove the POSIX message queue created with _name_.
 
 *-S*, *--semaphore-key* _semkey_::
@@ -66,7 +66,7 @@ Remove the semaphore created with _semkey_.
 *-s*, *--semaphore-id* _semid_::
 Remove the semaphore identified by _semid_.
 
-*-z*, *--posix-semaphore* _name_::
+*--posix-semaphore* _name_::
 Remove the POSIX named semaphore created with _name_.
 
 include::man-common/help-version.adoc[]


### PR DESCRIPTION
Short options -x, -y, and -z do not exist.
The man page was not revised after the local code was changed to follow Open Group requirements for ipcrm.