### PR TITLE
findmnt: add missing newline in --raw, --pair and --list output formats

### DIFF
--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1446,6 +1446,8 @@ static int poll_table(struct libmnt_table *tb, const char *tabfile,
 
 		if (count) {
 			rc = scols_table_print_range(table, NULL, NULL);
+			if (rc == 0 && !(findmnt->flags & FL_JSON))
+				fputc('\n', scols_table_get_stream(table));
 			fflush(scols_table_get_stream(table));
 			if (rc)
 				goto done;


### PR DESCRIPTION
Addresses: #3711