### PR TITLE
zramctl: ignore ENOENT when setting max_comp_streams

### DIFF
--- a/sys-utils/zramctl.c
+++ b/sys-utils/zramctl.c
@@ -973,7 +973,8 @@ int main(int argc, char **argv)
 			err(EXIT_FAILURE, _("%s: failed to reset"), zram->devname);
 
 		if (nstreams &&
-		    zram_set_u64parm(zram, "max_comp_streams", nstreams))
+		    zram_set_u64parm(zram, "max_comp_streams", nstreams) &&
+		    errno != ENOENT)
 			err(EXIT_FAILURE, _("%s: failed to set number of streams"), zram->devname);
 
 		if (algorithm &&


### PR DESCRIPTION
The `max_comp_streams` attribute of zram devices has been deprecated and all writes were silently ignored by the kernel since 2016. It was finally removed in 6.15, causing zramctl to fail on ENOENT, when it should just ignore the error.