### PR TITLE
logger: fix buffer overflow when reading stdin

### DIFF
--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -1025,7 +1025,9 @@ static void logger_stdin(struct logger_ctl *ctl)
 		if (ctl->prio_prefix && c == '<') {
 			pri = 0;
 			buf[i++] = c;
-			while (isdigit(c = getchar()) && pri <= 191) {
+			while (i < ctl->max_message_size
+			       && isdigit(c = getchar()) && pri <= 191) {
+
 				buf[i++] = c;
 				pri = pri * 10 + c - '0';
 			}


### PR DESCRIPTION
```
$ perl -e 'print "<" . "0"x10240' | logger --prio-prefix
Segmentation fault (core dumped)
```

It was initially reported as a security issue https://github.com/util-linux/util-linux/security/advisories/GHSA-47v8-f434-9f8r, but it is actually just an ordinary bug as logger has no unusual permissions or so ...