### PR TITLE
lscpu: New Arm C1 parts

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -99,8 +99,12 @@ static const struct id_part arm_part[] = {
     { 0xd87, "Cortex-A725" },
     { 0xd88, "Cortex-A520AE" },
     { 0xd89, "Cortex-A720AE" },
+    { 0xd8a, "C1-Nano" },
+    { 0xd8b, "C1-Pro" },
+    { 0xd8c, "C1-Ultra" },
     { 0xd8e, "Neoverse-N3" },
     { 0xd8f, "Cortex-A320" },
+    { 0xd90, "C1-Premium" },
     { -1, "unknown" },
 };
 


### PR DESCRIPTION
Arm has announced the C1-Nano with a TRM here:
https://developer.arm.com/documentation/107753/latest

The C1-Pro with a TRM here:
https://developer.arm.com/documentation/107771/latest

The C1-Ultra with a TRM here:
https://developer.arm.com/documentation/108014/latest

The C1-Premium with a TRM here:
https://developer.arm.com/documentation/109416/latest