### PR TITLE
libmount: don't report fsconfig errors with "nofail"

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1662,6 +1662,12 @@ int mnt_context_get_mount_excode(
 
 	/* Error with already generated messages (by kernel or libmount) */
 	if (buf && mnt_context_get_nmesgs(cxt, 'e')) {
+		if (syserr == ENOENT
+		    && uflags & MNT_MS_NOFAIL
+		    && cxt->syscall_name && strcmp(cxt->syscall_name, "fsconfig") == 0
+		    && src && !mnt_is_path(src))
+			return MNT_EX_SUCCESS;
+
 		if (cxt->syscall_name) {
 			size_t len = snprintf(buf, bufsz,
 					_("%s() failed: "),


### PR DESCRIPTION
The new kernel API returns EINVAL on FSCONFIG_CMD_CREATE if the mount source is inaccessible. We do not want to report this as an error when the "nofail" mount option is specified.

Note that EINVAL may also be returned by other fsconfig() settings, so we need to check whether a source is specified and whether it is really inaccessible. This is just a heuristic (as with the old mount(2)).

Fixes: https://github.com/util-linux/util-linux/issues/3741