### PR TITLE
runuser|su: elaborate man page regarding TIOCSTI/TIOCLINUX ioctl command injection

### DIFF
--- a/login-utils/runuser.1.adoc
+++ b/login-utils/runuser.1.adoc
@@ -34,6 +34,7 @@ Since version 2.38 *runuser* resets process resource limits RLIMIT_NICE, RLIMIT_
 
 *-c*, *--command*=_command_::
 Pass _command_ to the shell with the *-c* option.
+Creates a new session via *setsid*(2).
 
 *-f*, *--fast*::
 Pass *-f* to the shell, which may or may not be useful, depending on the shell.
@@ -59,6 +60,7 @@ Preserve the entire environment, i.e., do not set *HOME*, *SHELL*, *USER* or *LO
 Create a pseudo-terminal for the session. The independent terminal provides better security as the user does not share a terminal with the original session. This can be used to avoid TIOCSTI ioctl terminal injection and other security attacks against terminal file descriptors. The entire session can also be moved to the background (e.g., *runuser --pty* *-u* _user_ *--* _command_ *&*). If the pseudo-terminal is enabled, then *runuser* works as a proxy between the sessions (sync stdin and stdout).
 +
 This feature is mostly designed for interactive sessions. If the standard input is not a terminal, but for example a pipe (e.g., *echo "date" | runuser --pty -u* _user_), then the *ECHO* flag for the pseudo-terminal is disabled to avoid messy output.
+Furthermore note that using a pseudo-terminal to prevent TIOCSTI/TIOCLINUX ioctl command injection is irrelevant when using *-c* which creates a new session via *setsid*(2) anyway.
 
 *-s*, *--shell*=_shell_::
 Run the specified _shell_ instead of the default. The shell to run is selected according to the following rules, in order:
@@ -76,6 +78,7 @@ Same as *-c*, but do not create a new session. (Discouraged.)
 *-T*, *--no-pty*::
 Do not create a pseudo-terminal, opposite of *--pty* and *-P*.
 Note that running without a pseudo-terminal opens the security risk of privilege escalation through TIOCSTI/TIOCLINUX ioctl command injection.
+Furthermore note that using a pseudo-terminal to prevent TIOCSTI/TIOCLINUX ioctl command injection is irrelevant when using *-c* which creates a new session via *setsid*(2) anyway.
 
 *-u*, *--user*=_user_::
 Run _command_ with the effective user ID and group ID of the user name _user_.

--- a/login-utils/su.1.adoc
+++ b/login-utils/su.1.adoc
@@ -35,6 +35,7 @@ Since version 2.38 *su* resets process resource limits RLIMIT_NICE, RLIMIT_RTPRI
 
 *-c*, *--command* __command__::
 Pass _command_ to the shell with the *-c* option.
+Creates a new session via *setsid*(2).
 
 *-f*, *--fast*::
 Pass *-f* to the shell, which may or may not be useful, depending on the shell.
@@ -67,6 +68,7 @@ Preserve the entire environment, i.e., do not set *HOME*, *SHELL*, *USER* or *LO
 Create a pseudo-terminal for the session. The independent terminal provides better security as the user does not share a terminal with the original session. This can be used to avoid *TIOCSTI* ioctl terminal injection and other security attacks against terminal file descriptors. The entire session can also be moved to the background (e.g., *su --pty* **-** __user__ *-c* _application_ *&*). If the pseudo-terminal is enabled, then *su* works as a proxy between the sessions (sync stdin and stdout).
 +
 This feature is mostly designed for interactive sessions. If the standard input is not a terminal, but for example a pipe (e.g., *echo "date" | su --pty*), then the *ECHO* flag for the pseudo-terminal is disabled to avoid messy output.
+Furthermore note that using a pseudo-terminal to prevent TIOCSTI/TIOCLINUX ioctl command injection is irrelevant when using *-c* which creates a new session via *setsid*(2) anyway.
 
 *-s*, *--shell* __shell__::
 Run the specified _shell_ instead of the default. If the target user has a restricted shell (i.e., not listed in _/etc/shells_), the *--shell* option and the *SHELL* environment variables are ignored unless the calling user is root.
@@ -84,6 +86,7 @@ Same as *-c*, but do not create a new session. (Discouraged.)
 *-T*, *--no-pty*::
 Do not create a pseudo-terminal, opposite of *--pty* and *-P*.
 Note that running without a pseudo-terminal opens the security risk of privilege escalation through TIOCSTI/TIOCLINUX ioctl command injection.
+Furthermore note that using a pseudo-terminal to prevent TIOCSTI/TIOCLINUX ioctl command injection is irrelevant when using *-c* which creates a new session via *setsid*(2) anyway.
 
 *-w*, *--whitelist-environment* __list__::
 Don't reset the environment variables specified in the comma-separated _list_ when clearing the environment for *--login*. The whitelist is ignored for the environment variables *HOME*, *SHELL*, *USER*, *LOGNAME*, and *PATH*.


### PR DESCRIPTION
The man page already does very well mentioning TIOCSTI/TIOCLINUX ioctl command injection in the descriptions of `-P`/`--pty` and `-T`/`--no-pty`, most recently updated in #2685. However, it fails to mention that no further protection via pseudo-terminal is necessary if `-c` option is being used since that creates a new session via `setsid(2)` anyway - introduced in 2012 with c6a1746b5f5247b2fccaf5c7f68da3852a02e4fc.