### PR TITLE
libblkid: use snprintf() instead of sprintf()

### DIFF
--- a/libblkid/src/encode.c
+++ b/libblkid/src/encode.c
@@ -191,9 +191,11 @@ int blkid_encode_string(const char *str, char *str_enc, size_t len)
 			j += seqlen;
 			i += (seqlen-1);
 		} else if (str[i] == '\\' || !is_whitelisted(str[i], NULL)) {
-			if (len-j < 4)
+			int rc;
+
+			rc = snprintf(&str_enc[j], len-j, "\\x%02x", (unsigned char) str[i]);
+			if (rc != 4)
 				goto err;
-			sprintf(&str_enc[j], "\\x%02x", (unsigned char) str[i]);
 			j += 4;
 		} else {
 			if (len-j < 1)

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -2012,8 +2012,8 @@ static void blkid_probe_log_csum_mismatch(blkid_probe pr, size_t n, const void *
 	int hex_size = min(sizeof(csum_hex), n * 2);
 
 	for (int i = 0; i < hex_size; i+=2) {
-		sprintf(&csum_hex[i], "%02X", ((const unsigned char *) csum)[i / 2]);
-		sprintf(&expected_hex[i], "%02X", ((const unsigned char *) expected)[i / 2]);
+		snprintf(&csum_hex[i], sizeof(csum_hex) - i, "%02X", ((const unsigned char *) csum)[i / 2]);
+		snprintf(&expected_hex[i], sizeof(expected_hex) - i, "%02X", ((const unsigned char *) expected)[i / 2]);
 	}
 
 	DBG(LOWPROBE, ul_debug(


### PR DESCRIPTION
Replace sprintf() calls with snprintf() to ensure proper bounds checking when formatting strings.