### PR TITLE
ci: roll back the version of checkout for "build (compat, ubuntu:18.04)"

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -135,7 +135,7 @@ jobs:
       image: ${{ matrix.image }}
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v1
       - name: Ubuntu setup
         run: .github/workflows/cibuild-setup-ubuntu.sh
       - name: Configure


### PR DESCRIPTION
With the change https://github.com/util-linux/util-linux/commit/28af8ed133ff15d50b5e2d644c6617d0a3e17033, we got the
following error at "Post repository checkout" stage on "build (compat, ubuntu:18.04)":

  Post job cleanup.
  /usr/bin/docker exec  94db032be2efb37ea68b3ce562ce52ba3dea047f5ac970aabb7fded075116c20 sh -c "cat /etc/*release | grep ^ID"
  /__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)