### PR TITLE
umount: consider helper return status for success message

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -198,7 +198,7 @@ static int evaluate_permissions(struct libmnt_context *cxt)
 		/*
 		 * superuser mount
 		 *
-		 * Let's convert user, users, owenr and groups to MS_* flags
+		 * Let's convert user, users, owner and groups to MS_* flags
 		 * to be compatible with non-root execution.
 		 *
 		 * The old deprecated way is to use mnt_optstr_get_flags().

--- a/sys-utils/umount.c
+++ b/sys-utils/umount.c
@@ -138,7 +138,8 @@ static void success_message(struct libmnt_context *cxt)
 {
 	const char *tgt, *src;
 
-	if (mnt_context_helper_executed(cxt)
+	if ((mnt_context_helper_executed(cxt)
+	    && mnt_context_get_helper_status(cxt))
 	    || mnt_context_get_status(cxt) != 1)
 		return;
 


### PR DESCRIPTION
If a helper function was executed to unmount, we simply return without any user feedback. That can unintentionally surpress verbose messages (`--verbose`) for non-root users who use udisks2 to mount filesystems, and unmount via the unmount.udisks2 helper.

It would be better to check the helper return status as well for completeness and a more reliable way to test the success of the unmount operation.

mnt_context_get_helper_status() is only called if the helper was executed, i.e. mnt_context_helper_executed == 1, anything else wouldnt make sense anyways.

Addresses: #3790