### PR TITLE
tests: (libmount) improve explicit loop read-write mount check

### DIFF
--- a/tests/expected/libmount/loop-explicit-rw
+++ b/tests/expected/libmount/loop-explicit-rw
@@ -1,2 +1,1 @@
-rw
 Success

--- a/tests/ts/libmount/loop
+++ b/tests/ts/libmount/loop
@@ -142,7 +142,8 @@ ts_finalize_subtest
 ts_init_subtest "explicit-rw"
 [ -d "$TS_MOUNTPOINT" ] || mkdir -p $TS_MOUNTPOINT
 $TS_CMD_MOUNT -o rw "$BACKFILE" "$TS_MOUNTPOINT" >> $TS_OUTPUT 2>> $TS_ERRLOG
-$TS_CMD_FINDMNT -no FS-OPTIONS --mountpoint "$TS_MOUNTPOINT" >> $TS_OUTPUT 2>> $TS_ERRLOG
+FINDMNT_RES=$( $TS_CMD_FINDMNT -Q 'OPTIONS =~ "[,]?rw[,]?"' -no OPTIONS --mountpoint "$TS_MOUNTPOINT" )
+[ -n "$FINDMNT_RES" ] || ts_log "$TS_MOUNTPOINT not mounted as read-write"
 $TS_CMD_UMOUNT "$TS_MOUNTPOINT" >> $TS_OUTPUT 2>> $TS_ERRLOG
 udevadm settle
 ts_log "Success"


### PR DESCRIPTION
Some kernel configurations will affect default mount behavior and add extra mount options. As a result, the $TS_OUTPUT will not reliably match on all kernels. Therefore it is better to simply test whether 'rw' is an option and not write the full options list to $TS_OUTPUT.

Adresses: #3765