### PR TITLE
tests: optstr: test redundant commas

### DIFF
--- a/tests/ts/misc/optstr
+++ b/tests/ts/misc/optstr
@@ -8,7 +8,7 @@ ts_init "$*"
 
 ts_check_test_command "$TS_HELPER_STRUTILS"
 
-$TS_HELPER_STRUTILS --optstr "key=\"v,a,l,u,e\",foo,bar=BAR,\"/path/with/,comma\"=data" >> $TS_OUTPUT 2>> $TS_ERRLOG
+$TS_HELPER_STRUTILS --optstr ",,key=\"v,a,l,u,e\",foo,,,,bar=BAR,\"/path/with/,comma\"=data,," >> $TS_OUTPUT 2>> $TS_ERRLOG
 
 ts_finalize
 


### PR DESCRIPTION
optstr, used for parsing mount option lists, eats leading, trailing, and duplicated commas, but I can't find any test coverage for that behavior.

Amend the existing optstr test to hit all the cases I can think of



Note, I came to this via virt-v2v which processes fstab files in the wild. We use augeas but augeas's fstab understanding here missed some of these cases. I looked at this code and couldn't find any test coverage.

https://issues.redhat.com/browse/RHEL-77279
https://github.com/hercules-team/augeas/pull/866