### PR TITLE
libblkid/libmount: ntfs: make default mount option configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3100,6 +3100,23 @@ if test "x${build_alias}" != "x${host_alias}"; then
   link_all_deplibs=unknown
 fi
 
+AC_ARG_WITH([default-mount-type-ntfs],
+  [AS_HELP_STRING([--with-default-mount-type-ntfs=TYPE],
+                  [select the kernel driver to use as default mount type (ntfsplus, ntfs3, ntfs) [default=ntfs3]])],
+  [default_mount_type_ntfs="$withval"],
+  [default_mount_type_ntfs="ntfs3"]
+)
+case "$default_mount_type_ntfs" in
+  ntfsplus|ntfs3|ntfs)
+    AC_MSG_NOTICE([Using default NTFS mount type: $default_mount_type_ntfs])
+    ;;
+  *)
+    AC_MSG_ERROR([Invalid value for --with-default-mount-type-ntfs: $default_mount_type_ntfs. Choose from: ntfsplus, ntfs3, ntfs.])
+    ;;
+esac
+AC_SUBST([DEFAULT_MOUNT_TYPE_NTFS], [$default_mount_type_ntfs])
+AC_DEFINE_UNQUOTED([DEFAULT_MOUNT_TYPE_NTFS], ["$default_mount_type_ntfs"], [Default NTFS mount type])
+
 
 LIBS=""
 

--- a/libblkid/src/superblocks/ntfs.c
+++ b/libblkid/src/superblocks/ntfs.c
@@ -248,7 +248,7 @@ int blkid_probe_is_ntfs(blkid_probe pr)
 
 const struct blkid_idinfo ntfs_idinfo =
 {
-	.name		= "ntfs3",
+	.name		= DEFAULT_MOUNT_TYPE_NTFS,
 	.usage		= BLKID_USAGE_FILESYSTEM,
 	.probefunc	= probe_ntfs,
 	.magics		=
@@ -257,4 +257,3 @@ const struct blkid_idinfo ntfs_idinfo =
 		{ NULL }
 	}
 };
-

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -506,7 +506,7 @@ const char *mnt_statfs_get_fstype(struct statfs *vfs)
 	case STATFS_NCP_MAGIC:		return "ncp";
 	case STATFS_NFS_MAGIC:		return "nfs";
 	case STATFS_NILFS_MAGIC:	return "nilfs2";
-	case STATFS_NTFS_MAGIC:		return "ntfs3";
+	case STATFS_NTFS_MAGIC:		return DEFAULT_MOUNT_TYPE_NTFS;
 	case STATFS_OCFS2_MAGIC:	return "ocfs2";
 	case STATFS_OMFS_MAGIC:		return "omfs";
 	case STATFS_OPENPROMFS_MAGIC:	return "openpromfs";

--- a/meson.build
+++ b/meson.build
@@ -932,6 +932,8 @@ conf.set('USE_COLORS_BY_DEFAULT', get_option('colors-default') ? 1 : false)
 
 is_glibc = cc.has_header_symbol('limits.h', '__GLIBC__')
 
+conf.set_quoted('DEFAULT_MOUNT_TYPE_NTFS', get_option('default-mount-type-ntfs'))
+
 ############################################################
 
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -316,3 +316,9 @@ option('login-lastlogin', type : 'boolean',
 option('tty-setgid', type : 'boolean',
        value : true,
        description : 'setgid tty group for wall and write programs')
+
+option('default-mount-type-ntfs',
+       type : 'combo',
+       choices : ['ntfsplus', 'ntfs3', 'ntfs'],
+       value : 'ntfs3',
+       description : 'select the kernel driver to use as default mount type option')'


### PR DESCRIPTION
Add to the configure.ac and meson_options.txt options to configure the kernel driver that should be used per default when an 'ntfs' filesystem is detected.

This default is currently set to the 'ntfs3' driver, but already foresees the upstream going 'ntfsplus' driver.