### PR TITLE
swapon: (man page) use "defaults" (plural)

### DIFF
--- a/sys-utils/swapon.8.adoc
+++ b/sys-utils/swapon.8.adoc
@@ -116,7 +116,7 @@ Requires "swap" as the filesystem type.
 
 === The fourth field (options)
 
-It is formatted as a comma-separated list of options. All unknown options are silently ignored. If options are unnecessary, the recommended convention is to use "default". The options specified in _fstab_ extend or overwrite settings specified on the *swapon* command line.
+It is formatted as a comma-separated list of options. All unknown options are silently ignored. If options are unnecessary, the recommended convention is to use "defaults". The options specified in _fstab_ extend or overwrite settings specified on the *swapon* command line.
 
 Supported swap options:
 


### PR DESCRIPTION
A lot of documentation on the Internet seems to assume "defaults" is the /correct/ default value when no other options are intended. Documentation/example.files/fstab does not have an entry for swap, but it shows "defaults" for other file systems.

It seems prudent to align on a single variant, at least in the documentation, even if both are accepted by swapon.

Fixes: 5180f6590c7405f4c87f1529b160fef8ad64e88a
