### PR TITLE
Fix memory leak issue in read_Subid_range()

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -469,6 +469,7 @@ static struct map_range read_subid_range(char *filename, uid_t uid, int identity
 		fclose(idmap);
 		free(pw);
 		free(pwbuf);
+		free(line);
 
 		return map;
 	}


### PR DESCRIPTION
Problem Analysis
In the read_stubid_range function, if no match is found in the while loop, errx is executed but the previously allocated memory (line, pw, and pwbuf) is not released. This can lead to memory leaks.

Code before modification
```
static struct map_range read_subid_range(char *filename, uid_t uid, int identity) {
    char *line = NULL, *pwbuf;
       ...
    while (getline(&line, &n, idmap) != -1) {
        char *rest, *s;
        rest = strchr(line, ':');
        if (!rest) continue;
        .....
        if (!rest) continue;
        *rest = '\0';
         ....
        fclose(idmap);
        free(pw);
        free(pwbuf);
        return map;
    }
    errx(EXIT_FAILURE, _("no line matching user \"%s\" in %s"), pw->pw_name, filename);
}
```
Modified code
```
static struct map_range read_subid_range(char *filename, uid_t uid, int identity) {
    char *line = NULL, *pwbuf = NULL;
   ... 
    /** Each line in sub[ug]idmap looks like* username:subuid:count* OR* uid:subuid:count*/
    while (getline(&line, &n, idmap) != -1) {
        char *rest, *s;
        rest = strchr(line, ':');
        if (!rest) continue;
        ...
        if (!rest) continue;
        *rest = '\0';
       ...
        
        fclose(idmap);
        free(pw);
        free(pwbuf);
        free(line);
        return map;
    }
    errx(EXIT_FAILURE, _("no line matching user \"%s\" in %s"), pw->pw_name, filename);
}
```