### PR TITLE
In print_stummary(), cxt ->virt ->vendor did not handle VIRTV_VENDORN…

### DIFF
--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -1087,7 +1087,9 @@ static void print_summary(struct lscpu_cxt *cxt)
 		if (cxt->virt->hypervisor)
 			add_summary_s(tb, sec, _("Hypervisor:"), cxt->virt->hypervisor);
 		if (cxt->virt->vendor) {
-			add_summary_s(tb, sec, _("Hypervisor vendor:"), hv_vendors[cxt->virt->vendor]);
+            const char *vendor_str = (cxt->virt->vendor != VIRT_VENDOR_NONE) ?
+                hv_vendors[cxt->virt->vendor] : _("none");			
+			add_summary_s(tb, sec, _("Hypervisor vendor:"), vendor_str);
 			add_summary_s(tb, sec, _("Virtualization type:"), _(virt_types[cxt->virt->type]));
 		}
 		sec = NULL;


### PR DESCRIPTION
…E situation

Problem location: The part of the print_stummary function that handles virtualization information.
Problem analysis:
Cxt ->virt ->vendor may be VIRT_VENDOR-NONE, in which case hv-vendors [cxt ->virt ->vendor] is null,
Add_stummary_st will attempt to print NULL, which may cause the program to crash or output errors;