### PR TITLE
agetty: Fix reading /run/issue.d/ again

### DIFF
--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -1952,7 +1952,7 @@ skip:
 	ul_configs_file_list(&file_list,
 			     NULL,
 			     _PATH_SYSCONFDIR,
-			     _PATH_SYSCONFDIR,
+			     _PATH_RUNSTATEDIR,
 			     _PATH_SYSCONFSTATICDIR,
 			     "issue",
 			     ISSUEDIR_EXT);


### PR DESCRIPTION
Commit 63f7dcb5b072 ("lib/config: Make /run path configurable") added a second _PATH_SYSCONFDIR instead of _PATH_RUNSTATEDIR. Fix that.