### PR TITLE
libfdisk: (dos) fix off-by-one in maximum last sector calculation

### DIFF
--- a/libfdisk/src/dos.c
+++ b/libfdisk/src/dos.c
@@ -1241,8 +1241,8 @@ static int get_disk_ranges(struct fdisk_context *cxt, int logical,
 		else
 			*last = cxt->total_sectors - 1;
 
-		if (*last > UINT_MAX)
-			*last = UINT_MAX;
+		if (*last >= UINT_MAX)
+			*last = UINT_MAX - 1;
 		*first = cxt->first_lba;
 	}
 


### PR DESCRIPTION
The get_disk_ranges() function incorrectly capped the last usable sector at UINT_MAX, which could cause an overflow when calculating partition size for MBR partition tables.

MBR stores partition size as a 32-bit value with maximum UINT_MAX. The partition size is calculated as: size = stop - start + 1

For a partition starting at sector 0:
- If stop = UINT_MAX: size = UINT_MAX + 1 (overflow!)
- If stop = UINT_MAX - 1: size = UINT_MAX (correct maximum)

This fixes the inconsistency where dos_init() correctly warns about disks larger than UINT_MAX sectors (2TiB - 512 bytes for 512-byte sectors), but get_disk_ranges() allowed creating partitions that would overflow the 32-bit size field.

Addresses: https://issues.redhat.com/browse/RHEL-122367