### PR TITLE
There is an invalid memory logic called free() in the print_rartition_info() function

### DIFF
--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -1087,9 +1087,7 @@ static void print_summary(struct lscpu_cxt *cxt)
 		if (cxt->virt->hypervisor)
 			add_summary_s(tb, sec, _("Hypervisor:"), cxt->virt->hypervisor);
 		if (cxt->virt->vendor) {
-            const char *vendor_str = (cxt->virt->vendor != VIRT_VENDOR_NONE) ?
-                hv_vendors[cxt->virt->vendor] : _("none");			
-			add_summary_s(tb, sec, _("Hypervisor vendor:"), vendor_str);
+			add_summary_s(tb, sec, _("Hypervisor vendor:"), hv_vendors[cxt->virt->vendor]);
 			add_summary_s(tb, sec, _("Virtualization type:"), _(virt_types[cxt->virt->type]));
 		}
 		sec = NULL;


### PR DESCRIPTION
Modify the previous code logic:
```
int print_partition_info(struct fdisk_context *cxt)
{
	struct fdisk_partition *pa = NULL;
	int rc = 0;
	size_t i, nfields;
	int *fields = NULL;
	struct fdisk_label *lb = fdisk_get_label(cxt, NULL);

	if ((rc = fdisk_ask_partnum(cxt, &i, FALSE)))
		return rc;

	if ((rc = fdisk_get_partition(cxt, i, &pa))) {
		fdisk_warnx(cxt, _("Partition %zu does not exist yet!"), i + 1);
		return rc;
	}

	if ((rc = fdisk_label_get_fields_ids_all(lb, cxt, &fields, &nfields))) 
            goto clean_data;

	for (i = 0; i < nfields; ++i) {
		int id = fields[i];
		char *data = NULL;
		const struct fdisk_field *fd = fdisk_label_get_field(lb, id);

		if (!fd)
			continue;

		rc = fdisk_partition_to_string(pa, cxt, id, &data);
		if (rc < 0)
			goto clean_data;
		if (!data || !*data)
			continue;
		fdisk_info(cxt, "%15s: %s", fdisk_field_get_name(fd), data);
		free(data);
	}

clean_data:
	fdisk_unref_partition(pa);
	free(fields);
	return rc;
}
```

If fdisk_1abel_get_fields_ids_all (lb, cxt,&fields,&nfield); If this function fails to execute, no memory will be allocated to the variable fields, 
At this point, there will be an operationfree()invalid memory;

Modified function:
```
int print_partition_info(struct fdisk_context *cxt)
{
	struct fdisk_partition *pa = NULL;
	int rc = 0;
	size_t i, nfields;
	int *fields = NULL;
	struct fdisk_label *lb = fdisk_get_label(cxt, NULL);

	if ((rc = fdisk_ask_partnum(cxt, &i, FALSE)))
		return rc;

	if ((rc = fdisk_get_partition(cxt, i, &pa))) {
		fdisk_warnx(cxt, _("Partition %zu does not exist yet!"), i + 1);
		return rc;
	}

	if ((rc = fdisk_label_get_fields_ids_all(lb, cxt, &fields, &nfields))) {
    	fdisk_unref_partition(pa);	
		return rc;
	}

	for (i = 0; i < nfields; ++i) {
		int id = fields[i];
		char *data = NULL;
		const struct fdisk_field *fd = fdisk_label_get_field(lb, id);

		if (!fd)
			continue;

		rc = fdisk_partition_to_string(pa, cxt, id, &data);
		if (rc < 0)
			goto clean_data;
		if (!data || !*data)
			continue;
		fdisk_info(cxt, "%15s: %s", fdisk_field_get_name(fd), data);
		free(data);
	}

clean_data:
	fdisk_unref_partition(pa);
	free(fields);
	return rc;
}
```


