### PR TITLE
fincore: do not fall back to mincore if cachestat fails with EPERM

### DIFF
--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -370,7 +370,7 @@ static int fincore_fd (struct fincore_control *ctl,
 	if (errno != ENOSYS || ctl->cachestat)
 		warn(_("failed to do cachestat: %s"), st->name);
 
-	if (ctl->cachestat)
+	if (errno == EPERM || ctl->cachestat)
 		return -errno;
 
 	return mincore_fd(ctl, fd, st);


### PR DESCRIPTION
cachestat() and mincore() both require that the tested file is (potentially) writable by the current user. If this permission check fails, cachestat() will return EPERM while mincore() will simply mark all pages as resident in core, as a proper EPERM would violate its API contract. But when cachestat() fails with EPERM we know that mincore() will not return real data, so instead show an error message.

Reported-by: Christian Hesse <mail@eworm.de>