### PR TITLE
login: fix timeout message

### DIFF
--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1340,7 +1340,7 @@ static void initialize(int argc, char **argv, struct login_context *cxt)
 	timeout = (unsigned int)getlogindefs_num("LOGIN_TIMEOUT", LOGIN_TIMEOUT);
 
 	/* TRANSLATORS: The standard value for %u is 60. */
-	xasprintf(&timeout_msg, _("%s: timed out after %u seconds"),
+	xasprintf(&timeout_msg, _("%s: timed out after %u seconds\n"),
 				  program_invocation_short_name, timeout);
 
 	signal(SIGALRM, timedout);

--- a/po-man/sr.po
+++ b/po-man/sr.po
@@ -65207,8 +65207,8 @@ msgstr "*liblastlog2*(3), *pam.conf*(5), *pam.d*(5), *pam*(8)"
 #~ msgid " -H             suppress hostname in the login prompt"
 #~ msgstr " -H             потискује назив домаћина у упиту пријаве"
 
-#~ msgid "%s: timed out after %u seconds"
-#~ msgstr "%s: истекло је време након %u секунде"
+#~ msgid "%s: timed out after %u seconds\n"
+#~ msgstr "%s: истекло је време након %u секунде\n"
 
 #~ msgid "login: -h is for superuser only\n"
 #~ msgstr "пријава: „-h“ је само за администраторе\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -10696,7 +10696,7 @@ msgstr "No s'ha pogut assignar la memòria temporal.\n"
 #: login-utils/login.c:1347
 #, fuzzy, c-format
 #| msgid "Login timed out after %d seconds\n"
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr "S'ha excedit el temps d'espera per a l'entrada al cap de %d segons.\n"
 
 #: login-utils/login.c:1376

--- a/po/cs.po
+++ b/po/cs.po
@@ -3,7 +3,7 @@
 # header is not removed and modified versions are marked
 # as such.
 #
-# Czech translation of util-linux. 
+# Czech translation of util-linux.
 # This file is distributed under the same license as the util-linux package.
 #
 # Jiří Pavlovský <pavlovsk@ff.cuni.cz>, 1999 - 2001.
@@ -9055,8 +9055,8 @@ msgstr "kontext cesty se nepodařilo inicializovat"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: vypršel časový limit %u sekund"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: vypršel časový limit %u sekund\n"
 
 #: login-utils/login.c:1376
 #, c-format
@@ -32982,7 +32982,7 @@ msgstr "terminál „%s“ není znám, použije se „dump“"
 #~ msgid "current"
 #~ msgstr "současná"
 
-# pid %d's _new_ scheduling policy 
+# pid %d's _new_ scheduling policy
 #~ msgid "new"
 #~ msgstr "nová"
 

--- a/po/da.po
+++ b/po/da.po
@@ -9353,8 +9353,8 @@ msgstr "kunne ikke initialisere loopcxt"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: tidsudløb efter %u sekunder"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: tidsudløb efter %u sekunder\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -9155,8 +9155,8 @@ msgstr "Pfadkontext konnte nicht initialisiert werden"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: Zeit überschritten nach %u Sekunden"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: Zeit überschritten nach %u Sekunden\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/es.po
+++ b/po/es.po
@@ -8940,8 +8940,8 @@ msgstr "no se ha podido inicializar el contexto de ruta"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: superado el tiempo de espera tras %u segundos"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: superado el tiempo de espera tras %u segundos\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/et.po
+++ b/po/et.po
@@ -9566,7 +9566,7 @@ msgstr "ei jätku mälu kaartide puhvritele"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr "Login timed out after %d seconds\n"
 
 #: login-utils/login.c:1376

--- a/po/eu.po
+++ b/po/eu.po
@@ -9426,8 +9426,8 @@ msgstr "huts egin da lerro buffer-a hasieratzen\n"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "Baliogabeko zilindro baloreak"
+msgid "%s: timed out after %u seconds\n"
+msgstr "Baliogabeko zilindro baloreak\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -9466,7 +9466,7 @@ msgstr " -initialize\n"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr "Kirjautuminen aikakatkaistiin %d sekunnin jälkeen\n"
 
 #: login-utils/login.c:1376

--- a/po/fr.po
+++ b/po/fr.po
@@ -8944,8 +8944,8 @@ msgstr "échec d'initialisation du contexte de chemin"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s : expiration du délai après %u secondes"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s : expiration du délai après %u secondes\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -9279,7 +9279,7 @@ msgstr "volve a ler a táboa de particións"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr ""
 
 #: login-utils/login.c:1376

--- a/po/hr.po
+++ b/po/hr.po
@@ -9068,8 +9068,8 @@ msgstr "nije uspjelo inicijalizirati kontekst staze"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: %u sekunda za prijavu je isteklo"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: %u sekunda za prijavu je isteklo\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -9607,7 +9607,7 @@ msgstr "Nem foglalható le puffert.\n"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr "A bejelentkezés %d másodperc után túllépte az időkorlátot\n"
 
 #: login-utils/login.c:1376

--- a/po/id.po
+++ b/po/id.po
@@ -9610,7 +9610,7 @@ msgstr "gagal menginisialisasi baris penyangga\n"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr "Waktu habis untuk Login sesudah %d detik\n"
 
 #: login-utils/login.c:1376

--- a/po/it.po
+++ b/po/it.po
@@ -9616,7 +9616,7 @@ msgstr "Impossibile allocare il buffer.\n"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr "Login scaduto dopo %d secondi\n"
 
 #: login-utils/login.c:1376

--- a/po/ja.po
+++ b/po/ja.po
@@ -8917,8 +8917,8 @@ msgstr "パスコンテキストの準備に失敗しました"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: %u 秒で時間切れになりました"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: %u 秒で時間切れになりました\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/ka.po
+++ b/po/ka.po
@@ -8854,7 +8854,7 @@ msgstr "დანაყოფის ზომის შეცვლის შე
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr ""
 
 #: login-utils/login.c:1376

--- a/po/ko.po
+++ b/po/ko.po
@@ -8898,8 +8898,8 @@ msgstr "경로 컨텍스트 초기화 실패"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: %u초 후 시간 초과"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: %u초 후 시간 초과\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -9038,8 +9038,8 @@ msgstr "initialiseren van padcontext is mislukt"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: afgebroken na %u seconden (duurde te lang)"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: afgebroken na %u seconden (duurde te lang)\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -8927,8 +8927,8 @@ msgstr "nie udało się zainicjować kontekstu ścieżki"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: przekroczony limit czasu logowania (%u s)"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: przekroczony limit czasu logowania (%u s)\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/pt.po
+++ b/po/pt.po
@@ -8921,8 +8921,8 @@ msgstr "falha ao inicializar contexto de caminho"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: expirou após %u segundos"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: expirou após %u segundos\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1178,7 +1178,7 @@ msgstr "O dispositivo já contém uma assinatura \"%s\" e ela será removida por
 msgid "The device contains '%s' signature and it may remain on the device. It is recommended to wipe the device with wipefs(8) or fdisk --wipe, in order to avoid possible collisions."
 msgstr "O dispositivo contém a assinatura \"%s\" e ela pode ser mantida no dispositivo. É recomendado apagar o dispositivo com wipefs(8) ou fdisk --wipe, para evitar possíveis colisões."
 
-# Alinhamento reajustado às demais opções abaixo; vide fdisk --help 
+# Alinhamento reajustado às demais opções abaixo; vide fdisk --help
 #: disk-utils/fdisk.c:1082
 #, c-format
 msgid ""
@@ -9032,8 +9032,8 @@ msgstr "falha ao inicializar o contexto de caminho"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: tempo esgotado após %u segundos"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: tempo esgotado após %u segundos\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9119,8 +9119,8 @@ msgstr "nu s-a reușit să se inițializeze contextul rutei"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: a expirat după %u secunde"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: a expirat după %u secunde\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -9316,8 +9316,8 @@ msgstr "не удалось инициализировать loopcxt"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "истекло время ожидания в %u секунд"
+msgid "%s: timed out after %u seconds\n"
+msgstr "истекло время ожидания в %u секунд\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/sk.po
+++ b/po/sk.po
@@ -8954,7 +8954,7 @@ msgstr "loopctx sa nepodařilo inicializovať"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr ""
 
 #: login-utils/login.c:1376

--- a/po/sl.po
+++ b/po/sl.po
@@ -9615,7 +9615,7 @@ msgstr "Za medpomnilnik ni mogoèe dodeliti pomnilnika.\n"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr "Prijava je potekla po %d sekundah.\n"
 
 #: login-utils/login.c:1376

--- a/po/sr.po
+++ b/po/sr.po
@@ -9104,8 +9104,8 @@ msgstr "нисам успео да покренем контекст путањ�
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: истекло је време након %u секунде"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: истекло је време након %u секунде\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9369,8 +9369,8 @@ msgstr "misslyckades med att initialisera loopcxt"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: tidsutlösare efter %u sekunder"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: tidsutlösare efter %u sekunder\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -9501,8 +9501,8 @@ msgstr "loopcxt başlatılamadı"
 #: login-utils/login.c:1347
 #, fuzzy, c-format
 #| msgid "timed out after %u seconds"
-msgid "%s: timed out after %u seconds"
-msgstr "%u saniye sonra zaman aşımı"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%u saniye sonra zaman aşımı\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -8932,8 +8932,8 @@ msgstr "не вдалося ініціалізувати контекст шля
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s: час очікування було вичерпано за %u секунд"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s: час очікування було вичерпано за %u секунд\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/util-linux.pot
+++ b/po/util-linux.pot
@@ -8890,7 +8890,7 @@ msgstr ""
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
+msgid "%s: timed out after %u seconds\n"
 msgstr ""
 
 #: login-utils/login.c:1376

--- a/po/vi.po
+++ b/po/vi.po
@@ -9350,8 +9350,8 @@ msgstr "gặp lỗi khi khởi tạo loopcxt"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "lỗi quá lâu sau %u giây"
+msgid "%s: timed out after %u seconds\n"
+msgstr "lỗi quá lâu sau %u giây\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8936,8 +8936,8 @@ msgstr "无法初始化路径上下文"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "%s：%u 秒后超时"
+msgid "%s: timed out after %u seconds\n"
+msgstr "%s：%u 秒后超时\n"
 
 #: login-utils/login.c:1376
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -9626,8 +9626,8 @@ msgstr "初始化 loopcxt 時失敗"
 #. TRANSLATORS: The standard value for %u is 60.
 #: login-utils/login.c:1347
 #, fuzzy, c-format
-msgid "%s: timed out after %u seconds"
-msgstr "已逾時之後 %u 秒"
+msgid "%s: timed out after %u seconds\n"
+msgstr "已逾時之後 %u 秒\n"
 
 #: login-utils/login.c:1376
 #, fuzzy, c-format


### PR DESCRIPTION
Currently, timing out looks like this:
```
root@tarta:/# login nab
login: timed out after 60 secondsroot@tarta:/#
```

The output from login should really be a text file.

Fixes: f17bda66bd440fe8375f5fd13e2efa6bd3a0c942