### PR TITLE
fincore: The previous exit did not call munmap, resulting in a memory mapping leak.

### DIFF
--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -333,10 +333,10 @@ static int mincore_fd (struct fincore_control *ctl,
 		}
 
 		rc = do_mincore(ctl, window, len, st);
+		munmap (window, len);
 		if (rc)
 			break;
 
-		munmap (window, len);
 	}
 
 	return rc;


### PR DESCRIPTION
Fix reason: When do_mincore fails, the loop exits prematurely without calling munmap, resulting in a memory mapping leak.