### PR TITLE
fincore: close the ftsp to prevent fd leak

### DIFF
--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -610,6 +610,7 @@ int main(int argc, char ** argv)
 					rc |= fincore_name(&ctl, ent->fts_accpath, ent->fts_path, ent->fts_statp);
 				}
 			}
+			fts_close(fts);
 		}
 #endif
 	} else {


### PR DESCRIPTION
fincore: there is no close op after fts_read, it is better to close the ftsp to prevent fd leak.