### PR TITLE
Fix typos when "set up" is used as a verb

### DIFF
--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -442,7 +442,7 @@ static struct libmnt_fs *add_dummy_fs(const char *device)
 	}
 
 	mnt_unref_fs(fs);
-	err(FSCK_EX_ERROR, _("failed to setup description for %s"), device);
+	err(FSCK_EX_ERROR, _("failed to set up description for %s"), device);
 }
 
 static void fs_interpret_type(struct libmnt_fs *fs)

--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1584,7 +1584,7 @@ int mnt_context_get_mount_excode(
 			return MNT_EX_USAGE;
 		case -MNT_ERR_LOOPDEV:
 			if (buf)
-				snprintf(buf, bufsz, _("failed to setup loop device for %s"), src);
+				snprintf(buf, bufsz, _("failed to set up loop device for %s"), src);
 			return MNT_EX_FAIL;
 		case -MNT_ERR_LOOPOVERLAP:
 			if (buf)

--- a/libmount/src/hook_idmap.c
+++ b/libmount/src/hook_idmap.c
@@ -492,7 +492,7 @@ done:
 	return 0;
 
 err:
-	DBG(HOOK, ul_debugobj(hs, " failed to setup idmap"));
+	DBG(HOOK, ul_debugobj(hs, " failed to set up idmap"));
 	free_hook_data(hd);
 	free(buf);
 	return -MNT_ERR_MOUNTOPT;

--- a/libmount/src/hook_loopdev.c
+++ b/libmount/src/hook_loopdev.c
@@ -138,7 +138,7 @@ static int setup_loopdev(struct libmnt_context *cxt,
 	if (!backing_file)
 		return -EINVAL;
 
-	DBG(LOOP, ul_debugobj(cxt, "trying to setup device for %s", backing_file));
+	DBG(LOOP, ul_debugobj(cxt, "trying to set up device for %s", backing_file));
 
 	if (mnt_optlist_is_rdonly(ol)) {
 		DBG(LOOP, ul_debugobj(cxt, "enabling READ-ONLY flag"));
@@ -332,7 +332,7 @@ static int setup_loopdev(struct libmnt_context *cxt,
 			break;		/* success */
 
 		if (loopdev || rc != -EBUSY) {
-			DBG(LOOP, ul_debugobj(cxt, "failed to setup device"));
+			DBG(LOOP, ul_debugobj(cxt, "failed to set up device"));
 			rc = -MNT_ERR_LOOPDEV;
 			goto done;
 		}

--- a/sys-utils/losetup.8.adoc
+++ b/sys-utils/losetup.8.adoc
@@ -148,7 +148,7 @@ The *--remove* option completely removes the loop device node from the system us
 
 == NOTES
 
-Since version 2.37 *losetup* uses *LOOP_CONFIGURE* ioctl to setup a new loop device by one ioctl call. The old versions use *LOOP_SET_FD* and *LOOP_SET_STATUS64* ioctls to do the same.
+Since version 2.37 *losetup* uses *LOOP_CONFIGURE* ioctl to set up a new loop device by one ioctl call. The old versions use *LOOP_SET_FD* and *LOOP_SET_STATUS64* ioctls to do the same.
 
 == ENVIRONMENT
 

--- a/sys-utils/rtcwake.8.adoc
+++ b/sys-utils/rtcwake.8.adoc
@@ -24,7 +24,7 @@ This is normally used like the old *apmsleep* utility, to wake from a suspend st
 
 On some systems, this can also be used like *nvram-wakeup*, waking from states like ACPI S4 (suspend to disk). Not all systems have persistent media that are appropriate for such suspend modes.
 
-Note that alarm functionality depends on hardware; not every RTC is able to setup an alarm up to 24 hours in the future.
+Note that alarm functionality depends on hardware; not every RTC is able to set up an alarm up to 24 hours in the future.
 
 The suspend setup may be interrupted by active hardware; for example wireless USB input devices that continue to send events for some fraction of a second after the return key is pressed. *rtcwake* tries to avoid this problem and it waits to the terminal to settle down before entering a system sleep.
 

--- a/tests/expected/libmount/loop-o-loop-val-conflict
+++ b/tests/expected/libmount/loop-o-loop-val-conflict
@@ -1,2 +1,2 @@
-mount: <target> failed to setup loop device for <source>
+mount: <target> failed to set up loop device for <source>
 Success


### PR DESCRIPTION
Hi,
Here's a small fix after I noticed the typo in error messages.
The noun is "setup" while the verb is "set up".
I might have missed instanced, I looked for all instances of `to setup`.