### PR TITLE
kill: the situation where fd is opened but not closed

### DIFF
--- a/misc-utils/kill.c
+++ b/misc-utils/kill.c
@@ -557,6 +557,9 @@ static int kill_with_timeout(const struct kill_control *ctl)
 				err(EXIT_FAILURE, _("pidfd_send_signal() failed"));
 		}
 	}
+
+	close(pfd);
+
 	return 0;
 }
 #endif


### PR DESCRIPTION
The process file descriptor has been opened but has not been closed