### PR TITLE
lsfd: fix bsearch macro usage with glibc C23

### DIFF
--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -1875,8 +1875,12 @@ static void mark_poll_fds_as_multiplexed(char *buf,
 		struct file *file = list_entry(f, struct file, files);
 		if (is_opened_file(file) && !file->multiplexed) {
 			int fd = file->association;
-			if (bsearch(&(struct pollfd){.fd = fd,}, local.iov_base,
+			struct pollfd key = {
+				.fd = fd,
+			};
+			if (bsearch(&key, local.iov_base,
 				    nfds, sizeof(struct pollfd), pollfdcmp))
+
 				file->multiplexed = 1;
 		}
 	}


### PR DESCRIPTION
Recent glibc changes (e.g. cd748a63ab1a7ae846175c532a3daab341c62690) turn `bsearch` into a macro that is more strict about its arguments. The `lsfd` code was passing a compound literal with a trailing comma as the KEY argument:

    bsearch(&(struct pollfd){ .fd = fd, }, ...)

With `bsearch` now defined as a macro, the comma inside the braced initializer is seen as an extra argument and the build fails with:

    error: too many arguments provided to function-like macro invocation

Replace the compound literal with a temporary `struct pollfd` key and pass `&key` to `bsearch`. This keeps the behavior unchanged while compiling correctly with both old and new glibc.