### PR TITLE
lsfd: fix FTBS in C23

### DIFF
--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -1875,7 +1875,7 @@ static void mark_poll_fds_as_multiplexed(char *buf,
 		struct file *file = list_entry(f, struct file, files);
 		if (is_opened_file(file) && !file->multiplexed) {
 			int fd = file->association;
-			if (bsearch(&(struct pollfd){.fd = fd,}, local.iov_base,
+			if (bsearch((&(struct pollfd){.fd = fd,}), local.iov_base,
 				    nfds, sizeof(struct pollfd), pollfdcmp))
 				file->multiplexed = 1;
 		}


### PR DESCRIPTION
C23 requires bsearch to be a const preserving **macro**, build now fails with

```
../lsfd-cmd/lsfd.c:1879:75: error: macro ‘bsearch’ passed 6 arguments, but takes just 5
 1879 |                                     nfds, sizeof(struct pollfd), pollfdcmp))
      |                                                                           ^
In file included from ../include/c.h:17,
                 from ../lsfd-cmd/lsfd.c:48:
/usr/include/stdlib.h:987:10: note: macro ‘bsearch’ defined here
  987 | # define bsearch(KEY, BASE, NMEMB, SIZE, COMPAR)                        \

```
  add parenthesis around expression to fix it.