### PR TITLE
blkid: Drop const from blkid_partitions_get_name()

### DIFF
--- a/libblkid/src/blkid.h.in
+++ b/libblkid/src/blkid.h.in
@@ -339,7 +339,7 @@ extern uint64_t blkid_topology_get_diskseq(blkid_topology tp)
  * partitions probing
  */
 extern int blkid_known_pttype(const char *pttype);
-extern int blkid_partitions_get_name(const size_t idx, const char **name);
+extern int blkid_partitions_get_name(size_t idx, const char **name);
 
 extern int blkid_probe_enable_partitions(blkid_probe pr, int enable)
 			__ul_attribute__((nonnull));

--- a/libblkid/src/partitions/partitions.c
+++ b/libblkid/src/partitions/partitions.c
@@ -907,7 +907,7 @@ int blkid_known_pttype(const char *pttype)
  *
  * Returns: -1 if @idx is out of range, or 0 on success.
  */
-int blkid_partitions_get_name(const size_t idx, const char **name)
+int blkid_partitions_get_name(size_t idx, const char **name)
 {
 	if (idx < ARRAY_SIZE(idinfos)) {
 		*name = idinfos[idx]->name;


### PR DESCRIPTION
const for idx is useless as the value is copied anyway, so drop the const. AFAIK this doesn't change ABI.