### PR TITLE
lib, lscpu: fix const qualifier discarded warnings in bsearch

### DIFF
--- a/lib/color-names.c
+++ b/lib/color-names.c
@@ -54,7 +54,8 @@ const char *color_sequence_from_colorname(const char *str)
 		{ "white",      UL_COLOR_WHITE           },
 		{ "yellow",	UL_COLOR_BOLD_YELLOW     }
 	};
-	struct ul_color_name key = { .name = str }, *res;
+	struct ul_color_name key = { .name = str };
+	const struct ul_color_name *res;
 
 	if (!str)
 		return NULL;

--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -450,7 +450,8 @@ static char *key_cleanup(char *str, int *keynum)
 
 static const struct cpuinfo_pattern *cpuinfo_parse_line(char *str, char **value, int *keynum)
 {
-	struct cpuinfo_pattern key = { .id = 0 }, *pat;
+	struct cpuinfo_pattern key = { .id = 0 };
+	const struct cpuinfo_pattern *pat;
 	char *p, *v;
 	char buf[CPUTYPE_PATTERN_BUFSZ] = { 0 };
 


### PR DESCRIPTION
Fix compilation warnings from newer compilers with stricter const-correctness checks. When bsearch() searches in const arrays, the result pointer must also be const to avoid discarding the const qualifier.

Fixed in:
- lib/color-names.c: searching in static const basic_schemes[]
- sys-utils/lscpu-cputype.c: searching in const pattern arrays

The warnings were:
  lib/color-names.c:62:13: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]