### PR TITLE
lsfd: fix memory leak related to stat_error_class

### DIFF
--- a/lsfd-cmd/file.c
+++ b/lsfd-cmd/file.c
@@ -319,10 +319,16 @@ const struct file_class readlink_error_class = {
 	.fill_column = readlink_error_fill_column,
 };
 
+static void stat_error_file_free_content(struct file *file)
+{
+	free(file->name);
+}
+
 const struct file_class stat_error_class = {
 	.super = &error_class,
 	.size = sizeof(struct file),
 	.initialize_content = init_error_content,
+	.free_content = stat_error_file_free_content,
 };
 
 /*


### PR DESCRIPTION
Memory objects pointed by the name member of a file object allocate as an instance of stat_error_class are leaked.

I intrdouced this bug in a125e2eea7cea4d0bac1404c2e1b1d65d11cc10c.  In the commit, I arranged the class hierarchy.