### PR TITLE
column: add --input-separator as an alias for --separator

### DIFF
--- a/bash-completion/column
+++ b/bash-completion/column
@@ -13,7 +13,7 @@ _column_module()
 			COMPREPLY=( $(compgen -W "auto never always" -- $cur) )
 			return 0
 			;;
-		'-s'|'--separator'|'-o'|'--output-separator'|'-n'|'--table-name'|'-O')
+		'-s'|'--separator'|'--input-separator'|'-o'|'--output-separator'|'-n'|'--table-name'|'-O')
 			COMPREPLY=( $(compgen -W "string" -- $cur) )
 			return 0
 			;;
@@ -54,6 +54,7 @@ _column_module()
 				--tree-parent
 				--output-width
 				--separator
+				--input-separator
 				--output-separator
 				--wrap-separator
 				--fillrows

--- a/text-utils/column.1.adoc
+++ b/text-utils/column.1.adoc
@@ -99,7 +99,7 @@ Omit printing the header. This option allows having user-supplied column names o
 *-o, --output-separator* _string_::
 Column delimiter for table output (default is two spaces).
 
-*-s, --separator* _separators_::
+*-s, --input-separator, --separator* _separators_::
 Possible input-item delimiters (default is whitespace).
 
 *-S, --use-spaces* _number_::

--- a/text-utils/column.c
+++ b/text-utils/column.c
@@ -1021,7 +1021,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -c, --output-width <width>       width of output in number of characters\n"), out);
 	fputs(_(" -o, --output-separator <string>  columns separator for table output\n"
 		"                                    (default is two spaces)\n"), out);
-	fputs(_(" -s, --separator <string>         possible table delimiters\n"), out);
+	fputs(_(" -s, --input-separator, --separator <string>\n"
+		"                                    possible table delimiters\n"), out);
 	fputs(_(" -x, --fillrows                   fill rows before columns\n"), out);
 	fputs(_(" -S, --use-spaces <number>        minimal whitespaces between columns (no tabs)\n"), out);
 
@@ -1059,6 +1060,7 @@ int main(int argc, char **argv)
 		{ "color",               optional_argument, NULL, OPT_COLOR },
 		{ "fillrows",            no_argument,       NULL, 'x' },
 		{ "help",                no_argument,       NULL, 'h' },
+		{ "input-separator",     required_argument, NULL, 's' }, /* alias for --separator */
 		{ "json",                no_argument,       NULL, 'J' },
 		{ "keep-empty-lines",    no_argument,       NULL, 'L' },
 		{ "output-separator",    required_argument, NULL, 'o' },


### PR DESCRIPTION
This change adds --input-separator as an alias for the existing --separator option, providing symmetry with --output-separator.

The new alias is documented in:
- command-line help text
- man page
- bash completion

Fixes: https://github.com/util-linux/util-linux/issues/3889