### PR TITLE
[WIP] github: protect the version of actions/checkout used in build-compat job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    exclude-paths:
+      - ".github/workflows/build-compat.yml"

--- a/.github/workflows/build-compat.yml
+++ b/.github/workflows/build-compat.yml
@@ -1,0 +1,31 @@
+name: build-compat
+on:
+  workflow_call:
+    inputs:
+      image:
+        type: string
+        required: true
+        description: image name
+jobs:
+  build-compat:
+    name: ${{ inputs.image }}
+    runs-on: ubuntu-latest
+    env:
+      COMPILER: none
+    container:
+      image: ${{ inputs.image }}
+    steps:
+      - name: Repository checkout
+        # dependabot doesn't care this dependency.
+        # See .github/dependabot.yml.
+        uses: actions/checkout@v1
+      - name: Ubuntu setup
+        run: .github/workflows/cibuild-setup-ubuntu.sh
+      - name: Configure
+        run: .github/workflows/cibuild.sh CONFIGUREFAST
+      - name: Code checks
+        run: .github/workflows/cibuild.sh CODECHECK
+      - name: Configure & Make
+        run: .github/workflows/cibuild.sh MAKE
+      - name: Check
+        run: .github/workflows/cibuild.sh CHECK

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -118,34 +118,23 @@ jobs:
       - name: Make distcheck
         run: .github/workflows/cibuild.sh DISTCHECK
 
-  build-compat:
+  call-build-compat:
+    # We can preserve the version of actions/checkouts in the original
+    # job by placing it in a separate file. Dependabot will try to
+    # update the versions in your source tree. If your actions are in
+    # a separate file, you can add that file to Dependabot's exclude
+    # list.
+    uses: ./.github/workflows/build-compat.yml
+    with:
+      image: ${{ matrix.image }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - image: ubuntu:18.04
-    name: build (compat, ${{ matrix.image }})
-    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-build-compat-${{ github.ref }}
       cancel-in-progress: true
-    env:
-      COMPILER: none
-    container:
-      image: ${{ matrix.image }}
-    steps:
-      - name: Repository checkout
-        uses: actions/checkout@v1
-      - name: Ubuntu setup
-        run: .github/workflows/cibuild-setup-ubuntu.sh
-      - name: Configure
-        run: .github/workflows/cibuild.sh CONFIGUREFAST
-      - name: Code checks
-        run: .github/workflows/cibuild.sh CODECHECK
-      - name: Configure & Make
-        run: .github/workflows/cibuild.sh MAKE
-      - name: Check
-        run: .github/workflows/cibuild.sh CHECK
 
   build-arch:
     name: build (qemu-user, ${{ matrix.arch }})


### PR DESCRIPTION
Updating action/checkout proposed by the dependabot has caused troubles:
5756e7ba8aba220177099188c3d120e111199fa9,
561f0bb21d2e88b5feca2fdf56b283a6f48befc5, and
2af05e8d2794079d49d1e554a5146ce5291ba2c1.
    
This change places the original job in a separate file and adds that file to the exclude list.
