### PR TITLE
Fix memory leak in setpwnam()

### DIFF
--- a/login-utils/setpwnam.c
+++ b/login-utils/setpwnam.c
@@ -168,6 +168,7 @@ int setpwnam(struct passwd *pwd, const char *prefix)
 	/* finally:  success */
 	ulckpwdf();
 	free(linebuf);
+	free(tmpname);
 	return 0;
 
  fail:


### PR DESCRIPTION
Add memeory release for tmpname upon successful return.