### PR TITLE
unshare: fix user namespace bind mounts

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -1075,7 +1075,7 @@ int main(int argc, char *argv[])
 	/* clear any inherited settings */
 	signal(SIGCHLD, SIG_DFL);
 
-	if (npersists && (unshare_flags & CLONE_NEWNS))
+	if (npersists && (unshare_flags & (CLONE_NEWNS | CLONE_NEWUSER)))
 		pid_bind = bind_ns_files_from_child(&fd_bind);
 
 	if (usermap || groupmap)
@@ -1130,7 +1130,7 @@ int main(int argc, char *argv[])
 
 	if (npersists && (pid || !forkit)) {
 		/* run in parent */
-		if (pid_bind && (unshare_flags & CLONE_NEWNS))
+		if (pid_bind && (unshare_flags & (CLONE_NEWNS | CLONE_NEWUSER)))
 			sync_with_child(pid_bind, fd_bind);
 		else
 			/* simple way, just bind */


### PR DESCRIPTION
`unshare --user=<file>` always fails because we no longer have CAP_SYS_ADMIN in the parent user namespace after unsharing to create the new one. As with `unshare --mount=<file>`, fork a child to make the bind mount instead.

I've been using unshare in scripts for ages and only just noticed this because `--user=<file>` is so often used with `--mount=<file>` and using the latter is sufficient to trigger a fork - think it's a pretty long-standing bug.

I moved the sanity check that the mount namespace has changed with `--mount` so it is checked even if we're not binding the resulting mount namespace, and so it doesn't interfere with using `bind_ns_files_from_child()` for user namespaces too.

However, I wonder if I should just remove it? We don't sanity check that the namespace has actually changed for any other namespace that's unshared, and we didn't sanity check mount namespaces except in the rare case when we bound the result. Is there any reason to believe `unshare()` would silently fail to unshare mount namespaces in particular, despite returning a success exit code?

If we dropped the apparently-redundant check, we could also drop the otherwise-unused `get_mnt_ino()` in unshare.c too.