### PR TITLE
fix: use Py_REFCNT macro to work with free-threaded python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2850,6 +2850,9 @@ AC_ARG_WITH([python],
   [], [with_python=check withval=check]
 )
 
+# Minimum required Python version defined by use of Py_REFCNT
+m4_define([MIN_PYTHON_VER], [2.6])
+
 have_python=no
 have_libpython=no
 AS_IF([test "x$with_python" != xno], [
@@ -2870,6 +2873,9 @@ AS_IF([test "x$with_python" != xno], [
     [*:yes],
        # check for python development stuff
        [
+         AX_COMPARE_VERSION([$PYTHON_VERSION], [lt], [MIN_PYTHON_VER],
+           [AC_MSG_ERROR([python version $PYTHON_VERSION is too old])])
+
          PKG_CHECK_MODULES([PYTHON], [python-$PYTHON_VERSION], [have_libpython=yes], [have_libpython=no])
 
          # https://github.com/util-linux/util-linux/issues/2366

--- a/libmount/python/fs.c
+++ b/libmount/python/fs.c
@@ -640,7 +640,7 @@ static PyMethodDef Fs_methods[] = {
 static void Fs_destructor(FsObject *self)
 {
 	DBG(FS, pymnt_debug_h(self->fs, "destructor py-obj: %p, py-refcnt=%d",
-				self, (int) ((PyObject *) self)->ob_refcnt));
+				self, (int) Py_REFCNT((PyObject *) self)));
 	mnt_unref_fs(self->fs);
 	PyFree(self);
 }
@@ -774,7 +774,7 @@ PyObject *PyObjectResultFs(struct libmnt_fs *fs)
 	if (result) {
 		Py_INCREF(result);
 		DBG(FS, pymnt_debug_h(fs, "result py-obj %p: already exists, py-refcnt=%d",
-				result, (int) ((PyObject *) result)->ob_refcnt));
+				result, (int) Py_REFCNT((PyObject *) result)));
 		return (PyObject *) result;
 	}
 
@@ -792,7 +792,7 @@ PyObject *PyObjectResultFs(struct libmnt_fs *fs)
 	mnt_ref_fs(fs);
 
 	DBG(FS, pymnt_debug_h(fs, "result py-obj %p new, py-refcnt=%d",
-				result, (int) ((PyObject *) result)->ob_refcnt));
+				result, (int) Py_REFCNT((PyObject *) result)));
 	result->fs = fs;
 	mnt_fs_set_userdata(fs, result);
 	return (PyObject *) result;

--- a/libmount/python/tab.c
+++ b/libmount/python/tab.c
@@ -548,7 +548,7 @@ void Table_unref(struct libmnt_table *tab)
 static void Table_destructor(TableObject *self)
 {
 	DBG(TAB, pymnt_debug_h(self->tab, "destructor py-obj: %p, py-refcnt=%d",
-				self, (int) ((PyObject *) self)->ob_refcnt));
+				self, (int) Py_REFCNT((PyObject *) self)));
 	Table_unref(self->tab);
 	self->tab = NULL;
 
@@ -683,7 +683,7 @@ PyObject *PyObjectResultTab(struct libmnt_table *tab)
 	if (result) {
 		Py_INCREF(result);
 		DBG(TAB, pymnt_debug_h(tab, "result py-obj %p: already exists, py-refcnt=%d",
-				result, (int) ((PyObject *) result)->ob_refcnt));
+				result, (int) Py_REFCNT((PyObject *) result)));
 		return (PyObject *) result;
 	}
 
@@ -701,7 +701,7 @@ PyObject *PyObjectResultTab(struct libmnt_table *tab)
 	mnt_ref_table(tab);
 
 	DBG(TAB, pymnt_debug_h(tab, "result py-obj %p new, py-refcnt=%d",
-				result, (int) ((PyObject *) result)->ob_refcnt));
+				result, (int) Py_REFCNT((PyObject *) result)));
 	result->tab = tab;
 	result->iter = mnt_new_iter(MNT_ITER_FORWARD);
 	mnt_table_set_userdata(result->tab, result);


### PR DESCRIPTION
This PR adapts `libmount/python/{fs,tab}.c` to work with free-threaded python, where `ob_refcnt` is not a member of PyObject anymore, but where Py_REFCNT is recommended.

Note that https://docs.python.org/3/c-api/structures.html#c.PyObject.ob_refcnt says:
> Do not use this field directly; instead use functions and macros such as [`Py_REFCNT`](https://docs.python.org/3/c-api/refcounting.html#c.Py_REFCNT)

Py_REFCNT was added in python 2.6 (https://github.com/python/cpython/commit/90aa7646affbaee9628ca6ea6a702aec17b3b550) and that is now imposed as the minimum required version in `configure.ac` (meson already requires python3).

See e.g. https://github.com/boostorg/python/pull/475 (upon which this was based, but only as of python 3.12 and later).

Refs:
- https://docs.python.org/3/c-api/structures.html#c.PyObject.ob_refcnt
- https://docs.python.org/3/c-api/refcounting.html#c.Py_REFCNT
- https://docs.python.org/3.12/c-api/refcounting.html#c.Py_REFCNT (oldest version with `Py_REFCNT`)