### PR TITLE
rfkill: Output in JSON format if -J is provided.

### DIFF
--- a/sys-utils/rfkill.c
+++ b/sys-utils/rfkill.c
@@ -740,7 +740,7 @@ int main(int argc, char **argv)
 		 * For backward compatibility we use old output format if
 		 * "list" explicitly specified and --output not defined.
 		 */
-		if (!outarg && act == ACT_LIST)
+		if (!outarg && !ctrl.json && act == ACT_LIST)
 			act = ACT_LIST_OLD;
 	}
 


### PR DESCRIPTION
This patch teaches rfkill output in JSON format if -J is provided.

E.g.,

```
$ ./rfkill -J list
{
   "rfkilldevices": [
      {
         "id": 0,
         "type": "bluetooth",
         "device": "tpacpi_bluetooth_sw",
         "soft": "unblocked",
         "hard": "unblocked"
      },{
         "id": 1,
         "type": "wwan",
         "device": "tpacpi_wwan_sw",
         "soft": "unblocked",
         "hard": "unblocked"
      },{
         "id": 3,
         "type": "wlan",
         "device": "phy0",
         "soft": "unblocked",
         "hard": "unblocked"
      },{
         "id": 4,
         "type": "bluetooth",
         "device": "hci0",
         "soft": "unblocked",
         "hard": "unblocked"
      }
   ]
}

$ ./rfkill -J list bluetooth
{
   "rfkilldevices": [
      {
         "id": 0,
         "type": "bluetooth",
         "device": "tpacpi_bluetooth_sw",
         "soft": "unblocked",
         "hard": "unblocked"
      },{
         "id": 4,
         "type": "bluetooth",
         "device": "hci0",
         "soft": "unblocked",
         "hard": "unblocked"
      }
   ]
}
```