### PR TITLE
uuidd: use locked system user account if available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -189,6 +189,7 @@ edit_cmd = sed \
 	 -e 's|@usrlib_execdir[@]|$(usrlib_execdir)|g' \
 	 -e 's|@usrbin_execdir[@]|$(usrbin_execdir)|g' \
 	 -e 's|@usrsbin_execdir[@]|$(usrsbin_execdir)|g' \
+	 -e 's|@SYSTEMD_USER_LOCK[@]|$(SYSTEMD_USER_LOCK)|g' \
 	 -e 's|@SOCKET_LIBS[@]|$(SOCKET_LIBS)|g' \
 	 -e 's|@VERSION[@]|$(VERSION)|g' \
 	 -e 's|@ADJTIME_PATH[@]|$(ADJTIME_PATH)|g' \

--- a/configure.ac
+++ b/configure.ac
@@ -2683,7 +2683,14 @@ AC_ARG_WITH([systemd],
 have_systemd=no
 AS_IF([test "x$with_systemd" != xno], [
   # new version -- all libsystemd-* libs merged into libsystemd
-  PKG_CHECK_MODULES([SYSTEMD], [libsystemd], [have_systemd=yes], [have_systemd=no])
+  # if 257 or newer, use locked system user accounts
+  PKG_CHECK_MODULES([SYSTEMD], [libsystemd >= 257], [
+      have_systemd=yes
+      SYSTEMD_USER_LOCK="!"
+    ], [
+      SYSTEMD_USER_LOCK=
+      PKG_CHECK_MODULES([SYSTEMD], [libsystemd], [have_systemd=yes], [have_systemd=no])
+  ])
   # old versions
   AS_IF([test "x$have_systemd" != "xyes"], [
     PKG_CHECK_MODULES([SYSTEMD_DAEMON], [libsystemd-daemon],
@@ -2702,6 +2709,7 @@ AS_IF([test "x$with_systemd" != xno], [
        AC_CHECK_DECLS([sd_session_get_username], [], [], [#include <systemd/sd-login.h>])
        AC_CHECK_DECLS([sd_device_new_from_syspath], [], [], [#include <systemd/sd-device.h>])
        AC_CHECK_DECLS([sd_device_open], [], [], [#include <systemd/sd-device.h>])
+       AC_SUBST([SYSTEMD_USER_LOCK])
   )
 ])
 AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$have_systemd" = xyes])

--- a/meson.build
+++ b/meson.build
@@ -373,6 +373,11 @@ systemd = dependency(
   'systemd',
   required : get_option('systemd'))
 
+# Since systemd-257, which provides locked system user accounts.
+if systemd.version().version_compare('>=257')
+  conf.set('SYSTEMD_USER_LOCK', '!')
+endif
+
 lib_systemd = dependency(
   'libsystemd',
   required : get_option('systemd'))

--- a/misc-utils/uuidd-sysusers.conf.in
+++ b/misc-utils/uuidd-sysusers.conf.in
@@ -1,1 +1,1 @@
-u uuidd - "UUID generator helper daemon" @localstatedir@/lib/libuuid
+u@SYSTEMD_USER_LOCK@ uuidd - "UUID generator helper daemon" @localstatedir@/lib/libuuid


### PR DESCRIPTION
Beginning with systemd 257, it is possible to fully lock a sysuser account. Do so for systems with met requirements.

Older systemd versions still use unlocked accounts.

Supersedes https://github.com/util-linux/util-linux/pull/3468 by having full backwards compatibility.