### PR TITLE
login-utils: Use /etc/passwd- as backup file

### DIFF
--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -62,6 +62,7 @@
 #define _PATH_GROUP		"/etc/group"
 #define _PATH_SHADOW_PASSWD	"/etc/shadow"
 #define _PATH_SHELLS		"/etc/shells"
+#define _PATH_PASSWDBAK_SUFFIX  "-"
 
 #ifndef _PATH_TMP
 # define _PATH_TMP		"/tmp/"

--- a/login-utils/chfn.c
+++ b/login-utils/chfn.c
@@ -38,6 +38,7 @@
 #include "closestream.h"
 #include "islocal.h"
 #include "nls.h"
+#include "pathnames.h"
 #include "setpwnam.h"
 #include "strutils.h"
 #include "xalloc.h"

--- a/login-utils/setpwnam.c
+++ b/login-utils/setpwnam.c
@@ -61,6 +61,7 @@
 #include "c.h"
 #include "fileutils.h"
 #include "closestream.h"
+#include "pathnames.h"
 #include "setpwnam.h"
 
 static void pw_init(void);
@@ -94,7 +95,7 @@ int setpwnam(struct passwd *pwd, const char *prefix)
 	if (lckpwdf() < 0)
 		goto fail;
 	locked = 1;
-	pwf = fopen(PASSWD_FILE, "r");
+	pwf = fopen(_PATH_PASSWD, "r");
 	if (!pwf)
 		goto fail;
 
@@ -138,11 +139,11 @@ int setpwnam(struct passwd *pwd, const char *prefix)
 	}
 
 	/* we don't care if we can't remove the backup file */
-	unlink(PASSWD_FILE "-");
+	unlink(_PATH_PASSWD _PATH_PASSWDBAK_SUFFIX);
 	/* we don't care if we can't create the backup file */
-	ignore_result(link(PASSWD_FILE, PASSWD_FILE "-"));
+	ignore_result(link(_PATH_PASSWD, _PATH_PASSWD _PATH_PASSWDBAK_SUFFIX));
 	/* we DO care if we can't rename to the passwd file */
-	if (rename(tmpname, PASSWD_FILE) < 0)
+	if (rename(tmpname, _PATH_PASSWD) < 0)
 		goto fail;
 	/* finally:  success */
 	ulckpwdf();

--- a/login-utils/setpwnam.h
+++ b/login-utils/setpwnam.h
@@ -14,20 +14,6 @@
 #ifndef UTIL_LINUX_SETPWNAM_H
 #define UTIL_LINUX_SETPWNAM_H
 
-#include "pathnames.h"
-
-#ifndef DEBUG
-# define PASSWD_FILE	_PATH_PASSWD
-# define GROUP_FILE	_PATH_GROUP
-# define SHADOW_FILE	_PATH_SHADOW_PASSWD
-# define SGROUP_FILE	_PATH_GSHADOW
-#else
-# define PASSWD_FILE	"/tmp/passwd"
-# define GROUP_FILE	"/tmp/group"
-# define SHADOW_FILE	"/tmp/shadow"
-# define SGROUP_FILE	"/tmp/gshadow"
-#endif
-
 extern int setpwnam (struct passwd *pwd, const char *prefix);
 
 #endif /* UTIL_LINUX_SETPWNAM_H */

--- a/login-utils/vipw.c
+++ b/login-utils/vipw.c
@@ -67,7 +67,7 @@
 #include "fileutils.h"
 #include "closestream.h"
 #include "nls.h"
-#include "setpwnam.h"
+#include "pathnames.h"
 #include "strutils.h"
 #include "xalloc.h"
 #include "rpmatch.h"
@@ -145,7 +145,7 @@ static void pw_write(void)
 {
 	char tmp[FILENAMELEN + 4];
 
-	snprintf(tmp, sizeof(tmp), "%s%s", orig_file, "-");
+	snprintf(tmp, sizeof(tmp), "%s%s", orig_file, _PATH_PASSWDBAK_SUFFIX);
 	unlink(tmp);
 
 	if (link(orig_file, tmp))
@@ -325,10 +325,10 @@ int main(int argc, char *argv[])
 
 	if (!strcmp(program_invocation_short_name, "vigr")) {
 		program = VIGR;
-		xstrncpy(orig_file, GROUP_FILE, sizeof(orig_file));
+		xstrncpy(orig_file, _PATH_GROUP, sizeof(orig_file));
 	} else {
 		program = VIPW;
-		xstrncpy(orig_file, PASSWD_FILE, sizeof(orig_file));
+		xstrncpy(orig_file, _PATH_PASSWD, sizeof(orig_file));
 	}
 
 	while ((c = getopt_long(argc, argv, "Vh", longopts, NULL)) != -1) {
@@ -345,9 +345,9 @@ int main(int argc, char *argv[])
 	edit_file(0);
 
 	if (program == VIGR)
-		xstrncpy(orig_file, SGROUP_FILE, sizeof(orig_file));
+		xstrncpy(orig_file, _PATH_GSHADOW, sizeof(orig_file));
 	else
-		xstrncpy(orig_file, SHADOW_FILE, sizeof(orig_file));
+		xstrncpy(orig_file, _PATH_SHADOW, sizeof(orig_file));
 
 	if (access(orig_file, F_OK) == 0) {
 		char response[80];


### PR DESCRIPTION
The name /etc/passwd- is used as backup file by shadow and systemd.

Let's join the group and use /etc/passwd- instead of /etc/passwd.OLD as well. One backup file on a system is enough.

As reference:
- shadow: https://github.com/shadow-maint/shadow/blob/0afe2169537de5459f5129d2f7af68f675c6b27a/lib/commonio.c#L903
- systemd: https://github.com/systemd/systemd/blob/795e066d2247bf298272105287c608cf6ae430d9/src/sysusers/sysusers.c#L338