### PR TITLE
Fix gettext macro calls

### DIFF
--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -207,7 +207,7 @@ static int is_mounted(struct libmnt_fs *fs)
 	if (!mtab) {
 		mtab = mnt_new_table();
 		if (!mtab)
-			err(FSCK_EX_ERROR, ("failed to initialize libmount table"));
+			err(FSCK_EX_ERROR, _("failed to initialize libmount table"));
 		mnt_table_set_cache(mtab, mntcache);
 		mnt_table_parse_mtab(mtab, NULL);
 	}
@@ -485,7 +485,7 @@ static void load_fs_info(void)
 
 	fstab = mnt_new_table();
 	if (!fstab)
-		err(FSCK_EX_ERROR, ("failed to initialize libmount table"));
+		err(FSCK_EX_ERROR, _("failed to initialize libmount table"));
 
 	mnt_table_set_parser_errcb(fstab, parser_errcb);
 	mnt_table_set_cache(fstab, mntcache);

--- a/libfdisk/src/bsd.c
+++ b/libfdisk/src/bsd.c
@@ -859,7 +859,7 @@ static int bsd_readlabel(struct fdisk_context *cxt)
 	}
 
 	if (d->d_npartitions > BSD_MAXPARTITIONS)
-		fdisk_warnx(cxt, ("Too many partitions (%d, maximum is %d)."),
+		fdisk_warnx(cxt, _("Too many partitions (%d, maximum is %d)."),
 				d->d_npartitions, BSD_MAXPARTITIONS);
 
 	/* let's follow in-PT geometry */

--- a/login-utils/vipw.c
+++ b/login-utils/vipw.c
@@ -172,7 +172,7 @@ static void pw_write(void)
 	if (rename(tmp_file, orig_file) == -1) {
 		int errsv = errno;
 		errx(EXIT_FAILURE,
-		     ("cannot write %s: %s (your changes are still in %s)"),
+		     _("cannot write %s: %s (your changes are still in %s)"),
 		     orig_file, strerror(errsv), tmp_file);
 	}
 	unlink(tmp_file);


### PR DESCRIPTION
Four occurrences exist in tree in which only `()` was used, not `_()`, which effectively means that these messages were never translated.