### PR TITLE
chrt: (man) fix note about --sched-period lower limit

### DIFF
--- a/schedutils/chrt.1.adoc
+++ b/schedutils/chrt.1.adoc
@@ -75,7 +75,7 @@ Set scheduling policy to *SCHED_EXT* (BPF program-defined scheduling). Linux-spe
 Specifies runtime parameter for *SCHED_DEADLINE* and custom slice length for *SCHED_OTHER* and *SCHED_BATCH* policies (Linux-specific). Note that custom slice length via the runtime parameter is supported since Linux 6.12.
 
 *-P*, *--sched-period* _nanoseconds_::
-Specifies period parameter for *SCHED_DEADLINE* policy (Linux-specific). Note that the kernel's lower limit is 100 milliseconds.
+Specifies period parameter for *SCHED_DEADLINE* policy (Linux-specific). Note that the kernel's lower limit is 100 microseconds.
 
 *-D*, *--sched-deadline* _nanoseconds_::
 Specifies deadline parameter for *SCHED_DEADLINE* policy (Linux-specific).


### PR DESCRIPTION
Fix typo in `chrt` man page. 100ms minimum period for deadline scheduler seemed awfully long, and indeed [kernel source](https://github.com/torvalds/linux/blob/master/kernel/sched/deadline.c#L31) confirms it's actually 100us.