### PR TITLE
env: ignore only invalid environment variables

### DIFF
--- a/lib/env.c
+++ b/lib/env.c
@@ -97,7 +97,7 @@ static struct ul_env_list *env_list_add_from_string(struct ul_env_list *ls,
 
 	val = strchr(str, '=');
 	if (!val)
-		return NULL;
+		return ls;
 	namesz = val - str;
 
 	val++;


### PR DESCRIPTION
Returning `NULL` drops the start of the currently existing linked list, effectively removing all previously added environment variables.

Only ignore the invalid one, but keep the linked list available.

The effect can be best seen with `nsenter -e`:

1. Create a temporary directory to keep everything together
```
BASEDIR=$(mktemp -d)
cd $BASEDIR
```
2. Create `poc` which just prints environment variables and its pid and waits for input (to keep it running)
```
cat > poc.c << EOF
#include <stdio.h>
#include <unistd.h>

int
main(int argc, char *argv[], char *envp[])
{
        size_t i = 0;
        char *buf;
        while (envp[i] != NULL)
                printf("%s\n", envp[i++]);
        printf("pid: %ld\n", (long)getpid());
        i = 0;
        buf = NULL;
        getline(&buf, &i, stdin);
        return 0;
}
EOF
cc -o poc poc.c
```
3. Create `poc2` which starts `poc` with valid and invalid environment variables
```
cat > poc2.c << EOF
#include <unistd.h>
int
main(void)
{
        char *args[] = {"poc", NULL};
        char *env[] = {"INVALID", "key=value", "INVALID", NULL};
        execvpe("./poc", args, env);
        _exit(1);
}
EOF
cc -D_GNU_SOURCE -o poc2 poc2.c
```
4. Create a namespace (as root)
```
touch ./uts-ns
unshare --uts=./uts-ns
```
5. Run `poc2` in another terminal (or keep it running otherwise) and note the pid
```
./poc2
```
```
INVALID
key=value
INVALID
pid: 12345
```
6. Enter namespace and print environment variables there with `poc` (as root)
```
nsenter -t 12345 --env --uts=./uts-ns ./poc
```
```
pid: 54321
```
You can see that all environment variables were lost. If environment got mixed up, you might have to repeat until `INVALID` really is the last one.

And last but not least, don't forget to clean up, i.e. unmount :)
```
umount $BASEDIR/uts-ns
```