### PR TITLE
style: adapt function definitions to kernel style

### DIFF
--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -270,7 +270,8 @@ static int find_identical_file(struct entry *orig, struct entry *new, loff_t *fs
 		   find_identical_file(orig->next, new, fslen_ub);
 }
 
-static void eliminate_doubles(struct entry *root, struct entry *orig, loff_t *fslen_ub) {
+static void eliminate_doubles(struct entry *root, struct entry *orig, loff_t *fslen_ub)
+{
 	if (orig) {
 		if (orig->size && orig->path)
 			find_identical_file(root,orig, fslen_ub);

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -184,7 +184,8 @@ static void super_set_state(void)
 	}
 }
 
-static void write_tables(const struct fs_control *ctl) {
+static void write_tables(const struct fs_control *ctl)
+{
 	unsigned long imaps = get_nimaps();
 	unsigned long zmaps = get_nzmaps();
 	size_t buffsz = get_inode_buffer_size();
@@ -213,7 +214,8 @@ static void write_tables(const struct fs_control *ctl) {
 		err(MKFS_EX_ERROR, _("%s: unable to write inodes"), ctl->device_name);
 }
 
-static void write_block(const struct fs_control *ctl, int blk, char * buffer) {
+static void write_block(const struct fs_control *ctl, int blk, char * buffer)
+{
 	if (blk * MINIX_BLOCK_SIZE != lseek(ctl->device_fd, blk * MINIX_BLOCK_SIZE, SEEK_SET))
 		errx(MKFS_EX_ERROR, _("%s: seek failed in write_block"), ctl->device_name);
 
@@ -221,7 +223,8 @@ static void write_block(const struct fs_control *ctl, int blk, char * buffer) {
 		errx(MKFS_EX_ERROR, _("%s: write failed in write_block"), ctl->device_name);
 }
 
-static int get_free_block(struct fs_control *ctl) {
+static int get_free_block(struct fs_control *ctl)
+{
 	unsigned int blk;
 	unsigned int zones = get_nzones();
 	unsigned int first_zone = get_first_zone();
@@ -241,14 +244,16 @@ static int get_free_block(struct fs_control *ctl) {
 	return blk;
 }
 
-static void mark_good_blocks(const struct fs_control *ctl) {
+static void mark_good_blocks(const struct fs_control *ctl)
+{
 	int blk;
 
 	for (blk=0 ; blk < ctl->fs_used_blocks ; blk++)
 		mark_zone(good_blocks_table[blk]);
 }
 
-static inline int next(unsigned long zone) {
+static inline int next(unsigned long zone)
+{
 	unsigned long zones = get_nzones();
 	unsigned long first_zone = get_first_zone();
 
@@ -368,7 +373,8 @@ static void make_bad_inode(struct fs_control *ctl)
 	make_bad_inode_v2_v3(ctl);
 }
 
-static void make_root_inode_v1(struct fs_control *ctl) {
+static void make_root_inode_v1(struct fs_control *ctl)
+{
 	struct minix_inode * inode = &Inode[MINIX_ROOT_INO];
 
 	mark_inode(MINIX_ROOT_INO);
@@ -388,7 +394,8 @@ static void make_root_inode_v1(struct fs_control *ctl) {
 	write_block(ctl, inode->i_zone[0],root_block);
 }
 
-static void make_root_inode_v2_v3 (struct fs_control *ctl) {
+static void make_root_inode_v2_v3 (struct fs_control *ctl)
+{
 	struct minix2_inode *inode = &Inode2[MINIX_ROOT_INO];
 
 	mark_inode (MINIX_ROOT_INO);
@@ -500,7 +507,8 @@ static void super_set_magic(const struct fs_control *ctl)
 	}
 }
 
-static void setup_tables(const struct fs_control *ctl) {
+static void setup_tables(const struct fs_control *ctl)
+{
 	unsigned long inodes, zmaps, imaps, zones, i;
 
 	super_block_buffer = xcalloc(1, MINIX_BLOCK_SIZE);
@@ -582,7 +590,8 @@ static void setup_tables(const struct fs_control *ctl) {
  * Perform a test of a block; return the number of
  * blocks readable/writable.
  */
-static size_t do_check(const struct fs_control *ctl, char * buffer, int try, unsigned int current_block) {
+static size_t do_check(const struct fs_control *ctl, char * buffer, int try, unsigned int current_block)
+{
 	ssize_t got;
 
 	/* Seek to the correct loc. */
@@ -603,7 +612,8 @@ static size_t do_check(const struct fs_control *ctl, char * buffer, int try, uns
 
 static unsigned int currently_testing = 0;
 
-static void alarm_intr(int alnum __attribute__ ((__unused__))) {
+static void alarm_intr(int alnum __attribute__ ((__unused__)))
+{
 	unsigned long zones = get_nzones();
 
 	if (currently_testing >= zones)
@@ -616,7 +626,8 @@ static void alarm_intr(int alnum __attribute__ ((__unused__))) {
 	fflush(stdout);
 }
 
-static void check_blocks(struct fs_control *ctl) {
+static void check_blocks(struct fs_control *ctl)
+{
 	size_t try, got;
 	static char buffer[MINIX_BLOCK_SIZE * TEST_BUFFER_BLOCKS];
 	unsigned long zones = get_nzones();
@@ -648,7 +659,8 @@ static void check_blocks(struct fs_control *ctl) {
 		printf(P_("%d bad block\n", "%d bad blocks\n", ctl->fs_bad_blocks), ctl->fs_bad_blocks);
 }
 
-static void get_list_blocks(struct fs_control *ctl, char *filename) {
+static void get_list_blocks(struct fs_control *ctl, char *filename)
+{
 	FILE *listfile;
 	unsigned long blockno;
 

--- a/lib/crc64.c
+++ b/lib/crc64.c
@@ -17,7 +17,7 @@
  *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -308,7 +308,8 @@ const uint64_t crc_tab64[256] = {
  * indicating the length.
  */
 
-uint64_t ul_crc64_ecma( const unsigned char *input_str, size_t num_bytes ) {
+uint64_t ul_crc64_ecma( const unsigned char *input_str, size_t num_bytes )
+{
 
 	uint64_t crc;
 	const unsigned char *ptr;
@@ -334,7 +335,8 @@ uint64_t ul_crc64_ecma( const unsigned char *input_str, size_t num_bytes ) {
  * parameter indicating the length.
  */
 
-uint64_t ul_crc64_we( const unsigned char *input_str, size_t num_bytes ) {
+uint64_t ul_crc64_we( const unsigned char *input_str, size_t num_bytes )
+{
 
 	uint64_t crc;
 	const unsigned char *ptr;
@@ -359,7 +361,8 @@ uint64_t ul_crc64_we( const unsigned char *input_str, size_t num_bytes ) {
  * previous value of the CRC and the next byte of the data to be checked.
  */
 
-uint64_t ul_update_crc64( uint64_t crc, unsigned char c ) {
+uint64_t ul_update_crc64( uint64_t crc, unsigned char c )
+{
 
 	return (crc << 8) ^ crc_tab64[ ((crc >> 56) ^ (uint64_t) c) & 0x00000000000000FFull ];
 

--- a/lib/netaddrq.c
+++ b/lib/netaddrq.c
@@ -108,7 +108,8 @@ static char *ip_rating_as_string(enum ul_netaddrq_ip_rating q)
 
 /* Netlink callback evaluating the address quality and building the list of
  * interface lists */
-static int callback_addrq(struct ul_nl_data *nl) {
+static int callback_addrq(struct ul_nl_data *nl)
+{
 	struct ul_netaddrq_data *addrq = UL_NETADDRQ_DATA(nl);
 	struct list_head *li, *ipq_list;
 	struct ul_netaddrq_iface *ifaceq = NULL;
@@ -566,7 +567,8 @@ static void dump_iface_all(struct ul_nl_data *nl,
 		fputs("\n", netout);
 }
 
-static void dump_addrq(struct ul_nl_data *nl, enum addrq_print_mode c) {
+static void dump_addrq(struct ul_nl_data *nl, enum addrq_print_mode c)
+{
 	struct list_head *li;
 	struct ul_netaddrq_iface *ifaceq;
 	enum ul_netaddrq_ip_rating threshold;

--- a/lib/netlink.c
+++ b/lib/netlink.c
@@ -59,12 +59,14 @@ static void netlink_init_debug(void)
 				UL_DEBUG_MASKNAMES(netlink)));
 }
 
-void ul_nl_init(struct ul_nl_data *nl) {
+void ul_nl_init(struct ul_nl_data *nl)
+{
 	netlink_init_debug();
 	memset(nl, 0, sizeof(struct ul_nl_data));
 }
 
-int ul_nl_request_dump(struct ul_nl_data *nl, uint16_t nlmsg_type) {
+int ul_nl_request_dump(struct ul_nl_data *nl, uint16_t nlmsg_type)
+{
 	struct {
 		struct nlmsghdr nh;
 		struct rtgenmsg g;
@@ -326,12 +328,14 @@ int ul_nl_open(struct ul_nl_data *nl, uint32_t nl_groups)
 	}
 }
 
-int ul_nl_close(struct ul_nl_data *nl) {
+int ul_nl_close(struct ul_nl_data *nl)
+{
 	DBG(NLMSG, ul_debugobj(nl, "closing socket"));
 	return close(nl->fd);
 }
 
-struct ul_nl_addr *ul_nl_addr_dup(struct ul_nl_addr *addr) {
+struct ul_nl_addr *ul_nl_addr_dup(struct ul_nl_addr *addr)
+{
 	struct ul_nl_addr *newaddr;
 	newaddr = calloc(1, sizeof(struct ul_nl_addr));
 	if (!newaddr)
@@ -363,7 +367,8 @@ error:
 	return NULL;
 }
 
-void ul_nl_addr_free(struct ul_nl_addr *addr) {
+void ul_nl_addr_free(struct ul_nl_addr *addr)
+{
 	if (addr) {
 		free(addr->ifa_address);
 		free(addr->ifa_local);
@@ -401,7 +406,8 @@ const char *ul_nl_addr_ntop(const struct ul_nl_addr *addr, int addrid) {
 #ifdef TEST_PROGRAM_NETLINK
 #include <stdio.h>
 
-static int callback_addr(struct ul_nl_data *nl) {
+static int callback_addr(struct ul_nl_data *nl)
+{
 	char *str;
 
 	printf("%s address:\n", ((nl->rtm_event ? "Add" : "Delete")));

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -158,7 +158,8 @@ static void sha256_update(struct sha256 *s, const void *m, unsigned long len)
 	memcpy(s->buf, p, len);
 }
 
-void ul_SHA256(unsigned char hash_out[UL_SHA256LENGTH], const unsigned char *str, size_t len) {
+void ul_SHA256(unsigned char hash_out[UL_SHA256LENGTH], const unsigned char *str, size_t len)
+{
 	struct sha256 state = {};
 	sha256_init(&state);
 	sha256_update(&state, str, len);

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -23,7 +23,8 @@
 
 static int STRTOXX_EXIT_CODE = EXIT_FAILURE;
 
-void strutils_set_exitcode(int ex) {
+void strutils_set_exitcode(int ex)
+{
 	STRTOXX_EXIT_CODE = ex;
 }
 

--- a/lib/strv.c
+++ b/lib/strv.c
@@ -24,7 +24,8 @@
 #include "strutils.h"
 #include "strv.h"
 
-static void ul_strv_clear(char **l) {
+static void ul_strv_clear(char **l)
+{
         char **k;
 
         if (!l)
@@ -36,13 +37,15 @@ static void ul_strv_clear(char **l) {
         *l = NULL;
 }
 
-char **ul_strv_free(char **l) {
+char **ul_strv_free(char **l)
+{
         ul_strv_clear(l);
         free(l);
         return NULL;
 }
 
-char **ul_strv_copy(char * const *l) {
+char **ul_strv_copy(char * const *l)
+{
         char **r, **k;
 
         k = r = malloc(sizeof(char *) * (ul_strv_length(l) + 1));
@@ -74,7 +77,8 @@ unsigned ul_strv_length(char * const *l) {
         return n;
 }
 
-static char **ul_strv_new_ap(const char *x, va_list ap) {
+static char **ul_strv_new_ap(const char *x, va_list ap)
+{
         const char *s;
         char **a;
         unsigned n = 0, i = 0;
@@ -133,7 +137,8 @@ fail:
         return NULL;
 }
 
-char **ul_strv_new(const char *x, ...) {
+char **ul_strv_new(const char *x, ...)
+{
         char **r;
         va_list ap;
 
@@ -144,7 +149,8 @@ char **ul_strv_new(const char *x, ...) {
         return r;
 }
 
-int ul_strv_extend_strv(char ***a, char **b) {
+int ul_strv_extend_strv(char ***a, char **b)
+{
         int r;
         char **s;
 
@@ -157,7 +163,8 @@ int ul_strv_extend_strv(char ***a, char **b) {
         return 0;
 }
 
-int ul_strv_extend_strv_concat(char ***a, char **b, const char *suffix) {
+int ul_strv_extend_strv_concat(char ***a, char **b, const char *suffix)
+{
         int r;
         char **s;
 
@@ -186,7 +193,8 @@ int ul_strv_extend_strv_concat(char ***a, char **b, const char *suffix) {
         _FOREACH_WORD(word, length, s, separator, false, state)
 
 
-char **ul_strv_split(const char *s, const char *separator) {
+char **ul_strv_split(const char *s, const char *separator)
+{
         const char *word, *state;
         size_t l;
         unsigned n, i;
@@ -217,7 +225,8 @@ char **ul_strv_split(const char *s, const char *separator) {
         return r;
 }
 
-char *ul_strv_join(char **l, const char *separator) {
+char *ul_strv_join(char **l, const char *separator)
+{
         char *r, *e;
         char **s;
         size_t n, k;
@@ -251,7 +260,8 @@ char *ul_strv_join(char **l, const char *separator) {
         return r;
 }
 
-int ul_strv_push(char ***l, char *value) {
+int ul_strv_push(char ***l, char *value)
+{
         char **c;
         unsigned n, m;
 
@@ -276,7 +286,8 @@ int ul_strv_push(char ***l, char *value) {
         return 0;
 }
 
-int ul_strv_push_prepend(char ***l, char *value) {
+int ul_strv_push_prepend(char ***l, char *value)
+{
         char **c;
         unsigned n, m, i;
 
@@ -306,7 +317,8 @@ int ul_strv_push_prepend(char ***l, char *value) {
         return 0;
 }
 
-int ul_strv_consume(char ***l, char *value) {
+int ul_strv_consume(char ***l, char *value)
+{
         int r;
 
         r = ul_strv_push(l, value);
@@ -316,7 +328,8 @@ int ul_strv_consume(char ***l, char *value) {
         return r;
 }
 
-int ul_strv_consume_prepend(char ***l, char *value) {
+int ul_strv_consume_prepend(char ***l, char *value)
+{
         int r;
 
         r = ul_strv_push_prepend(l, value);
@@ -326,7 +339,8 @@ int ul_strv_consume_prepend(char ***l, char *value) {
         return r;
 }
 
-int ul_strv_extend(char ***l, const char *value) {
+int ul_strv_extend(char ***l, const char *value)
+{
         char *v;
 
         if (!value)
@@ -339,7 +353,8 @@ int ul_strv_extend(char ***l, const char *value) {
         return ul_strv_consume(l, v);
 }
 
-char **ul_strv_remove(char **l, const char *s) {
+char **ul_strv_remove(char **l, const char *s)
+{
         char **f, **t;
 
         if (!l)
@@ -360,7 +375,8 @@ char **ul_strv_remove(char **l, const char *s) {
         return l;
 }
 
-int ul_strv_extendf(char ***l, const char *format, ...) {
+int ul_strv_extendf(char ***l, const char *format, ...)
+{
         va_list ap;
         char *x;
         int r;
@@ -375,7 +391,8 @@ int ul_strv_extendf(char ***l, const char *format, ...) {
         return ul_strv_consume(l, x);
 }
 
-int ul_strv_extendv(char ***l, const char *format, va_list ap) {
+int ul_strv_extendv(char ***l, const char *format, va_list ap)
+{
         char *x;
         int r;
 
@@ -386,7 +403,8 @@ int ul_strv_extendv(char ***l, const char *format, va_list ap) {
         return ul_strv_consume(l, x);
 }
 
-char **ul_strv_reverse(char **l) {
+char **ul_strv_reverse(char **l)
+{
         unsigned n, i;
 
         n = ul_strv_length(l);

--- a/libblkid/src/fuzz.c
+++ b/libblkid/src/fuzz.c
@@ -19,7 +19,8 @@ static int process_file(const char *name)
     return rc;
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
     int fd;
     char name[] = "/tmp/test-script-fuzz.XXXXXX";
 

--- a/libblkid/src/partitions/atari.c
+++ b/libblkid/src/partitions/atari.c
@@ -66,7 +66,8 @@ static const unsigned char _linux_isalnum[] = {
 1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1
 };
 
-static int linux_isalnum(unsigned char c) {
+static int linux_isalnum(unsigned char c)
+{
 	return _linux_isalnum[c];
 }
 

--- a/libmount/python/pylibmount.c
+++ b/libmount/python/pylibmount.c
@@ -172,12 +172,14 @@ static PyMethodDef pylibmount_methods[] = {
 
 #if PY_MAJOR_VERSION >= 3
 
-static int pylibmount_traverse(PyObject *m, visitproc visit, void *arg) {
+static int pylibmount_traverse(PyObject *m, visitproc visit, void *arg)
+{
     Py_VISIT(GETSTATE(m)->error);
     return 0;
 }
 
-static int pylibmount_clear(PyObject *m) {
+static int pylibmount_clear(PyObject *m)
+{
     Py_CLEAR(GETSTATE(m)->error);
     return 0;
 }

--- a/libmount/src/fuzz.c
+++ b/libmount/src/fuzz.c
@@ -5,7 +5,8 @@
 #include <stdlib.h>
 #include <stddef.h>
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
         struct libmnt_table *tb = NULL;
         FILE *f = NULL;
 

--- a/libuuid/src/gen_uuid.c
+++ b/libuuid/src/gen_uuid.c
@@ -620,7 +620,8 @@ static void reset_uuidd_cache(void)
 }
 #endif /* HAVE_LIBPTHREAD */
 
-static int uuid_generate_time_generic(uuid_t out) {
+static int uuid_generate_time_generic(uuid_t out)
+{
 #ifdef HAVE_LIBPTHREAD
 	static volatile sig_atomic_t atfork_registered;
 	time_t	now;

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -936,7 +936,8 @@ static void process_wtmp_file(const struct last_control *ctl,
 #ifdef FUZZ_TARGET
 # include "all-io.h"
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
 	struct last_control ctl = {
 		.showhost = TRUE,
 		.name_len = LAST_LOGIN_LEN,

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1298,7 +1298,8 @@ static void __attribute__((__noreturn__)) usage(void)
 	exit(EXIT_SUCCESS);
 }
 
-static void load_credentials(struct login_context *cxt) {
+static void load_credentials(struct login_context *cxt)
+{
 	char str[32] = { 0 };
 	char *env;
 	struct path_cxt *pc;

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -948,7 +948,8 @@ static void sushell(struct passwd *pwd, struct console *con)
 }
 
 #ifdef HAVE_LIBSELINUX
-static void tcreset_selinux(struct list_head *consoles) {
+static void tcreset_selinux(struct list_head *consoles)
+{
 	struct list_head *ptr;
 	struct console *con;
 

--- a/lsfd-cmd/cdev.c
+++ b/lsfd-cmd/cdev.c
@@ -290,7 +290,8 @@ static const struct ttydrv *get_ttydrv(unsigned long major,
 /*
  * generic (fallback implementation)
  */
-static bool cdev_generic_probe(struct cdev *cdev __attribute__((__unused__))) {
+static bool cdev_generic_probe(struct cdev *cdev __attribute__((__unused__)))
+{
 	return true;
 }
 
@@ -329,7 +330,8 @@ static struct cdev_ops cdev_generic_ops = {
 /*
  * misc device driver
  */
-static bool cdev_misc_probe(struct cdev *cdev) {
+static bool cdev_misc_probe(struct cdev *cdev)
+{
 	return cdev->devdrv && strcmp(cdev->devdrv, "misc") == 0;
 }
 
@@ -542,7 +544,8 @@ struct ttydata {
 	struct ipc_endpoint endpoint;
 };
 
-static bool cdev_tty_probe(struct cdev *cdev) {
+static bool cdev_tty_probe(struct cdev *cdev)
+{
 	const struct ttydrv *ttydrv = get_ttydrv(major(cdev->file.stat.st_rdev),
 						 minor(cdev->file.stat.st_rdev));
 	struct ttydata *data;

--- a/sys-utils/zramctl.c
+++ b/sys-utils/zramctl.c
@@ -298,7 +298,8 @@ static int zram_lock(struct zram *z, int operation)
 	return 0;
 }
 
-static void zram_unlock(struct zram *z) {
+static void zram_unlock(struct zram *z)
+{
 	if (z && z->lock_fd >= 0) {
 		close(z->lock_fd);
 		z->lock_fd = -EBADF;

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -3113,7 +3113,8 @@ static void reload_agettys(void)
 #endif
 }
 
-static void load_credentials(struct options *op) {
+static void load_credentials(struct options *op)
+{
 	char *env;
 	DIR *dir;
 	struct dirent *d;


### PR DESCRIPTION
The util-linux project preferred coding style is based on the kernel coding-style (https://docs.kernel.org/process/coding-style.html), which explains that opening braces should be on a line on their own after the function signature. Therefore, let us adapt functions that violate this convention.