### PR TITLE
login: remove signal handler before cleanup

### DIFF
--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1091,7 +1091,6 @@ static void fork_session(struct login_context *cxt)
 {
 	struct sigaction sa, oldsa_hup, oldsa_term;
 
-	signal(SIGALRM, SIG_DFL);
 	signal(SIGQUIT, SIG_DFL);
 	signal(SIGTSTP, SIG_IGN);
 
@@ -1570,6 +1569,7 @@ int main(int argc, char **argv)
 
 	/* committed to login -- turn off timeout */
 	alarm((unsigned int)0);
+	signal(SIGALRM, SIG_DFL);
 	free(timeout_msg);
 	timeout_msg = NULL;
 


### PR DESCRIPTION
Even though alarm(0) is called, another process could still send a SIGALRM signal to the login process, which could trigger a use after free for a tiny amount of time.

Not able to reproduce without adding a proper sleep.