### PR TITLE
login: only print regular files for motd

### DIFF
--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -296,6 +296,7 @@ static const char *get_thishost(struct login_context *cxt, const char **domain)
 #ifdef MOTDDIR_SUPPORT
 static int motddir_filter(const struct dirent *d)
 {
+	struct stat st;
 	size_t namesz;
 
 #ifdef _DIRENT_HAVE_D_TYPE
@@ -309,6 +310,11 @@ static int motddir_filter(const struct dirent *d)
 	namesz = strlen(d->d_name);
 	if (!namesz || namesz < MOTDDIR_EXTSIZ + 1 ||
 	    strcmp(d->d_name + (namesz - MOTDDIR_EXTSIZ), MOTDDIR_EXT) != 0)
+		return 0;
+
+	if (stat(d->d_name, &st) < 0)
+		return 0;
+	if (!S_ISREG(st.st_mode) || st.st_size == 0)
 		return 0;
 
 	return 1; /* accept */


### PR DESCRIPTION
The existing code tries to only print content of non-empty files, but does not check the target of an encountered symbolic link, which could be even something else, e.g. a fifo. Add the missing check to the motddir_filter function.

Proof of Concept:

1. Add MOTD_FILE to /etc/login.defs
```
echo "MOTD_FILE /tmp/motds" >> /etc/login.defs
```
2. Create a FIFO in /tmp/motds
```
mkdir -p /tmp/motds
mkfifo /tmp/motds/fifo
```
3. Add a symbolic link to fifo
```
ln -s fifo /tmp/motds/fifo.motd
```
4. Try to login

The login hangs until something is written into the fifo.