### PR TITLE
findmnt: fix fallacious warning messages for ntfs3

### DIFF
--- a/misc-utils/findmnt-verify.c
+++ b/misc-utils/findmnt-verify.c
@@ -465,6 +465,11 @@ static int verify_fstype(struct verify_context *vfy, struct findmnt *findmnt)
 		vfy->no_fsck = strcmp(realtype, "xfs") == 0
 				|| strcmp(realtype, "btrfs") == 0;
 
+		if (strcmp(type, "ntfs3") == 0) {
+			type = "ntfs";
+			add_filesystem(vfy, type);
+		}
+
 		if (type && !isauto && strcmp(type, realtype) != 0) {
 			verify_warn(vfy, _("%s does not match with on-disk %s"), type, realtype);
 			goto done;


### PR DESCRIPTION
When the mount table contents are verified with the --verify option, the filesystem type defined in
/etc/fstab or --tab-file is compared to the actual real file system on the device. In case that these differ, findmnt logs a warning. It also does so when the filesystem type is not found in the list of
supported filesystems, which is maintained by the
kernel in '/proc/filesystems'.

This behavior becomes an issue when an NTFS device is mounted with the in-tree kernel driver 'ntfs3', i.e. the filesystem type in /etc/fstab and listed
in /proc/filesystems is 'ntfs3', however the real
filesystem type identified by libmount or libblkid is 'ntfs', resulting in an error message when the
--verbose flag is used.

To workaround this problem we can override the fs
type from the fstab(5) ("ntfs3") with the value
of the real fs type ("ntfs") and add the latter
to the list of supported filesystems since the
'ntfs3' driver is compatible with NTFS devices.

Closes: #3912