### PR TITLE
lslocks: (bugfix) don't set rawdata in COL_PID if rawdata is null

### DIFF
--- a/misc-utils/lslocks.c
+++ b/misc-utils/lslocks.c
@@ -635,7 +635,7 @@ static char *get_data(struct lslocks *lslocks, struct lock *l, int num,
 		break;
 	case COL_PID:
 		xasprintf(&str, "%d", l->pid);
-		if (l->pid >= 0)
+		if (l->pid >= 0 && rawdata)
 			*rawdata = (uint64_t)l->pid;
 		break;
 	case COL_TYPE:

--- a/tests/expected/lslocks/filter
+++ b/tests/expected/lslocks/filter
@@ -1,3 +1,5 @@
+#### crash when printing PID column ####
+PID: 0
 #### flock  (common) ####
 # -Q PID == ...
 test_mkfds FLOCK WRITE 4K 0 0 0

--- a/tests/ts/lslocks/filter
+++ b/tests/ts/lslocks/filter
@@ -49,6 +49,18 @@ if ! dd if=/dev/zero of="$FILE" bs=$SIZE count=1 status=none; then
     ts_skip "failed to create a temporary file"
 fi
 
+do_lslocks_flock_crash()
+{
+    local pid=$1
+
+    echo "#### crash when printing PID column ####"
+    [[ "$pid" == $("$TS_CMD_LSLOCKS" \
+		       -r -n -p "$PID" \
+		       -Q 'PATH =~ '"'.*/$FILE'"" and TYPE == 'FLOCK'" \
+		       -o PID) ]]
+    echo "PID: $?"
+}
+
 do_lslocks_common()
 {
     local pid=$1
@@ -132,6 +144,7 @@ do_lslocks_fcntl()
 		       "$FILE" \
 		       "$TS_HELPER_MKFDS" nop; }
     if read -r -u "${MKFDS[0]}" PID; then
+	do_lslocks_flock_crash $PID
 	do_lslocks_common $PID flock
 	echo DONE >&"${MKFDS[1]}"
     fi


### PR DESCRIPTION
Fix a crash I introdued in 92513f5fff7f18ab0a9767a2281629e7bfd60506.