### PR TITLE
Add fuse.kio-fuse to list of pseudo file systems

### DIFF
--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -395,6 +395,7 @@ int mnt_fstype_is_pseudofs(const char *type)
 		"fuse.encfs", /* Not a true pseudofs (has source), but source is not reported. */
 		"fuse.gvfs-fuse-daemon", /* Old name, not used by gvfs any more. */
 		"fuse.gvfsd-fuse",
+		"fuse.kio-fuse",
 		"fuse.lxcfs",
 		"fuse.portal",
 		"fuse.rofiles-fuse",


### PR DESCRIPTION
Since it’s similar to gvfsd-fuse, might just add it.