### PR TITLE
lib/pager: Simplify code

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -209,7 +209,7 @@ static void __setup_pager(void)
 	sigaction(SIGPIPE, &sa, &pager_process.orig_sigpipe);
 }
 
-/* Setup pager and redirects output to the $PAGER. The pager is closed at exit.
+/* Setup pager and redirect output to the $PAGER. The pager is closed at exit.
  */
 void pager_redirect(void)
 {
@@ -250,7 +250,7 @@ void pager_close(void)
 	close(pager_process.org_out);
 	close(pager_process.org_err);
 
-	/* restore original segnals setting */
+	/* restore original signal settings */
 	sigaction(SIGINT,  &pager_process.orig_sigint, NULL);
 	sigaction(SIGHUP,  &pager_process.orig_sighup, NULL);
 	sigaction(SIGTERM, &pager_process.orig_sigterm, NULL);


### PR DESCRIPTION
This code derived from pager handling functionality of git (as the initial source code comment states), which includes their generic execution handling.

We "just" need the pager handling, which eventually looks like this:

```
main process stdout/stderr --- pipe ---> stdin $PAGER
```

- The stdin of the pager is always the newly created pipe
- Output (stderr/stdout) of the pager is never redirected

This already removes some struct fields and never reached code.

With this removal, it also becomes obvious that:

- The main process does not care how the pager exits (just THAT it exits eventually)

Which, again, removes some code.

In total, this is just a preparation pull request to fix some quirky behavior of the pager. But given this rather difficult to read code due to unreachable branches and more functionality stubs than needed, it would be nice to clean it up with this PR, first.

Basically no functional change (binary changes, but functionality stays the same). Please see the single commits for explanation, which makes it easier to review.

How to test:

- `dmesg -H` calls the pager
- `fdisk` and entering `l` in menu calls the pager

These are the two programs which currently use the pager functionality.