### PR TITLE
lsfd: fix dependency on errnos.h

### DIFF
--- a/lsfd-cmd/Makemodule.am
+++ b/lsfd-cmd/Makemodule.am
@@ -1,6 +1,6 @@
 if BUILD_LSFD
 
-lsfd-cmd/file.c: errnos.h
+lsfd-cmd/error.c: errnos.h
 
 bin_PROGRAMS += lsfd
 MANPAGES += lsfd-cmd/lsfd.1


### PR DESCRIPTION
Fix a bug that I introduced in 764f1d396f.

Makemodule.am listed a dependency on errnos.h for file.c, but the header is actually used by error.c.  Fix the dependency to ensure correct rebuilds.