### PR TITLE
lscpu: Implement options for dumping ARM implementer/model name tables

### DIFF
--- a/bash-completion/lscpu
+++ b/bash-completion/lscpu
@@ -30,6 +30,8 @@ _lscpu_module()
 		-*)
 			OPTS_ALL="--all
 				--annotate
+				--arm-id
+				--arm-model
 				--online
 				--bytes
 				--caches

--- a/sys-utils/lscpu.1.adoc
+++ b/sys-utils/lscpu.1.adoc
@@ -108,6 +108,16 @@ Display physical IDs for all columns with topology elements (core, socket, etc.)
 +
 The CPU logical numbers are not affected by this option.
 
+*--arm-id*[**=**_list_]::
+Print a list of the known ARM core implementers and their human readable names.
++
+If an argument is given, print a list of the individual core IDs and their
+names, for the given implementer.
+
+*--arm-model* _id_::
+Print the name for this specific core model. This requires passing
+*--arm-id=_id_* to indicate the implementer id as well.
+
 include::man-common/annotate.adoc[]
 
 == ENVIRONMENT

--- a/sys-utils/lscpu.h
+++ b/sys-utils/lscpu.h
@@ -212,7 +212,10 @@ enum {
 	LSCPU_OUTPUT_SUMMARY = 0,	/* default */
 	LSCPU_OUTPUT_CACHES,
 	LSCPU_OUTPUT_PARSABLE,
-	LSCPU_OUTPUT_READABLE
+	LSCPU_OUTPUT_READABLE,
+	LSCPU_OUTPUT_ARM_IMPLEMENTERS,
+	LSCPU_OUTPUT_ARM_MODELS,
+	LSCPU_OUTPUT_ARM_SINGLE_MODEL,
 };
 
 struct lscpu_cxt {
@@ -324,6 +327,9 @@ struct lscpu_cpu *lscpu_cpus_loopup_by_type(struct lscpu_cxt *cxt, struct lscpu_
 
 void lscpu_decode_arm(struct lscpu_cxt *cxt);
 void lscpu_format_isa_riscv(struct lscpu_cputype *ct);
+void lscpu_print_arm_implementers(struct lscpu_cxt *cxt);
+void lscpu_print_arm_models(struct lscpu_cxt *cxt, int implementer);
+void lscpu_print_arm_model(struct lscpu_cxt *cxt, int implementer, int model);
 
 int lookup(char *line, char *pattern, char **value);
 


### PR DESCRIPTION
This allows extracting the contents of the tables, which itself is uncopyrightable, for use in other projects with different code licenses.