### PR TITLE
lsns: make the synopsis more coherent

### DIFF
--- a/sys-utils/lsns.8.adoc
+++ b/sys-utils/lsns.8.adoc
@@ -19,7 +19,7 @@ lsns - list namespaces
 
 == SYNOPSIS
 
-*lsns* [options] [_namespace_]
+*lsns* [options] [_namespace ID_]
 
 == DESCRIPTION
 

--- a/sys-utils/lsns.c
+++ b/sys-utils/lsns.c
@@ -1563,7 +1563,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_HEADER, out);
 
 	fprintf(out,
-		_(" %s [options] [<namespace>]\n"), program_invocation_short_name);
+		_(" %s [options] [<namespace ID>]\n"), program_invocation_short_name);
 
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("List system namespaces.\n"), out);


### PR DESCRIPTION
Using _namespace ID_ in the synopsis as argument definition is more coherent as it lets a user easily infer that a numeric value is required to identify a namespace.