### PR TITLE
blkdev: Correct zone report size calculation

### DIFF
--- a/lib/blkdev.c
+++ b/lib/blkdev.c
@@ -432,7 +432,7 @@ struct blk_zone_report *blkdev_get_zonereport(int fd, uint64_t sector, uint32_t 
 	size_t rep_size;
 	int ret;
 
-	rep_size = sizeof(struct blk_zone_report) + sizeof(struct blk_zone) * 2;
+	rep_size = sizeof(struct blk_zone_report) + sizeof(struct blk_zone) * nzones;
 	rep = calloc(1, rep_size);
 	if (!rep)
 		return NULL;


### PR DESCRIPTION
The original code hardcoded the blk_zone array size to 2 when
calculating rep_size, which caused incorrect buffer allocation when
requesting more/less than 2 zones via nzones parameter.