### PR TITLE
lib: (strutils.c) fix unchecked lookahead in ul_parse_size()

### DIFF
--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -139,9 +139,9 @@ check_suffix:
 			} else
 				end = (char *) p;
 
-			if (frac && (!end  || !*end)) {
+			if (!end || !*end) {
 				rc = -EINVAL;
-				goto err;		/* without suffix, but with frac */
+				goto err;	/* without suffix, but with fractions */
 			}
 			p = end;
 			goto check_suffix;


### PR DESCRIPTION
If the numeric value provided to ul_parse_size() via @str is a decimal with fractions only containing zeros, the logic fails to identify the end of the string and goes to the label 'check_suffix' and will do an unchecked lookahead (*p + 1) that will result in an out-of-bounds read.

This is because the logic only checks for null-termination when a fraction has been parsed, i.e. a fraction not only containing zeros.

To fix the issue, we implicitly check for null-termination when we have finished parsing the fraction.

Reported-by: Yashashree Gund <yash_gund@live.com>