### PR TITLE
dmesg: Fix possible out of boundary accesses with memory mapped files

### DIFF
--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -667,6 +667,8 @@ static ssize_t mmap_file_buffer(struct dmesg_control *ctl, char **buf)
 		err(EXIT_FAILURE, _("cannot open %s"), ctl->filename);
 	if (fstat(fd, &st))
 		err(EXIT_FAILURE, _("stat of %s failed"), ctl->filename);
+	if ((intmax_t)st.st_size >= (intmax_t)SINT_MAX(ssize_t))
+		err(EXIT_FAILURE, _("%s is too large"), ctl->filename);
 
 	*buf = mmap(NULL, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
 	if (*buf == MAP_FAILED)


### PR DESCRIPTION
This PR fixes two scenarios in which dmesg could trigger an out of boundary read with memory mapped files:

1. If a file ends without terminating character, `strtol` might read past the end of file
2. If a file does not end with a newline, last newline check triggers read past the end of file

Proof of Concept (both cases):

1. Create a sufficiently large file ending at a page boundary (large enough to not have an adjacent page next to it)
```
python -c 'print(5171199*"<[111]a\n"+"<[111111",end="")' > poc.txt
```
2. Open the file with dmesg
```
dmesg -F poc.txt > /dev/null
Segmentation fault         (core dumped) dmesg -F poc.txt > /dev/null
```

This triggers the `strtol` out of boundary access. With first commit applied, it triggers the newline check (and yes, that's how I noticed the second issue :) ).

Note:

The newline check if end of file is reached (previously "undefined behavior") matches the supposed behavior with empty files, e.g. the old check

```
if (*end != '\n' && *(end - 1) == '\n')
```

is replaced with

```
if ((!rec->next || *end != '\n') && *(end - 1) == '\n')
```

As long as the file is not at a page boundary, `*end` should be `\0` i.e. not `\n` so these checks are equivalent.

Identical output is expected for current and patched dmesg with:

```
echo > newline.txt
dmesg -JF newline.txt
```

While at it, fixes a silent truncation of large files on 32 bit systems.