### PR TITLE
lib/pager: Set SIGCHLD to default handling

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -35,6 +35,7 @@ struct child_process {
 
 	int org_err;
 	int org_out;
+	struct sigaction orig_sigchld;
 	struct sigaction orig_sigint;
 	struct sigaction orig_sighup;
 	struct sigaction orig_sigterm;
@@ -186,6 +187,12 @@ static void __setup_pager(void)
 	pager_process.argv = pager_argv;
 	pager_process.in = -1;
 
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = SIG_DFL;
+
+	/* this makes sure that waitpid works as expected */
+	sigaction(SIGCHLD, &sa, &pager_process.orig_sigchld);
+
 	if (start_command(&pager_process))
 		return;
 
@@ -198,7 +205,6 @@ static void __setup_pager(void)
 	}
 	close(pager_process.in);
 
-	memset(&sa, 0, sizeof(sa));
 	sa.sa_handler = wait_for_pager_signal;
 
 	/* this makes sure that the parent terminates after the pager */
@@ -251,6 +257,7 @@ void pager_close(void)
 	close(pager_process.org_err);
 
 	/* restore original signal settings */
+	sigaction(SIGCHLD, &pager_process.orig_sigchld, NULL);
 	sigaction(SIGINT,  &pager_process.orig_sigint, NULL);
 	sigaction(SIGHUP,  &pager_process.orig_sighup, NULL);
 	sigaction(SIGTERM, &pager_process.orig_sigterm, NULL);


### PR DESCRIPTION
If `SIGCHLD` is ignored, then `waitpid` might return an error if child process is already terminated, since zombie process generation would be blocked.

This is the first of a few PRs I will open for lib/pager.c to get a smoother experience even in edge cases.

You can see the difference if you ignore `SIGCHLD` in the parent:

1. Compile `poc` which disables `SIGCHLD` and spawns the specified process
```
cat > poc.c << EOF
#include <err.h>
#include <signal.h>
#include <stdlib.h>
#include <unistd.h>

int
main(int argc, char *argv[])
{
        if (argc < 2)
                errx(EXIT_FAILURE, "usage: poc cmd [args]");
        signal(SIGCHLD, SIG_IGN);
        execvp(argv[1], &argv[1]);
        return 0;
}
EOF
cc -o poc poc.c
```

2. Run `strace ./poc dmesg -H` and immediately press `q` to trigger a `SIGPIPE` (it's really `enter` and `q` at the same time, basically)

```
strace ./poc dmesg -H
...
write(1, "\33[32m[  +0.000020] \33[0mfound SMP"..., 73) = -1 EPIPE (Broken pipe)
--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER, si_pid=15834, si_uid=0} ---
close(1)                                = 0
close(2)                                = 0
wait4(15835, 0x7ffe112120e4, 0, NULL)   = -1 ECHILD (No child processes)
write(2, "dmesg: waitpid failed\n", 22) = -1 EBADF (Bad file descriptor)
exit_group(1)                           = ?
+++ exited with 1 +++
```

You can see that `wait4` immediately fails.

With this PR applied (or when run without `./poc`):
```
strace ./poc dmesg -H
...
write(1, "\33[32m[  +0.000020] \33[0mfound SMP"..., 73) = -1 EPIPE (Broken pipe)
--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER, si_pid=15893, si_uid=0} ---
close(1)                                = 0
close(2)                                = 0
wait4(15894, [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL) = 15894
gettid()                                = 15893
getpid()                                = 15893
tgkill(15893, 15893, SIGPIPE)           = 0
rt_sigreturn({mask=[]})                 = -1 EPIPE (Broken pipe)
--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_TKILL, si_pid=15893, si_uid=0} ---
close(1)                                = -1 EBADF (Bad file descriptor)
close(2)                                = -1 EBADF (Bad file descriptor)
wait4(15894, 0x7ffccf4fb9e4, 0, NULL)   = -1 ECHILD (No child processes)
write(2, "dmesg: waitpid failed\n", 22) = -1 EBADF (Bad file descriptor)
exit_group(1)                           = ?
+++ exited with 1 +++
```

The first `wait4` call succeeds, the second one (which shouldn't be there but I won't adjust too much in a single PR) fails, since `wait4` was called for the PID already.