### PR TITLE
lib/pager: Do not resolve directories with PATH

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -136,7 +136,7 @@ static int has_command(const char *cmd)
 	if (!b)
 		goto cleanup;
 
-	if (*b == '/') {
+	if (strchr(b, '/')) {
 		rc = access(b, X_OK) == 0;
 		goto cleanup;
 	}


### PR DESCRIPTION
If `PAGER` contains any slash in program part, avoid resolving it with `PATH` environment variable. Even if it is found there (in a subdirectory), `sh -c` won't execute it.

Proof of Concept:

```
BASE=$(mktemp -d)
mkdir -p $BASE/my
cp $(which cat) $BASE/my/program
PATH="$PATH:$BASE" PAGER="my/program" dmesg -H
```
```
sh: line 1: my/program: No such file or directory
```

This assume of course that there is no `./my/program` executable in current working directory. :)