### PR TITLE
lib/pager: Call _exit in signal handler, not raise

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -113,11 +113,11 @@ static void wait_for_pager(void)
 	} while (waiting == -1);
 }
 
-static void wait_for_pager_signal(int signo)
+static void wait_for_pager_signal(int signo __attribute__ ((__unused__)))
 {
 	UL_PROTECT_ERRNO;
 	wait_for_pager();
-	raise(signo);
+	_exit(EXIT_FAILURE);
 }
 
 static int has_command(const char *cmd)


### PR DESCRIPTION
The signals are registered without `SA_RESETHAND`, which means that the same signal handler is called over and over again.

This originates from the original source of pager.c, i.e. git, which implements its own stacked signal processing. Neither needed in util-linux nor implemented.

This just works because eventually, the `waitpid` call will fail, leading to a suppressed error message (because stderr is already closed) and then an `_exit(EXIT_FAILURE)` call.

Just call `_exit(EXIT_FAILURE)` directly to avoid unneeded and failing system calls.

You can see the difference with strace:

1. Run `strace dmesg -H` and immediately press `q` to trigger a `SIGPIPE` (press `q` as fast as you can)

Currently, you can see this:
```
write(1, "\33[32m[  +0.000020] \33[0mfound SMP"..., 73) = -1 EPIPE (Broken pipe)
--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER, si_pid=4647, si_uid=0} ---
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=4648, si_uid=0, si_status=0, si_utime=0, si_stime=0} ---
close(1)                                = 0
close(2)                                = 0
wait4(4648, [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL) = 4648
gettid()                                = 4647
getpid()                                = 4647
tgkill(4647, 4647, SIGPIPE)             = 0
rt_sigreturn({mask=[]})                 = -1 EPIPE (Broken pipe)
--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_TKILL, si_pid=4647, si_uid=0} ---
close(1)                                = -1 EBADF (Bad file descriptor)
close(2)                                = -1 EBADF (Bad file descriptor)
wait4(4648, 0x7fff5613c824, 0, NULL)    = -1 ECHILD (No child processes)
write(2, "dmesg: waitpid failed\n", 22) = -1 EBADF (Bad file descriptor)
exit_group(1)                           = ?
+++ exited with 1 +++
```
The second `SIGPIPE` happens due to the `raise` call. It repeats the same steps, eventually runs into the `waitpid` error case and calls `ul_sig_err` (which calls `write` and then `_exit`).


With PR applied, you can see this:
```
write(1, "\33[32m[  +0.000020] \33[0mfound SMP"..., 73) = -1 EPIPE (Broken pipe)
--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER, si_pid=4666, si_uid=0} ---
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=4667, si_uid=0, si_status=0, si_utime=0, si_stime=0} ---
close(1)                                = 0
close(2)                                = 0
wait4(4667, NULL, 0, NULL)              = 4667
sigaltstack(NULL, {ss_sp=0x7faa51571000, ss_flags=0, ss_size=32768}) = 0
exit_group(1)                           = ?
+++ exited with 1 +++
```
Less system calls and no errors.

I'm not happy about the current signal handling, but since we talk about signal handling here, this is the smallest yet in itself useful adjustment to come to a much more reasonable signal processing. By itself, this PR is more like one step forward, one step back. But one easy and reviewable step a time ...