### PR TITLE
style: convert tabs to spaces in meson.build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,8 @@ indent_style = tab
 indent_size = 8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[meson.build]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/meson.build
+++ b/meson.build
@@ -220,8 +220,8 @@ headers = '''
         linux/falloc.h
         linux/fd.h
         linux/fs.h
-	linux/fiemap.h
-	linux/gsmmux.h
+        linux/fiemap.h
+        linux/gsmmux.h
         linux/if_alg.h
         linux/landlock.h
         linux/kcmp.h
@@ -257,7 +257,7 @@ headers = '''
         sys/pidfd.h
         sys/prctl.h
         sys/resource.h
-	sys/sendfile.h
+        sys/sendfile.h
         sys/signalfd.h
         sys/socket.h
         sys/sockio.h
@@ -273,7 +273,7 @@ headers = '''
         sys/ucred.h
         sys/un.h
         sys/vfs.h
-	sys/xattr.h
+        sys/xattr.h
 '''.split()
 
 lib_m = cc.find_library('m')


### PR DESCRIPTION
Hello,

I noticed some formatting inconsistencies in the meson.build files. I'd like to propose and help with standardizing the alignment for better readability.

Thank you for your consideration.