### PR TITLE
dmesg: Fix short memory allocation with 32 bit

### DIFF
--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -1787,6 +1787,9 @@ int main(int argc, char *argv[])
 					_("invalid buffer size argument"));
 			if (ctl.bufsize < 4096)
 				ctl.bufsize = 4096;
+			if (ctl.bufsize > SIZE_MAX - 8)
+				errx(EXIT_FAILURE, "%s: '%s'",
+						_("invalid buffer size argument"), optarg);
 			break;
 		case 'T':
 			include_time_fmt(&ctl, DMESG_TIMEFTM_CTIME);


### PR DESCRIPTION
The buffer size can be specified as 32 bit `unsigned int` with command line argument. In `read_syslog_buffer`, the allocation is increased by 8 bytes. This means that an unsigned integer overflow could occur, leading to less amount of memory allocated than expected.

Please note that this does not lead to a security issue, just an incomplete message.

Proof of Concept (32 bit):
```
$ dmesg -Ss 4294967280
dmesg: cannot allocate 4294967288 bytes: Cannot allocate memory
$ dmesg -Ss 4294967290
$ _
```

With PR applied:
```
$ dmesg -Ss 4294967290
dmesg: invalid buffer size argument: '4294967290'
```
