### PR TITLE
lib/pager: Release resources on pager_open error

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -238,6 +238,12 @@ void pager_open(void)
 	pager_process.org_err = dup(STDERR_FILENO);
 
 	__setup_pager();
+
+	if (!pager_process.pid) {
+		close(pager_process.org_out);
+		close(pager_process.org_err);
+		memset(&pager_process, 0, sizeof(pager_process));
+	}
 }
 
 /* Close pager and restore original std{out,err}.


### PR DESCRIPTION
If __setup_pager is unable to spawn a new process, close the duplicated file descriptors on error path. Also, for the sake of completeness, clear all other fields in pager_process as well.

Proof of Concept:

1. Run fdisk and continuously list known partition types
```
yes l | PAGER=cat fdisk /dev/sda
```
2. Send process to background by pressing `^Z`
3. Check open file descriptors in /proc/PID/fd
```
ls /proc/$(jobs -l | tail -n 1 | awk '{print $1}')/fd | wc -l
```
```
1024
```
The output depends on runtime environment, of course.