### PR TITLE
tests: add tests for column --table-header-as-columns

### DIFF
--- a/tests/expected/column/table-header-as-columns
+++ b/tests/expected/column/table-header-as-columns
@@ -1,0 +1,3 @@
+NAME   AGE  CITY  
+Alice  30   New   York
+Bob    25   Los   Angeles

--- a/tests/expected/column/table-header-as-columns-csv
+++ b/tests/expected/column/table-header-as-columns-csv
@@ -1,0 +1,3 @@
+NAME   AGE  CITY
+Alice  30   New York
+Bob    25   Los Angeles

--- a/tests/expected/column/table-header-as-columns-empty
+++ b/tests/expected/column/table-header-as-columns-empty
@@ -1,0 +1,2 @@
+COL1   COL3   
+Data1  Data2  Data3

--- a/tests/expected/column/table-header-as-columns-json
+++ b/tests/expected/column/table-header-as-columns-json
@@ -1,0 +1,13 @@
+{
+   "table": [
+      {
+         "name": "Alice",
+         "age": "30",
+         "city": "New York"
+      },{
+         "name": "Bob",
+         "age": "25",
+         "city": "Los Angeles"
+      }
+   ]
+}

--- a/tests/ts/column/table
+++ b/tests/ts/column/table
@@ -201,4 +201,20 @@ ts_init_subtest "wrap-separator-multiple-separators"
 echo -e 'A:B:C\naa:b1|b2|b3:cc\nxx:y1|y2:zz' | $TS_CMD_COLUMN --table --separator ':' --table-wrap 2 --wrap-separator '|' >> $TS_OUTPUT 2>> $TS_ERRLOG
 ts_finalize_subtest
 
+ts_init_subtest "header-as-columns"
+echo -e 'NAME\tAGE\tCITY\nAlice\t30\tNew York\nBob\t25\tLos Angeles' | $TS_CMD_COLUMN --table -K >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "header-as-columns-csv"
+echo -e 'NAME,AGE,CITY\nAlice,30,New York\nBob,25,Los Angeles' | $TS_CMD_COLUMN --table -K --separator ',' >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "header-as-columns-json"
+echo -e 'NAME,AGE,CITY\nAlice,30,New York\nBob,25,Los Angeles' | $TS_CMD_COLUMN --table -K --separator ',' --json >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
+ts_init_subtest "header-as-columns-empty"
+echo -e 'COL1\t\tCOL3\nData1\tData2\tData3' | $TS_CMD_COLUMN --table -K >> $TS_OUTPUT 2>> $TS_ERRLOG
+ts_finalize_subtest
+
 ts_finalize


### PR DESCRIPTION
Add test coverage for the --table-header-as-columns (-K) option added in PR #4003.

Tests cover:
- Basic tab-separated input with header line
- CSV input with comma separator
- JSON output with header-derived column names
- Empty column names in header

Addresses: https://github.com/util-linux/util-linux/pull/4003