### PR TITLE
prlimit: raise a nicer error message when modifying NOFILE

### DIFF
--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -202,6 +202,7 @@
 /* sysctl fs paths */
 #define _PATH_PROC_SYS_FS	"/proc/sys/fs"
 #define _PATH_PROC_PIPE_MAX_SIZE	_PATH_PROC_SYS_FS "/pipe-max-size"
+#define _PATH_PROC_NR_OPEN	_PATH_PROC_SYS_FS "/nr_open"
 #define _PATH_PROC_BINFMT_MISC	_PATH_PROC_SYS_FS "/binfmt_misc"
 
 /* Posix ipc paths */


### PR DESCRIPTION
When attempting to set RLIMIT_NOFILE to a value exceeding the kernel's fs.nr_open limit, prlimit(2) returns EPERM. This can mislead users into thinking they need elevated permissions, even when running as root.

Add a check to detect when the requested NOFILE limit exceeds fs.nr_open and provide a clear error message indicating the actual constraint. The check is optional: if /proc/sys/fs/nr_open cannot be read (e.g., /proc not mounted), the validation is silently skipped to avoid introducing a hard dependency on /proc.

The nr_open value is cached and read only once per prlimit invocation for efficiency when setting multiple limits.

Addresses: https://github.com/util-linux/util-linux/issues/4017