### PR TITLE
libblkid: (btrfs) use BTRFS_NR_SB_LOG_ZONES and rep->zones

### DIFF
--- a/libblkid/src/superblocks/btrfs.c
+++ b/libblkid/src/superblocks/btrfs.c
@@ -179,12 +179,12 @@ static int sb_log_offset(blkid_probe pr, uint64_t *bytenr_ret)
 
 
 	zone_size_sector = pr->zone_size >> SECTOR_SHIFT;
-	rep = blkdev_get_zonereport(pr->fd, zone_num * zone_size_sector, 2);
+	rep = blkdev_get_zonereport(pr->fd, zone_num * zone_size_sector, BTRFS_NR_SB_LOG_ZONES);
 	if (!rep) {
 		ret = -errno;
 		goto out;
 	}
-	zones = (struct blk_zone *)(rep + 1);
+	zones = rep->zones;
 
 	/*
 	 * Use the head of the first conventional zone, if the zones


### PR DESCRIPTION
Use the BTRFS_NR_SB_LOG_ZONES constant instead of a hardcoded 2 when calling blkdev_get_zonereport() to be consistent with the rest of the function that already uses this constant.

Replace the pointer arithmetic (struct blk_zone *)(rep + 1) with the more readable rep->zones flexible array member access.

Addresses: https://github.com/util-linux/util-linux/pull/3995