### PR TITLE
lib/netlink: set SOCK_CLOEXEC on netlink socket

### DIFF
--- a/lib/netlink.c
+++ b/lib/netlink.c
@@ -310,7 +310,7 @@ int ul_nl_open(struct ul_nl_data *nl, uint32_t nl_groups)
 	int rc;
 
 	DBG(NLMSG, ul_debugobj(nl, "opening socket"));
-	sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+	sock = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_ROUTE);
 	if (sock < 0)
 		return sock;
 	addr.nl_family = AF_NETLINK;


### PR DESCRIPTION
Set SOCK_CLOEXEC when creating the NETLINK_ROUTE socket in ul_nl_open() to prevent the file descriptor from leaking to child processes across execv().

In agetty, the netlink socket used to monitor IP address changes for \4/\6 issue escapes was inherited by the login program, causing SELinux AVC denials (local_login_t denied read/write on getty_t's netlink_route_socket).

Fixes: https://github.com/util-linux/util-linux/issues/4032