### PR TITLE
setpriv: use AppArmor LSM-specific proc interface

### DIFF
--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -110,6 +110,7 @@
 
 #define _PATH_PROC_ATTR_CURRENT	"/proc/self/attr/current"
 #define _PATH_PROC_ATTR_EXEC	"/proc/self/attr/exec"
+#define _PATH_PROC_ATTR_APPARMOR_EXEC	"/proc/self/attr/apparmor/exec"
 #define _PATH_PROC_CAPLASTCAP	"/proc/sys/kernel/cap_last_cap"
 
 


### PR DESCRIPTION
Remove the check for /sys/kernel/security/apparmor (securityfs) before writing to the proc attr interface. The securityfs check fails in environments where AppArmor is enabled but securityfs is not mounted (e.g., containers, WSL2, embedded systems).

Use the LSM-specific /proc/self/attr/apparmor/exec interface introduced in Linux 5.8 (kernel commit 6413f852ce08) which is not affected by LSM load ordering issues. Fall back to the legacy /proc/self/attr/exec for older kernels.

Fixes: https://github.com/util-linux/util-linux/issues/4033