### PR TITLE
nsenter: Support specifying namespace by ID

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1052,6 +1052,10 @@ char *c = crypt("abc","pw");
 ])
 AM_CONDITIONAL([HAVE_LIBCRYPT], [test "x$have_libcrypt" = xyes])
 
+AC_CHECK_TYPES([struct nsfs_file_handle], [], [], [[
+#include <linux/nsfs.h>
+]])
+
 
 AC_ARG_WITH([selinux],
   AS_HELP_STRING([--with-selinux], [compile with SELinux support]),

--- a/meson.build
+++ b/meson.build
@@ -915,6 +915,9 @@ conf.set('USE_COLORS_BY_DEFAULT', get_option('colors-default') ? 1 : false)
 
 is_glibc = cc.has_header_symbol('limits.h', '__GLIBC__')
 
+have = cc.has_type('struct nsfs_file_handle', prefix : '#include <linux/nsfs.h>')
+conf.set('HAVE_STRUCT_NSFS_FILE_HANDLE', have ? 1 : false)
+
 ############################################################
 
 

--- a/sys-utils/nsenter.1.adoc
+++ b/sys-utils/nsenter.1.adoc
@@ -87,36 +87,36 @@ Optionally, a process can be addressed with the format _PID:inode_. The _inode_
 identifies the unique process's file descriptor. To retrieve a process's inode
 number you can use the *getino*(1) utility.
 
-*-m*, *--mount*[**=**_file_]::
-Enter the mount namespace. If no file is specified, enter the mount namespace of the target process. If _file_ is specified, enter the mount namespace specified by _file_.
+*-m*, *--mount*[**=**<__file__|:__nsid__>]::
+Enter the mount namespace. If no argument is specified, enter the mount namespace of the target process. If _file_ or :__nsid__ is specified, enter the mount namespace specified by _file_ or _nsid_.
 
-*-u*, *--uts*[**=**_file_]::
-Enter the UTS namespace. If no file is specified, enter the UTS namespace of the target process. If _file_ is specified, enter the UTS namespace specified by _file_.
+*-u*, *--uts*[**=**<__file__|:__nsid__>]::
+Enter the UTS namespace. If no argument is specified, enter the UTS namespace of the target process. If _file_ or :__nsid__ is specified, enter the UTS namespace specified by _file_ or _nsid_.
 
-*-i*, *--ipc*[**=**_file_]::
-Enter the IPC namespace. If no file is specified, enter the IPC namespace of the target process. If _file_ is specified, enter the IPC namespace specified by _file_.
+*-i*, *--ipc*[**=**<__file__|:__nsid__>]::
+Enter the IPC namespace. If no argument is specified, enter the IPC namespace of the target process. If _file_ or :__nsid__ is specified, enter the IPC namespace specified by _file_ or _nsid_.
 
-*-n*, *--net*[**=**_file_]::
-Enter the network namespace. If no file is specified, enter the network namespace of the target process. If _file_ is specified, enter the network namespace specified by _file_.
+*-n*, *--net*[**=**<__file__|:__nsid__>]::
+Enter the network namespace. If no argument is specified, enter the network namespace of the target process. If _file_ or :__nsid__ is specified, enter the network namespace specified by _file_ or _nsid_.
 
 *-N*, *--net-socket* _fd_::
 Enter the network namespace of the target process's socket. It requires *--target* process specified. Supported since Linux 5.6.
 
-*-p*, *--pid*[**=**_file_]::
-Enter the PID namespace. If no file is specified, enter the PID namespace of the target process. If _file_ is specified, enter the PID namespace specified by _file_.
+*-p*, *--pid*[**=**<__file__|:__nsid__>]::
+Enter the PID namespace. If no argument is specified, enter the PID namespace of the target process. If _file_ or :__nsid__ is specified, enter the PID namespace specified by _file_ or _nsid_.
 
-*-U*, *--user*[**=**_file_]::
-Enter the user namespace. If no file is specified, enter the user namespace of the target process. If _file_ is specified, enter the user namespace specified by _file_. See also the *--setuid* and *--setgid* options.
+*-U*, *--user*[**=**<__file__|:__nsid__>]::
+Enter the user namespace. If no argument is specified, enter the user namespace of the target process. If _file_ or :__nsid__ is specified, enter the user namespace specified by _file_ or _nsid_. See also the *--setuid* and *--setgid* options.
 
 *--user-parent*::
 Enter the parent user namespace. Parent user namespace will be acquired from any other enabled namespace.
 If combined with *--user* option the parent user namespace will be fetched from the user namespace and replace it.
 
-*-C*, *--cgroup*[**=**_file_]::
-Enter the cgroup namespace. If no file is specified, enter the cgroup namespace of the target process. If _file_ is specified, enter the cgroup namespace specified by _file_.
+*-C*, *--cgroup*[**=**<__file__|:__nsid__>]::
+Enter the cgroup namespace. If no argument is specified, enter the cgroup namespace of the target process. If _file_ or :__nsid__ is specified, enter the cgroup namespace specified by _file_ or _nsid_.
 
-*-T*, *--time*[**=**_file_]::
-Enter the time namespace. If no file is specified, enter the time namespace of the target process. If _file_ is specified, enter the time namespace specified by _file_.
+*-T*, *--time*[**=**<__file__|:__nsid__>]::
+Enter the time namespace. If no argument is specified, enter the time namespace of the target process. If _file_ or :__nsid__ is specified, enter the time namespace specified by _file_ or _nsid_.
 
 *-G*, *--setgid* _gid_::
 Set the group ID which will be used in the entered namespace and drop supplementary groups.
@@ -160,6 +160,8 @@ include::man-common/help-version.adoc[]
 == NOTES
 
 The *--user-parent* option requires Linux 4.9 or higher, older kernels will raise inappropriate ioctl for device error.
+
+Specifying namesapces by _nsid_ requires Linux 6.19 or higher.
 
 == AUTHORS
 


### PR DESCRIPTION
Linux kernel v6.19 introduces listns() syscall that lists namespace IDs, as well as the support for opening an nsfile by a file_handle of ns ID.

This patch allows specifying namespaces by ID for nsenter. For example:

  # nsenter --net=:7

enters init net namespace (7 for NET_NS_INIT_ID).

In the rare case that a ns file name starts with a colon, prepend "./" for disambiguation.