### PR TITLE
pg: Fix compiler warning

### DIFF
--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -615,7 +615,8 @@ static void prompt(long long pageno)
 	char key;
 	int state = COUNT;
 	int escape = 0;
-	char b[LINE_MAX], *p;
+	char b[LINE_MAX];
+	const char *p;
 
 	if (pageno != -1) {
 		if ((p = strstr(pstring, "%d")) == NULL) {


### PR DESCRIPTION
Seen compiler warning with GCC 15.2.1 and glibc 2.43:
```
text-utils/pg.c: In function ‘prompt’:
text-utils/pg.c:621:24: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  621 |                 if ((p = strstr(pstring, "%d")) == NULL) {
      |                        ^
```

This happens if strstr is actually a preprocessor definition with a __glibc_const_generic. For this, __GLIBC_USE (ISOC23) must be true.

Setting the pointer to const does not hurt and clarifies that the content is not modfied.