### PR TITLE
lib/fileeq: Improve debug messages

### DIFF
--- a/lib/fileeq.c
+++ b/lib/fileeq.c
@@ -473,7 +473,7 @@ static ssize_t get_intro(struct ul_fileeq *eq, struct ul_fileeq_data *data,
 		if (fd < 0)
 			return -1;
 		rsz = read_all(fd, (char *) data->intro, sizeof(data->intro));
-		DBG(DATA, ul_debugobj(data, " read %zu bytes intro", sizeof(data->intro)));
+		DBG(DATA, ul_debugobj(data, " read %zd bytes [%zu wanted] intro", rsz, sizeof(data->intro)));
 		if (rsz < 0)
 			return -1;
 		data->nblocks = 1;


### PR DESCRIPTION
- Use correct formatters
- Extend one message to showcase that intro is not always fully populated, i.e. with files smaller than 32 bytes