### PR TITLE
dmesg: Handle long kmsg file records as well

### DIFF
--- a/sys-utils/dmesg.c
+++ b/sys-utils/dmesg.c
@@ -1450,7 +1450,7 @@ static int init_kmsg(struct dmesg_control *ctl)
 
 static int parse_kmsg_record(struct dmesg_control *ctl,
 			     struct dmesg_record *rec,
-			     char *buf,
+			     const char *buf,
 			     size_t sz)
 {
 	const char *p = buf, *end;
@@ -1568,17 +1568,10 @@ static int print_kmsg_file(struct dmesg_control *ctl, size_t sz)
 		return -1;
 
 	while (sz > 0) {
-		char str[sizeof(ctl->kmsg_buf)];
 		struct dmesg_record rec;
-		size_t len;
+		size_t len = strnlen(ctl->mmap_buff, sz);
 
-		len = strnlen(ctl->mmap_buff, sz);
-		if (len > sizeof(str))
-			errx(EXIT_FAILURE, _("record too large"));
-
-		memcpy(str, ctl->mmap_buff, len);
-
-		if (parse_kmsg_record(ctl, &rec, str, len) == 0)
+		if (parse_kmsg_record(ctl, &rec, ctl->mmap_buff, len) == 0)
 			print_record(ctl, &rec);
 
 		if (len < sz)


### PR DESCRIPTION
The `print_kmsg_file` function copies entries from a memory-mapped file into a temporary array on the stack before parsing it. Since the content is not modified (clarified by adding a const to a function argument), the memory can be accessed directly.

This in turn allows `print_kmsg_file` to handle arbitrarily long records, and `parse_kmsg_record` can handle these as well.

Removes another `errx` route while pager is possibly running. Also, more obscure files can be supported this way.