### PR TITLE
agetty: add support for more systemd credentials for configuration

### DIFF
--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -254,7 +254,7 @@ int isxdigit_strend(const char *str, const char **end)
 int ul_strtobool(const char *str, bool *result)
 {
 	static const char *bool_true[]  = { "1", "y", "t", "yes", "true", "on", "enable" };
-	static const char *bool_false[] = { "0", "no", "not", "false", "off", "disable" };
+	static const char *bool_false[] = { "0", "n", "f", "no", "false", "off", "disable", "not", };
 	size_t i;
 
 	if (!str || !result)

--- a/term-utils/agetty.8.adoc
+++ b/term-utils/agetty.8.adoc
@@ -377,10 +377,10 @@ Possible boolean values are listed at the end of this section.
 Boolean credentials accept the following values::
 
 Positive;;
-"true", "t", "yes", "y", "on", "1"
+"true", "t", "yes", "y", "on", "1", "enable"
 
 Negative;;
-"false", "f", "no", "n", "off", "0"
+"false", "f", "not", "no", "n", "off", "0", "disable"
 
 
 == BUGS

--- a/term-utils/agetty.8.adoc
+++ b/term-utils/agetty.8.adoc
@@ -341,6 +341,48 @@ _/etc/inittab_::
 
 If set, configures *agetty* to automatically log in the specified user without asking for a username or password, similarly to the *--autologin* option.
 
+*agetty.delay* (unsigned int)::
+
+If set, configures *agetty* to sleep for a specified number of seconds before opening the tty. Similar to the *--delay* option.
+
+*agetty.hangup* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to do a virtual hangup of the specified terminal. Similar to the *--hangup* option.
+Possible boolean values are listed at the end of this section.
+
+*agetty.nice* (int)::
+
+If set, configures *agetty* to run the login program with the specified priority. Similar to the *--nice* option.
+
+*agetty.noclear* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to not clear the screen before prompting for the login name. Similar to the *--noclear* option.
+Possible boolean values are listed at the end of this section.
+
+*agetty.nohints* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to not print hints about Num, Caps and Scroll Locks. Similar to the *--nohints* option.
+Possible boolean values are listed at the end of this section.
+
+*agetty.nohostname* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to show no hostname. Similar to the *--nohostname* option.
+Possible boolean values are listed at the end of this section.
+
+*agetty.noissue* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to not show contents of */etc/issue* before writing the login prompt. Similar to the *--noissue* option.
+Possible boolean values are listed at the end of this section.
+
+Boolean credentials accept the following values::
+
+Positive;;
+"true", "t", "yes", "y", "on", "1"
+
+Negative;;
+"false", "f", "no", "n", "off", "0"
+
+
 == BUGS
 
 The baud-rate detection feature (the *--extract-baud* option) requires that *agetty* be scheduled soon enough after completion of a dial-in call (within 30 ms with modems that talk at 2400 baud). For robustness, always use the *--extract-baud* option in combination with a multiple baud rate command-line argument, so that BREAK processing is enabled.

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -3131,12 +3131,53 @@ static void reload_agettys(void)
 #endif
 }
 
+/*
+ * Set or clear flags according to the boolean value provided by
+ * a systemd credential.
+ *
+ * @str: credential value
+ * @flags: pointer to the flags bitmask that will be updated
+ * @flag: the flag to set or clear
+ * @invert: 0 = no rule inversion, 1 = invert the default
+ *          (true = set) / (false = clear) rule
+ *
+ * In some cases inverting the default rule is needed, e.g. F_ISSUE
+ * is set by default and needs to be cleared when the agetty.noissue
+ * credential is set to 'true'.
+ *
+ * Returns 0 on success and < 0 on error.
+ */
+static int update_flags_from_bool_cred(const char *str, int *flags, int flag, int invert)
+{
+	int rc;
+	bool res;
+
+	if (!str || !flags)
+		return -EINVAL;
+
+	rc = ul_strtobool(str, &res);
+	if (rc < 0)
+		return rc;
+
+	if ((res == true && !invert) || (res == false && invert)) {
+		*flags |= flag;
+		return 0;
+	} else if ((res == false && !invert) || (res == true && invert)) {
+		*flags &= ~flag;
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
 static void load_credentials(struct options *op)
 {
 	char *env;
 	DIR *dir;
 	struct dirent *d;
 	struct path_cxt *pc;
+	int rc, num;
+	uint32_t u32num;
 
 	env = safe_getenv("CREDENTIALS_DIRECTORY");
 	if (!env)
@@ -3161,6 +3202,72 @@ static void load_credentials(struct options *op)
 			ul_path_read_string(pc, &str, d->d_name);
 			free(op->autolog);
 			op->autolog = str;
+			continue;
+		}
+
+		if (strcmp(d->d_name, "agetty.delay") == 0) {
+			ul_path_read_string(pc, &str, d->d_name);
+			rc = ul_strtou32(str, &u32num, 10);
+			if (rc)
+				log_warn(_("invalid 'delay' argument provided by credential"));
+			op->delay = u32num;
+			free(str);
+			continue;
+		}
+
+		if (strcmp(d->d_name, "agetty.hangup") == 0) {
+			ul_path_read_string(pc, &str, d->d_name);
+			rc = update_flags_from_bool_cred(str, &op->flags, F_HANGUP, 0);
+			if (rc < 0)
+				log_warn(_("invalid 'hangup' boolean value provided by credential"));
+			free(str);
+			continue;
+		}
+
+		if (strcmp(d->d_name, "agetty.nice") == 0) {
+			ul_path_read_string(pc, &str, d->d_name);
+			rc = ul_strtos32(str, &num, 10);
+			if (rc)
+				log_warn(_("invalid 'nice' argument provided by credential"));
+			op->nice = num;
+			free(str);
+			continue;
+		}
+
+		if (strcmp(d->d_name, "agetty.noclear") == 0) {
+			ul_path_read_string(pc, &str, d->d_name);
+			rc = update_flags_from_bool_cred(str, &op->flags, F_NOCLEAR, 0);
+			if (rc < 0)
+				log_warn(_("invalid 'noclear' boolean value provided by credential"));
+			free(str);
+			continue;
+		}
+
+		if (strcmp(d->d_name, "agetty.nohints") == 0) {
+			ul_path_read_string(pc, &str, d->d_name);
+			rc = update_flags_from_bool_cred(str, &op->flags, F_NOHINTS, 0);
+			if (rc < 0)
+				log_warn(_("invalid 'nohints' boolean value provided by credential"));
+			free(str);
+			continue;
+		}
+
+		if (strcmp(d->d_name, "agetty.nohostname") == 0) {
+			ul_path_read_string(pc, &str, d->d_name);
+			rc = update_flags_from_bool_cred(str, &op->flags, F_NOHOSTNAME, 0);
+			if (rc < 0)
+				log_warn(_("invalid 'nohostname' boolean value provided by credential"));
+			free(str);
+			continue;
+		}
+
+		if (strcmp(d->d_name, "agetty.noissue") == 0) {
+			ul_path_read_string(pc, &str, d->d_name);
+			rc = update_flags_from_bool_cred(str, &op->flags, F_ISSUE, 1);
+			if (rc < 0)
+				log_warn(_("invalid 'noissue' boolean value provided by credential"));
+			free(str);
+			continue;
 		}
 	}
 	closedir(dir);


### PR DESCRIPTION
Add support for more configuration options via systemd credentials:

agetty.delay == --delay
agetty.hangup == --hangup
agetty.nice == --nice
agetty.noclear == --noclear
agetty.nohints == --nohints
agetty.nohostname == --nohostname
agetty.noissue == --noissue

Closes: #2255