### PR TITLE
lib/pager: Use fully async-signal safe signal handler

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -104,9 +104,6 @@ static int wait_for_pager(void)
 	pid_t waiting;
 	int status;
 
-	if (!pager_process.pid)
-		return 0;
-
 	do {
 		waiting = waitpid(pager_process.pid, &status, 0);
 	} while (waiting == -1 && errno == EINTR);
@@ -134,8 +131,6 @@ static void catch_sigpipe(int signo)
 
 static void wait_for_pager_signal(int signo __attribute__ ((__unused__)))
 {
-	UL_PROTECT_ERRNO;
-
 	/* signal EOF to pager */
 	close(STDOUT_FILENO);
 	close(STDERR_FILENO);


### PR DESCRIPTION
The signal handler accesses the child pid, located on heap in a variable which (obviously) is not volatile sigatomic_t. From a very strict C language standard view, this is not safe.

We know the two consumers of lib/pager.c, i.e. dmesg and fdisk. Both have only one child: the pager. It is safe to wait for all children. Since no more heap variables are accessed, the signal handler becomes fully safe. Only calls left: `close`, `wait`, `_exit` with const arguments.

This in turn allows wait_for_pager to be only accessed from regular execution path, i.e. no special signal handling has to be considered here. Thus, `err` instead of `ul_sig_err` can be used which could in turn run other registered exit handlers.