### PR TITLE
lib/pager: Handle dup errors

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -249,11 +249,14 @@ void pager_open(void)
 	pager_process.org_out = dup(STDOUT_FILENO);
 	pager_process.org_err = dup(STDERR_FILENO);
 
-	__setup_pager();
+	if (pager_process.org_out != -1 && pager_process.org_err != -1)
+		__setup_pager();
 
 	if (!pager_process.pid) {
-		close(pager_process.org_out);
-		close(pager_process.org_err);
+		if (pager_process.org_out != -1)
+			close(pager_process.org_out);
+		if (pager_process.org_err != -1)
+			close(pager_process.org_err);
 		memset(&pager_process, 0, sizeof(pager_process));
 	}
 }


### PR DESCRIPTION
If dup fails, e.g. due to open file descriptor limitations, gracefully handle the situation and do not start the pager.