### PR TITLE
blkzone: add more checks when printing zone write_pointer

### DIFF
--- a/sys-utils/blkzone.c
+++ b/sys-utils/blkzone.c
@@ -291,7 +291,10 @@ static int blkzone_report(struct blkzone_control *ctl)
 				cap = entry.len;
 
 			if (type == BLK_ZONE_TYPE_CONVENTIONAL ||
-			    cond == BLK_ZONE_COND_FULL)
+			    (cond == BLK_ZONE_COND_FULL ||
+			     cond == BLK_ZONE_COND_READONLY ||
+			     cond == BLK_ZONE_COND_OFFLINE ||
+			     cond == BLK_ZONE_COND_NOT_WP))
 				snprintf(wp_str, sizeof(wp_str), "%s", _("N/A"));
 			else
 				snprintf(wp_str, sizeof(wp_str),


### PR DESCRIPTION
The zone write pointer is also invalid for READONLY and OFFLINE zones, so handle such cases appropriately by not displaying a write pointer for READONLY and OFFLINE zones.