### PR TITLE
man pages: consolidate libsmartcols environment variables

### DIFF
--- a/disk-utils/cfdisk.8.adoc
+++ b/disk-utils/cfdisk.8.adoc
@@ -137,11 +137,7 @@ enables libfdisk debug output.
 *LIBBLKID_DEBUG*=all::
 enables libblkid debug output.
 
-*LIBSMARTCOLS_DEBUG*=all::
-enables libsmartcols debug output.
-
-*LIBSMARTCOLS_DEBUG_PADDING*=on::
-use visible padding characters. Requires enabled *LIBSMARTCOLS_DEBUG*.
+include::man-common/env-smartcols.adoc[]
 
 *LOCK_BLOCK_DEVICE*=<mode>::
 use exclusive BSD lock. The mode is "1" or "0". See *--lock* for more details.

--- a/disk-utils/fdisk.8.adoc
+++ b/disk-utils/fdisk.8.adoc
@@ -210,11 +210,7 @@ enables libfdisk debug output.
 *LIBBLKID_DEBUG*=all::
 enables libblkid debug output.
 
-*LIBSMARTCOLS_DEBUG*=all::
-enables libsmartcols debug output.
-
-*LIBSMARTCOLS_DEBUG_PADDING*=on::
-use visible padding characters.
+include::man-common/env-smartcols.adoc[]
 
 *LOCK_BLOCK_DEVICE*=<mode>::
 use exclusive BSD lock. The mode is "1" or "0". See *--lock* for more details.

--- a/disk-utils/sfdisk.8.adoc
+++ b/disk-utils/sfdisk.8.adoc
@@ -440,8 +440,8 @@ enables *sfdisk* debug output.
 enables libfdisk debug output.
 *LIBBLKID_DEBUG*=all::
 enables libblkid debug output.
-*LIBSMARTCOLS_DEBUG*=all::
-enables libsmartcols debug output.
+include::man-common/env-smartcols.adoc[]
+
 *LOCK_BLOCK_DEVICE*=<mode>::
 use exclusive BSD lock. The mode is "1" or "0". See *--lock* for more details.
 

--- a/man-common/Makemodule.am
+++ b/man-common/Makemodule.am
@@ -9,4 +9,5 @@ ADOCFILES_COMMON += \
 	      man-common/hyperlink.adoc \
 	      man-common/in-bytes.adoc \
 	      man-common/manpage-stub.adoc \
+	      man-common/env-smartcols.adoc \
 	      man-common/translation.adoc

--- a/man-common/env-smartcols.adoc
+++ b/man-common/env-smartcols.adoc
@@ -1,0 +1,11 @@
+*LIBSMARTCOLS_DEBUG*=all::
+enables libsmartcols debug output.
+
+*LIBSMARTCOLS_DEBUG_PADDING*=on::
+use visible padding characters.
+
+*LIBSMARTCOLS_JSON*=compact|lines::
+Controls JSON output format when using *--json*. Supported values are
+*compact* for JSON output with minimal whitespace, and *lines* for JSON Lines
+format (one JSON object per line). If unset or set to any other value,
+pretty-printed JSON is used.

--- a/man-common/meson.build
+++ b/man-common/meson.build
@@ -9,5 +9,6 @@ man_common_adocs = files(
   'hyperlink.adoc',
   'in-bytes.adoc',
   'manpage-stub.adoc',
+  'env-smartcols.adoc',
   'translation.adoc',
 )

--- a/misc-utils/findmnt.8.adoc
+++ b/misc-utils/findmnt.8.adoc
@@ -224,11 +224,7 @@ overrides the default location of the _mtab_ file
 *LIBMOUNT_DEBUG*=all::
 enables libmount debug output
 
-*LIBSMARTCOLS_DEBUG*=all::
-enables libsmartcols debug output
-
-*LIBSMARTCOLS_DEBUG_PADDING*=on::
-use visible padding characters.
+include::man-common/env-smartcols.adoc[]
 
 == EXAMPLES
 

--- a/misc-utils/lsblk.8.adoc
+++ b/misc-utils/lsblk.8.adoc
@@ -228,11 +228,7 @@ enables *libblkid* debug output.
 *LIBMOUNT_DEBUG*=all::
 enables *libmount* debug output.
 
-*LIBSMARTCOLS_DEBUG*=all::
-enables *libsmartcols* debug output.
-
-*LIBSMARTCOLS_DEBUG_PADDING*=on::
-use visible padding characters.
+include::man-common/env-smartcols.adoc[]
 
 *LSBLK_COLUMNS*=::
 specifies a comma-separated list of output columns to print. All columns listed by *--list-columns* can be used.

--- a/po-man/po4a.cfg
+++ b/po-man/po4a.cfg
@@ -4,6 +4,7 @@
 [type:asciidoc] ../man-common/annotate.adoc      $lang:$lang/man-common/annotate.adoc    opt:"--keep 0"
 [type:asciidoc] ../man-common/bugreports.adoc    $lang:$lang/man-common/bugreports.adoc    opt:"--keep 0"
 [type:asciidoc] ../man-common/colors.adoc        $lang:$lang/man-common/colors.adoc        opt:"--keep 0"
+[type:asciidoc] ../man-common/env-smartcols.adoc $lang:$lang/man-common/env-smartcols.adoc opt:"--keep 0"
 [type:asciidoc] ../man-common/footer-config.adoc $lang:$lang/man-common/footer-config.adoc opt:"--keep 0"
 [type:asciidoc] ../man-common/footer-lib.adoc    $lang:$lang/man-common/footer-lib.adoc    opt:"--keep 0"
 [type:asciidoc] ../man-common/footer.adoc        $lang:$lang/man-common/footer.adoc        opt:"--keep 0"

--- a/text-utils/column.1.adoc
+++ b/text-utils/column.1.adoc
@@ -255,15 +255,7 @@ will be colorized by direct color names.
 *COLUMNS*::
 is used to determine the size of the screen if no other information is available.
 
-*LIBSMARTCOLS_JSON*::
-Controls JSON output format when using *--json*. Supported values:
-+
-*compact*::
-Output JSON in compact form (minified, minimal whitespace).
-*lines*::
-Output in JSON Lines format (one JSON object per line).
-+
-If unset or set to any other value, pretty-printed JSON is used.
+include::man-common/env-smartcols.adoc[]
 
 == HISTORY
 


### PR DESCRIPTION
Introduce man-common/env-smartcols.adoc to describe all libsmartcols environment variables (LIBSMARTCOLS_DEBUG, LIBSMARTCOLS_DEBUG_PADDING, LIBSMARTCOLS_JSON) in one place.

Replace duplicated LIBSMARTCOLS_DEBUG descriptions in cfdisk, fdisk, sfdisk, findmnt, lsblk, and column man pages with an include of the new common file.

Addresses: https://github.com/util-linux/util-linux/issues/3971