### PR TITLE
lib/fileeq: Check arithmetic in ul_fileeq_set_size

### DIFF
--- a/include/fileeq.h
+++ b/include/fileeq.h
@@ -53,8 +53,8 @@ extern void ul_fileeq_data_init(struct ul_fileeq_data *data);
 extern void ul_fileeq_data_deinit(struct ul_fileeq_data *data);
 extern void ul_fileeq_data_set_file(struct ul_fileeq_data *data,
 				    const char *name);
-extern size_t ul_fileeq_set_size(struct ul_fileeq *eq, uint64_t filesiz,
-                                 size_t readsiz, size_t memsiz);
+extern bool ul_fileeq_set_size(struct ul_fileeq *eq, int64_t st_size,
+                               size_t readsiz, size_t memsiz);
 
 extern int ul_fileeq(struct ul_fileeq *eq,
               struct ul_fileeq_data *a, struct ul_fileeq_data *b);

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -1097,8 +1097,12 @@ static void visitor(const void *nodep, const VISIT which, const int depth)
 
 		/* per-file cache size */
 		memsiz = opts.cache_size / nnodes;
-		/*                                filesiz,      readsiz,      memsiz */
-		ul_fileeq_set_size(&fileeq, master->st.st_size, opts.io_size, memsiz);
+		/*                               st_size,            readsiz,      memsiz */
+		if (!ul_fileeq_set_size(&fileeq, master->st.st_size, opts.io_size, memsiz)) {
+			jlog(VERBOSE2,
+			     printf(_("Skipped (memory constraints) %s"), master->links->path));
+			continue;
+		}
 
 #ifdef USE_REFLINK
 		if (reflink_mode || reflinks_skip) {


### PR DESCRIPTION
Make sure that arithmetics do not overflow data types. Such overflows could occur with large hardlink options or on 32 bit systems with large files (due to size_t usage).

Proof of Concept (32 bit):
```
dd if=/dev/zero of=/tmp/test1 bs=1 count=1 seek=137438953440
cp -a /tmp/test1 /tmp/test2
hardlink -b 32 -r 1K -n /tmp/test1 /tmp/test2
```
```
Floating point exception   (core dumped) hardlink -b 32 -r 1K -n /tmp/test /tmp/test2
```

With applied PR on a 64 bit system (adjusted numbers for reproducibility):
```
echo a > /tmp/test1
cp -a /tmp/test1 /tmp/test2
hardlink -s 0 -vv -y memcmp -b 18446744073709551615 -n a b
```
```
[DryRun] Linking /tmp/test1 to /tmp/test2 (-5 B)
Mode:                     dry-run
Method:                   memcmp
Files:                    2
Linked:                   1 files
Compared:                 0 xattrs
Compared:                 1 files
Saved:                    5 B
Duration:                 0.000040 seconds
```

Shoutout to [Let's Read OSS](https://github.com/stoeckmann/lets-read-oss)