### PR TITLE
lib/fileeq: Handle large files on 32 bit correctly

### DIFF
--- a/lib/fileeq.c
+++ b/lib/fileeq.c
@@ -361,7 +361,7 @@ static void memcmp_reset(struct ul_fileeq *eq, struct ul_fileeq_data *data)
 }
 
 static ssize_t read_block(struct ul_fileeq *eq, struct ul_fileeq_data *data,
-				size_t n, unsigned char **block)
+				uint64_t n, unsigned char **block)
 {
 	int fd;
 	off_t off = 0;
@@ -402,7 +402,7 @@ static ssize_t read_block(struct ul_fileeq *eq, struct ul_fileeq_data *data,
 
 #ifdef USE_FILEEQ_CRYPTOAPI
 static ssize_t get_digest(struct ul_fileeq *eq, struct ul_fileeq_data *data,
-				size_t n, unsigned char **block)
+				uint64_t n, unsigned char **block)
 {
 	off_t off = 0;
 	ssize_t rsz;
@@ -486,7 +486,7 @@ static ssize_t get_intro(struct ul_fileeq *eq, struct ul_fileeq_data *data,
 }
 
 static ssize_t get_cmp_data(struct ul_fileeq *eq, struct ul_fileeq_data *data,
-				size_t blockno, unsigned char **block)
+				uint64_t blockno, unsigned char **block)
 {
 	if (blockno == 0)
 		return get_intro(eq, data, block);
@@ -512,7 +512,7 @@ int ul_fileeq(struct ul_fileeq *eq,
 	      struct ul_fileeq_data *a, struct ul_fileeq_data *b)
 {
 	int cmp;
-	size_t n = 0;
+	uint64_t n = 0;
 
 	DBG(EQ, ul_debugobj(eq, "--> compare %s %s", a->name, b->name));
 
@@ -525,7 +525,7 @@ int ul_fileeq(struct ul_fileeq *eq,
 		unsigned char *da, *db;
 		ssize_t ca, cb;
 
-		DBG(EQ, ul_debugobj(eq, "compare block #%zu", n));
+		DBG(EQ, ul_debugobj(eq, "compare block #%" PRIu64, n));
 
 		ca = get_cmp_data(eq, a, n, &da);
 		if (ca < 0)
@@ -539,7 +539,7 @@ int ul_fileeq(struct ul_fileeq *eq,
 
 		}
 		cmp = memcmp(da, db, ca);
-		DBG(EQ, ul_debugobj(eq, "#%zu=%s", n, cmp == 0 ? "match" : "not-match"));
+		DBG(EQ, ul_debugobj(eq, "#%" PRIu64 "=%s", n, cmp == 0 ? "match" : "not-match"));
 		n++;
 	} while (cmp == 0);
 


### PR DESCRIPTION
The size_t iterator in ul_fileeq could overflow on 32 bit systems with large file support. If this happens, the intro array is erroneously overwritten, which could lead to false positive matches later on.

The iterator is checked against a size_t limit in get_digest, which is a safe operation on 32 and 64 bit architectures.

Proof of Concept (32 bit):

We need at least three files (at least I don't know how to make a smaller/faster PoC):

file1 content: `[intro block 1][SIZE_MAX - 1 bytes][intro block 2]`
file2 content: `[intro block 1][SIZE_MAX - 1 bytes][intro block 2]`
file3 content: `[intro block 2][SIZE_MAX - 1 bytes][intro block 2]`

This means that file1 and file2 are identical, and both will eventually overwrite their intro array (which will contain the content of intro block 2 then). If file1 and file3 are compared, the intro array will be read instead of accessing the data on disk again, which means that due to the "intro array poisoning" during file1/file2 comparison, file1/file3 are treated identical, even though they are not.

1. Create these three files
```
BASEDIR=$(mktemp -d)
touch $BASEDIR/file{1,2,3}
dd if=/dev/zero of=$BASEDIR/file1 count=1 bs=1 seek=4294967358
echo -n intro1 | dd of=$BASEDIR/file1 conv=notrunc
echo -n intro2 | dd of=$BASEDIR/file1 bs=1 conv=notrunc seek=4294967327
cp -a $BASEDIR/file{1,2}
cp -a $BASEDIR/file{1,3}
echo -n intro2 | dd of=$BASEDIR/file3 conv=notrunc
touch $BASEDIR/file{1,2,3}
```
2. Just to clarify that file1 and file2 are equal and file3 differs, calculate sha256 sum
```
sha256sum $BASEDIR/*
```
```
a192ecde5db20183de4a96d09cca5ddb2b1730e2ce15f7d1671e306d2cf4b145  /tmp/tmp.pfAjyQ6tu1/file1
a192ecde5db20183de4a96d09cca5ddb2b1730e2ce15f7d1671e306d2cf4b145  /tmp/tmp.pfAjyQ6tu1/file2
9b8838713121e11b5e97bcd073fc9312975734768a5dbae46af221c21ab725ca  /tmp/tmp.pfAjyQ6tu1/file3
```
3. Enforce a read size of 1 byte and memcmp mode with hardlink
```
hardlink -v -y memcmp -b 1 -n $BASEDIR
```
```
[DryRun] Linking /tmp/tmp.pfAjyQ6tu1/file1 to /tmp/tmp.pfAjyQ6tu1/file2 (-4 GiB)
[DryRun] Linking /tmp/tmp.pfAjyQ6tu1/file1 to /tmp/tmp.pfAjyQ6tu1/file3 (-4 GiB)
Mode:                     dry-run
Method:                   memcmp
Files:                    3
Linked:                   2 files
Compared:                 0 xattrs
Compared:                 2 files
Saved:                    8 GiB
Duration:                 3537.438299 seconds
```

As you can see, all files were treated identical. In case someone wants to reproduce this: Please note that it really takes around an hour ...

Shoutout to [Let's Read OSS](https://github.com/stoeckmann/lets-read-oss)