### PR TITLE
lib/pager: Backport some git improvements

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -55,18 +55,6 @@ static inline void close_pair(int fd[2])
 
 static void pager_preexec(void)
 {
-	/*
-	 * Work around bug in "less" by not starting it until we
-	 * have real input
-	 */
-	fd_set in, ex;
-
-	FD_ZERO(&in);
-	FD_SET(STDIN_FILENO, &in);
-	ex = in;
-
-	select(STDIN_FILENO + 1, &in, NULL, &ex, NULL);
-
 	if (getenv("LESS") == NULL && setenv("LESS", "FRSX", 0) != 0)
 		warn(_("failed to set the %s environment variable"), "LESS");
 	if (getenv("LV") == NULL && setenv("LV", "-c", 0) != 0)


### PR DESCRIPTION
The lib/pager.c logic is based on git's pager.c, which has some more improvements added to it over the years:

- Drop the less workaround for a less bug fixed in 2007 (https://github.com/git/git/commit/e8320f350f523c3219ff8ec639663193941af57d)
- Do not overwrite LESS environment variable if it already exists (https://github.com/git/git/commit/25fc1786ab147daa9ffa43ebcbaf5c1cc6e50d4f)
- Add LV environment variable for lv support (https://github.com/git/git/commit/e54c1f2d2533c5406abeb8e3e0cf78c68ca9c21e)