### PR TITLE
libblkid: (probe) Account for IO bias when retrieving buffer from parent

### DIFF
--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -770,7 +770,7 @@ const unsigned char *blkid_probe_get_buffer(blkid_probe pr, uint64_t off, uint64
 		 * begin of the device.
 		 */
 		return blkid_probe_get_buffer(pr->parent,
-				pr->off + off - pr->parent->off, len);
+				pr->off + off + bias - pr->parent->off, len);
 	}
 
 	/* try buffers we already have in memory or read from device */


### PR DESCRIPTION
The 'off' variable gets aligned to 'pr->io_size'. However when delegating to the parent prober, the value for 'off' from the original function parameter needs to be used.

Undo the bias before calling into the parent prober.

Fixes: 8a534253bc52 ("libblkid: (probe) read data in chunks")
Closes: https://github.com/util-linux/util-linux/issues/4078