### PR TITLE
lsmem: apply --sysroot prefix to all sysfs paths

### DIFF
--- a/sys-utils/lsmem.c
+++ b/sys-utils/lsmem.c
@@ -32,7 +32,7 @@
 #include "optutils.h"
 
 #define _PATH_SYS_MEMORY		"/sys/devices/system/memory"
-#define _PATH_SYS_MEMMAP_PARM		"/sys/module/memory_hotplug/parameters/memmap_on_memory"
+#define _PATH_SYS_MEMPARAM		"/sys/module/memory_hotplug/parameters"
 #define _PATH_SYS_MEMCONFIG		"/sys/firmware/memory"
 
 #define MEMORY_STATE_ONLINE		0
@@ -361,7 +361,8 @@ static int get_memmap_mode(char *res, char *src, int len)
 static void print_summary(struct lsmem *lsmem)
 {
 	char buf[8], res[8];
-	FILE *memmap;
+	struct path_cxt *pc;
+	const char *prefix;
 
 	if (lsmem->bytes) {
 		printf("%-32s %15"PRId64"\n",_("Memory block size:"), lsmem->block_size);
@@ -382,18 +383,23 @@ static void print_summary(struct lsmem *lsmem)
 			printf("%-32s %5s\n",_("Total offline memory:"), p);
 		free(p);
 	}
-	memmap = fopen(_PATH_SYS_MEMMAP_PARM, "r");
-	if (!memmap)
+
+	pc = ul_new_path(_PATH_SYS_MEMPARAM);
+	if (!pc)
 		return;
-	if (fgets(buf, sizeof(buf), memmap)) {
-		if (!get_memmap_mode(res, buf, sizeof(res))) {
-			if (lsmem->bytes)
-				printf("%-32s %15s\n", _("Memmap on memory parameter:"), _(res));
-			else
-				printf("%-32s %5s\n", _("Memmap on memory parameter:"), _(res));
-		}
+	prefix = ul_path_get_prefix(lsmem->sysmem);
+	if (prefix && ul_path_set_prefix(pc, prefix) != 0)
+		goto done;
+	if (ul_path_read_buffer(pc, buf, sizeof(buf), "memmap_on_memory") <= 0)
+		goto done;
+	if (!get_memmap_mode(res, buf, sizeof(res))) {
+		if (lsmem->bytes)
+			printf("%-32s %15s\n", _("Memmap on memory parameter:"), _(res));
+		else
+			printf("%-32s %5s\n", _("Memmap on memory parameter:"), _(res));
 	}
-	fclose(memmap);
+done:
+	ul_unref_path(pc);
 }
 
 static int memory_block_get_node(struct lsmem *lsmem, char *name)
@@ -801,19 +807,25 @@ int main(int argc, char **argv)
 
 	ul_path_init_debug();
 
+	/* open /sys/devices/system/memory handler (required) */
 	lsmem->sysmem = ul_new_path(_PATH_SYS_MEMORY);
 	if (!lsmem->sysmem)
 		err(EXIT_FAILURE, _("failed to initialize %s handler"), _PATH_SYS_MEMORY);
-	lsmem->sysmemconfig = ul_new_path(_PATH_SYS_MEMCONFIG);
-	/* Always check for the existence of /sys/firmware/memory/memory0 first */
-	if (ul_path_access(lsmem->sysmemconfig, F_OK, "memory0") == 0)
-		lsmem->have_memconfig = 1;
-	if (!lsmem->sysmemconfig)
-		err(EXIT_FAILURE, _("failed to initialized %s handler"), _PATH_SYS_MEMCONFIG);
 	if (prefix && ul_path_set_prefix(lsmem->sysmem, prefix) != 0)
 		err(EXIT_FAILURE, _("invalid argument to --sysroot"));
 	if (!ul_path_is_accessible(lsmem->sysmem))
 		err(EXIT_FAILURE, _("cannot open %s"), _PATH_SYS_MEMORY);
+
+	/* open /sys/firmware/memory handler (optional) */
+	lsmem->sysmemconfig = ul_new_path(_PATH_SYS_MEMCONFIG);
+	if (!lsmem->sysmemconfig)
+		err(EXIT_FAILURE, _("failed to initialized %s handler"), _PATH_SYS_MEMCONFIG);
+	if (prefix && ul_path_set_prefix(lsmem->sysmemconfig, prefix) != 0)
+		err(EXIT_FAILURE, _("invalid argument to --sysroot"));
+
+	/* Always check for the existence of /sys/firmware/memory/memory0 first */
+	if (ul_path_access(lsmem->sysmemconfig, F_OK, "memory0") == 0)
+		lsmem->have_memconfig = 1;
 
 	/* Shortcut to avoid scols machinery on --summary=only */
 	if (lsmem->want_table == 0 && lsmem->want_summary) {
@@ -918,6 +930,7 @@ int main(int argc, char **argv)
 
 	scols_unref_table(lsmem->table);
 	ul_unref_path(lsmem->sysmem);
+	ul_unref_path(lsmem->sysmemconfig);
 	free_info(lsmem);
 	return 0;
 }

--- a/tests/expected/lsmem/lsmem-s390-zvm-6g
+++ b/tests/expected/lsmem/lsmem-s390-zvm-6g
@@ -17,7 +17,6 @@ RANGE                                  SIZE   STATE REMOVABLE BLOCK
 Memory block size:                256M
 Total online memory:              4.8G
 Total offline memory:             1.3G
-Memmap on memory parameter:         no
 
 ---
 
@@ -28,7 +27,6 @@ RANGE                                 SIZE
 Memory block size:                256M
 Total online memory:              4.8G
 Total offline memory:             1.3G
-Memmap on memory parameter:         no
 
 ---
 
@@ -42,7 +40,6 @@ RANGE                                  SIZE   STATE
 Memory block size:                256M
 Total online memory:              4.8G
 Total offline memory:             1.3G
-Memmap on memory parameter:         no
 
 ---
 
@@ -76,7 +73,6 @@ RANGE                                  SIZE   STATE REMOVABLE BLOCK NODE        
 Memory block size:                256M
 Total online memory:              4.8G
 Total offline memory:             1.3G
-Memmap on memory parameter:         no
 
 ---
 
@@ -220,7 +216,6 @@ RANGE                                  SIZE   STATE REMOVABLE BLOCK          ZON
 Memory block size:                256M
 Total online memory:              4.8G
 Total offline memory:             1.3G
-Memmap on memory parameter:         no
 
 ---
 
@@ -242,7 +237,6 @@ RANGE                                  SIZE   STATE REMOVABLE BLOCK NODE        
 Memory block size:                256M
 Total online memory:              4.8G
 Total offline memory:             1.3G
-Memmap on memory parameter:         no
 
 ---
 
@@ -262,4 +256,3 @@ RANGE                                  SIZE   STATE REMOVABLE BLOCK
 Memory block size:                256M
 Total online memory:              4.8G
 Total offline memory:             1.3G
-Memmap on memory parameter:         no

--- a/tests/expected/lsmem/lsmem-x86_64-16g
+++ b/tests/expected/lsmem/lsmem-x86_64-16g
@@ -37,7 +37,6 @@ RANGE                                  SIZE  STATE REMOVABLE   BLOCK
 Memory block size:                128M
 Total online memory:               16G
 Total offline memory:               0B
-Memmap on memory parameter:         no
 
 ---
 
@@ -49,7 +48,6 @@ RANGE                                 SIZE
 Memory block size:                128M
 Total online memory:               16G
 Total offline memory:               0B
-Memmap on memory parameter:         no
 
 ---
 
@@ -61,7 +59,6 @@ RANGE                                 SIZE  STATE
 Memory block size:                128M
 Total online memory:               16G
 Total offline memory:               0B
-Memmap on memory parameter:         no
 
 ---
 
@@ -199,7 +196,6 @@ RANGE                                  SIZE  STATE REMOVABLE BLOCK NODE  ZONES
 Memory block size:                128M
 Total online memory:               16G
 Total offline memory:               0B
-Memmap on memory parameter:         no
 
 ---
 
@@ -523,7 +519,6 @@ RANGE                                  SIZE  STATE REMOVABLE   BLOCK  ZONES
 Memory block size:                128M
 Total online memory:               16G
 Total offline memory:               0B
-Memmap on memory parameter:         no
 
 ---
 
@@ -563,7 +558,6 @@ RANGE                                  SIZE  STATE REMOVABLE   BLOCK NODE  ZONES
 Memory block size:                128M
 Total online memory:               16G
 Total offline memory:               0B
-Memmap on memory parameter:         no
 
 ---
 
@@ -603,4 +597,3 @@ RANGE                                  SIZE  STATE REMOVABLE   BLOCK
 Memory block size:                128M
 Total online memory:               16G
 Total offline memory:               0B
-Memmap on memory parameter:         no


### PR DESCRIPTION
Tests fail on architectures where /sys/module/memory_hotplug/parameters/ memmap_on_memory does not exist (e.g., loong64), because lsmem reads from the real /sys instead of the --sysroot directory.

 - Route memmap_on_memory read through ul_path API with a local handler in print_summary(), so --sysroot prefix is respected.

 - Apply --sysroot prefix to sysmemconfig (/sys/firmware/memory) before the memory0 existence check.

 - Fix sysmemconfig memory leak (missing ul_unref_path).

 - Update expected test output (remove "Memmap on memory parameter" lines, not available in test dumps).

Reported-by: Chris Hofstaedtler <zeha@debian.org>