### PR TITLE
lib/pager: Handle fork failure

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -302,7 +302,7 @@ void pager_close(void)
 	errno = safe_errno;
 
 	if (ret == -1)
-		err(EXIT_FAILURE, "waitpid failed");
+		err(EXIT_FAILURE, _("waitpid failed"));
 
 	if (pager_caught_signal || (pager_caught_sigpipe && ret))
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
The code assumes that a pid != 0 means that a pager is running, but if fork returns -1, there is actually no child. And an eventual waitpid call with -1 as pid will wait for any child. Since there are none, an error is returned and the tool (dmesg, fdisk) will fail.

Handle the situation properly. And while at it, reset signals in all error cases.

Proof of Concept:

Run dmesg with pager and an actually failing fork (clone system call)
```
strace -f -o /dev/null --inject=clone:retval=-1:when=1 dmesg -H
```
```
[dmesg output]
dmesg: waitpid failed: No child processes
```

Note: I didn't expect that it would ever be really useful to see the error message in case of a waitpid failure, since previous PRs fixed the stdout/stderr handling, but here we are. :)