### PR TITLE
eject: Fix OOB access with empty argument

### DIFF
--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -868,9 +868,10 @@ int main(int argc, char **argv)
 		verbose(&ctl, _("using default device `%s'"), ctl.device);
 	} else {
 		char *p;
+		size_t len = strlen(ctl.device);
 
-		if (ctl.device[strlen(ctl.device) - 1] == '/')
-			ctl.device[strlen(ctl.device) - 1] = '\0';
+		if (len && ctl.device[len - 1] == '/')
+			ctl.device[len - 1] = '\0';
 
 		/* figure out full device or mount point name */
 		p = find_device(ctl.device);


### PR DESCRIPTION
The the supplied argument is an empty string, eject triggers an out of boundary access due to strlen() - 1 calculation.

Verify that the string is not empty before checking its last character.

Proof of Concept:

1. Ideally, compile eject with address sanitizer
2. Run eject with empty argument
```
eject ""
```
```
=================================================================
==12735==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7c03fa7e020f at pc 0x561429e3736c bp 0x7ffe3195a520 sp 0x7ffe3195a510
READ of size 1 at 0x7c03fa7e020f thread T0
```