### PR TITLE
eject: Reset SIGCHLD to default for wait

### DIFF
--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -671,13 +671,12 @@ static void umount_one(const struct eject_control *ctl, const char *name)
 		break;
 
 	default: /* parent */
-		wait(&status);
-		if (WIFEXITED(status) == 0)
+		if (wait(&status) == -1 || WIFEXITED(status) == 0)
 			errx(EXIT_FAILURE,
 			     _("unmount of `%s' did not exit normally"), name);
 
 		if (WEXITSTATUS(status) != 0)
-			errx(EXIT_FAILURE, _("unmount of `%s' failed\n"), name);
+			errx(EXIT_FAILURE, _("unmount of `%s' failed"), name);
 		break;
 	}
 }
@@ -862,6 +861,9 @@ int main(int argc, char **argv)
 		info(_("default device: `%s'"), EJECT_DEFAULT_DEVICE);
 		return EXIT_SUCCESS;
 	}
+
+	/* clear any inherited settings */
+	signal(SIGCHLD, SIG_DFL);
 
 	if (!ctl.device) {
 		ctl.device = mnt_resolve_path(EJECT_DEFAULT_DEVICE, NULL);


### PR DESCRIPTION
If SIGCHLD is ignored, the wait call which waits for the umount command to finish could fail with -1 and ECHILD. Since its return value is not checked, the uninitialized status variable would be read, leading to undefined behavior.

While at it, removed the additionally printed newline from errx message.

Proof of Concept:
1. Mount some ejectable media at /mnt with super user
```
sudo mount /dev/cdrom /mnt
```
2. Try to eject it as regular user with ignored SIGCHLD
```
(trap "" SIGCHLD; ./build2/eject /mnt)
```
```
umount: /mnt: must be superuser to unmount.
eject: cannot open /dev/sr0: Device or resource busy
```
Expected output would be:
```
umount: /mnt: must be superuser to unmount.
eject: unmount of `/mnt' failed
```

The former message indicates that the `wait` error was not detected.