### PR TITLE
pg: Reset SIGCHLD to default

### DIFF
--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -1687,6 +1687,10 @@ int main(int argc, char **argv)
 			invopt(argv[arg]);
 		}
 	}
+
+	/* clear any inherited settings */
+	signal(SIGCHLD, SIG_DFL);
+
 	if (argc == 1)
 		pgfile(stdin, "stdin");
 	else


### PR DESCRIPTION
When pg runs a child process, i.e. evaluating an "!" command, it calls wait to receive status for the child.

If SIGCHLD is ignored, this results in an endless loop. Fix this by resetting SIGCHLD to default before the any fork() call is performed.

Proof of Concept:
1. Call pg with ignored SIGCHLD
```
(trap "" SIGCHLD; pg $(which pg))
```
2. Enter `!ls` or any other command
```
!ls
```
3. The command never returns and pg consumes 100 % cpu