### PR TITLE
lib/debug: Move debug functions into c file

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -106,75 +106,11 @@ struct ul_debug_maskname {
 		__UL_INIT_DEBUG_FROM_STRING(lib, pref, mask, envstr); \
 	} while (0)
 
-
-
-static inline void __attribute__ ((__format__ (__printf__, 1, 2)))
-ul_debug(const char *mesg, ...)
-{
-	va_list ap;
-	va_start(ap, mesg);
-	vfprintf(stderr, mesg, ap);
-	va_end(ap);
-	fputc('\n', stderr);
-}
-
-static inline int ul_debug_parse_mask(
-			const struct ul_debug_maskname flagnames[],
-			const char *mask)
-{
-	int res;
-	char *ptr;
-
-	/* let's check for a numeric mask first */
-	res = strtoul(mask, &ptr, 0);
-
-	/* perhaps it's a comma-separated string? */
-	if (ptr && *ptr && flagnames && flagnames[0].name) {
-		char *msbuf, *ms, *name;
-		res = 0;
-
-		ms = msbuf = strdup(mask);
-		if (!ms)
-			return res;
-
-		while ((name = strtok_r(ms, ",", &ptr))) {
-			const struct ul_debug_maskname *d;
-			ms = ptr;
-
-			for (d = flagnames; d && d->name; d++) {
-				if (strcmp(name, d->name) == 0) {
-					res |= d->mask;
-					break;
-				}
-			}
-			/* nothing else we can do by OR-ing the mask */
-			if (res == 0xffff)
-				break;
-		}
-		free(msbuf);
-	} else if (ptr && strcmp(ptr, "all") == 0)
-		res = 0xffff;
-
-	return res;
-}
-
-static inline void ul_debug_print_masks(
-			const char *env,
-			const struct ul_debug_maskname flagnames[])
-{
-	const struct ul_debug_maskname *d;
-
-	if (!flagnames)
-		return;
-
-	fprintf(stderr, "Available \"%s=<name>[,...]|<mask>\" debug masks:\n",
-			env);
-	for (d = flagnames; d && d->name; d++) {
-		if (!d->help)
-			continue;
-		fprintf(stderr, "   %-8s [0x%06x] : %s\n",
-				d->name, d->mask, d->help);
-	}
-}
+extern void ul_debug(const char *mesg, ...)
+		__attribute__ ((__format__ (__printf__, 1, 2)));
+extern int ul_debug_parse_mask(const struct ul_debug_maskname flagnames[],
+			       const char *mask);
+extern void ul_debug_print_masks(const char *env,
+				 const struct ul_debug_maskname flagnames[]);
 
 #endif /* UTIL_LINUX_DEBUG_H */

--- a/lib/Makemodule.am
+++ b/lib/Makemodule.am
@@ -21,6 +21,7 @@ libcommon_la_SOURCES = \
 	lib/crc32c.c \
 	lib/crc64.c \
 	lib/c_strtod.c \
+	lib/debug.c \
 	lib/encode.c \
 	lib/env.c \
 	lib/fileutils.c \
@@ -71,7 +72,7 @@ endif
 EXTRA_LTLIBRARIES += libtcolors.la
 libtcolors_la_CFLAGS = $(AM_CFLAGS)
 libtcolors_la_SOURCES = lib/colors.c lib/color-names.c include/colors.h include/color-names.h
-libtcolors_la_LIBADD =
+libtcolors_la_LIBADD = libcommon.la
 # tinfo or ncurses are optional
 if HAVE_TINFO
 libtcolors_la_LIBADD += $(TINFO_LIBS)
@@ -203,10 +204,10 @@ test_loopdev_SOURCES = lib/loopdev.c
 test_loopdev_CFLAGS = $(AM_CFLAGS) -DTEST_PROGRAM_LOOPDEV
 test_loopdev_LDADD = $(LDADD) libcommon.la
 
-test_netlink_SOURCES = lib/netlink.c
+test_netlink_SOURCES = lib/debug.c lib/netlink.c
 test_netlink_CFLAGS = $(AM_CFLAGS) -DTEST_PROGRAM_NETLINK
 
-test_netaddrq_SOURCES = lib/netaddrq.c lib/netlink.c
+test_netaddrq_SOURCES = lib/debug.c lib/netaddrq.c lib/netlink.c
 test_netaddrq_CFLAGS = $(AM_CFLAGS) -DTEST_PROGRAM_NETADDRQ
 endif
 
@@ -214,7 +215,7 @@ test_configs_SOURCES = lib/configs.c
 test_configs_CFLAGS = $(AM_CFLAGS) -DTEST_PROGRAM_CONFIGS
 test_configs_LDADD = $(LDADD) libcommon.la
 
-test_fileeq_SOURCES = lib/fileeq.c
+test_fileeq_SOURCES = lib/debug.c lib/fileeq.c
 test_fileeq_CFLAGS = $(AM_CFLAGS) -DTEST_PROGRAM_FILEEQ
 
 test_fileutils_SOURCES = lib/fileutils.c

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -1,0 +1,78 @@
+/*
+ * No copyright is claimed.  This code is in the public domain; do with
+ * it what you wish.
+ */
+
+#include "debug.h"
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+
+void ul_debug(const char *mesg, ...)
+{
+	va_list ap;
+	va_start(ap, mesg);
+	vfprintf(stderr, mesg, ap);
+	va_end(ap);
+	fputc('\n', stderr);
+}
+
+int ul_debug_parse_mask(const struct ul_debug_maskname flagnames[],
+			const char *mask)
+{
+	int res;
+	char *ptr;
+
+	/* let's check for a numeric mask first */
+	res = strtoul(mask, &ptr, 0);
+
+	/* perhaps it's a comma-separated string? */
+	if (ptr && *ptr && flagnames && flagnames[0].name) {
+		char *msbuf, *ms, *name;
+		res = 0;
+
+		ms = msbuf = strdup(mask);
+		if (!ms)
+			return res;
+
+		while ((name = strtok_r(ms, ",", &ptr))) {
+			const struct ul_debug_maskname *d;
+			ms = ptr;
+
+			for (d = flagnames; d && d->name; d++) {
+				if (strcmp(name, d->name) == 0) {
+					res |= d->mask;
+					break;
+				}
+			}
+			/* nothing else we can do by OR-ing the mask */
+			if (res == 0xffff)
+				break;
+		}
+		free(msbuf);
+	} else if (ptr && strcmp(ptr, "all") == 0)
+		res = 0xffff;
+
+	return res;
+}
+
+void ul_debug_print_masks(const char *env,
+			  const struct ul_debug_maskname flagnames[])
+{
+	const struct ul_debug_maskname *d;
+
+	if (!flagnames)
+		return;
+
+	fprintf(stderr, "Available \"%s=<name>[,...]|<mask>\" debug masks:\n",
+			env);
+	for (d = flagnames; d && d->name; d++) {
+		if (!d->help)
+			continue;
+		fprintf(stderr, "   %-8s [0x%06x] : %s\n",
+				d->name, d->mask, d->help);
+	}
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -7,6 +7,7 @@ lib_common_sources = '''
 	crc32c.c
 	crc64.c
 	c_strtod.c
+	debug.c
 	encode.c
 	env.c
 	fileutils.c


### PR DESCRIPTION
Having the debug functions as static inline functions throughout the code base leads to code bloat, since they always serve the same purpose without custom modifications.

Keep defines and everything specific to an including file in a header, but move function bodies into their own c file.

Reduces size of util-linux installation by up to 80 KB on x86_64.

PS: I'm not claiming any copyright and neither do I put the code into public domain, which I legally cannot do. No change within the functions, so I keep the copyright and ownership from header in the c source itself, since code was just moved and not modified.