### PR TITLE
mbsalign: add support for SCS escape sequences 

### DIFF
--- a/lib/mbsalign.c
+++ b/lib/mbsalign.c
@@ -43,7 +43,12 @@ size_t mbs_nwidth(const char *buf, size_t bufsz)
 
 	while (p && *p && p <= last) {
 		if (iscntrl((unsigned char) *p)) {
+			char ctrl_char = *p;
 			p++;
+
+			/* only process escape sequences if the control char is ESC */
+			if (ctrl_char != '\e')
+				continue;
 
 			/* try detect "\e[x;ym" and skip on success */
 			if (*p && *p == '[') {


### PR DESCRIPTION
Add handling for SCS (Select Character Set) escape sequences:
\e(X, \e)X, \e*X, \e+X. These sequences are now properly skipped
when calculating string width.

And only process escape sequences when the control character is ESC.
This prevents \n[ or \n( from being misidentified as escape sequences.

Addresses: https://github.com/util-linux/util-linux/issues/4121