### PR TITLE
fallocate: give up when SEEK_HOLE/DATA misbehaves

### DIFF
--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -298,7 +298,7 @@ static void dig_holes(int fd, off_t file_off, off_t len)
 		if (file_end && end > file_end)
 			end = file_end;
 
-		if (off < 0 || end < 0)
+		if (off < 0 || end < 0 || off == end)
 			break;
 
 #if defined(POSIX_FADV_SEQUENTIAL) && defined(HAVE_POSIX_FADVISE)


### PR DESCRIPTION
There's a bug in Linux kernel that renders fallocate in an infinite loop.

drivers/char/mem.c:

	static loff_t null_lseek(struct file *file, loff_t offset, int orig)
	{
	       return file->f_pos = 0;
	}

This is caused by lseek() of /dev/null and /dev/zero always returning 0 regardless of whence. If fallocate is run on /dev/zero or /dev/null with the option -d or -z, the length to skip in the main loop logic in dig_holes() is always calculated as zero.

A conforming VFS never behaves like this so it's safe to assume that the SEEK_DATA and SEEK_HOLE behaviour is broken.