### PR TITLE
unshare: fix incomplete argument parsing for --map-{user,group}

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -326,21 +326,27 @@ static pid_t bind_ns_files_from_child(int *fd)
 static uid_t get_user(const char *s)
 {
 	struct passwd *pw;
+	uid_t uid;
 
 	pw = ul_getuserpw_str(s);
-	if (!pw)
-		errx(EXIT_FAILURE, _("failed to parse uid '%s'"), s);
-	return pw->pw_uid;
+	if (pw)
+		uid = pw->pw_uid;
+	else
+		uid = strtoul_or_err(s, _("failed to parse uid"));
+	return uid;
 }
 
 static gid_t get_group(const char *s)
 {
 	struct group *gr;
+	gid_t gid;
 
 	gr = ul_getgrp_str(s);
-	if (!gr)
-		errx(EXIT_FAILURE, _("failed to parse gid '%s'"), s);
-	return gr->gr_gid;
+	if (gr)
+		gid = gr->gr_gid;
+	else
+		gid = strtoul_or_err(s, _("failed to parse gid"));
+	return gid;
 }
 
 /**


### PR DESCRIPTION
If ul_getuserpw_str() or ul_getgrp_str() cannot find any user/group with the provided UID/GID or user/group name, the unshare internal helper functions get_user() and get_group() will return early and stop argument parsing, even if a valid numeric value was provided.

This behavior was mistakenly introduced in commit 0a7fb80, and is fixed in this change, where we also fallback to simply converting the string to an unsigned int, if possible, and then return it as uid_t.