### PR TITLE
liblastlog2: Install missing manual pages

### DIFF
--- a/liblastlog2/man/Makemodule.am
+++ b/liblastlog2/man/Makemodule.am
@@ -2,19 +2,23 @@
 MANPAGES += \
 	liblastlog2/man/lastlog2.3 \
 	liblastlog2/man/ll2_import_lastlog.3 \
+	liblastlog2/man/ll2_new_context.3 \
 	liblastlog2/man/ll2_read_all.3 \
 	liblastlog2/man/ll2_read_entry.3 \
 	liblastlog2/man/ll2_remove_entry.3 \
 	liblastlog2/man/ll2_rename_user.3 \
+	liblastlog2/man/ll2_unref_context.3 \
 	liblastlog2/man/ll2_update_login_time.3 \
 	liblastlog2/man/ll2_write_entry.3
 
 dist_noinst_DATA += \
 	liblastlog2/man/lastlog2.3.adoc \
 	liblastlog2/man/ll2_import_lastlog.3.adoc \
+	liblastlog2/man/ll2_new_context.3.adoc \
 	liblastlog2/man/ll2_read_all.3.adoc \
 	liblastlog2/man/ll2_read_entry.3.adoc \
 	liblastlog2/man/ll2_remove_entry.3.adoc \
 	liblastlog2/man/ll2_rename_user.3.adoc \
+	liblastlog2/man/ll2_unref_context.3.adoc \
 	liblastlog2/man/ll2_update_login_time.3.adoc \
 	liblastlog2/man/ll2_write_entry.3.adoc

--- a/liblastlog2/man/meson.build
+++ b/liblastlog2/man/meson.build
@@ -3,8 +3,10 @@ lib_lastlog2_manadocs = files(
   'll2_write_entry.3.adoc',
   'll2_read_entry.3.adoc',
   'll2_import_lastlog.3.adoc',
+  'll2_new_context.3.adoc',
   'll2_read_all.3.adoc',
   'll2_remove_entry.3.adoc',
   'll2_rename_user.3.adoc',
-  'll2_update_login_time.3.adoc'
+  'll2_update_login_time.3.adoc',
+  'll2_unref_context.3.adoc'
 )


### PR DESCRIPTION
The manual pages ll2_new_context.3 and ll2_unref_context.3 were never installed. Add them to autools and meson files.