### PR TITLE
meson: Install missing manual pages

### DIFF
--- a/disk-utils/meson.build
+++ b/disk-utils/meson.build
@@ -53,6 +53,7 @@ mkfs_cramfs_sources = files(
   'cramfs.h',
   'cramfs_common.c',
 )
+mkfs_cramfs_manadocs = files('mkfs.cramfs.8.adoc')
 
 fsck_cramfs_sources = files(
   'fsck.cramfs.c',

--- a/meson.build
+++ b/meson.build
@@ -2389,7 +2389,7 @@ exe3 = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += [exe, exe2, exe3]
-  manadocs += fsck_minix_manadocs
+  manadocs += [mkfs_minix_manadocs, fsck_minix_manadocs]
   bashcompletions += ['mkfs.minix', 'fsck.minix']
 endif
 
@@ -2414,7 +2414,7 @@ exe2 = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += [exe, exe2]
-  manadocs += fsck_cramfs_manadocs
+  manadocs += [mkfs_cramfs_manadocs, fsck_cramfs_manadocs]
   bashcompletions += ['mkfs.cramfs', 'fsck.cramfs']
 endif
 
@@ -3108,6 +3108,7 @@ exe = executable(
   build_by_default : opt)
 if opt and not is_disabler(exe)
   exes += exe
+  manadocs += copyfilerange_manadocs
   bashcompletions += ['copyfilerange']
 endif
 


### PR DESCRIPTION
The manual pages for copyfilerange, mkfs.cramfs, and mkfs.minix are not installed with meson, but with autotools.

Add them to meson files as well.