### PR TITLE
su: Fix signal race during shutdown

### DIFF
--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -633,6 +633,8 @@ static void create_watching_parent(struct su_context *su)
 	supam_cleanup(su, PAM_SUCCESS);
 
 	if (caught_signal) {
+		int sig;
+
 		if (su->child != (pid_t)-1) {
 			DBG(SIG, ul_debug("killing child"));
 			sleep(2);
@@ -647,7 +649,8 @@ static void create_watching_parent(struct su_context *su)
 		 * terminal settings (kzak -- Jun 2013).
 		 */
 		DBG(SIG, ul_debug("restore signals setting"));
-		switch (caught_signal) {
+		sig = caught_signal;
+		switch (sig) {
 		case SIGTERM:
 			sigaction(SIGTERM, &su->oldact[SIGTERM_IDX], NULL);
 			break;
@@ -660,11 +663,11 @@ static void create_watching_parent(struct su_context *su)
 		default:
 			/* just in case that signal stuff initialization failed and
 			 * caught_signal = true */
-			caught_signal = SIGKILL;
+			sig = SIGKILL;
 			break;
 		}
-		DBG(SIG, ul_debug("self-send %d signal", caught_signal));
-		kill(getpid(), caught_signal);
+		DBG(SIG, ul_debug("self-send %d signal", sig));
+		kill(getpid(), sig);
 	}
 
 	DBG(MISC, ul_debug("exiting [rc=%d]", status));


### PR DESCRIPTION
The `caught_signal` variable could be modified while the original signal handler is restored. If this happens, su does not kill itself with the signal but just triggers another installed signal handler, ultimately exiting with return value 1 instead.

Prevent this race by storing the value on stack and then proceed with this unmodifiable value.

This is definitely not security relevant. I just add this write-up since it's a rare situation in which I can add a reproducer for a signal race ... :)

#### How to actually reproduce this signal race reliably

This reproducer uses the debug infrastructure to halt `su` at the critical point, which is here:
https://github.com/util-linux/util-linux/blob/e13492cdcd0f96b0a6249a0ab30f2550a25953f0/login-utils/su-common.c#L649-L667

In line 650, the content of `caught_signal` is read. This variable is populated by signal handlers for e.g. `SIGINT` and `SIGTERM` (depending on su invocation). If between line 650 and 667 another signal is generated, `caught_signal` is modified. This means that the restoration of signal handler in switch block is void, leading `su` to continue after calling `kill` on itself (since the handler still just updates `caught_signal` again).

In order to have enough time to send a signal, line 666 (how fitting) comes in handy. We can activate the debug messages and redirect stderr to a prepared pipe which is almost full. It just has to reach Linux' pipe buffer limit during debug output in line 666, which will block `su` until the pipe can take more data. Then, we can send another signal to `su` and trigger the desired effect. For all of this to work, we must reach a page boundary, otherwise the pipe won't block. Since `su`'s debug output can be adjusted by the caller due to supplied command being printed as debug message, this is rather easy to calculate.

Last but not least, we have to run `su` for the current user to make sure that `SIGINT` actually has a signal handler installed.

Proof of Concept (requires 3 terminals, keep in mind to copy `$BASE` to all of them):

1. Prepare files in temporary directory (pipe and python script which fills pipe so only one page is left)
```
BASE=$(mktemp -d)
mkfifo $BASE/pipe
cat > $BASE/block.py << EOF
import os
import sys

fd = os.open(sys.argv[1], os.O_RDWR)
os.write(fd, b'A' * (65536 - 4096))
input("Press enter to read a page... ")
os.read(fd, 4096)
EOF
```
2. Retrieve amount of bytes currently used to print information to stderr
```
# on terminal 1 (keep in mind that we run su for the current user, NOT root)
SU_DEBUG=all su -c 'read #' $(whoami) 2>&1 | grep -v ^Terminated > $BASE/terminated.txt
<enter user's password>
# on terminal 2
kill -TERM <SU_PID>
```
3. Prepare a pipe which is almost full (one page left)
```
# on terminal 3
python $BASE/block.py $BASE/pipe
```
4. Run `su` with prepared command to reach end of page in critical section
```
# on terminal 1
SU_DEBUG=all su -c "read #$(python -c "print(int(4096 + 5 - $(wc -m < $BASE/terminated.txt))*'A')")" $(whoami) 2> $BASE/pipe
<enter user's password>
# on terminal 2
kill -TERM <SU_PID>; kill -INT <SU_PID>
# on terminal 3
<press enter>
```
5. `su` erroneously exits with exit code 1
```
# on terminal 1
echo $?
1
```