### PR TITLE
meson: Remove unused variable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4128,7 +4128,6 @@ endif
 asciidoctor = find_program('asciidoctor', required : false)
 if asciidoctor.found()
   foreach adoc : manadocs
-    name = fs.name(adoc)
     page = fs.stem(adoc)
     section = page.split('.')[-1]
     mandirn = mandir / 'man' + section


### PR DESCRIPTION
The variable "name" within manadocs loop is unused. Remove it.