### PR TITLE
Avoiding 'SQL error: database is locked' when lastlog2 writes lastlog2     databese.

### DIFF
--- a/bash-completion/lastlog2
+++ b/bash-completion/lastlog2
@@ -17,6 +17,10 @@ _lastlog2_module()
 			COMPREPLY=( $(compgen -W "file" -- "$cur") )
 			return 0
 			;;
+		'-j'|'--journal')
+			COMPREPLY=( $(compgen -W "WAL DELETE TRUNCATE PERSIST MEMORY OFF" -- $cur) )
+			return 0
+			;;
 		'-r'|'--rename')
 			COMPREPLY=( $(compgen -W "user_name" -- "$cur") )
 			return 0
@@ -24,11 +28,11 @@ _lastlog2_module()
 		'-u'|'--user')
 			COMPREPLY=( $(compgen -W "login" -- "$cur") )
 			return 0
-			;;			
+			;;
 		'-d'|'--database')
 			COMPREPLY=( $(compgen -W "file" -- "$cur") )
 			return 0
-			;;			
+			;;
 		'-h'|'--help'|'-V'|'--version')
 			return 0
 			;;
@@ -41,6 +45,7 @@ _lastlog2_module()
 				--database
 				--help
 				--import
+				--journal
 				--rename
 				--service
 				--set

--- a/liblastlog2/man/Makemodule.am
+++ b/liblastlog2/man/Makemodule.am
@@ -1,24 +1,28 @@
 
 MANPAGES += \
 	liblastlog2/man/lastlog2.3 \
+	liblastlog2/man/ll2_get_journal_mode.3 \
 	liblastlog2/man/ll2_import_lastlog.3 \
 	liblastlog2/man/ll2_new_context.3 \
 	liblastlog2/man/ll2_read_all.3 \
 	liblastlog2/man/ll2_read_entry.3 \
 	liblastlog2/man/ll2_remove_entry.3 \
 	liblastlog2/man/ll2_rename_user.3 \
+	liblastlog2/man/ll2_set_journal_mode.3 \
 	liblastlog2/man/ll2_unref_context.3 \
 	liblastlog2/man/ll2_update_login_time.3 \
 	liblastlog2/man/ll2_write_entry.3
 
 dist_noinst_DATA += \
 	liblastlog2/man/lastlog2.3.adoc \
+	liblastlog2/man/ll2_get_journal_mode.3.adoc \
 	liblastlog2/man/ll2_import_lastlog.3.adoc \
 	liblastlog2/man/ll2_new_context.3.adoc \
 	liblastlog2/man/ll2_read_all.3.adoc \
 	liblastlog2/man/ll2_read_entry.3.adoc \
 	liblastlog2/man/ll2_remove_entry.3.adoc \
 	liblastlog2/man/ll2_rename_user.3.adoc \
+	liblastlog2/man/ll2_set_journal_mode.3.adoc \
 	liblastlog2/man/ll2_unref_context.3.adoc \
 	liblastlog2/man/ll2_update_login_time.3.adoc \
 	liblastlog2/man/ll2_write_entry.3.adoc

--- a/liblastlog2/man/ll2_get_journal_mode.3.adoc
+++ b/liblastlog2/man/ll2_get_journal_mode.3.adoc
@@ -1,0 +1,96 @@
+//po4a: entry man manual
+= ll2_get_journal_mode(3)
+:doctype: manpage
+:man manual: Programmer's Manual
+:man source: util-linux {release-version}
+:page-layout: base
+:lib: liblastlog2
+:firstversion: 2.43
+
+== NAME
+
+ll2_get_journal_mode - get current SQLite journal mode for lastlog2 database
+
+== SYNOPSIS
+
+*#include <lastlog2.h>*
+
+*int ll2_get_journal_mode(struct ll2_context *__context__, char **__mode__, char **__error__);*
+
+== DESCRIPTION
+
+The *ll2_get_journal_mode*() function retrieves the current SQLite journal mode
+for the lastlog2 database associated with _context_.
+
+If _context_ is NULL, the default database, defined in _LL2_DEFAULT_DATABASE_,
+will be taken.
+
+The returned journal mode string is in uppercase (e.g., "WAL", "DELETE") for
+consistency with user input.
+
+Common journal modes include:
+
+* *WAL* - Write-Ahead Logging mode
+* *DELETE* - Default mode
+* *TRUNCATE* - Truncate mode
+* *PERSIST* - Persist mode
+* *MEMORY* - Memory mode
+* *OFF* - Journaling disabled
+
+--------------------------------------
+struct ll2_context *ctx;
+char *mode = NULL;
+char *error = NULL;
+
+ctx = ll2_new_context(NULL);
+if (!ctx) {
+    fprintf(stderr, "Failed to create context\n");
+    return 1;
+}
+
+if (ll2_get_journal_mode(ctx, &mode, &error) != 0) {
+    fprintf(stderr, "Failed to get journal mode: %s\n", error);
+    free(error);
+    ll2_unref_context(ctx);
+    return 1;
+}
+
+printf("Current journal mode: %s\n", mode);
+free(mode);
+ll2_unref_context(ctx);
+--------------------------------------
+
+== RETURN VALUE
+
+Returns 0 on success, -ENOMEM or -1 on other failure.
+_error_ contains an error string if the return value is -1.
+_error_ is not guaranteed to contain an error string, could also be NULL.
+_error_ should be freed by the caller.
+If successful, _mode_ will be set to a newly allocated string containing
+the current journal mode. The caller must free this string.
+
+== AUTHORS
+
+mailto:kukuk@suse.de[Thorsten Kukuk],
+mailto:wanbingjiang@webray.com.cn[WanBingjiang]
+
+== SEE ALSO
+
+*lastlog2*(3),
+*ll2_set_journal_mode*(3),
+*ll2_new_context*(3),
+*ll2_unref_context*(3),
+*ll2_read_all*(3),
+*ll2_write_entry*(3),
+*ll2_read_entry*(3),
+*ll2_remove_entry*(3),
+*ll2_update_login_time*(3),
+*ll2_import_lastlog*(3)
+
+include::man-common/bugreports.adoc[]
+
+include::man-common/footer-lib.adoc[]
+
+ifdef::translation[]
+include::man-common/translation.adoc[]
+endif::[]

--- a/liblastlog2/man/ll2_set_journal_mode.3.adoc
+++ b/liblastlog2/man/ll2_set_journal_mode.3.adoc
@@ -1,0 +1,96 @@
+//po4a: entry man manual
+= ll2_set_journal_mode(3)
+:doctype: manpage
+:man manual: Programmer's Manual
+:man source: util-linux {release-version}
+:page-layout: base
+:lib: liblastlog2
+:firstversion: 2.43
+
+== NAME
+
+ll2_set_journal_mode - set SQLite journal mode for lastlog2 database
+
+== SYNOPSIS
+
+*#include <lastlog2.h>*
+
+*int ll2_set_journal_mode(struct ll2_context *__context__, const char *__mode__, char **__error__);*
+
+== DESCRIPTION
+
+The *ll2_set_journal_mode*() function sets the SQLite journal mode for the
+lastlog2 database associated with _context_ to the specified _mode_.
+
+If _context_ is NULL, the default database, defined in _LL2_DEFAULT_DATABASE_,
+will be taken.
+
+The journal mode setting is persistent and will be retained across database
+connections.
+
+Common journal modes include:
+
+* *WAL* - Write-Ahead Logging mode (recommended for high concurrency)
+* *DELETE* - Default mode, deletes journal file after commit
+* *TRUNCATE* - Truncates journal file to zero length after commit
+* *PERSIST* - Keeps journal file after commit
+* *MEMORY* - Stores journal in memory
+* *OFF* - Disables journaling (not recommended)
+
+WAL (Write-Ahead Logging) mode is recommended for high-concurrency scenarios
+as it allows readers and writers to operate concurrently without blocking
+each other. This significantly reduces database lock contention in environments
+with frequent SSH logins.
+
+--------------------------------------
+struct ll2_context *ctx;
+char *error = NULL;
+
+ctx = ll2_new_context(NULL);
+if (!ctx) {
+    fprintf(stderr, "Failed to create context\n");
+    return 1;
+}
+
+if (ll2_set_journal_mode(ctx, "WAL", &error) != 0) {
+    fprintf(stderr, "Failed to set journal mode: %s\n", error);
+    free(error);
+    ll2_unref_context(ctx);
+    return 1;
+}
+
+ll2_unref_context(ctx);
+--------------------------------------
+
+== RETURN VALUE
+
+Returns 0 on success, -ENOMEM or -1 on other failure.
+_error_ contains an error string if the return value is -1.
+_error_ is not guaranteed to contain an error string, could also be NULL.
+_error_ should be freed by the caller.
+
+== AUTHORS
+
+mailto:kukuk@suse.de[Thorsten Kukuk],
+mailto:wanbingjiang@webray.com.cn[WanBingjiang]
+
+== SEE ALSO
+
+*lastlog2*(3),
+*ll2_get_journal_mode*(3),
+*ll2_new_context*(3),
+*ll2_unref_context*(3),
+*ll2_read_all*(3),
+*ll2_write_entry*(3),
+*ll2_read_entry*(3),
+*ll2_remove_entry*(3),
+*ll2_update_login_time*(3),
+*ll2_import_lastlog*(3)
+
+include::man-common/bugreports.adoc[]
+
+include::man-common/footer-lib.adoc[]
+
+ifdef::translation[]
+include::man-common/translation.adoc[]
+endif::[]

--- a/liblastlog2/man/meson.build
+++ b/liblastlog2/man/meson.build
@@ -1,5 +1,6 @@
 lib_lastlog2_manadocs = files(
   'lastlog2.3.adoc',
+  'll2_get_journal_mode.3.adoc',
   'll2_write_entry.3.adoc',
   'll2_read_entry.3.adoc',
   'll2_import_lastlog.3.adoc',
@@ -7,6 +8,7 @@ lib_lastlog2_manadocs = files(
   'll2_read_all.3.adoc',
   'll2_remove_entry.3.adoc',
   'll2_rename_user.3.adoc',
+  'll2_set_journal_mode.3.adoc',
   'll2_update_login_time.3.adoc',
   'll2_unref_context.3.adoc'
 )

--- a/liblastlog2/src/lastlog2.c
+++ b/liblastlog2/src/lastlog2.c
@@ -155,6 +155,7 @@ read_entry(sqlite3 *db, const char *user,
 	   char **pam_service, char **error)
 {
 	int retval = 0;
+	int step;
 	sqlite3_stmt *res = NULL;
 	static const char *sql = "SELECT Name,Time,TTY,RemoteHost,Service FROM Lastlog2 WHERE Name = ?";
 
@@ -176,7 +177,7 @@ read_entry(sqlite3 *db, const char *user,
 		goto out_read_entry;
 	}
 
-	int step = sqlite3_step(res);
+	step = sqlite3_step(res);
 
 	if (step == SQLITE_ROW) {
 		const unsigned char *luser = sqlite3_column_text(res, 0);
@@ -267,6 +268,7 @@ write_entry(sqlite3 *db, const char *user,
 	    const char *pam_service, char **error)
 {
 	int retval = 0;
+	int step;
 	char *err_msg = NULL;
 	sqlite3_stmt *res = NULL;
 	static const char *sql_table = "CREATE TABLE IF NOT EXISTS Lastlog2(Name TEXT PRIMARY KEY, Time INTEGER, TTY TEXT, RemoteHost TEXT, Service TEXT);";
@@ -336,7 +338,7 @@ write_entry(sqlite3 *db, const char *user,
 		goto out_ll2_read_entry;
 	}
 
-	int step = sqlite3_step(res);
+	step = sqlite3_step(res);
 
 	if (step != SQLITE_DONE) {
 		retval = -1;
@@ -477,6 +479,7 @@ static int
 remove_entry(sqlite3 *db, const char *user, char **error)
 {
 	int retval = 0;
+	int step;
 	sqlite3_stmt *res = NULL;
 	static const char *sql = "DELETE FROM Lastlog2 WHERE Name = ?";
 
@@ -498,7 +501,7 @@ remove_entry(sqlite3 *db, const char *user, char **error)
 		goto out_remove_entry;
 	}
 
-	int step = sqlite3_step(res);
+	step = sqlite3_step(res);
 
 	if (step != SQLITE_DONE) {
 		retval = -1;
@@ -745,6 +748,7 @@ ll2_get_journal_mode(struct ll2_context *context, char **mode, char **error)
 	sqlite3 *db;
 	sqlite3_stmt *res = NULL;
 	int retval = 0;
+	int step;
 	static const char *sql = "PRAGMA journal_mode;";
 
 	retval = open_database_ro(context, &db, error);
@@ -759,7 +763,7 @@ ll2_get_journal_mode(struct ll2_context *context, char **mode, char **error)
 		goto out;
 	}
 
-	int step = sqlite3_step(res);
+	step = sqlite3_step(res);
 	if (step == SQLITE_ROW) {
 		const unsigned char *mode_str = sqlite3_column_text(res, 0);
 		if (mode_str && mode) {

--- a/liblastlog2/src/lastlog2.c
+++ b/liblastlog2/src/lastlog2.c
@@ -26,6 +26,7 @@
 */
 
 #include <pwd.h>
+#include <ctype.h>
 #include <errno.h>
 #include <time.h>
 #include <stdio.h>
@@ -657,6 +658,131 @@ out_import_lastlog:
 	sqlite3_close(db);
 done:
 	fclose(ll_fp);
+
+	return retval;
+}
+
+static const char *valid_journal_modes[] = {
+	"WAL", "DELETE", "TRUNCATE", "PERSIST", "MEMORY", "OFF", NULL
+};
+
+static int
+is_valid_journal_mode(const char *mode)
+{
+	for (size_t i = 0; valid_journal_modes[i]; i++)
+		if (strcasecmp(mode, valid_journal_modes[i]) == 0)
+			return 1;
+	return 0;
+}
+
+/* Set journal mode.
+   Returns 0 on success, -ENOMEM or -1 on other failure. */
+extern int
+ll2_set_journal_mode(struct ll2_context *context, const char *mode,
+		     char **error)
+{
+	sqlite3 *db;
+	sqlite3_stmt *res = NULL;
+	const unsigned char *actual;
+	char *sql = NULL;
+	int retval = 0;
+
+	if (!mode || !is_valid_journal_mode(mode)) {
+		if (error && asprintf(error, "Invalid journal mode: %s", mode ? mode : "(null)") < 0)
+			return -ENOMEM;
+		return -1;
+	}
+
+	retval = open_database_rw(context, &db, error);
+	if (retval != 0)
+		return retval;
+
+	if (asprintf(&sql, "PRAGMA journal_mode = %s;", mode) < 0) {
+		sqlite3_close(db);
+		return -ENOMEM;
+	}
+
+	if (sqlite3_prepare_v2(db, sql, -1, &res, 0) != SQLITE_OK) {
+		retval = -1;
+		if (error && asprintf(error, "Failed to set journal mode to %s: %s",
+				     mode, sqlite3_errmsg(db)) < 0)
+			retval = -ENOMEM;
+		goto out;
+	}
+
+	if (sqlite3_step(res) != SQLITE_ROW) {
+		retval = -1;
+		if (error && asprintf(error, "Failed to set journal mode to %s: %s",
+				     mode, sqlite3_errmsg(db)) < 0)
+			retval = -ENOMEM;
+		goto out;
+	}
+
+	/* Verify SQLite actually applied the requested mode */
+	actual = sqlite3_column_text(res, 0);
+	if (!actual || strcasecmp((const char *)actual, mode) != 0) {
+		retval = -1;
+		if (error && asprintf(error,
+				     "Journal mode not changed: requested %s, got %s",
+				     mode, actual ? (const char *)actual : "(null)") < 0)
+			retval = -ENOMEM;
+	}
+
+out:
+	if (res)
+		sqlite3_finalize(res);
+	free(sql);
+	sqlite3_close(db);
+
+	return retval;
+}
+
+/* Get current journal mode.
+   Returns 0 on success, -ENOMEM or -1 on other failure. */
+extern int
+ll2_get_journal_mode(struct ll2_context *context, char **mode, char **error)
+{
+	sqlite3 *db;
+	sqlite3_stmt *res = NULL;
+	int retval = 0;
+	static const char *sql = "PRAGMA journal_mode;";
+
+	retval = open_database_ro(context, &db, error);
+	if (retval != 0)
+		return retval;
+
+	if (sqlite3_prepare_v2(db, sql, -1, &res, 0) != SQLITE_OK) {
+		retval = -1;
+		if (error && asprintf(error, "Failed to query journal mode: %s",
+				     sqlite3_errmsg(db)) < 0)
+				retval = -ENOMEM;
+		goto out;
+	}
+
+	int step = sqlite3_step(res);
+	if (step == SQLITE_ROW) {
+		const unsigned char *mode_str = sqlite3_column_text(res, 0);
+		if (mode_str && mode) {
+			*mode = strdup((const char *)mode_str);
+			if (*mode == NULL) {
+				retval = -ENOMEM;
+			} else {
+				/* Convert to uppercase for consistency */
+				for (char *p = *mode; *p; p++)
+					*p = toupper((unsigned char)*p);
+			}
+		}
+	} else {
+		retval = -1;
+		if (error && asprintf(error, "Failed to get journal mode: %s",
+				     sqlite3_errmsg(db)) < 0)
+				retval = -ENOMEM;
+	}
+
+out:
+	if (res)
+		sqlite3_finalize(res);
+	sqlite3_close(db);
 
 	return retval;
 }

--- a/liblastlog2/src/lastlog2.h.in
+++ b/liblastlog2/src/lastlog2.h.in
@@ -89,6 +89,17 @@ extern int ll2_rename_user (struct ll2_context *context, const char *user,
 extern int ll2_import_lastlog (struct ll2_context *context,
 		               const char *lastlog_file, char **error);
 
+/* Set journal mode (e.g., "WAL", "DELETE").
+   Returns 0 on success, -ENOMEM or -1 on other failure. */
+extern int ll2_set_journal_mode (struct ll2_context *context,
+				 const char *mode, char **error);
+
+/* Get current journal mode.
+   Returns 0 on success, -ENOMEM or -1 on other failure.
+   Caller must free the returned mode string. */
+extern int ll2_get_journal_mode (struct ll2_context *context,
+				 char **mode, char **error);
+
 #ifdef __cplusplus
 }
 #endif

--- a/liblastlog2/src/liblastlog2.sym
+++ b/liblastlog2/src/liblastlog2.sym
@@ -11,3 +11,9 @@ LIBLASTLOG2_2_40 {
         ll2_import_lastlog;
   local: *;
 };
+
+LIBLASTLOG2_2_43 {
+  global:
+        ll2_set_journal_mode;
+        ll2_get_journal_mode;
+} LIBLASTLOG2_2_40;

--- a/misc-utils/lastlog2.8.adoc
+++ b/misc-utils/lastlog2.8.adoc
@@ -55,6 +55,20 @@ Use _file_ as *lastlog2* database.
 Import data from an old lastlog file named _file_.
 Existing entries in the lastlog2 database will be overwritten.
 
+*-j*, *--journal* [_mode_]::
+Show the current SQLite journal mode, or set it to _mode_.
+Without an argument, displays the current journal mode.
+With an argument, sets the journal mode to the specified value.
++
+Supported modes: *WAL*, *DELETE*, *TRUNCATE*, *PERSIST*, *MEMORY*, *OFF*.
++
+*WAL* (Write-Ahead Logging) mode is recommended for high-concurrency scenarios
+as it allows readers and writers to operate concurrently without blocking each other.
+This significantly reduces database lock contention in environments with frequent
+SSH logins. The journal mode setting is persistent and only needs to be set once.
++
+See *sqlite3*(1) PRAGMA journal_mode for more details about journal modes.
+
 *-r*, *--rename* _newname_::
 Rename the user given with *-u* to this _newname_.
 This option can only be used together with *-u* (*--user*).
@@ -73,6 +87,23 @@ Print only last-login records more recent than _days_.
 Print (or modify) the last-login record of the user _login_.
 
 include::man-common/help-version.adoc[]
+
+== EXAMPLES
+
+Display the current journal mode:
+----
+lastlog2 -j
+----
+
+Enable WAL mode for better concurrency (recommended for high-traffic servers):
+----
+lastlog2 -j WAL
+----
+
+Switch back to the default DELETE mode:
+----
+lastlog2 -j DELETE
+----
 
 == FILES
 

--- a/misc-utils/lastlog2.c
+++ b/misc-utils/lastlog2.c
@@ -116,6 +116,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -C, --clear             clear record of a user (requires -u)\n"), output);
 	fputs(_(" -d, --database FILE     use FILE as lastlog2 database\n"), output);
 	fputs(_(" -i, --import FILE       import data from old lastlog file\n"), output);
+	fputs(_(" -j, --journal [MODE]    show current journal mode, or set it (WAL, DELETE, etc.)\n"), output);
 	fputs(_(" -r, --rename NEWNAME    rename existing user to NEWNAME (requires -u)\n"), output);
 	fputs(_(" -s, --service           display PAM service\n"), output);
 	fputs(_(" -S, --set               set lastlog record to current time (requires -u)\n"), output);
@@ -141,6 +142,7 @@ int main(int argc, char **argv)
 		{"database", required_argument, NULL, 'd'},
 		{"help",     no_argument,       NULL, 'h'},
 		{"import",   required_argument, NULL, 'i'},
+		{"journal",  optional_argument, NULL, 'j'},
 		{"rename",   required_argument, NULL, 'r'},
 		{"service",  no_argument,       NULL, 's'},
 		{"set",      no_argument,       NULL, 'S'},
@@ -152,17 +154,19 @@ int main(int argc, char **argv)
 	char *error = NULL;
 	int Cflg = 0;
 	int iflg = 0;
+	int jflg = 0;
 	int rflg = 0;
 	int Sflg = 0;
 	int uflg = 0;
 	const char *user = NULL;
 	const char *newname = NULL;
 	const char *lastlog_file = NULL;
+	const char *journal_mode = NULL;
 	struct ll2_context *db_context = NULL;
 
 	int c;
 
-	while ((c = getopt_long(argc, argv, "ab:Cd:hi:r:sSt:u:vV", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "ab:Cd:hi:j::r:sSt:u:vV", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'a': /* active; print lastlog excluding '**Never logged in**' users */
 			aflg = 1;
@@ -188,6 +192,15 @@ int main(int argc, char **argv)
 		case 'i': /* import <FILE>; Import data from old lastlog file */
 			lastlog_file = optarg;
 			iflg = 1;
+			break;
+		case 'j': /* journal [MODE]; Set or show journal mode */
+			jflg = 1;
+			if (optarg) {
+				journal_mode = optarg;
+			} else if (optind < argc && argv[optind][0] != '-') {
+				/* Check if next argument looks like a mode name */
+				journal_mode = argv[optind++];
+			}
 			break;
 		case 'r': /* rename <NEWNAME>; Rename existing user to NEWNAME (requires -u) */
 			rflg = 1;
@@ -222,8 +235,8 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if ((Cflg + Sflg + iflg) > 1)
-		errx(EXIT_FAILURE, _("Option -C, -i and -S cannot be used together"));
+	if ((Cflg + Sflg + iflg + jflg) > 1)
+		errx(EXIT_FAILURE, _("Option -C, -i, -j and -S cannot be used together"));
 
 	db_context = ll2_new_context(lastlog2_path);
 	if (!db_context)
@@ -234,6 +247,28 @@ int main(int argc, char **argv)
 		if (ll2_import_lastlog(db_context, lastlog_file, &error) != 0) {
 			warnx(_("Couldn't import entries from '%s'"), lastlog_file);
 			goto err;
+		}
+		goto done;
+	}
+
+	if (jflg) {
+		/* Journal mode operations */
+		if (journal_mode) {
+			/* Set journal mode */
+			if (ll2_set_journal_mode(db_context, journal_mode, &error) != 0) {
+				warnx(_("Couldn't set journal mode to '%s'"), journal_mode);
+				goto err;
+			}
+			printf(_("Journal mode set to '%s' successfully\n"), journal_mode);
+		} else {
+			/* Show current journal mode */
+			char *mode = NULL;
+			if (ll2_get_journal_mode(db_context, &mode, &error) != 0) {
+				warnx(_("Couldn't get journal mode"));
+				goto err;
+			}
+			printf(_("Current journal mode: %s\n"), mode);
+			free(mode);
 		}
 		goto done;
 	}


### PR DESCRIPTION
- Use `sqlite3_busy_timeout` to block until the lock is acquired, avoiding the `SQLITE_BUSY` error.  
- add --journal option to manage SQLite journal mode