### PR TITLE
tests: improve lsfd test

### DIFF
--- a/tests/ts/lsfd/assoc-pidfs
+++ b/tests/ts/lsfd/assoc-pidfs
@@ -20,6 +20,10 @@ TS_DESC="pidfs association"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 
+if ts_kernel_ver_lt 6 9; then
+	TS_KNOWN_FAIL="yes"
+fi
+
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_CMD_GETINO"
 ts_check_test_command "$TS_HELPER_MKFDS"


### PR DESCRIPTION
The assoc-pidfs use the getino command. Set "TS_KNOWN_FAIL" if the condition are not met.