### PR TITLE
libuser: fix misleading error message

### DIFF
--- a/login-utils/libuser.c
+++ b/login-utils/libuser.c
@@ -28,7 +28,7 @@ static int auth_lu(const char *service_name, struct lu_context *ctx, uid_t uid,
 		if (setegid(getgid()) == -1)
 			err(EXIT_FAILURE, _("Couldn't drop group privileges"));
 		if (seteuid(getuid()) == -1)
-			err(EXIT_FAILURE, _("Couldn't drop group privileges"));
+			err(EXIT_FAILURE, _("Couldn't drop user privileges"));
 		return TRUE;
 	}
 


### PR DESCRIPTION
When setting the effective user fails the code prints a misleading error message stating that 'group' privileges could not be dropped, but it should state 'user' instead.