### PR TITLE
fincore: (tests) fix tmpfs detection for out-of-tree builds

### DIFF
--- a/tests/ts/fincore/count
+++ b/tests/ts/fincore/count
@@ -9,7 +9,7 @@ ts_init "$*"
 ts_check_test_command "$TS_CMD_FINDMNT"
 ts_check_test_command "$TS_HELPER_SYSINFO"
 
-FS="$("$TS_CMD_FINDMNT" -nr -o FSTYPE -T "$PWD")"
+FS="$("$TS_CMD_FINDMNT" -nr -o FSTYPE -T "$TS_OUTDIR")"
 if [[ "$FS" = "tmpfs" || "$FS" = "overlay" || "$FS" = "" ]]; then
 	ts_skip "fincore does not work on tmpfs or unknown fs"
 fi


### PR DESCRIPTION
The tmpfs check used $PWD which points to the source directory, not to the output directory where test files are actually created. When tests are run with --builddir on tmpfs (e.g. /tmp), the check fails to detect it and the test produces wrong results because O_DIRECT has no effect on tmpfs.

Use $TS_OUTDIR instead, which is the actual directory where dd creates test files and fincore inspects them.