### PR TITLE
bash-completion: complete relative path for filenames as well

### DIFF
--- a/bash-completion/umount
+++ b/bash-completion/umount
@@ -89,7 +89,7 @@ _umount_module()
 		COMPREPLY=( $( compgen -W '$( _umount_points_list )'  -- "$cur" ) )
 	else
 		compopt -o filenames
-		COMPREPLY=( $(compgen -o dirnames -- "$cur") )
+		COMPREPLY=( $(compgen -f -- "$cur") )
 		return 0
 	fi
 }


### PR DESCRIPTION
Commit 1a76e3e only helped with the completion of directory names for relative paths. Let us complete filenames too for completeness (no pun intended).