### PR TITLE
pwdutils: Set errno with out of range UIDs/GIDs

### DIFF
--- a/lib/pwdutils.c
+++ b/lib/pwdutils.c
@@ -186,8 +186,10 @@ struct group *ul_getgrp_str(const char *str, gid_t *result)
                         *result = gr->gr_gid;
                 return gr;
         }
-        if (num > MAX_OF_UINT_TYPE(gid_t))
+        if (num > MAX_OF_UINT_TYPE(gid_t)) {
+                errno = ERANGE;
                 return NULL;
+        }
 
         if (result)
                 *result = (gid_t) num;
@@ -219,8 +221,10 @@ struct passwd *ul_getuserpw_str(const char *str, uid_t *result)
                         *result = pw->pw_uid;
                 return pw;
         }
-        if (num > MAX_OF_UINT_TYPE(uid_t))
+        if (num > MAX_OF_UINT_TYPE(uid_t)) {
+                errno = ERANGE;
                 return NULL;
+        }
 
         if (result)
                 *result = (uid_t) num;


### PR DESCRIPTION
If a UID/GID is larger than its respective data type allows (but smaller than uint64_t), then tools like newgrp erroneously assume that the user or group simply does not exist.

Set errno to indicate that the supplied UID/GID is out of range instead.

Proof of Concept:
```
newgrp 4294967296
```

Before:
```
newgrp: no such group
```

After:
```
newgrp: no such group: Numerical result out of range
```

This is in sync with values larger than UINT64_MAX