### PR TITLE
Use correct formatters for given data types

### DIFF
--- a/disk-utils/blockdev.c
+++ b/disk-utils/blockdev.c
@@ -351,7 +351,7 @@ static void do_commands(int fd, char **argv, int d)
 			if (res == 0) {
 				if (verbose)
 					printf(_("get size in 512-byte sectors: "));
-				printf("%lld\n", llu);
+				printf("%llu\n", llu);
 			}
 			else
 				errx(EXIT_FAILURE,
@@ -523,7 +523,7 @@ static int report_device(char *device, int quiet)
 	    ioctl(fd, BLKSSZGET, &ssz) == 0 &&
 	    ioctl(fd, BLKBSZGET, &bsz) == 0 &&
 	    blkdev_get_size(fd, &bytes) == 0) {
-		printf("%s %5ld %5d %5d %s %15lld   %s\n",
+		printf("%s %5ld %5d %5d %s %15llu   %s\n",
 			ro ? "ro" : "rw", ra, ssz, bsz, start_str, bytes, device);
 	} else {
 		if (!quiet)

--- a/disk-utils/fdisk-list.c
+++ b/disk-utils/fdisk-list.c
@@ -78,12 +78,12 @@ void list_disk_geometry(struct fdisk_context *cxt)
 		fdisk_info(cxt, _("Disk model: %s"), fdisk_get_devmodel(cxt));
 
 	if (lb && (fdisk_label_require_geometry(lb) || fdisk_use_cylinders(cxt)))
-		fdisk_info(cxt, _("Geometry: %d heads, %ju sectors/track, %ju cylinders"),
+		fdisk_info(cxt, _("Geometry: %u heads, %ju sectors/track, %ju cylinders"),
 			       fdisk_get_geom_heads(cxt),
 			       (uintmax_t) fdisk_get_geom_sectors(cxt),
 			       (uintmax_t) fdisk_get_geom_cylinders(cxt));
 
-	fdisk_info(cxt, _("Units: %s of %d * %ld = %ld bytes"),
+	fdisk_info(cxt, _("Units: %s of %u * %lu = %lu bytes"),
 	       fdisk_get_unit(cxt, FDISK_PLURAL),
 	       fdisk_get_units_per_sector(cxt),
 	       fdisk_get_sector_size(cxt),
@@ -353,7 +353,7 @@ int list_freespace_get_table(struct fdisk_context *cxt,
 		color_disable();
 		free(strsz);
 
-		fdisk_info(cxt, _("Units: %s of %d * %ld = %ld bytes"),
+		fdisk_info(cxt, _("Units: %s of %u * %lu = %lu bytes"),
 		       fdisk_get_unit(cxt, FDISK_PLURAL),
 		       fdisk_get_units_per_sector(cxt),
 		       fdisk_get_sector_size(cxt),

--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -319,7 +319,7 @@ static int is_irrotational_disk(dev_t disk)
 
 
 	rc = snprintf(path, sizeof(path),
-			"/sys/dev/block/%d:%d/queue/rotational",
+			"/sys/dev/block/%u:%u/queue/rotational",
 			major(disk), minor(disk));
 
 	if (rc < 0 || (unsigned int) rc >= sizeof(path))

--- a/disk-utils/fsck.cramfs.c
+++ b/disk-utils/fsck.cramfs.c
@@ -202,7 +202,7 @@ static void test_super(int *start)
 
 	/* What are valid superblock sizes? */
 	if (super.size < *start + sizeof(struct cramfs_super))
-		errx(FSCK_EX_UNCORRECTED, _("superblock size (%d) too small"),
+		errx(FSCK_EX_UNCORRECTED, _("superblock size (%"PRIu32") too small"),
 		     super.size);
 
 	if (super.flags & CRAMFS_FLAG_FSID_VERSION_2) {
@@ -289,7 +289,7 @@ static void print_node(char type, struct cramfs_inode *i, char *name)
 
 	if (S_ISCHR(i->mode) || (S_ISBLK(i->mode)))
 		/* major/minor numbers can be as high as 2^12 or 4096 */
-		snprintf(info, 10, "%4d,%4d", major(i->size), minor(i->size));
+		snprintf(info, 10, "%4u,%4u", major(i->size), minor(i->size));
 	else
 		/* size be as high as 2^24 or 16777216 */
 		snprintf(info, 10, "%9d", i->size);
@@ -412,11 +412,11 @@ static void do_uncompress(char *path, int outfd, unsigned long offset,
 		if (size >= blksize) {
 			if (out != blksize)
 				errx(FSCK_EX_UNCORRECTED,
-				     _("non-block (%ld) bytes"), out);
+				     _("non-block (%lu) bytes"), out);
 		} else {
 			if (out != size)
 				errx(FSCK_EX_UNCORRECTED,
-				     _("non-size (%ld vs %ld) bytes"), out,
+				     _("non-size (%lu vs %lu) bytes"), out,
 				     size);
 		}
 		size -= out;

--- a/disk-utils/fsck.minix.c
+++ b/disk-utils/fsck.minix.c
@@ -648,15 +648,15 @@ read_tables(void) {
 	}
 	get_dirsize();
 	if (show) {
-		printf(_("%ld inodes\n"), inodes);
-		printf(_("%ld blocks\n"), zones);
+		printf(_("%lu inodes\n"), inodes);
+		printf(_("%lu blocks\n"), zones);
 		printf(_("Firstdatazone=%jd (%jd)\n"),
 			(intmax_t)first_zone, (intmax_t)norm_first_zone);
 		printf(_("Zonesize=%d\n"), MINIX_BLOCK_SIZE << get_zone_size());
 		printf(_("Maxsize=%zu\n"), get_max_size());
 		if (fs_version < 3)
 			printf(_("Filesystem state=%d\n"), Super.s_state);
-		printf(_("namelen=%zd\n\n"), namelen);
+		printf(_("namelen=%zu\n\n"), namelen);
 	}
 }
 
@@ -671,7 +671,7 @@ get_inode(unsigned int nr) {
 	if (!inode_count[nr]) {
 		if (!inode_in_use(nr)) {
 			get_current_name();
-			printf(_("Inode %d marked unused, "
+			printf(_("Inode %u marked unused, "
 				 "but used for file '%s'\n"), nr, current_name);
 			if (repair) {
 				if (ask(_("Mark in use"), 1))
@@ -721,7 +721,7 @@ get_inode2(unsigned int nr) {
 	if (!inode_count[nr]) {
 		if (!inode_in_use(nr)) {
 			get_current_name();
-			printf(_("Inode %d marked unused, "
+			printf(_("Inode %u marked unused, "
 				 "but used for file '%s'\n"), nr, current_name);
 			if (repair) {
 				if (ask(_("Mark in use"), 1))
@@ -1008,7 +1008,7 @@ check_file(struct minix_inode *dir, unsigned int offset) {
 	name_depth++;
 	if (list) {
 		if (verbose)
-			printf("%6d %07o %3d ", ino,
+			printf("%6u %07o %3d ", ino,
 			       inode->i_mode, inode->i_nlinks);
 		get_current_name();
 		printf("%s", current_name);
@@ -1398,13 +1398,13 @@ main(int argc, char **argv) {
 		for (inode = 1, free = 0; inode <= get_ninodes(); inode++)
 			if (!inode_in_use(inode))
 				free++;
-		printf(_("\n%6ld inodes used (%ld%%)\n"),
+		printf(_("\n%6lu inodes used (%lu%%)\n"),
 		       (get_ninodes() - free),
 		       100 * (get_ninodes() - free) / get_ninodes());
 		for (inode = get_first_zone(), free = 0; inode < get_nzones(); inode++)
 			if (!zone_in_use(inode))
 				free++;
-		printf(_("%6ld zones used (%ld%%)\n"), (get_nzones() - free),
+		printf(_("%6lu zones used (%lu%%)\n"), (get_nzones() - free),
 		       100 * (get_nzones() - free) / get_nzones());
 		printf(_("\n%6d regular files\n"
 			 "%6d directories\n"

--- a/disk-utils/mkfs.bfs.c
+++ b/disk-utils/mkfs.bfs.c
@@ -285,7 +285,7 @@ int main(int argc, char **argv)
 			fprintf(stderr, _("Inodes: %ld (in %llu blocks)\n"),
 				inodes, ino_blocks);
 		fprintf(stderr, _("Blocks: %llu\n"), total_blocks);
-		fprintf(stderr, _("Inode end: %d, Data end: %d\n"),
+		fprintf(stderr, _("Inode end: %"PRIu32", Data end: %"PRIu32"\n"),
 			le32_to_cpu(sb.s_start) - 1, le32_to_cpu(sb.s_end));
 	}
 

--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -603,7 +603,7 @@ do_compress(char *base, unsigned int offset, unsigned char const *name,
 		if (len > blksize*2) {
 			/* (I don't think this can happen with zlib.) */
 			printf(_("AIEEE: block \"compressed\" to > "
-				 "2*blocklength (%ld)\n"),
+				 "2*blocklength (%lu)\n"),
 			       len);
 			exit(MKFS_EX_ERROR);
 		}
@@ -887,7 +887,7 @@ int main(int argc, char **argv)
 	/* Write the superblock now that we can fill in all of the fields. */
 	write_superblock(root_entry, rom_image+opt_pad, offset);
 	if (verbose)
-		printf(_("Super block: %zd bytes\n"),
+		printf(_("Super block: %zu bytes\n"),
 		       sizeof(struct cramfs_super));
 
 	/* Put the checksum in. */
@@ -900,7 +900,7 @@ int main(int argc, char **argv)
 	if (fslen_ub < offset)
 		errx(MKFS_EX_ERROR,
 			_("not enough space allocated for ROM image "
-			  "(%lld allocated, %zu used)"),
+			  "(%lld allocated, %zd used)"),
 			(long long) fslen_ub, offset);
 
 	written = write(fd, rom_image, offset);
@@ -917,21 +917,21 @@ int main(int argc, char **argv)
 	if (warn_namelen)
 		/* Can't happen when reading from ext2fs. */
 		/* Bytes, not chars: think UTF8. */
-		warnx(_("warning: filenames truncated to %u bytes."), MAX_INPUT_NAMELEN);
+		warnx(_("warning: filenames truncated to %d bytes."), MAX_INPUT_NAMELEN);
 	if (warn_skip)
 		warnx(_("warning: files were skipped due to errors."));
 	if (warn_size)
-		warnx(_("warning: file sizes truncated to %luMB "
+		warnx(_("warning: file sizes truncated to %ldMB "
 			"(minus 1 byte)."), 1L << (CRAMFS_SIZE_WIDTH - 20));
 	if (warn_uid)
 		/* (not possible with current Linux versions) */
-		warnx(_("warning: uids truncated to %u bits.  "
+		warnx(_("warning: uids truncated to %d bits.  "
 			"(This may be a security concern.)"), CRAMFS_UID_WIDTH);
 	if (warn_gid)
-		warnx(_("warning: gids truncated to %u bits.  "
+		warnx(_("warning: gids truncated to %d bits.  "
 			"(This may be a security concern.)"), CRAMFS_GID_WIDTH);
 	if (warn_dev)
-		warnx(_("WARNING: device numbers truncated to %u bits.  "
+		warnx(_("WARNING: device numbers truncated to %d bits.  "
 			"This almost certainly means\n"
 			"that some device files will be wrong."),
 		      CRAMFS_OFFSET_WIDTH);

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -163,7 +163,7 @@ static inline time_t mkfs_minix_time(time_t *t)
 	const char *str = getenv("MKFS_MINIX_TEST_SECOND_SINCE_EPOCH");
 	uint64_t sec;
 
-	if (str && sscanf(str, "%"SCNd64, &sec) == 1)
+	if (str && sscanf(str, "%"SCNu64, &sec) == 1)
 		return sec;
 	return time(t);
 }

--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -130,7 +130,7 @@ static void init_signature_page(struct mkswap_control *ctl)
 		if (ctl->user_pagesize < 0 || !is_power_of_2(ctl->user_pagesize) ||
 		    (size_t) ctl->user_pagesize < sizeof(struct swap_header_v1_2) + 10)
 			errx(EXIT_FAILURE,
-			     _("Bad user-specified page size %u"),
+			     _("Bad user-specified page size %d"),
 			       ctl->user_pagesize);
 		if (!ctl->quiet && ctl->user_pagesize != kernel_pagesize)
 			warnx(_("Using user-specified page size %d, "
@@ -763,7 +763,7 @@ int main(int argc, char **argv)
 			~permMask & 0666, ctl.devname);
 	if (!ctl.quiet
 	    && getuid() == 0 && S_ISREG(ctl.devstat.st_mode) && ctl.devstat.st_uid != 0)
-		warnx(_("%s: insecure file owner %d, fix with: chown 0:0 %s"),
+		warnx(_("%s: insecure file owner %u, fix with: chown 0:0 %s"),
 			ctl.devname, ctl.devstat.st_uid, ctl.devname);
 
 

--- a/disk-utils/partx.c
+++ b/disk-utils/partx.c
@@ -235,7 +235,7 @@ static int get_max_partno(const char *disk, dev_t devno)
 		goto dflt;
 	parent++;
 
-	snprintf(path, sizeof(path), _PATH_SYS_DEVBLOCK "/%d:%d/",
+	snprintf(path, sizeof(path), _PATH_SYS_DEVBLOCK "/%u:%u/",
 			major(devno), minor(devno));
 
 	dir = opendir(path);
@@ -601,15 +601,15 @@ static int add_scols_line(struct libscols_table *table, blkid_partition par)
 			xasprintf(&str, "%d", blkid_partition_get_partno(par));
 			break;
 		case COL_START:
-			xasprintf(&str, "%ju", blkid_partition_get_start(par));
+			xasprintf(&str, "%"PRId64, blkid_partition_get_start(par));
 			break;
 		case COL_END:
-			xasprintf(&str, "%ju",
+			xasprintf(&str, "%"PRId64,
 					blkid_partition_get_start(par) +
 					blkid_partition_get_size(par) - 1);
 			break;
 		case COL_SECTORS:
-			xasprintf(&str, "%ju", blkid_partition_get_size(par));
+			xasprintf(&str, "%"PRId64, blkid_partition_get_size(par));
 			break;
 		case COL_SIZE:
 			if (partx_flags & FL_BYTES)

--- a/include/iso9660.h
+++ b/include/iso9660.h
@@ -5,6 +5,7 @@
 #ifndef UTIL_LINUX_ISO_H
 #define UTIL_LINUX_ISO_H
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -56,7 +57,7 @@ static inline uint32_t isonum_733(const unsigned char *p, bool check_match)
 
 	if (check_match && le != be)
 		/* translation is useless */
-		warnx("733error: le=%d be=%d", le, be);
+		warnx("733error: le=%"PRIu32" be=%"PRIu32, le, be);
 	return(le);
 }
 

--- a/lib/logindefs.c
+++ b/lib/logindefs.c
@@ -615,7 +615,7 @@ int main(int argc, char *argv[])
 	if (strcmp(type, "str") == 0)
 		printf("$%s: '%s'\n", name, getlogindefs_str(name, "DEFAULT"));
 	else if (strcmp(type, "num") == 0)
-		printf("$%s: '%ld'\n", name, getlogindefs_num(name, 0));
+		printf("$%s: '%lu'\n", name, getlogindefs_num(name, 0));
 	else if (strcmp(type, "bool") == 0)
 		printf("$%s: '%s'\n", name,
 		       getlogindefs_bool(name, 0) ? "Y" : "N");

--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -686,7 +686,7 @@ int is_loopdev(const char *device)
 		 */
 		char name[PATH_MAX], *cn, *p = NULL;
 
-		snprintf(name, sizeof(name), _PATH_SYS_DEVBLOCK "/%d:%d",
+		snprintf(name, sizeof(name), _PATH_SYS_DEVBLOCK "/%u:%u",
 				major(st.st_rdev), minor(st.st_rdev));
 		cn = ul_canonicalize_path(name);
 		if (cn)
@@ -1167,7 +1167,7 @@ int loopcxt_set_offset(struct loopdev_cxt *lc, uint64_t offset)
 		return -EINVAL;
 	lc->config.info.lo_offset = offset;
 
-	DBG_OBJ(CXT, lc, ul_debug("set offset=%jd", offset));
+	DBG_OBJ(CXT, lc, ul_debug("set offset=%"PRIu64, offset));
 	return 0;
 }
 
@@ -1180,7 +1180,7 @@ int loopcxt_set_sizelimit(struct loopdev_cxt *lc, uint64_t sizelimit)
 		return -EINVAL;
 	lc->config.info.lo_sizelimit = sizelimit;
 
-	DBG_OBJ(CXT, lc, ul_debug("set sizelimit=%jd", sizelimit));
+	DBG_OBJ(CXT, lc, ul_debug("set sizelimit=%"PRIu64, sizelimit));
 	return 0;
 }
 
@@ -1196,7 +1196,7 @@ int loopcxt_set_blocksize(struct loopdev_cxt *lc, uint64_t blocksize)
 		return -EINVAL;
 	lc->blocksize = blocksize;
 
-	DBG_OBJ(CXT, lc, ul_debug("set blocksize=%jd", blocksize));
+	DBG_OBJ(CXT, lc, ul_debug("set blocksize=%"PRIu64, blocksize));
 	return 0;
 }
 

--- a/lib/netaddrq.c
+++ b/lib/netaddrq.c
@@ -354,7 +354,7 @@ ul_netaddrq_bestaddr(struct ul_nl_data *nl,
 		if (t < threshold)
 		{
 			DBG_OBJ(BEST, *best,
-			    ul_debug("best iface %s, threshold %hhd",
+			    ul_debug("best iface %s, threshold %u",
 					ifaceq->ifname, t));
 			*best_ifaceq = ifaceq;
 			threshold = t;

--- a/lib/path.c
+++ b/lib/path.c
@@ -1270,11 +1270,11 @@ int main(int argc, char *argv[])
 
 		if (ul_path_read_s64(pc, &res, file) != 0)
 			err(EXIT_FAILURE, "read u64 failed");
-		printf("read:  %s: %" PRIu64 "\n", file, res);
+		printf("read:  %s: %" PRId64 "\n", file, res);
 
 		if (ul_path_readf_s64(pc, &res, "%s", file) != 0)
 			err(EXIT_FAILURE, "readf u64 failed");
-		printf("readf: %s: %" PRIu64 "\n", file, res);
+		printf("readf: %s: %" PRId64 "\n", file, res);
 
 	} else if (strcmp(command, "read-majmin") == 0) {
 		dev_t res;

--- a/lib/pwdutils.c
+++ b/lib/pwdutils.c
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
 		err(EXIT_FAILURE, "failed to get %s pwd entry", argv[1]);
 
 	printf("Username: %s\n", pwd->pw_name);
-	printf("UID:      %d\n", pwd->pw_uid);
+	printf("UID:      %u\n", pwd->pw_uid);
 	printf("HOME:     %s\n", pwd->pw_dir);
 	printf("GECO:     %s\n", pwd->pw_gecos);
 

--- a/lib/randutils.c
+++ b/lib/randutils.c
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
 	printf("Multiple random calls:\n");
 	for (i = 0; i < n; i++) {
 		ul_random_get_bytes(&v, sizeof(v));
-		printf("#%02zu: %25"PRIu64"\n", i, v);
+		printf("#%02zu: %25"PRId64"\n", i, v);
 	}
 
 
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
 	ul_random_get_bytes(buf, bufsz);
 	for (i = 0; i < n; i++) {
 		vp = (int64_t *) (buf + (i * sizeof(*vp)));
-		printf("#%02zu: %25"PRIu64"\n", i, *vp);
+		printf("#%02zu: %25"PRId64"\n", i, *vp);
 	}
 
 	return EXIT_SUCCESS;

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -5,6 +5,7 @@
  * Written by Karel Zak <kzak@redhat.com> [2011]
  */
 #include <ctype.h>
+#include <inttypes.h>
 #include <libgen.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -77,7 +78,7 @@ int sysfs_blkdev_init_path(struct path_cxt *pc, dev_t devno, struct path_cxt *pa
 		 + 3];
 
 	/* define path to devno stuff */
-	snprintf(buf, sizeof(buf), _PATH_SYS_DEVBLOCK "/%d:%d", major(devno), minor(devno));
+	snprintf(buf, sizeof(buf), _PATH_SYS_DEVBLOCK "/%u:%u", major(devno), minor(devno));
 	rc = ul_path_set_dir(pc, buf);
 	if (rc)
 		return rc;
@@ -1184,12 +1185,12 @@ int main(int argc, char *argv[])
 		err(EXIT_FAILURE, "failed to read devno");
 
 	printf("non-context:\n");
-	printf(" DEVNO:   %u (%d:%d)\n", (unsigned int) devno, major(devno), minor(devno));
+	printf(" DEVNO:   %u (%u:%u)\n", (unsigned int) devno, major(devno), minor(devno));
 	printf(" DEVNAME: %s\n", sysfs_devno_to_devname(devno, path, sizeof(path)));
 	printf(" DEVPATH: %s\n", sysfs_devno_to_devpath(devno, path, sizeof(path)));
 
 	sysfs_devno_to_wholedisk(devno, diskname, sizeof(diskname), &disk_devno);
-	printf(" WHOLEDISK-DEVNO:   %u (%d:%d)\n", (unsigned int) disk_devno, major(disk_devno), minor(disk_devno));
+	printf(" WHOLEDISK-DEVNO:   %u (%u:%u)\n", (unsigned int) disk_devno, major(disk_devno), minor(disk_devno));
 	printf(" WHOLEDISK-DEVNAME: %s\n", diskname);
 
 	pc = ul_new_sysfs_path(devno, NULL, NULL);
@@ -1198,12 +1199,12 @@ int main(int argc, char *argv[])
 
 	printf("context based:\n");
 	devno = sysfs_blkdev_get_devno(pc);
-	printf(" DEVNO:   %u (%d:%d)\n", (unsigned int) devno, major(devno), minor(devno));
+	printf(" DEVNO:   %u (%u:%u)\n", (unsigned int) devno, major(devno), minor(devno));
 	printf(" DEVNAME: %s\n", sysfs_blkdev_get_name(pc, path, sizeof(path)));
 	printf(" DEVPATH: %s\n", sysfs_blkdev_get_path(pc, path, sizeof(path)));
 
 	sysfs_devno_to_wholedisk(devno, diskname, sizeof(diskname), &disk_devno);
-	printf(" WHOLEDISK-DEVNO: %u (%d:%d)\n", (unsigned int) disk_devno, major(disk_devno), minor(disk_devno));
+	printf(" WHOLEDISK-DEVNO: %u (%u:%u)\n", (unsigned int) disk_devno, major(disk_devno), minor(disk_devno));
 	printf(" WHOLEDISK-DEVNAME: %s\n", diskname);
 
 	is_part = ul_path_access(pc, F_OK, "partition") == 0;
@@ -1225,14 +1226,14 @@ int main(int argc, char *argv[])
 		for (i = 1; i <= 5; i++) {
 			dev_t dev = sysfs_blkdev_partno_to_devno(pc, i);
 			if (dev)
-				printf("\t#%d %d:%d\n", i, major(dev), minor(dev));
+				printf("\t#%d %u:%u\n", i, major(dev), minor(dev));
 		}
 	}
 
 	if (ul_path_read_u64(pc, &u64, "size") != 0)
 		printf(" (!) read SIZE failed\n");
 	else
-		printf(" SIZE: %jd\n", u64);
+		printf(" SIZE: %"PRIu64"\n", u64);
 
 	if (ul_path_read_s32(pc, &i, "queue/hw_sector_size"))
 		printf(" (!) read SECTOR failed\n");

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -675,7 +675,7 @@ int strtimespec_relative(const struct timespec *ts, char *buf, size_t bufsz)
 
 	if (ts->tv_nsec) {
 		if (ts->tv_nsec % NSEC_PER_MSEC) {
-			rc = snprintf(buf, bufsz, "%*luns",
+			rc = snprintf(buf, bufsz, "%*ldns",
 				      parts ? 10 : 0, ts->tv_nsec);
 			if (rc < 0 || (size_t) rc > bufsz)
 				goto err;
@@ -755,7 +755,7 @@ static int run_unittest_timestamp(void)
 		}
 
 		if (result != t.expected) {
-			fprintf(stderr, "#%02zu %-25s: %"PRId64" != %"PRId64"\n",
+			fprintf(stderr, "#%02zu %-25s: %"PRIu64" != %"PRIu64"\n",
 				i, t.input, result, t.expected);
 			rc = EXIT_FAILURE;
 		}

--- a/libblkid/samples/topology.c
+++ b/libblkid/samples/topology.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
 				blkid_topology_get_physical_sector_size(tp));
 		printf("\tdax support          : %lu\n",
 				blkid_topology_get_dax(tp));
-		printf("\tdiskseq              : %"PRId64"\n",
+		printf("\tdiskseq              : %"PRIu64"\n",
 				blkid_topology_get_diskseq(tp));
 	}
 

--- a/libblkid/src/evaluate.c
+++ b/libblkid/src/evaluate.c
@@ -119,7 +119,7 @@ int blkid_send_uevent(const char *devname, const char *action)
 	if (stat(devname, &st) || !S_ISBLK(st.st_mode))
 		return -1;
 
-	snprintf(uevent, sizeof(uevent), "/sys/dev/block/%d:%d/uevent",
+	snprintf(uevent, sizeof(uevent), "/sys/dev/block/%u:%u/uevent",
 			major(st.st_rdev), minor(st.st_rdev));
 
 	f = fopen(uevent, "w" UL_CLOEXECSTR);

--- a/libblkid/src/partitions/dos.c
+++ b/libblkid/src/partitions/dos.c
@@ -8,6 +8,7 @@
  *
  * Inspired by fdisk, partx, Linux kernel and libparted.
  */
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -51,7 +52,7 @@ static int parse_dos_extended(blkid_probe pr, blkid_parttable tab,
 	int ct_nodata = 0;	/* count ext.partitions without data partitions */
 	int i;
 
-	DBG(LOWPROBE, ul_debug("parse EBR [start=%d, size=%d]", ex_start/ssf, ex_size/ssf));
+	DBG(LOWPROBE, ul_debug("parse EBR [start=%"PRIu32", size=%"PRIu32"]", ex_start/ssf, ex_size/ssf));
 	if (ex_start == 0) {
 		DBG(LOWPROBE, ul_debug("Bad offset in primary extended partition -- ignore"));
 		return 0;

--- a/libblkid/src/partitions/gpt.c
+++ b/libblkid/src/partitions/gpt.c
@@ -383,7 +383,7 @@ static int probe_gpt_pt(blkid_probe pr,
 		/* the partition has to inside usable range */
 		if (start < fu || start + size - 1 > lu) {
 			DBG(LOWPROBE, ul_debug(
-				"GPT entry[%d] overflows usable area - ignore",
+				"GPT entry[%"PRIu32"] overflows usable area - ignore",
 				i));
 			blkid_partlist_increment_partno(ls);
 			continue;

--- a/libblkid/src/partitions/partitions.c
+++ b/libblkid/src/partitions/partitions.c
@@ -425,7 +425,7 @@ blkid_parttable blkid_partlist_new_parttable(blkid_partlist ls,
 	list_add_tail(&tab->t_tabs, &ls->l_tabs);
 
 	DBG(LOWPROBE, ul_debug("parts: create a new partition table "
-		       "(type=%s, offset=%"PRId64")", type, offset));
+		       "(type=%s, offset=%"PRIu64")", type, offset));
 	return tab;
 }
 
@@ -855,7 +855,7 @@ int blkid_probe_is_covered_by_pt(blkid_probe pr,
 
 		if (par->start + par->size > (pr->size >> 9)) {
 			DBG(LOWPROBE, ul_debug("partition #%d overflows "
-				"device (off=%" PRId64 " size=%" PRId64 ")",
+				"device (off=%" PRIu64 " size=%" PRIu64 ")",
 				par->partno, par->start, par->size));
 			goto done;
 		}

--- a/libblkid/src/partitions/solaris_x86.c
+++ b/libblkid/src/partitions/solaris_x86.c
@@ -6,6 +6,7 @@
  * This file may be redistributed under the terms of the
  * GNU Lesser General Public License.
  */
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -77,7 +78,7 @@ static int probe_solaris_pt(blkid_probe pr,
 
 	if (le32_to_cpu(l->v_version) != 1) {
 		DBG(LOWPROBE, ul_debug(
-			"WARNING: unsupported solaris x86 version %d, ignore",
+			"WARNING: unsupported solaris x86 version %"PRIu32", ignore",
 			le32_to_cpu(l->v_version)));
 		goto nothing;
 	}

--- a/libblkid/src/superblocks/drbdmanage.c
+++ b/libblkid/src/superblocks/drbdmanage.c
@@ -66,7 +66,7 @@ static int probe_drbdmanage(blkid_probe pr,
 		return errno ? -errno : 1;
 
 	if (memcmp(prs->magic, persistence_magic, sizeof(prs->magic)) == 0 &&
-	    blkid_probe_sprintf_version(pr, "%d", be32_to_cpu(prs->version_le)) != 0)
+	    blkid_probe_sprintf_version(pr, "%"PRIu32, be32_to_cpu(prs->version_le)) != 0)
 		return errno ? -errno : 1;
 
 	return 0;

--- a/libblkid/src/superblocks/jmicron_raid.c
+++ b/libblkid/src/superblocks/jmicron_raid.c
@@ -95,7 +95,7 @@ static int probe_jmraid(blkid_probe pr,
 	if (jm->mode > 5)
 		return 1;
 
-	if (blkid_probe_sprintf_version(pr, "%u.%u",
+	if (blkid_probe_sprintf_version(pr, "%hu.%hu",
 			JM_MAJOR_VERSION(jm), JM_MINOR_VERSION(jm)) != 0)
 		return 1;
 	if (blkid_probe_set_magic(pr, off, sizeof(jm->signature),

--- a/libblkid/src/superblocks/luks.c
+++ b/libblkid/src/superblocks/luks.c
@@ -81,7 +81,7 @@ static int luks_attributes(blkid_probe pr, struct luks2_phdr *header, uint64_t o
 		return BLKID_PROBE_NONE;
 
 	version = be16_to_cpu(header->version);
-	blkid_probe_sprintf_version(pr, "%u", version);
+	blkid_probe_sprintf_version(pr, "%d", version);
 
 	if (version == 1) {
 		header_v1 = (struct luks_phdr *)header;

--- a/libblkid/src/superblocks/superblocks.c
+++ b/libblkid/src/superblocks/superblocks.c
@@ -411,7 +411,7 @@ static int superblocks_probe(blkid_probe pr, struct blkid_chain *chn)
 			continue;
 		}
 
-		DBG(LOWPROBE, ul_debug("[%zd] %s:", i, id->name));
+		DBG(LOWPROBE, ul_debug("[%zu] %s:", i, id->name));
 
 		rc = blkid_probe_get_idmag(pr, id, &off, &mag);
 		if (rc < 0)

--- a/libblkid/src/superblocks/ubifs.c
+++ b/libblkid/src/superblocks/ubifs.c
@@ -4,6 +4,7 @@
  * This file may be redistributed under the terms of the
  * GNU Lesser General Public License.
  */
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -115,7 +116,7 @@ static int probe_ubifs(blkid_probe pr, const struct blkid_idmag *mag)
 		return 1;
 
 	blkid_probe_set_uuid(pr, sb->uuid);
-	blkid_probe_sprintf_version(pr, "w%dr%d",
+	blkid_probe_sprintf_version(pr, "w%"PRIu32"r%"PRIu32,
 			le32_to_cpu(sb->fmt_version),
 			le32_to_cpu(sb->ro_compat_version));
 	blkid_probe_set_fssize(pr,

--- a/libblkid/src/superblocks/vfat.c
+++ b/libblkid/src/superblocks/vfat.c
@@ -171,7 +171,7 @@ static int search_fat_label(blkid_probe pr, uint64_t offset, uint32_t entries, u
 
 		if ((ent->attr & (FAT_ATTR_VOLUME_ID | FAT_ATTR_DIR)) ==
 		    FAT_ATTR_VOLUME_ID) {
-			DBG(LOWPROBE, ul_debug("\tfound fs LABEL at entry %d", i));
+			DBG(LOWPROBE, ul_debug("\tfound fs LABEL at entry %"PRIu32, i));
 			memcpy(out, ent->name, 11);
 			if (out[0] == 0x05)
 				out[0] = 0xE5;

--- a/libblkid/src/superblocks/zfs.c
+++ b/libblkid/src/superblocks/zfs.c
@@ -219,7 +219,7 @@ static bool zfs_extract_guid_name(blkid_probe pr, void *buf, size_t size, bool f
 			goto cont;
 		}
 
-		DBG(LOWPROBE, ul_debug("left %zd nvp_size %u",
+		DBG(LOWPROBE, ul_debug("left %zu nvp_size %"PRIu32,
 				       size, nvp_size));
 
 		/* nvpair fits in buffer and name fits in nvpair? */

--- a/libblkid/src/topology/dm.c
+++ b/libblkid/src/topology/dm.c
@@ -76,8 +76,8 @@ static int probe_dm_tp(blkid_probe pr,
 		if (drop_permissions() != 0)
 			 _exit(1);
 
-		snprintf(maj, sizeof(maj), "%d", major(devno));
-		snprintf(min, sizeof(min), "%d", minor(devno));
+		snprintf(maj, sizeof(maj), "%u", major(devno));
+		snprintf(min, sizeof(min), "%u", minor(devno));
 
 		dmargv[0] = cmd;
 		dmargv[1] = "table";

--- a/libfdisk/src/alignment.c
+++ b/libfdisk/src/alignment.c
@@ -574,9 +574,9 @@ int fdisk_discover_topology(struct fdisk_context *cxt)
 	if (!cxt->io_size)
 		cxt->io_size = cxt->sector_size;
 
-	DBG_OBJ(CXT, cxt, ul_debug("result: log/phy sector size: %ld/%ld",
+	DBG_OBJ(CXT, cxt, ul_debug("result: log/phy sector size: %lu/%lu",
 			cxt->sector_size, cxt->phy_sector_size));
-	DBG_OBJ(CXT, cxt, ul_debug("result: fdisk/optimal/minimal io: %ld/%ld/%ld",
+	DBG_OBJ(CXT, cxt, ul_debug("result: fdisk/optimal/minimal io: %lu/%lu/%lu",
 		       cxt->io_size, cxt->optimal_io_size, cxt->min_io_size));
 	return 0;
 }

--- a/libfdisk/src/bsd.c
+++ b/libfdisk/src/bsd.c
@@ -162,7 +162,7 @@ static int bsd_assign_dos_partition(struct fdisk_context *cxt)
 
 		ss = dos_partition_get_start(l->dos_part);
 		if (!ss) {
-			fdisk_warnx(cxt, _("Partition %zd: has invalid starting "
+			fdisk_warnx(cxt, _("Partition %zu: has invalid starting "
 					   "sector 0."), i + 1);
 			return -1;
 		}

--- a/libfdisk/src/dos.c
+++ b/libfdisk/src/dos.c
@@ -1625,18 +1625,18 @@ static int check(struct fdisk_context *cxt, size_t n,
 		nerrors++;
 	}
 	if (h >= cxt->geom.heads) {
-		fdisk_warnx(cxt, _("Partition %zu: head %d greater than "
-				   "maximum %d"), n, h + 1, cxt->geom.heads);
+		fdisk_warnx(cxt, _("Partition %zu: head %u greater than "
+				   "maximum %u"), n, h + 1, cxt->geom.heads);
 		nerrors++;
 	}
 	if (real_s >= cxt->geom.sectors) {
-		fdisk_warnx(cxt, _("Partition %zu: sector %d greater than "
+		fdisk_warnx(cxt, _("Partition %zu: sector %u greater than "
 				   "maximum %ju"), n, real_s + 1,
 				(uintmax_t) cxt->geom.sectors);
 		nerrors++;
 	}
 	if (real_c >= cxt->geom.cylinders) {
-		fdisk_warnx(cxt, _("Partition %zu: cylinder %d greater than "
+		fdisk_warnx(cxt, _("Partition %zu: cylinder %u greater than "
 				   "maximum %ju"),
 				n, real_c + 1,
 				(uintmax_t) cxt->geom.cylinders);
@@ -1704,7 +1704,7 @@ static int check_consistency(struct fdisk_context *cxt, struct dos_partition *p,
 	    && (pbc != lbc || pbh != lbh || pbs != lbs)) {
 		fdisk_warnx(cxt, _("Partition %zu: different physical/logical "
 			"beginnings (non-Linux?): "
-			"phys=(%d, %d, %d), logical=(%d, %d, %d)"),
+			"phys=(%u, %u, %u), logical=(%u, %u, %u)"),
 			partition + 1,
 			pbc, pbh, pbs,
 			lbc, lbh, lbs);
@@ -1715,7 +1715,7 @@ static int check_consistency(struct fdisk_context *cxt, struct dos_partition *p,
 	if (lec < 1024
 	    && (pec != lec || peh != leh || pes != les)) {
 		fdisk_warnx(cxt, _("Partition %zu: different physical/logical "
-			"endings: phys=(%d, %d, %d), logical=(%d, %d, %d)"),
+			"endings: phys=(%u, %u, %u), logical=(%u, %u, %u)"),
 			partition + 1,
 			pec, peh, pes,
 			lec, leh, les);
@@ -1849,7 +1849,7 @@ static int dos_verify_disklabel(struct fdisk_context *cxt)
 			fdisk_info(cxt, _("Total allocated sectors %ju greater "
 				"than the maximum %ju."), (uintmax_t) total, (uintmax_t) n_sectors);
 		else if (total < n_sectors)
-			fdisk_info(cxt, _("Remaining %ju unallocated %ld-byte "
+			fdisk_info(cxt, _("Remaining %ju unallocated %lu-byte "
 				"sectors."), (uintmax_t) n_sectors - total, cxt->sector_size);
 	} else
 		fdisk_warnx(cxt,
@@ -2053,7 +2053,7 @@ static int dos_add_partition(struct fdisk_context *cxt,
 		fdisk_ask_menu_set_default(ask, free_primary == 1
 						&& !l->ext_offset ? 'e' : 'p');
 		snprintf(hint, sizeof(hint),
-				_("%u primary, %d extended, %u free"),
+				_("%d primary, %d extended, %d free"),
 				4 - (l->ext_offset ? 1 : 0) - free_primary,
 				l->ext_offset ? 1 : 0,
 				free_primary);
@@ -2119,7 +2119,7 @@ static int write_sector(struct fdisk_context *cxt, fdisk_sector_t secno,
 
 	rc = seek_sector(cxt, secno);
 	if (rc != 0) {
-		fdisk_warn(cxt, _("Cannot write sector %jd: seek failed"),
+		fdisk_warn(cxt, _("Cannot write sector %ju: seek failed"),
 				(uintmax_t) secno);
 		return rc;
 	}
@@ -2683,8 +2683,8 @@ int fdisk_dos_fix_chs(struct fdisk_context *cxt)
 		if (obc != nbc || obh != nbh || obs != nbs ||
 		    oec != nec || oeh != neh || oes != nes) {
 			DBG(LABEL, ul_debug("DOS: changing %zu partition CHS "
-				"from (%d, %d, %d)-(%d, %d, %d) "
-				"to (%d, %d, %d)-(%d, %d, %d)",
+				"from (%u, %u, %u)-(%u, %u, %u) "
+				"to (%u, %u, %u)-(%u, %u, %u)",
 				i, obc, obh, obs, oec, oeh, oes,
 				nbc, nbh, nbs, nec, neh, nes));
 			p->bc = nbc & 0xff;

--- a/libfdisk/src/label.c
+++ b/libfdisk/src/label.c
@@ -545,7 +545,7 @@ int fdisk_set_partition_type(struct fdisk_context *cxt,
 			return -ENOMEM;
 		fdisk_partition_set_type(pa, t);
 
-		DBG_OBJ(CXT, cxt, ul_debug("partition: %zd: set type", partnum));
+		DBG_OBJ(CXT, cxt, ul_debug("partition: %zu: set type", partnum));
 		rc = cxt->label->op->set_part(cxt, partnum, pa);
 		fdisk_unref_partition(pa);
 		return rc;
@@ -576,7 +576,7 @@ int fdisk_toggle_partition_flag(struct fdisk_context *cxt,
 
 	rc = cxt->label->op->part_toggle_flag(cxt, partnum, flag);
 
-	DBG_OBJ(CXT, cxt, ul_debug("partition: %zd: toggle: 0x%04lx [rc=%d]", partnum, flag, rc));
+	DBG_OBJ(CXT, cxt, ul_debug("partition: %zu: toggle: 0x%04lx [rc=%d]", partnum, flag, rc));
 	return rc;
 }
 

--- a/libfdisk/src/partition.c
+++ b/libfdisk/src/partition.c
@@ -1571,7 +1571,7 @@ int fdisk_delete_partition(struct fdisk_context *cxt, size_t partno)
 
 	fdisk_wipe_partition(cxt, partno, 0);
 
-	DBG_OBJ(CXT, cxt, ul_debug("deleting %s partition number %zd",
+	DBG_OBJ(CXT, cxt, ul_debug("deleting %s partition number %zu",
 				cxt->label->name, partno));
 	return cxt->label->op->del_part(cxt, partno);
 }

--- a/libfdisk/src/sgi.c
+++ b/libfdisk/src/sgi.c
@@ -622,12 +622,12 @@ static int verify_disklabel(struct fdisk_context *cxt, int verbose)
 
 		if (verbose && sgi_get_start_sector(cxt, Index[0]) != 0)
 			fdisk_info(cxt, _("The entire disk partition should "
-					  "start at block 0, not at block %d."),
+					  "start at block 0, not at block %u."),
 				   sgi_get_start_sector(cxt, Index[0]));
 
 		if (verbose && sgi_get_num_sectors(cxt, Index[0]) != lastblock)
 			DBG(LABEL, ul_debug(
-				"entire disk partition=%ds, but disk=%ds",
+				"entire disk partition=%us, but disk=%us",
 				sgi_get_num_sectors(cxt, Index[0]),
 				lastblock));
 		lastblock = sgi_get_num_sectors(cxt, Index[0]);
@@ -656,8 +656,8 @@ static int verify_disklabel(struct fdisk_context *cxt, int verbose)
 		if (start > sgi_get_start_sector(cxt, Index[i])) {
 			if (verbose)
 				fdisk_info(cxt,
-					   P_("Partitions %d and %d overlap by %d sector.",
-					      "Partitions %d and %d overlap by %d sectors.",
+					   P_("Partitions %d and %d overlap by %u sector.",
+					      "Partitions %d and %d overlap by %u sectors.",
 					      start - sgi_get_start_sector(cxt, Index[i])),
 					   Index[i-1]+1, Index[i]+1,
 					   start - sgi_get_start_sector(cxt, Index[i]));
@@ -682,7 +682,7 @@ static int verify_disklabel(struct fdisk_context *cxt, int verbose)
 		if (cylsize && start % cylsize)
 			start += cylsize - (start % cylsize);
 
-		DBG(LABEL, ul_debug("%2d:%12d\t%12d\t%12d", Index[i],
+		DBG(LABEL, ul_debug("%2d:%12u\t%12u\t%12d", Index[i],
 				       sgi_get_start_sector(cxt, Index[i]),
 				       sgi_get_num_sectors(cxt, Index[i]),
 				       sgi_get_sysid(cxt, Index[i])));

--- a/libfdisk/src/sun.c
+++ b/libfdisk/src/sun.c
@@ -6,6 +6,7 @@
  *   Merged with fdisk for other architectures, aeb, June 1998.
  *   Arnaldo Carvalho de Melo <acme@conectiva.com.br> Mar 1999, Internationalization
  */
+#include <inttypes.h>
 #include <stdio.h>		/* stderr */
 #include <stdlib.h>		/* qsort */
 #include <string.h>		/* strstr */
@@ -150,7 +151,7 @@ static int sun_probe_label(struct fdisk_context *cxt)
 		fdisk_apply_user_device_properties(cxt);
 
 	if (be32_to_cpu(sunlabel->vtoc.version) != SUN_VTOC_VERSION) {
-		fdisk_warnx(cxt, _("Detected sun disklabel with wrong version [%d]."),
+		fdisk_warnx(cxt, _("Detected sun disklabel with wrong version [%"PRIu32"]."),
 			be32_to_cpu(sunlabel->vtoc.version));
 		need_fixing = 1;
 	}
@@ -630,7 +631,7 @@ static int sun_add_partition(
 				    whole_disk = 1;
 				    break;
 				}
-				fdisk_warnx(cxt, _("Sector %d is already allocated"), first);
+				fdisk_warnx(cxt, _("Sector %u is already allocated"), first);
 			} else
 				break;
 		}

--- a/libfdisk/src/utils.c
+++ b/libfdisk/src/utils.c
@@ -121,7 +121,7 @@ char *fdisk_partname(const char *dev, size_t partno)
 	int w = 0;
 
 	if (!dev || !*dev) {
-		if (asprintf(&res, "%zd", partno) > 0)
+		if (asprintf(&res, "%zu", partno) > 0)
 			return res;
 		return NULL;
 	}

--- a/libmount/python/fs.c
+++ b/libmount/python/fs.c
@@ -136,7 +136,7 @@ static PyObject *Fs_print_debug(FsObject *self)
 	if (mnt_fs_get_parent_id(self->fs))
 		PySys_WriteStdout("parent: %d\n", mnt_fs_get_parent_id(self->fs));
 	if (mnt_fs_get_devno(self->fs))
-		PySys_WriteStdout("devno:  %d:%d\n", major(mnt_fs_get_devno(self->fs)),
+		PySys_WriteStdout("devno:  %u:%u\n", major(mnt_fs_get_devno(self->fs)),
 						minor(mnt_fs_get_devno(self->fs)));
 	if (mnt_fs_get_tid(self->fs))
 		PySys_WriteStdout("tid:    %d\n", mnt_fs_get_tid(self->fs));

--- a/libmount/src/btrfs.c
+++ b/libmount/src/btrfs.c
@@ -143,7 +143,7 @@ uint64_t btrfs_get_default_subvol_id(const char *path)
 		DBG(BTRFS, ul_debug("root tree dir object id not found"));
 		goto out;
 	}
-	DBG(BTRFS, ul_debug("found %d root tree dir object id items", sk->nr_items));
+	DBG(BTRFS, ul_debug("found %"PRIu32" root tree dir object id items", sk->nr_items));
 
 	sh = (struct btrfs_ioctl_search_header *)args.buf;
 

--- a/libmount/src/cache.c
+++ b/libmount/src/cache.c
@@ -240,7 +240,7 @@ static int cache_add_entry(struct libmnt_cache *cache, char *key,
 	e->flag = flag;
 	cache->nents++;
 
-	DBG_OBJ(CACHE, cache, ul_debug("add entry [%2zd] (%s): %s: %s",
+	DBG_OBJ(CACHE, cache, ul_debug("add entry [%2zu] (%s): %s: %s",
 			cache->nents,
 			(flag & MNT_CACHE_ISPATH) ? "path" : "tag",
 			value, key));
@@ -415,7 +415,7 @@ static int read_from_blkid(struct libmnt_cache *cache, const char *devname)
 	}
 
 done:
-	DBG_OBJ(CACHE, cache, ul_debug("\tread %zd tags [rc=%d]", ntags, rc));
+	DBG_OBJ(CACHE, cache, ul_debug("\tread %zu tags [rc=%d]", ntags, rc));
 	blkid_free_probe(pr);
 	free(cacheval);
 
@@ -468,7 +468,7 @@ static int read_from_udev(struct libmnt_cache *cache, const char *devname)
 		free(tagval), tagval = NULL;
 	}
 
-	DBG_OBJ(CACHE, cache, ul_debug("\tread %zd tags [rc=%d]", ntags, rc));
+	DBG_OBJ(CACHE, cache, ul_debug("\tread %zu tags [rc=%d]", ntags, rc));
 	sd_device_unref(sd);
 	free(cacheval);
 	free(tagval);

--- a/libmount/src/context_umount.c
+++ b/libmount/src/context_umount.c
@@ -644,7 +644,7 @@ static int evaluate_permissions(struct libmnt_context *cxt)
 		}
 		if (!curr_user) {
 			DBG_OBJ(CXT, cxt, ul_debug("umount %s: cannot "
-				"convert %d to username", tgt, getuid()));
+				"convert %u to username", tgt, getuid()));
 			goto eperm;
 		}
 

--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -1973,7 +1973,7 @@ int mnt_fs_print_debug(struct libmnt_fs *fs, FILE *file)
 		fprintf(file, "uniq-parent: %" PRIu64 "\n", mnt_fs_get_parent_uniq_id(fs));
 
 	if (mnt_fs_get_devno(fs))
-		fprintf(file, "devno:  %d:%d\n", major(mnt_fs_get_devno(fs)),
+		fprintf(file, "devno:  %u:%u\n", major(mnt_fs_get_devno(fs)),
 						minor(mnt_fs_get_devno(fs)));
 	if (mnt_fs_get_tid(fs))
 		fprintf(file, "tid:    %d\n", mnt_fs_get_tid(fs));

--- a/libmount/src/optstr.c
+++ b/libmount/src/optstr.c
@@ -1140,7 +1140,7 @@ static int test_get(struct libmnt_test *ts __attribute__((unused)),
 	if (rc == 0) {
 		printf("found; name: %s", name);
 		if (sz) {
-			printf(", argument: size=%zd data=", sz);
+			printf(", argument: size=%zu data=", sz);
 			if (fwrite(val, 1, sz, stdout) != sz)
 				return -1;
 		}

--- a/libmount/src/utils.c
+++ b/libmount/src/utils.c
@@ -1636,7 +1636,7 @@ static int tests_stat(struct libmnt_test *ts __attribute__((unused)),
 		printf(" S_ISREG: %s\n", S_ISREG(st.st_mode) ? "y" : "n");
 		printf(" S_IFLNK: %s\n", S_ISLNK(st.st_mode) ? "y" : "n");
 
-		printf("   devno: %lu (%d:%d)\n", (unsigned long) st.st_dev,
+		printf("   devno: %lu (%u:%u)\n", (unsigned long) st.st_dev,
 					  major(st.st_dev), minor(st.st_dev));
 		printf("     ino: %lu\n", (unsigned long) st.st_ino);
 

--- a/libsmartcols/src/calculate.c
+++ b/libsmartcols/src/calculate.c
@@ -12,7 +12,7 @@ static void dbg_column(struct libscols_table *tb, struct libscols_column *cl)
 
 	st = &cl->wstat;
 
-	DBG_OBJ(COL, cl, ul_debug("#%zu %12s: width=%zd "
+	DBG_OBJ(COL, cl, ul_debug("#%zu %12s: width=%zu "
 				 "hint=%d max=%zu min=%zu "
 				 "0x04%x [%s%s%s]",
 
@@ -400,7 +400,7 @@ static int reduce_column(struct libscols_table *tb,
 		cl->flags |= SCOLS_FL_HIDDEN;
 
 	if (cl->width != org_width)
-		DBG_OBJ(COL, cl, ul_debug(" [%02zd] %s reduced %zu-->%zu",
+		DBG_OBJ(COL, cl, ul_debug(" [%02zu] %s reduced %zu-->%zu",
 					cl->seqnum,
 					cl->header.data, org_width, cl->width));
 
@@ -551,7 +551,7 @@ int __scols_calculate(struct libscols_table *tb, struct ul_buffer *buf)
 
 				if (!add)
 					continue;
-				DBG_OBJ(COL, cl, ul_debug("  add +%zd (%s)",
+				DBG_OBJ(COL, cl, ul_debug("  add +%zu (%s)",
 							add, cl->header.data));
 				cl->width += add;
 				width += add;

--- a/login-utils/chfn.c
+++ b/login-utils/chfn.c
@@ -445,7 +445,7 @@ int main(int argc, char **argv)
 	if (!ctl.username) {
 		ctl.pw = getpwuid(uid);
 		if (!ctl.pw)
-			errx(EXIT_FAILURE, _("your user %d does not exist"),
+			errx(EXIT_FAILURE, _("your user %u does not exist"),
 			     uid);
 	} else {
 		ctl.pw = ul_getuserpw_str(ctl.username, NULL);

--- a/login-utils/chsh.c
+++ b/login-utils/chsh.c
@@ -204,7 +204,7 @@ int main(int argc, char **argv)
 	if (!info.username) {
 		pw = xgetpwuid(uid, &pwbuf);
 		if (!pw)
-			errx(EXIT_FAILURE, _("you (user %d) don't exist."),
+			errx(EXIT_FAILURE, _("you (user %u) don't exist."),
 			     uid);
 	} else {
 		pw = xgetuserpw(info.username, &pwbuf);

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -629,7 +629,7 @@ static int is_phantom(const struct last_control *ctl, struct utmpx *ut)
 	pw = getpwnam(user);
 	if (!pw)
 		return 1;
-	snprintf(path, sizeof(path), "/proc/%u/loginuid", ut->ut_pid);
+	snprintf(path, sizeof(path), "/proc/%d/loginuid", ut->ut_pid);
 	if (access(path, R_OK) == 0) {
 		unsigned int loginuid;
 		FILE *f = NULL;

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -1417,7 +1417,7 @@ static void print_journal_tail(const char *journal_path, uid_t uid, size_t len, 
 	else
 		sd_journal_open(&j, SD_JOURNAL_LOCAL_ONLY);
 
-	xasprintf(&match, "_UID=%d", uid);
+	xasprintf(&match, "_UID=%u", uid);
 
 	sd_journal_add_match(j, match, 0);
 	sd_journal_seek_tail(j);

--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -771,7 +771,7 @@ static void init_groups(struct su_context *su, gid_t *groups, size_t ngroups)
 
 static void change_identity(const struct passwd *pw)
 {
-	DBG(MISC, ul_debug("changing identity [GID=%d, UID=%d]", pw->pw_gid, pw->pw_uid));
+	DBG(MISC, ul_debug("changing identity [GID=%u, UID=%u]", pw->pw_gid, pw->pw_uid));
 
 	if (setgid(pw->pw_gid))
 		err(EXIT_FAILURE, _("cannot set group id"));

--- a/lsfd-cmd/file.c
+++ b/lsfd-cmd/file.c
@@ -375,7 +375,7 @@ static bool file_fill_column(struct proc *proc __attribute__((__unused__)),
 		xasprintf(&str, "%d", file->stat.st_nlink == 0);
 		break;
 	case COL_MNT_ID:
-		xasprintf(&str, "%d", has_mnt_id(file)? file->mnt_id: 0);
+		xasprintf(&str, "%u", has_mnt_id(file)? file->mnt_id: 0);
 		break;
 	case COL_MODE:
 		if (does_file_has_fdinfo_alike(file))

--- a/misc-utils/lsblk.c
+++ b/misc-utils/lsblk.c
@@ -816,7 +816,7 @@ static void process_mq(struct lsblk_device *dev, char **str)
 		return;
 	}
 
-	DBG_OBJ(DEV, dev, ul_debug("%s: has %d queues", dev->name, queues));
+	DBG_OBJ(DEV, dev, ul_debug("%s: has %u queues", dev->name, queues));
 	xasprintf(str, "%3u", queues);
 }
 
@@ -889,19 +889,19 @@ static char *device_get_data(
 		break;
 	case COL_MAJMIN:
 		if (is_parsable(lsblk))
-			xasprintf(&str, "%u:%u", dev->maj, dev->min);
+			xasprintf(&str, "%d:%d", dev->maj, dev->min);
 		else
-			xasprintf(&str, "%3u:%-3u", dev->maj, dev->min);
+			xasprintf(&str, "%3d:%-3d", dev->maj, dev->min);
 		if (rawdata)
 			*rawdata = makedev(dev->maj, dev->min);
 		break;
 	case COL_MAJ:
-		xasprintf(&str, "%u", dev->maj);
+		xasprintf(&str, "%d", dev->maj);
 		if (rawdata)
 			*rawdata = dev->maj;
 		break;
 	case COL_MIN:
-		xasprintf(&str, "%u", dev->min);
+		xasprintf(&str, "%d", dev->min);
 		if (rawdata)
 			*rawdata = dev->min;
 		break;
@@ -1811,7 +1811,7 @@ static int __process_one_device(struct lsblk_devtree *tr, char *devname, dev_t d
 		}
 		devno = st.st_rdev;
 	} else if (devno) {
-		DBG(DEV, ul_debug("%d:%d: reading alone device", major(devno), minor(devno)));
+		DBG(DEV, ul_debug("%u:%u: reading alone device", major(devno), minor(devno)));
 	} else {
 		assert(devno || devname);
 		return -EINVAL;

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -123,7 +123,7 @@ static const char *clock_type_name(enum CLOCK_TYPE type)
 	case CT_RTC:
 		return "rtc";
 	}
-	errx(EXIT_FAILURE, _("Unknown clock type %d"), type);
+	errx(EXIT_FAILURE, _("Unknown clock type %u"), type);
 }
 
 struct clockinfo {
@@ -251,7 +251,7 @@ static void __attribute__((__noreturn__)) usage(void)
 
 static void scols_line_format_timespec(struct libscols_line *ln, size_t n, const struct timespec *ts)
 {
-	scols_line_sprintf(ln, n, "%ju.%09" PRId32, (uintmax_t) ts->tv_sec, (uint32_t) ts->tv_nsec);
+	scols_line_sprintf(ln, n, "%ju.%09" PRIu32, (uintmax_t) ts->tv_sec, (uint32_t) ts->tv_nsec);
 }
 
 static clockid_t parse_clock(const char *name)
@@ -656,7 +656,7 @@ int main(int argc, char **argv)
 		rc = clock_gettime(clock, &now);
 		if (rc)
 			err(EXIT_FAILURE, _("failed to get time"));
-		printf("%ju.%09"PRId32"\n", (uintmax_t) now.tv_sec, (uint32_t) now.tv_nsec);
+		printf("%ju.%09"PRIu32"\n", (uintmax_t) now.tv_sec, (uint32_t) now.tv_nsec);
 		return EXIT_SUCCESS;
 	}
 

--- a/misc-utils/pipesz.c
+++ b/misc-utils/pipesz.c
@@ -74,7 +74,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_OPTIONS, stdout);
 	fputsln(_(" -g, --get          examine pipe buffers"), stdout);
 	fprintf(stdout,
-		_(" -s, --set <size>   the buffer size to be used (default: %u)\n"), opt_size);
+		_(" -s, --set <size>   the buffer size to be used (default: %d)\n"), opt_size);
 
 	fputs(USAGE_SEPARATOR, stdout);
 	fputsln(_(" -f, --file <path>  act on a file"), stdout);

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -454,7 +454,7 @@ static void server_loop(const char *socket_path, const char *pidfile_path,
 		}
 		if (ret == 0) {		/* true when poll() times out */
 			if (uuidd_cxt->debug)
-				fprintf(stderr, _("timeout [%d sec]\n"), uuidd_cxt->timeout);
+				fprintf(stderr, _("timeout [%"PRIu32" sec]\n"), uuidd_cxt->timeout);
 			all_done(uuidd_cxt, EXIT_SUCCESS);
 		}
 		if (pfd[POLLFD_SIGNAL].revents != 0)

--- a/schedutils/uclampset.c
+++ b/schedutils/uclampset.c
@@ -96,7 +96,7 @@ static void show_uclamp_pid_info(pid_t pid, char *cmd)
 	else
 		comm = pid_get_cmdname(pid);
 
-	printf(_("%s (%d) util_clamp: min: %d max: %d\n"),
+	printf(_("%s (%d) util_clamp: min: %"PRIu32" max: %"PRIu32"\n"),
 	       comm ? : "unknown", pid, sa.sched_util_min, sa.sched_util_max);
 
 	if (!cmd)

--- a/sys-utils/blkzone.c
+++ b/sys-utils/blkzone.c
@@ -264,7 +264,7 @@ static int blkzone_report(struct blkzone_control *ctl)
 			err(EXIT_FAILURE, _("%s: BLKREPORTZONE ioctl failed"), ctl->devname);
 
 		if (ctl->verbose)
-			printf(_("Found %d zones from 0x%"PRIx64"\n"),
+			printf(_("Found %"PRIu32" zones from 0x%"PRIx64"\n"),
 				zi->nr_zones, ctl->offset);
 
 		if (!zi->nr_zones)

--- a/sys-utils/chcpu.c
+++ b/sys-utils/chcpu.c
@@ -80,23 +80,23 @@ static int cpu_enable(struct path_cxt *sys, cpu_set_t *cpu_set, size_t setsize, 
 		if (!CPU_ISSET_S(cpu, setsize, cpu_set))
 			continue;
 		if (ul_path_accessf(sys, F_OK, "cpu%d", cpu) != 0) {
-			warnx(_("CPU %u does not exist"), cpu);
+			warnx(_("CPU %d does not exist"), cpu);
 			fails++;
 			continue;
 		}
 		if (ul_path_accessf(sys, F_OK, "cpu%d/online", cpu) != 0) {
-			warnx(_("CPU %u is not hot pluggable"), cpu);
+			warnx(_("CPU %d is not hot pluggable"), cpu);
 			fails++;
 			continue;
 		}
 		if (ul_path_readf_s32(sys, &online, "cpu%d/online", cpu) == 0
 		    && online == 1
 		    && enable == 1) {
-			printf(_("CPU %u is already enabled\n"), cpu);
+			printf(_("CPU %d is already enabled\n"), cpu);
 			continue;
 		}
 		if (online == 0 && enable == 0) {
-			printf(_("CPU %u is already disabled\n"), cpu);
+			printf(_("CPU %d is already disabled\n"), cpu);
 			continue;
 		}
 		if (ul_path_accessf(sys, F_OK, "cpu%d/configure", cpu) == 0)
@@ -104,25 +104,25 @@ static int cpu_enable(struct path_cxt *sys, cpu_set_t *cpu_set, size_t setsize, 
 		if (enable) {
 			rc = ul_path_writef_string(sys, "1", "cpu%d/online", cpu);
 			if (rc != 0 && configured == 0) {
-				warn(_("CPU %u enable failed (CPU is deconfigured)"), cpu);
+				warn(_("CPU %d enable failed (CPU is deconfigured)"), cpu);
 				fails++;
 			} else if (rc != 0) {
-				warn(_("CPU %u enable failed"), cpu);
+				warn(_("CPU %d enable failed"), cpu);
 				fails++;
 			} else
-				printf(_("CPU %u enabled\n"), cpu);
+				printf(_("CPU %d enabled\n"), cpu);
 		} else {
 			if (onlinecpus && num_online_cpus() == 1) {
-				warnx(_("CPU %u disable failed (last enabled CPU)"), cpu);
+				warnx(_("CPU %d disable failed (last enabled CPU)"), cpu);
 				fails++;
 				continue;
 			}
 			rc = ul_path_writef_string(sys, "0", "cpu%d/online", cpu);
 			if (rc != 0) {
-				warn(_("CPU %u disable failed"), cpu);
+				warn(_("CPU %d disable failed"), cpu);
 				fails++;
 			} else {
-				printf(_("CPU %u disabled\n"), cpu);
+				printf(_("CPU %d disabled\n"), cpu);
 				if (onlinecpus)
 					CPU_CLR_S(cpu, setsize, onlinecpus);
 			}
@@ -177,44 +177,44 @@ static int cpu_configure(struct path_cxt *sys, cpu_set_t *cpu_set, size_t setsiz
 		if (!CPU_ISSET_S(cpu, setsize, cpu_set))
 			continue;
 		if (ul_path_accessf(sys, F_OK, "cpu%d", cpu) != 0) {
-			warnx(_("CPU %u does not exist"), cpu);
+			warnx(_("CPU %d does not exist"), cpu);
 			fails++;
 			continue;
 		}
 		if (ul_path_accessf(sys, F_OK, "cpu%d/configure", cpu) != 0) {
-			warnx(_("CPU %u is not configurable"), cpu);
+			warnx(_("CPU %d is not configurable"), cpu);
 			fails++;
 			continue;
 		}
 		ul_path_readf_s32(sys, &current, "cpu%d/configure", cpu);
 		if (current == 1 && configure == 1) {
-			printf(_("CPU %u is already configured\n"), cpu);
+			printf(_("CPU %d is already configured\n"), cpu);
 			continue;
 		}
 		if (current == 0 && configure == 0) {
-			printf(_("CPU %u is already deconfigured\n"), cpu);
+			printf(_("CPU %d is already deconfigured\n"), cpu);
 			continue;
 		}
 		if (current == 1 && configure == 0 && onlinecpus &&
 		    is_cpu_online(cpu)) {
-			warnx(_("CPU %u deconfigure failed (CPU is enabled)"), cpu);
+			warnx(_("CPU %d deconfigure failed (CPU is enabled)"), cpu);
 			fails++;
 			continue;
 		}
 		if (configure) {
 			rc = ul_path_writef_string(sys, "1", "cpu%d/configure", cpu);
 			if (rc != 0) {
-				warn(_("CPU %u configure failed"), cpu);
+				warn(_("CPU %d configure failed"), cpu);
 				fails++;
 			} else
-				printf(_("CPU %u configured\n"), cpu);
+				printf(_("CPU %d configured\n"), cpu);
 		} else {
 			rc = ul_path_writef_string(sys, "0", "cpu%d/configure", cpu);
 			if (rc != 0) {
-				warn(_("CPU %u deconfigure failed"), cpu);
+				warn(_("CPU %d deconfigure failed"), cpu);
 				fails++;
 			} else
-				printf(_("CPU %u deconfigured\n"), cpu);
+				printf(_("CPU %d deconfigured\n"), cpu);
 		}
 	}
 

--- a/sys-utils/ipcs.c
+++ b/sys-utils/ipcs.c
@@ -272,10 +272,10 @@ static void do_shm (char format, int unit)
 		 * "swap performance = %ld attempts, %ld successes\n"
 		 */
 		printf (_("segments allocated %d\n"
-			  "pages allocated %ld\n"
-			  "pages resident  %ld\n"
-			  "pages swapped   %ld\n"
-			  "Swap performance: %ld attempts\t %ld successes\n"),
+			  "pages allocated %lu\n"
+			  "pages resident  %lu\n"
+			  "pages swapped   %lu\n"
+			  "Swap performance: %lu attempts\t %lu successes\n"),
 			shm_info->used_ids,
 			shm_info->shm_tot,
 			shm_info->shm_rss,
@@ -346,7 +346,7 @@ static void do_shm (char format, int unit)
 				printf ("%-10d %-10.10s", shmdsp->shm_perm.id, pw->pw_name);
 			else
 				printf ("%-10d %-10u", shmdsp->shm_perm.id, shmdsp->shm_perm.uid);
-			printf (" %-10u %-10u\n",
+			printf (" %-10d %-10d\n",
 				shmdsp->shm_cprid, shmdsp->shm_lprid);
 			break;
 
@@ -612,7 +612,7 @@ static void print_shm(int shmid, int unit)
 	       shmdata->shm_perm.mode & 0777);
 	ipc_print_size(unit, unit == IPC_UNIT_HUMAN ? _("size=") : _("bytes="),
 		       shmdata->shm_segsz, "\t", 0);
-	printf(_("lpid=%u\tcpid=%u\tnattch=%jd\n"),
+	printf(_("lpid=%d\tcpid=%d\tnattch=%"PRIu64"\n"),
 	       shmdata->shm_lprid, shmdata->shm_cprid,
 	       shmdata->shm_nattch);
 	printf(_("att_time=%-26.24s\n"),
@@ -643,7 +643,7 @@ static void print_msg(int msgid, int unit)
 		       msgdata->q_cbytes, "\t", 0);
 	ipc_print_size(unit, unit == IPC_UNIT_HUMAN ? _("qsize=") : _("qbytes="),
 		       msgdata->q_qbytes, "\t", 0);
-	printf("qnum=%jd\tlspid=%d\tlrpid=%d\n",
+	printf("qnum=%"PRIu64"\tlspid=%d\tlrpid=%d\n",
 	       msgdata->q_qnum,
 	       msgdata->q_lspid, msgdata->q_lrpid);
 	printf(_("send_time=%-26.24s\n"),

--- a/sys-utils/irq-common.c
+++ b/sys-utils/irq-common.c
@@ -184,10 +184,10 @@ static void add_scols_line(struct irq_output *out,
 			xasprintf(&str, "%s", info->irq);
 			break;
 		case COL_TOTAL:
-			xasprintf(&str, "%ld", info->total);
+			xasprintf(&str, "%lu", info->total);
 			break;
 		case COL_DELTA:
-			xasprintf(&str, "%ld", info->delta);
+			xasprintf(&str, "%lu", info->delta);
 			break;
 		case COL_NAME:
 			xasprintf(&str, "%s", info->name);

--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -292,11 +292,11 @@ static int set_scols_data(struct loopdev_cxt *lc, struct libscols_line *ln)
 			break;
 		case COL_OFFSET:
 			if (loopcxt_get_offset(lc, &x) == 0)
-				xasprintf(&np, "%jd", x);
+				xasprintf(&np, "%"PRIu64, x);
 			break;
 		case COL_SIZELIMIT:
 			if (loopcxt_get_sizelimit(lc, &x) == 0)
-				xasprintf(&np, "%jd", x);
+				xasprintf(&np, "%"PRIu64, x);
 			break;
 		case COL_BACK_MAJMIN:
 		{
@@ -361,7 +361,7 @@ static int set_scols_data(struct loopdev_cxt *lc, struct libscols_line *ln)
 			break;
 		case COL_LOGSEC:
 			if (loopcxt_get_blocksize(lc, &x) == 0)
-				xasprintf(&np, "%jd", x);
+				xasprintf(&np, "%"PRIu64, x);
 			break;
 		case COL_REF:
 			np = loopcxt_get_refname(lc);

--- a/sys-utils/lscpu-topology.c
+++ b/sys-utils/lscpu-topology.c
@@ -454,7 +454,7 @@ static int read_caches(struct lscpu_cxt *cxt, struct lscpu_cpu *cpu)
 				"cpu%d/l1_icache_size", num) == 0)
 		return read_sparc_caches(cxt, cpu);
 
-	DBG_OBJ(CPU, cpu, ul_debug("#%d reading %zd caches", num, ncaches));
+	DBG_OBJ(CPU, cpu, ul_debug("#%d reading %zu caches", num, ncaches));
 
 	for (i = 0; i < ncaches; i++) {
 		struct lscpu_cache *ca;

--- a/sys-utils/lsipc.c
+++ b/sys-utils/lsipc.c
@@ -979,10 +979,10 @@ static void do_msg(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 							  (time_t) p->q_rtime));
 				break;
 			case COL_LSPID:
-				rc = scols_line_sprintf(ln, n, "%u", p->q_lspid);
+				rc = scols_line_sprintf(ln, n, "%d", p->q_lspid);
 				break;
 			case COL_LRPID:
-				rc = scols_line_sprintf(ln, n, "%u", p->q_lrpid);
+				rc = scols_line_sprintf(ln, n, "%d", p->q_lrpid);
 				break;
 			}
 			if (rc != 0)
@@ -1294,10 +1294,10 @@ static void do_shm(int id, struct lsipc_control *ctl, struct libscols_table *tb)
 							  (time_t) p->shm_dtim));
 				break;
 			case COL_CPID:
-				rc = scols_line_sprintf(ln, n, "%u", p->shm_cprid);
+				rc = scols_line_sprintf(ln, n, "%d", p->shm_cprid);
 				break;
 			case COL_LPID:
-				rc = scols_line_sprintf(ln, n, "%u", p->shm_lprid);
+				rc = scols_line_sprintf(ln, n, "%d", p->shm_lprid);
 				break;
 			case COL_COMMAND:
 				arg = pid_get_cmdline(p->shm_cprid);

--- a/sys-utils/lsmem.c
+++ b/sys-utils/lsmem.c
@@ -277,7 +277,7 @@ static void add_scols_line(struct lsmem *lsmem, struct memory_block *blk)
 		}
 		case COL_SIZE:
 			if (lsmem->bytes)
-				xasprintf(&str, "%"PRId64, (uint64_t) blk->count * lsmem->block_size);
+				xasprintf(&str, "%"PRIu64, (uint64_t) blk->count * lsmem->block_size);
 			else
 				str = size_to_human_string(SIZE_SUFFIX_1LETTER,
 						(uint64_t) blk->count * lsmem->block_size);
@@ -295,9 +295,9 @@ static void add_scols_line(struct lsmem *lsmem, struct memory_block *blk)
 			break;
 		case COL_BLOCK:
 			if (blk->count == 1)
-				xasprintf(&str, "%"PRId64, blk->index);
+				xasprintf(&str, "%"PRIu64, blk->index);
 			else
-				xasprintf(&str, "%"PRId64"-%"PRId64,
+				xasprintf(&str, "%"PRIu64"-%"PRIu64,
 					 blk->index, blk->index + blk->count - 1);
 			break;
 		case COL_NODE:
@@ -365,9 +365,9 @@ static void print_summary(struct lsmem *lsmem)
 	const char *prefix;
 
 	if (lsmem->bytes) {
-		printf("%-32s %15"PRId64"\n",_("Memory block size:"), lsmem->block_size);
-		printf("%-32s %15"PRId64"\n",_("Total online memory:"), lsmem->mem_online);
-		printf("%-32s %15"PRId64"\n",_("Total offline memory:"), lsmem->mem_offline);
+		printf("%-32s %15"PRIu64"\n",_("Memory block size:"), lsmem->block_size);
+		printf("%-32s %15"PRIu64"\n",_("Total online memory:"), lsmem->mem_online);
+		printf("%-32s %15"PRIu64"\n",_("Total offline memory:"), lsmem->mem_offline);
 	} else {
 		char *p;
 

--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -164,7 +164,7 @@ static void open_target_fd(int *fd, const char *type, const char *path)
 	char pathbuf[PATH_MAX];
 
 	if (!path && namespace_target_pid) {
-		snprintf(pathbuf, sizeof(pathbuf), "/proc/%u/%s",
+		snprintf(pathbuf, sizeof(pathbuf), "/proc/%d/%s",
 			 namespace_target_pid, type);
 		path = pathbuf;
 	}
@@ -431,7 +431,7 @@ static void open_target_sk_netns(int pidfd, int sock_fd)
 
 	sk = pidfd_getfd(pidfd, sock_fd, 0);
 	if (sk < 0)
-		err(EXIT_FAILURE, _("pidfd_getfd(%d, %u)"), pidfd, sock_fd);
+		err(EXIT_FAILURE, _("pidfd_getfd(%d, %d)"), pidfd, sock_fd);
 
 	if (fstat(sk, &sb) < 0)
 		err(EXIT_FAILURE, _("fstat(%d)"), sk);
@@ -516,7 +516,7 @@ static int is_usable_namespace(pid_t target, const struct namespace_file *nsfile
 	int rc;
 
 	/* Check NS accessibility */
-	snprintf(path, sizeof(path), "/proc/%u/%s", getpid(), nsfile->name);
+	snprintf(path, sizeof(path), "/proc/%d/%s", getpid(), nsfile->name);
 	rc = get_ns_ino(path, &my_ino);
 	if (rc == -ENOENT)
 		return false; /* Unsupported NS */
@@ -527,7 +527,7 @@ static int is_usable_namespace(pid_t target, const struct namespace_file *nsfile
 	if (nsfile->nstype & CLONE_NEWUSER) {
 		ino_t target_ino = 0;
 
-		snprintf(path, sizeof(path), "/proc/%u/%s", target, nsfile->name);
+		snprintf(path, sizeof(path), "/proc/%d/%s", target, nsfile->name);
 		if (get_ns_ino(path, &target_ino) != 0)
 			err(EXIT_FAILURE, _("stat of %s failed"), path);
 

--- a/sys-utils/rfkill.c
+++ b/sys-utils/rfkill.c
@@ -553,7 +553,7 @@ static int __rfkill_block(int fd, struct rfkill_id *id, uint8_t block, const cha
 	case RFKILL_IS_INDEX:
 		event.op = RFKILL_OP_CHANGE;
 		event.idx = id->index;
-		xasprintf(&message, "id %d", id->index);
+		xasprintf(&message, "id %"PRIu32, id->index);
 		break;
 	case RFKILL_IS_ALL:
 		message = xstrdup("all");

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -561,7 +561,7 @@ int main(int argc, char **argv)
 
 	if (ctl.verbose)
 		printf(_("alarm %"PRId64", sys_time %"PRId64", "
-			 "rtc_time %"PRId64", seconds %"PRIu64"\n"),
+			 "rtc_time %"PRId64", seconds %"PRId64"\n"),
 				(int64_t) alarm, (int64_t) ctl.sys_time,
 				(int64_t) ctl.rtc_time,
 				(int64_t) seconds);

--- a/sys-utils/swapon.c
+++ b/sys-utils/swapon.c
@@ -558,7 +558,7 @@ static int swapon_checks(const struct swapon_ctl *ctl, struct swap_device *dev)
 				~permMask & 0666);
 
 	if (S_ISREG(st.st_mode) && st.st_uid != 0)
-		warnx(_("%s: insecure file owner %d, 0 (root) suggested."),
+		warnx(_("%s: insecure file owner %u, 0 (root) suggested."),
 				dev->path, st.st_uid);
 
 	/* test for holes by LBT */
@@ -583,7 +583,7 @@ static int swapon_checks(const struct swapon_ctl *ctl, struct swap_device *dev)
 	}
 
 	if (ctl->verbose)
-		warnx(_("%s: found signature [pagesize=%d, signature=%s]"),
+		warnx(_("%s: found signature [pagesize=%u, signature=%s]"),
 			dev->path,
 			dev->pagesize,
 			sig == SIG_SWAPSPACE ? "swap" :
@@ -594,7 +594,7 @@ static int swapon_checks(const struct swapon_ctl *ctl, struct swap_device *dev)
 		int syspg = getpagesize();
 
 		if (ctl->verbose)
-			warnx(_("%s: pagesize=%d, swapsize=%llu, devsize=%llu"),
+			warnx(_("%s: pagesize=%u, swapsize=%llu, devsize=%llu"),
 				dev->path, dev->pagesize, swapsize, devsize);
 
 		if (swapsize > devsize) {

--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -409,7 +409,7 @@ static struct map_range read_subid_range(char *filename, uid_t uid, int identity
 
 	pw = xgetpwuid(uid, &pwbuf);
 	if (!pw)
-		errx(EXIT_FAILURE, _("you (user %d) don't exist."), uid);
+		errx(EXIT_FAILURE, _("you (user %u) don't exist."), uid);
 
 	idmap = fopen(filename, "r");
 	if (!idmap)
@@ -612,7 +612,7 @@ map_ids_external(const char *idmapper, int ppid, struct map_range *chain)
 		length += 3;
 	argv = xcalloc(length, sizeof(*argv));
 	argv[i++] = xstrdup(idmapper);
-	xasprintf(&argv[i++], "%u", ppid);
+	xasprintf(&argv[i++], "%d", ppid);
 
 	for (struct map_range *map = chain; map; map = map->next) {
 		xasprintf(&argv[i++], "%u", map->inner);
@@ -640,7 +640,7 @@ static void map_ids_internal(const char *type, int ppid, struct map_range *chain
 	unsigned int length = 0;
 	char buffer[4096], *path;
 
-	xasprintf(&path, "/proc/%u/%s", ppid, type);
+	xasprintf(&path, "/proc/%d/%s", ppid, type);
 	for (struct map_range *map = chain; map; map = map->next) {
 		count = snprintf(buffer + length, sizeof(buffer) - length,
 				 "%u %u %u\n",

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -485,7 +485,7 @@ static ssize_t log_write(struct script_control *ctl,
 
 		gettime_monotonic(&now);
 		timersub(&now, &log->oldtime, &delta);
-		ssz = fprintf(log->fp, "%"PRId64".%06"PRId64" %zd\n",
+		ssz = fprintf(log->fp, "%"PRId64".%06"PRId64" %zu\n",
 			(int64_t)delta.tv_sec, (int64_t)delta.tv_usec, bytes);
 		if (ssz < 0)
 			return -errno;
@@ -498,7 +498,7 @@ static ssize_t log_write(struct script_control *ctl,
 
 		gettime_monotonic(&now);
 		timersub(&now, &log->oldtime, &delta);
-		ssz = fprintf(log->fp, "%c %"PRId64".%06"PRId64" %zd\n",
+		ssz = fprintf(log->fp, "%c %"PRId64".%06"PRId64" %zu\n",
 			stream->ident,
 			(int64_t)delta.tv_sec, (int64_t)delta.tv_usec, bytes);
 		if (ssz < 0)

--- a/tests/helpers/test_mbsencode.c
+++ b/tests/helpers/test_mbsencode.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
 		size_t width;
 		char *res;
 		res = encode_fn(argv[i], &width);
-		printf("%zi %s\n", width, res);
+		printf("%zu %s\n", width, res);
 		free(res);
 	}
 

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -3127,7 +3127,7 @@ static void map_root_user(uid_t uid, uid_t gid)
 	int mapfd;
 	int r;
 
-	n = snprintf(buf, sizeof(buf), "0 %d 1", uid);
+	n = snprintf(buf, sizeof(buf), "0 %u 1", uid);
 	mapfd = open("/proc/self/uid_map", O_WRONLY);
 	if (mapfd < 0)
 		err(EXIT_FAILURE,
@@ -3154,7 +3154,7 @@ static void map_root_user(uid_t uid, uid_t gid)
 		     "failed to write to /proc/self/setgroups");
 	close(mapfd);
 
-	n = snprintf(buf, sizeof(buf), "0 %d 1", gid);
+	n = snprintf(buf, sizeof(buf), "0 %u 1", gid);
 	mapfd = open("/proc/self/gid_map", O_WRONLY);
 	if (mapfd < 0)
 		err(EXIT_FAILURE,


### PR DESCRIPTION
Use required formatters for given data types (signedness).

This is the easiest part of a patch series to fix all `-Wformat-signedness` issues within util-linux. No casts are introduced, no data types are modified. Except one test tool, no scanf formatters are adjusted.

Compile-tested on 32 bit as well just to make sure.