### PR TITLE
lib/pager: Fix SIGPIPE handling

### DIFF
--- a/lib/pager.c
+++ b/lib/pager.c
@@ -120,21 +120,22 @@ static int start_command(struct child_process *cmd)
 static int wait_for_pager(void)
 {
 	pid_t waiting;
-	int status;
+	int ret, status;
 
 	do {
 		waiting = waitpid(pager_process.pid, &status, 0);
 	} while (waiting == -1 && errno == EINTR);
 
+	if (waiting == -1)
+		ret = -1;
+	else if (waiting == pager_process.pid && WIFEXITED(status))
+		ret = WEXITSTATUS(status);
+	else
+		ret = 1;
+
 	pager_process.pid = 0;
 
-	if (waiting == -1)
-		return -1;
-
-	if (waiting == pager_process.pid && WIFEXITED(status))
-		return WEXITSTATUS(status);
-
-	return 1;
+	return ret;
 }
 
 static void catch_signal(int signo)


### PR DESCRIPTION
Reset the child pid only after comparison with waitpid result. Currently, this leads to returning -1 or 1, which ultimately leads to exit code 1 in case of a SIGPIPE. This is the behavior as of 2.41, which means that no regression between releases occurred. Yet, fix it nonetheless.

Proof of Concept:
1. Provoke a SIGPIPE by running the following command, immediately pressing `q`
```
strace -f dmesg -H
```
2. Check exit code
```
+++ exited with 1 +++
```
The exit code should be 0, not 1.