### PR TITLE
sys-utils: fix overflow in switch statement

### DIFF
--- a/sys-utils/blkpr.c
+++ b/sys-utils/blkpr.c
@@ -269,7 +269,7 @@ static int do_pr(char *path, uint64_t key, uint64_t oldkey, int op, int type, in
 	if (fd < 0)
 		err(EXIT_FAILURE, _("cannot open %s"), path);
 
-	switch (op) {
+	switch ((int64_t)op) {
 	case IOC_PR_REGISTER:
 		pr_reg.old_key = oldkey;
 		pr_reg.new_key = key;


### PR DESCRIPTION
IOC_PR_READ_KEYS and IOC_PR_READ_RESERVATION
has greater values than INT_MAX, so extend `switch` variable to wider type