### PR TITLE
last: Improve max records parsing

### DIFF
--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -1060,7 +1060,7 @@ int main(int argc, char **argv)
 			ctl.extended = 1;
 			break;
 		case 'n':
-			ctl.maxrecs = strtos32_or_err(optarg, _("failed to parse number"));
+			ctl.maxrecs = strtou32_or_err(optarg, _("failed to parse number"));
 			break;
 		case 'f':
 			if (!files)


### PR DESCRIPTION
The maximum amount of records to print can be specified in two different ways: Either with `-n`/`--limit` or by specifying the number as argument, i.e. `-number`.

The current parser does not check for possible overflow with `-number` arguments and mixes `-number` arguments with `-n` arguments.

Properly split these two notations and use `strtou32_or_err` for overflow checks. And, while at it, also for `-n` arguments.

Some examples:
```
# prints 104 entries
last -n 10 -4
# prints 10
last -n 10
# prints 10
last -4 -n 10
# prints 12 entries
last -1 -2
# prints 12 entries
last -12
# prints 12 entries
last -1a2
# overflows -n and prints 11 entries
last -n -2147483647 -1
```

This PR puts `-number` and `-n` on same priority, i.e. the last one overrides the former. Arguments like `1a2` lead to `2` because the parser stops whenever a non-digit is encountered. `-1 -2` also leads to `2` because the parser stops at the end of an argument.

The only downside is that in case of an overflow, the error message looks a bit off:
```
last -12345678901234567890
```
```
last: failed to parse number: '123456789012345': Numerical result out of range
```
This happens because I need a temporary buffer to hold the characters of these arguments. I think it's still a good trade-off between keeping the `getopt` logic intact and bending this "let's concatenate single arguments into a larger meaning" idea into manageable code.