### PR TITLE
libblkid: Ignore secondary LUKS2 header in blkid_do_safeprobe()

### DIFF
--- a/libblkid/src/blkidP.h
+++ b/libblkid/src/blkidP.h
@@ -245,6 +245,7 @@ struct blkid_struct_probe
 
 /* private per-probing flags */
 #define BLKID_PROBE_FL_IGNORE_PT (1 << 1)	/* ignore partition table */
+#define BLKID_PROBE_FL_SAFEPROBE (1 << 2)	/* safeprobe mode */
 
 extern blkid_probe blkid_clone_probe(blkid_probe parent);
 extern blkid_probe blkid_probe_get_wholedisk_probe(blkid_probe pr);

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -1809,6 +1809,7 @@ int blkid_do_safeprobe(blkid_probe pr)
 		return BLKID_PROBE_NONE;
 
 	blkid_probe_start(pr);
+	pr->prob_flags |= BLKID_PROBE_FL_SAFEPROBE;
 
 	for (i = 0; i < BLKID_NCHAINS; i++) {
 		struct blkid_chain *chn;

--- a/libblkid/src/superblocks/luks.c
+++ b/libblkid/src/superblocks/luks.c
@@ -126,16 +126,19 @@ static int probe_luks(blkid_probe pr, const struct blkid_idmag *mag __attribute_
 		return luks_attributes(pr, header, 0);
 	}
 
-	/* No primary header, scan for known offsets of LUKS2 secondary header. */
-	for (i = 0; i < ARRAY_SIZE(secondary_offsets); i++) {
-		header = (struct luks2_phdr *) blkid_probe_get_buffer(pr,
-			  secondary_offsets[i], sizeof(struct luks2_phdr));
 
-		if (!header)
-			return errno ? -errno : BLKID_PROBE_NONE;
+	/* No primary header, scan for known offsets of LUKS2 secondary header unless this is a safeprobe */
+	if (!(pr->prob_flags & BLKID_PROBE_FL_SAFEPROBE)) {
+		for (i = 0; i < ARRAY_SIZE(secondary_offsets); i++) {
+			header = (struct luks2_phdr *) blkid_probe_get_buffer(pr,
+				  secondary_offsets[i], sizeof(struct luks2_phdr));
 
-		if (luks_valid(header, LUKS_MAGIC_2, secondary_offsets[i]))
-			return luks_attributes(pr, header, secondary_offsets[i]);
+			if (!header)
+				return errno ? -errno : BLKID_PROBE_NONE;
+
+			if (luks_valid(header, LUKS_MAGIC_2, secondary_offsets[i]))
+				return luks_attributes(pr, header, secondary_offsets[i]);
+		}
 	}
 
 	return BLKID_PROBE_NONE;


### PR DESCRIPTION
The secondary LUKS2 header can match file data content on other filesystems (e.g. an image file of a LUKS2 device stored on XFS whose data blocks happen to land at device offsets where blkid looks for the secondary LUKS2 header). This causes blkid to report a crypto_LUKS superblock instead of the real filesystem.

Add a new flag BLKID_PROBE_FL_SAFEPROBE and skip scanning for the secondary LUKS2 header in blkid_do_safeprobe(). The secondary LUKS2 header is only important for wipefs which uses a promiscuous probe.

I've tested that this fix works and allows blkid to correctly detect my XFS filesystem again:
```
$ blkid /dev/sde1
/dev/sde1: UUID="c7d586b5-8bd3-4f78-909e-4741104fcf8c" TYPE="crypto_LUKS" PARTUUID="5d9b5f5d-fc1b-e54c-a0eb-5dd00f9143b9"
$ LD_LIBRARY_PATH=~/util-linux-patched/.libs/ ~/util-linux-patched/blkid /dev/sde1
/dev/sde1: LABEL="backup-disk" UUID="c1645bce-0eb1-4a35-a843-8c7b6d17d26c" BLOCK_SIZE="4096" TYPE="xfs" PARTUUID="5d9b5f5d-fc1b-e54c-a0eb-5dd00f9143b9"

```
Nevertheless, please review this change thoroughly as I'm not a C developer.

Fixes: #4170
Fixes: 8bee1a2
Tested-by: Timo Sigurdsson <public_timo.s@silentcreek.de>