### PR TITLE
eject: tolerate ILLEGAL REQUEST on ALLOW_MEDIUM_REMOVAL

### DIFF
--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -597,7 +597,17 @@ static int eject_scsi(const struct eject_control *ctl)
 
 	io_hdr.cmdp = allowRmBlk;
 	status = ioctl(ctl->fd, SG_IO, (void *)&io_hdr);
-	if (status < 0 || io_hdr.host_status || io_hdr.driver_status)
+	if (status < 0 || io_hdr.host_status)
+		return 0;
+
+	/*
+	 * Ignore ILLEGAL REQUEST -- the device does not support
+	 * ALLOW_MEDIUM_REMOVAL, but it may still support START_STOP
+	 * for eject (e.g. USB mass storage devices).
+	 */
+	if (io_hdr.driver_status != 0 &&
+	    !(io_hdr.driver_status == DRIVER_SENSE && io_hdr.sbp &&
+		                             (io_hdr.sbp[2] & 0x0f) == ILLEGAL_REQUEST))
 		return 0;
 
 	io_hdr.cmdp = startStop1Blk;


### PR DESCRIPTION
Some USB devices using the UAS driver do not support the SCSI
ALLOW_MEDIUM_REMOVAL command and return ILLEGAL REQUEST (sense key 0x05).
Previously, eject_scsi() treated any non-zero driver_status as fatal,
aborting before attempting START_STOP.

Now, when the device reports DRIVER_SENSE with sense key ILLEGAL REQUEST,
we continue to the START_STOP eject commands instead of bailing out.


Addresses: https://github.com/util-linux/util-linux/issues/4125