### PR TITLE
build: Fix asciidoctor error and warnings

### DIFF
--- a/disk-utils/fsck.minix.8.adoc
+++ b/disk-utils/fsck.minix.8.adoc
@@ -31,10 +31,10 @@ The _device_ name will usually have the following form:
 ____
 [cols=",",]
 |===
-|/dev/hda[1-63] |IDE disk 1
-|/dev/hdb[1-63] |IDE disk 2
-|/dev/sda[1-15] |SCSI disk 1
-|/dev/sdb[1-15] |SCSI disk 2
+| /dev/hda[1-63] | IDE disk 1
+| /dev/hdb[1-63] | IDE disk 2
+| /dev/sda[1-15] | SCSI disk 1
+| /dev/sdb[1-15] | SCSI disk 2
 |===
 ____
 

--- a/po-man/po4a.cfg
+++ b/po-man/po4a.cfg
@@ -172,10 +172,12 @@
 
 [type:asciidoc] ../liblastlog2/man/lastlog2.3.adoc                $lang:$lang/lastlog2.3.adoc
 [type:asciidoc] ../liblastlog2/man/ll2_import_lastlog.3.adoc      $lang:$lang/ll2_import_lastlog.3.adoc
+[type:asciidoc] ../liblastlog2/man/ll2_new_context.3.adoc         $lang:$lang/ll2_new_context.3.adoc
 [type:asciidoc] ../liblastlog2/man/ll2_read_all.3.adoc            $lang:$lang/ll2_read_all.3.adoc
 [type:asciidoc] ../liblastlog2/man/ll2_read_entry.3.adoc          $lang:$lang/ll2_read_entry.3.adoc
 [type:asciidoc] ../liblastlog2/man/ll2_remove_entry.3.adoc        $lang:$lang/ll2_remove_entry.3.adoc
 [type:asciidoc] ../liblastlog2/man/ll2_rename_user.3.adoc         $lang:$lang/ll2_rename_user.3.adoc
+[type:asciidoc] ../liblastlog2/man/ll2_unref_context.3.adoc       $lang:$lang/ll2_unref_context.3.adoc
 [type:asciidoc] ../liblastlog2/man/ll2_update_login_time.3.adoc   $lang:$lang/ll2_update_login_time.3.adoc
 [type:asciidoc] ../liblastlog2/man/ll2_write_entry.3.adoc         $lang:$lang/ll2_write_entry.3.adoc
 [type:asciidoc] ../pam_lastlog2/man/pam_lastlog2.8.adoc           $lang:$lang/pam_lastlog2.8.adoc


### PR DESCRIPTION
A local build with asciidoctor 2.0.26 triggers an error message for fsck.minix' manual page. Also, two manual pages which I recently linked into the build lacked translation entries, leading to warnings.

Fix both issues.