### PR TITLE
libblkid: Fix `%.*s` typo leading to out of boundary access with debug messages

### DIFF
--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -2020,9 +2020,9 @@ int blkid_probe_set_magic(blkid_probe pr, uint64_t offset,
 static void blkid_probe_log_csum_mismatch(blkid_probe pr, size_t n, const void *csum,
 		const void *expected)
 {
-	char csum_hex[256];
-	char expected_hex[sizeof(csum_hex)];
-	int hex_size = min(sizeof(csum_hex), n * 2);
+	char csum_hex[256 + 1] = "";
+	char expected_hex[sizeof(csum_hex)] = "";
+	int hex_size = min(sizeof(csum_hex) - 1, n * 2);
 
 	for (int i = 0; i < hex_size; i+=2) {
 		snprintf(&csum_hex[i], sizeof(csum_hex) - i, "%02X", ((const unsigned char *) csum)[i / 2]);
@@ -2031,9 +2031,9 @@ static void blkid_probe_log_csum_mismatch(blkid_probe pr, size_t n, const void *
 
 	DBG(LOWPROBE, ul_debug(
 		"incorrect checksum for type %s,"
-		" got %*s, expected %*s",
+		" got %s, expected %s",
 		blkid_probe_get_probername(pr),
-		hex_size, csum_hex, hex_size, expected_hex));
+		csum_hex, expected_hex));
 }
 
 

--- a/libblkid/src/read.c
+++ b/libblkid/src/read.c
@@ -187,8 +187,12 @@ static int parse_dev(blkid_cache cache, blkid_dev *dev, char **cp)
 	start = skip_over_blank(start + 1);
 	end = skip_over_word(start);
 
-	DBG(READ, ul_debug("device should be %*s",
-			       (int)(end - start), start));
+	ON_DBG(READ, {
+		char c = *end;
+		*end = '\0';
+		ul_debug("device should be %s", start);
+		*end = c;
+	});
 
 	if (**cp == '>')
 		*cp = end;

--- a/libblkid/src/superblocks/zfs.c
+++ b/libblkid/src/superblocks/zfs.c
@@ -223,7 +223,7 @@ static bool zfs_extract_guid_name(blkid_probe pr, void *buf, size_t size, bool f
 				       size, nvp_size));
 
 		/* nvpair fits in buffer and name fits in nvpair? */
-		if (nvp_size > size || namesize + sizeof(*nvp) > nvp_size)
+		if (nvp_size > size || namesize + sizeof(*nvp) + 4 > nvp_size)
 			return (false);
 
 		DBG(LOWPROBE,

--- a/libblkid/src/superblocks/zfs.c
+++ b/libblkid/src/superblocks/zfs.c
@@ -303,7 +303,7 @@ static int probe_zfs(blkid_probe pr,
 #else
 	int host_endian = 0;
 #endif
-	int swab_endian = 0;
+	int swap_endian = 0;
 	loff_t offset = 0;
 	int label_no;
 	struct nvs_header_t *label = NULL;
@@ -336,7 +336,7 @@ static int probe_zfs(blkid_probe pr,
 			continue;
 
 		if (host_endian != label->nvh_endian)
-			swab_endian = 1;
+			swap_endian = 1;
 
 		if (zfs_extract_guid_name(pr, label, VDEV_PHYS_SIZE, true)) {
 			found_label = true;
@@ -356,7 +356,7 @@ static int probe_zfs(blkid_probe pr,
 	    (unsigned char *) label))
 		return (1);
 
-	blkid_probe_set_fsendianness(pr, !swab_endian ?
+	blkid_probe_set_fsendianness(pr, !swap_endian ?
 			BLKID_ENDIANNESS_NATIVE : BLKID_ENDIANNESS_OTHER);
 
 	return (0);

--- a/libblkid/src/superblocks/zfs.c
+++ b/libblkid/src/superblocks/zfs.c
@@ -115,8 +115,8 @@ static bool zfs_process_value(blkid_probe pr, const char *name, size_t namelen,
 		if ((uint64_t)nvs_strlen + sizeof(*nvs) > max_value_size)
 			return (false);
 
-		DBG(LOWPROBE, ul_debug("nvstring: type %u string %*s",
-				       type, nvs_strlen, nvs->nvs_string));
+		DBG(LOWPROBE, ul_debug("nvstring: type %u string %.*s",
+				       type, (int)nvs_strlen, nvs->nvs_string));
 
 		blkid_probe_set_label(pr, nvs->nvs_string, nvs_strlen);
 		(*found)++;
@@ -227,8 +227,8 @@ static bool zfs_extract_guid_name(blkid_probe pr, void *buf, size_t size, bool f
 			return (false);
 
 		DBG(LOWPROBE,
-		    ul_debug("nvlist: size %u, namelen %u, name %*s",
-			     nvp_size, nvp_namelen, nvp_namelen,
+		    ul_debug("nvlist: size %u, namelen %u, name %.*s",
+			     nvp_size, nvp_namelen, (int)nvp_namelen,
 			     nvp->nvp_name));
 
 		max_value_size = nvp_size - (namesize + sizeof(*nvp));


### PR DESCRIPTION
In libblkid, typos exist in the `%s` formatter. While precision (`%.*s`) is meant, field width (`%*s`) is in use.

Two cases are harmless (one cannot be triggered, in the other case too much data is printed), but the ZFS detection code can lead to an out of boundary access.

Fix all these cases by trying to avoid any form of `%s` modification and do a proper cast if it cannot be avoided.

While at it, fixed an out of boundary access in ZFS which is only out of boundary in logical sense, not technical. Also, a typo.

Proof of Concept:
1. Create a 128 MB image with required ZFS signature and a non-terminated string
```
dd if=/dev/zero bs=1024 count=131072 | tr '\0' 'A' > zfs.iso
echo -n AQAAAAAAAAAAAAAAAAG/9AAAAAAAAAAA | base64 -d |
dd of=zfs.iso bs=1 count=24 seek=133971968 conv=notrunc
```
2. Setup file as loop device
```
losetup -f zfs.iso
```
2. Try to open the loop device with cfdisk
```
LIBBLKID_DEBUG=all cfdisk /dev/loop0
```
```
Segmentation fault         (core dumped) LIBBLKID_DEBUG=all cfdisk /dev/loop0
```