### PR TITLE
irqtop: improve printing on screen and portability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1223,6 +1223,10 @@ AS_IF([test "x$have_slang" = xyes || test "x$have_ncursesw" = xyes || test "x$ha
 		     AC_DEFINE(HAVE_RESIZETERM, 1,
 			       [Define if curses library has the resizeterm().])
 	])
+	AC_CHECK_LIB([$CURSES_LIB_NAME], vw_printw, [
+		     AC_DEFINE(HAVE_VW_PRINTW, 1,
+			       [Define if curses library has the vw_printw().])
+	])
 ])
 
 

--- a/meson.build
+++ b/meson.build
@@ -320,6 +320,8 @@ foreach curses_libs : [lib_slang, lib_ncursesw, lib_ncurses]
     conf.set('HAVE_USE_DEFAULT_COLORS', have ? 1 : false)
     have = cc.has_function('resizeterm', dependencies : curses_libs)
     conf.set('HAVE_RESIZETERM', have ? 1 : false)
+    have = cc.has_function('vw_printw', dependencies : curses_libs)
+    conf.set('HAVE_VW_PRINTW', have ? 1 : false)
     break
   endif
 endforeach

--- a/sys-utils/irqtop.c
+++ b/sys-utils/irqtop.c
@@ -101,6 +101,22 @@ static inline int vw_printw(WINDOW *win, const char *fmt, va_list args)
 }
 #endif
 
+/* Write pre-formatted data to the screen, followed by @nl newlines */
+static inline void irqtop_puts(struct irqtop_ctl *ctl, const char *data, int nl)
+{
+	if (ctl->batch) {
+		fputs(data, stdout);
+		while (nl--)
+			fputc('\n', stdout);
+	} else {
+		waddstr(ctl->win, (char *) data);
+		while (nl--)
+			waddch(ctl->win, '\n');
+		wrefresh(ctl->win);
+	}
+}
+
+/* Write formatted output to the screen */
 static inline int irqtop_printf(struct irqtop_ctl *ctl, const char *fmt, ...)
 {
 	int ret = 0;
@@ -184,7 +200,7 @@ static int update_screen(struct irqtop_ctl *ctl, struct irq_output *out)
 	if (cpus) {
 		scols_print_table_to_string(cpus, &data);
 		if (data && *data)
-			irqtop_printf(ctl, "%s\n\n", data);
+			irqtop_puts(ctl, data, 2);
 		free(data);
 	}
 
@@ -199,14 +215,14 @@ static int update_screen(struct irqtop_ctl *ctl, struct irq_output *out)
 		*p = '\0';
 		if (!ctl->batch)
 			attron(A_REVERSE);
-		irqtop_printf(ctl, "%s\n", data);
+		irqtop_puts(ctl, data, 1);
 		if (!ctl->batch)
 			attroff(A_REVERSE);
 		data = p + 1;
 	}
 
 	if (data && *data)
-		irqtop_printf(ctl, "%s\n\n", data);
+		irqtop_puts(ctl, data, 2);
 	free(data0);
 
 	/* clean up */

--- a/sys-utils/irqtop.c
+++ b/sys-utils/irqtop.c
@@ -86,6 +86,21 @@ struct irqtop_ctl {
 		softirq;
 };
 
+#ifndef OK
+# define OK 0
+#endif
+
+#ifndef HAVE_VW_PRINTW
+static inline int vw_printw(WINDOW *win, const char *fmt, va_list args)
+{
+	char buf[BUFSIZ];
+
+	if (vsnprintf(buf, sizeof(buf), fmt, args) < 0)
+		return ERR;
+	return waddstr(win, buf);
+}
+#endif
+
 static inline int irqtop_printf(struct irqtop_ctl *ctl, const char *fmt, ...)
 {
 	int ret = 0;


### PR DESCRIPTION
  Fixes #4177                                                                                           
                                                                                                        
  The `vw_printw()` function and `OK` macro are ncurses-specific and                                    
  not available in slang's curses compatibility layer, causing build                                    
  failures.                                                                                             
                                                                                                        
  - Add configure/meson checks for `vw_printw()` availability                                           
    (`HAVE_VW_PRINTW`) and provide a portable fallback using                                            
    `vsnprintf()` + `waddstr()`                                                                         
  - Define `OK` when not provided by the curses library                                                 
  - Introduce `irqtop_puts()` for pre-formatted table data output,                                      
    avoiding unnecessary printf formatting and extra buffer allocation                          