### PR TITLE
lib: use _() instead of N_() in err() calls

### DIFF
--- a/lib/pidfd-utils.c
+++ b/lib/pidfd-utils.c
@@ -41,7 +41,7 @@ uint64_t pidfd_get_inode(int pidfd)
 	rc = statx(pidfd, "", AT_EMPTY_PATH, STATX_INO, &stx);
 	if (rc < 0) {
 		close(pidfd);
-		err(EXIT_FAILURE, N_("failed to statx() pidfd"));
+		err(EXIT_FAILURE, _("failed to statx() pidfd"));
 	}
 	return stx.stx_ino;
 }
@@ -72,7 +72,7 @@ int ul_get_valid_pidfd_or_err(pid_t pid, uint64_t pidfd_ino __attribute__((__unu
 
 	pfd = ul_get_valid_pidfd(pid, pidfd_ino);
 	if (pfd < 0)
-		err(EXIT_FAILURE, N_("failed to obtain a valid file descriptor for PID %d"), pid);
+		err(EXIT_FAILURE, _("failed to obtain a valid file descriptor for PID %d"), pid);
 
 	return pfd;
 }

--- a/lib/pidutils.c
+++ b/lib/pidutils.c
@@ -85,7 +85,7 @@ int ul_parse_pid_str(char *pidstr, pid_t *pid_num, uint64_t *pfd_ino, int flags)
 void ul_parse_pid_str_or_err(char *pidstr, pid_t *pid_num, uint64_t *pfd_ino, int flags)
 {
 	if (ul_parse_pid_str(pidstr, pid_num, pfd_ino, flags) < 0) {
-		err(EXIT_FAILURE, N_("failed to parse PID argument '%s'"), pidstr);
+		err(EXIT_FAILURE, _("failed to parse PID argument '%s'"), pidstr);
 	}
 }
 


### PR DESCRIPTION
N_() only marks a string for translation extraction but does not translate at runtime. Use _() to ensure the error messages are actually translated when displayed.