### PR TITLE
build: Fix --disable-copyfilerange

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2674,8 +2674,7 @@ AC_ARG_ENABLE([copyfilerange],
   AS_HELP_STRING([--disable-copyfilerange], [do not build copyfilerange]),
   [], [UL_DEFAULT_ENABLE([copyfilerange], [check])]
 )
-
-UL_BUILD_INIT([copyfilerange], [check])
+UL_BUILD_INIT([copyfilerange])
 UL_REQUIRES_LINUX([copyfilerange])
 UL_REQUIRES_SYSCALL_CHECK([copyfilerange], [UL_CHECK_SYSCALL([copy_file_range])], [copy_file_range])
 AM_CONDITIONAL([BUILD_COPYFILERANGE], [test "x$build_copyfilerange" = xyes])


### PR DESCRIPTION
The --disable-copyfilerange flag is overridden by BUILD_INIT, because it's given a second argument.

Remove it to make copyfilerange an option tool (built by default) as intended.