### PR TITLE
man: Unify SEE ALSO sections

### DIFF
--- a/misc-utils/findmnt.8.adoc
+++ b/misc-utils/findmnt.8.adoc
@@ -260,7 +260,7 @@ mailto:kzak@redhat.com[Karel Zak]
 == SEE ALSO
 
 *fstab*(5),
-*mount*(8)
+*mount*(8),
 *scols-filter*(5)
 
 include::man-common/bugreports.adoc[]

--- a/misc-utils/getino.1.adoc
+++ b/misc-utils/getino.1.adoc
@@ -82,7 +82,9 @@ mailto:cgoesc2@wgu.edu[Christian Goeschel Ndjomouo]
 
 == SEE ALSO
 
-*kill*(1) *pidfd_open(2)* *namespaces(7)*
+*kill*(1),
+*pidfd_open*(2),
+*namespaces*(7)
 
 include::man-common/bugreports.adoc[]
 

--- a/misc-utils/lsblk.8.adoc
+++ b/misc-utils/lsblk.8.adoc
@@ -253,7 +253,7 @@ mailto:kzak@redhat.com[Karel Zak]
 == SEE ALSO
 
 *blkid*(8),
-*findmnt*(8)
+*findmnt*(8),
 *ls*(1),
 *scols-filter*(5)
 

--- a/misc-utils/waitpid.1.adoc
+++ b/misc-utils/waitpid.1.adoc
@@ -60,7 +60,9 @@ mailto:thomas@t-8ch.de[Thomas Weißschuh]
 
 == SEE ALSO
 
-*waitpid*(2) *wait*(1P) *getino*(1)
+*waitpid*(2),
+*wait*(1P),
+*getino*(1)
 
 include::man-common/bugreports.adoc[]
 

--- a/pam_lastlog2/man/pam_lastlog2.8.adoc
+++ b/pam_lastlog2/man/pam_lastlog2.8.adoc
@@ -67,7 +67,10 @@ It is up to the administrator to decide if the user can login (optional/required
 
 == SEE ALSO
 
-*liblastlog2*(3), *pam.conf*(5), *pam.d*(5), *pam*(8)
+*liblastlog2*(3),
+*pam.conf*(5),
+*pam.d*(5),
+*pam*(8)
 
 include::man-common/bugreports.adoc[]
 

--- a/schedutils/coresched.1.adoc
+++ b/schedutils/coresched.1.adoc
@@ -115,6 +115,7 @@ mailto:pauld@redhat.com[Phil Auld]
 Copyright {copyright} 2024 Thijs Raymakers and Phil Auld. This is free software licensed under the EUPL.
 
 == SEE ALSO
+
 *chrt*(1),
 *nice*(1),
 *renice*(1),

--- a/sys-utils/setarch.8.adoc
+++ b/sys-utils/setarch.8.adoc
@@ -104,7 +104,7 @@ mailto:kzak@redhat.com[Karel Zak]
 == SEE ALSO
 
 *personality*(2),
-*select*(2)
+*select*(2),
 *proc_pid_personality(5)
 
 include::man-common/bugreports.adoc[]


### PR DESCRIPTION
- Manual pages are separated by comma
- Sections are not bold
- One entry per line

Inspired by changes in https://github.com/util-linux/util-linux/pull/4219 (thus, `kill` manual page not included to avoid merge conflicts).