### PR TITLE
autotools: Fix setpriv build with econf

### DIFF
--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -599,4 +599,7 @@ if HAVE_LINUX_LANDLOCK_H
 setpriv_SOURCES += sys-utils/setpriv-landlock.c
 endif
 setpriv_LDADD = $(LDADD) -lcap-ng libcommon.la
+if HAVE_ECONF
+setpriv_LDADD += $(ECONF_LIBS)
 endif
+endif # BUILD_SETPRIV


### PR DESCRIPTION
Link setpriv with libeconf if used due to its usage in lib/logindefs.c.

Fixes: https://github.com/util-linux/util-linux/issues/4217