### PR TITLE
meson: test for statx::stx_mnt_id in sys/stat.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -111,7 +111,7 @@ conf.set('HAVE_MOUNTFD_API', have_mountfd_api ? 1 : false)
 have_struct_statx = cc.has_type('struct statx', args : '-D_GNU_SOURCE', prefix : '#include <sys/stat.h>')
 conf.set('HAVE_STRUCT_STATX', have_struct_statx ? 1 : false)
 have = cc.has_member('struct statx', 'stx_mnt_id',
-                     prefix : '#include <linux/stat.h>')
+                     prefix : '#include <sys/stat.h>')
 conf.set('HAVE_STRUCT_STATX_STX_MNT_ID', have ? 1 : false)
 
 


### PR DESCRIPTION
Both the check for the general availability of 'struct statx' and the code actual code use sys/stat.h and not linux/stat.h.

The test for stx_mnt_id also needs to test in sys/stat.h as otherwise the detection result is wrong.

This should be backported.