### PR TITLE
Fix `optarg` memory management

### DIFF
--- a/lib/cpuset.c
+++ b/lib/cpuset.c
@@ -395,10 +395,10 @@ int main(int argc, char *argv[])
 			ncpus = atoi(optarg);
 			break;
 		case 'm':
-			mask = strdup(optarg);
+			mask = optarg;
 			break;
 		case 'r':
-			range = strdup(optarg);
+			range = optarg;
 			break;
 		default:
 			goto usage_err;
@@ -435,8 +435,6 @@ int main(int argc, char *argv[])
 	printf("[%s]\n", cpulist_create(buf, buflen, set, setsize));
 
 	free(buf);
-	free(mask);
-	free(range);
 	cpuset_free(set);
 
 	return EXIT_SUCCESS;

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -994,7 +994,7 @@ int main(int argc, char **argv)
 		.domain_len = LAST_DOMAIN_LEN,
 		.fullnames_mode = false,
 	};
-	char **files = NULL;
+	const char **files = NULL;
 	struct number_buffer nb = {
 		.pos = 0
 	};
@@ -1065,7 +1065,7 @@ int main(int argc, char **argv)
 		case 'f':
 			if (!files)
 				files = xmalloc(sizeof(char *) * argc);
-			files[nfiles++] = xstrdup(optarg);
+			files[nfiles++] = optarg;
 			break;
 		case 'd':
 			ctl.usedns = 1;
@@ -1133,13 +1133,12 @@ int main(int argc, char **argv)
 
 	if (!files) {
 		files = xmalloc(sizeof(char *));
-		files[nfiles++] = xstrdup(ctl.lastb ? _PATH_BTMP : _PATH_WTMP);
+		files[nfiles++] = ctl.lastb ? _PATH_BTMP : _PATH_WTMP;
 	}
 
 	for (i = 0; i < nfiles; i++) {
 		get_boot_time(&ctl.boot_time);
 		process_wtmp_file(&ctl, files[i]);
-		free(files[i]);
 	}
 	free(files);
 	return EXIT_SUCCESS;

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1446,7 +1446,7 @@ static void initialize(int argc, char **argv, struct login_context *cxt)
 			break;
 
 		case 's':
-			cxt->shell_arg = xstrdup(optarg);
+			cxt->shell_arg = optarg;
 			break;
 
 		case 'V':

--- a/misc-utils/blkid.c
+++ b/misc-utils/blkid.c
@@ -755,7 +755,9 @@ int main(int argc, char **argv)
 			break;
 		case 'L':
 			ctl.eval = 1;
+			free(search_value);
 			search_value = xstrdup(optarg);
+			free(search_type);
 			search_type = xstrdup("LABEL");
 			break;
 		case 'n':
@@ -766,7 +768,9 @@ int main(int argc, char **argv)
 			break;
 		case 'U':
 			ctl.eval = 1;
+			free(search_value);
 			search_value = xstrdup(optarg);
+			free(search_type);
 			search_type = xstrdup("UUID");
 			break;
 		case 'i':

--- a/misc-utils/copyfilerange.c
+++ b/misc-utils/copyfilerange.c
@@ -168,7 +168,7 @@ static void handle_range(char* str, struct rangeitem *range)
 	copy_range(range);
 }
 
-static void handle_range_files(struct rangeitem *range, size_t nrange_files, char **range_files)
+static void handle_range_files(struct rangeitem *range, size_t nrange_files, const char **range_files)
 {
 	for (size_t i = 0; i < nrange_files; i++) {
 		FILE *f = fopen(range_files[i], "r");
@@ -187,7 +187,6 @@ static void handle_range_files(struct rangeitem *range, size_t nrange_files, cha
 			handle_range(line, range);
 		}
 
-		free(range_files[i]);
 		free(line);
 		fclose(f);
 	}
@@ -196,7 +195,7 @@ static void handle_range_files(struct rangeitem *range, size_t nrange_files, cha
 
 int main(const int argc, char **argv)
 {
-	char **range_files = NULL;
+	const char **range_files = NULL;
 	size_t nrange_files = 0;
 	struct stat sb;
 	struct rangeitem range = {0};
@@ -220,7 +219,7 @@ int main(const int argc, char **argv)
 		case 'r':
 			if (!range_files)
 				range_files = xmalloc(sizeof(char *) * argc);
-			range_files[nrange_files++] = xstrdup(optarg);
+			range_files[nrange_files++] = optarg;
 			break;
 		case 'v':
 			verbose = 1;

--- a/misc-utils/getopt.c
+++ b/misc-utils/getopt.c
@@ -246,7 +246,6 @@ static int generate_output(struct getopt_control *ctl, char *argv[], int argc)
 		free((char *)ctl->long_options[longindex].name);
 	free(ctl->long_options);
 	free(ctl->optstr);
-	free(ctl->name);
 	return exit_code;
 }
 
@@ -451,8 +450,7 @@ int main(int argc, char *argv[])
 			add_long_options(&ctl, optarg);
 			break;
 		case 'n':
-			free(ctl.name);
-			ctl.name = xstrdup(optarg);
+			ctl.name = optarg;
 			break;
 		case 'q':
 			ctl.quiet_errors = 1;

--- a/sys-utils/chmem.c
+++ b/sys-utils/chmem.c
@@ -721,7 +721,7 @@ int main(int argc, char **argv)
 			desc->verbose = 1;
 			break;
 		case 'z':
-			zone = xstrdup(optarg);
+			zone = optarg;
 			break;
 		case 'c':
 			cmd = CMD_MEMORY_CONFIGURE;

--- a/sys-utils/lsirq.c
+++ b/sys-utils/lsirq.c
@@ -28,7 +28,6 @@
 #include "closestream.h"
 #include "optutils.h"
 #include "strutils.h"
-#include "xalloc.h"
 #include "pathnames.h"
 
 #include "irq-common.h"
@@ -106,7 +105,7 @@ int main(int argc, char **argv)
 	cpu_set_t *cpuset = NULL;
 	size_t setsize = 0;
 	int softirq = 0;
-	char *input_file = NULL;
+	const char *input_file = NULL;
 
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
@@ -124,7 +123,7 @@ int main(int argc, char **argv)
 			out.pairs = 1;
 			break;
 		case 'i':
-			input_file = xstrdup(optarg);
+			input_file = optarg;
 			break;
 		case 'n':
 			out.no_headings = 1;
@@ -169,9 +168,9 @@ int main(int argc, char **argv)
 
 	if (input_file == NULL) {
 		if (softirq == 1)
-			input_file = xstrdup(_PATH_PROC_SOFTIRQS);
+			input_file = _PATH_PROC_SOFTIRQS;
 		else
-			input_file = xstrdup(_PATH_PROC_INTERRUPTS);
+			input_file = _PATH_PROC_INTERRUPTS;
 	}
 
 	/* default */
@@ -192,8 +191,6 @@ int main(int argc, char **argv)
 
 	if (print_irq_data(input_file, &out, softirq, threshold, setsize, cpuset) < 0)
 		return EXIT_FAILURE;
-
-	free(input_file);
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Sometimes, `optarg` string duplication leaks memory. In some of these cases, the string duplication can be fully removed. In other cases, `free` should be called before duplication.

Here are some command lines which reach the code in question. Using tools like `valgrind` in front can reveal changes in memory usage:

```
blkid -L label -L label
chmem -z a -z a
copyfilerange -r /dev/null -r /dev/null a b
getopt -n a "w:a" -w x --a
last -f /var/log/wtmp -f /var/log/wtmp
login -s shell -s shell
lsirq -i /dev/null -i /dev/null
```

Note that lsirq results in:
```
lsirq: cannot read /dev/null: Success
```
But that's something for another PR (https://github.com/util-linux/util-linux/pull/4232).