### PR TITLE
Handle EOF cases with getline

### DIFF
--- a/login-utils/newgrp.c
+++ b/login-utils/newgrp.c
@@ -38,6 +38,7 @@ static char *xgetpass(FILE *input, const char *prompt)
 	const int fd = fileno(input);
 	size_t dummy = 0;
 	ssize_t len;
+	int save_errno;
 
 	fputs(prompt, stdout);
 	if (isatty(fd)) {
@@ -50,12 +51,17 @@ static char *xgetpass(FILE *input, const char *prompt)
 			err(EXIT_FAILURE, _("could not set terminal attributes"));
 	}
 	len = getline(&pass, &dummy, input);
+	save_errno = errno;
 	if (isatty(fd))
 		/* restore terminal */
 		if (tcsetattr(fd, TCSANOW, &saved))
 			err(EXIT_FAILURE, _("could not set terminal attributes"));
-	if (len < 0)
+	if (len < 0) {
+		if (feof(input))
+			errx(EXIT_FAILURE, _("failed to read password"));
+		errno = save_errno;
 		err(EXIT_FAILURE, _("getline() failed"));
+	}
 	if (0 < len && *(pass + len - 1) == '\n')
 		*(pass + len - 1) = '\0';
 	return pass;

--- a/sys-utils/irq-common.c
+++ b/sys-utils/irq-common.c
@@ -257,7 +257,8 @@ static struct irq_stat *get_irqinfo(const char *input_file, int softirq,
 
 	/* read header firstly */
 	if (getline(&line, &len, irqfile) < 0) {
-		warn(_("cannot read %s"), input_file);
+		if (!feof(irqfile))
+			warn(_("cannot read %s"), input_file);
 		goto close_file;
 	}
 


### PR DESCRIPTION
If `getline` encounters EOF, check the FILE handle status before assuming that an error occurred to fix wrong error messages.

Also, in case of `newgrp`, preserve the correct `errno` value in case of `getline` failure.

Proof of Concept:
1. Call lsirq with empty file
```
lsirq -i /dev/null
```
```
lsirq: cannot read /dev/null: Success
```
2. Call newgrp with a group for which you have no permissions and an empty input
```
newgrp root < /dev/null
```
```
newgrp: getline() failed: Inappropriate ioctl for device
Password: 
```