### PR TITLE
Avoid PRI specifiers in translated messages

### DIFF
--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -1778,8 +1778,8 @@ static int ui_refresh(struct cfdisk *cf)
 	attron(A_BOLD);
 	ui_center(0, _("Disk: %s"), fdisk_get_devname(cf->cxt));
 	attroff(A_BOLD);
-	ui_center(1, _("Size: %s, %"PRIu64" bytes, %ju sectors"),
-			strsz, bytes, (uintmax_t) fdisk_get_nsectors(cf->cxt));
+	ui_center(1, _("Size: %s, %ju bytes, %ju sectors"),
+			strsz, (uintmax_t) bytes, (uintmax_t) fdisk_get_nsectors(cf->cxt));
 	if (fdisk_get_disklabel_id(cf->cxt, &id) == 0 && id)
 		ui_center(2, _("Label: %s, identifier: %s"),
 				fdisk_label_get_name(lb), id);
@@ -1963,7 +1963,7 @@ static int ui_get_size(struct cfdisk *cf,	/* context */
 			if (insec)
 				user *= fdisk_get_sector_size(cf->cxt);
 			if (user < low) {
-				ui_warnx(_("Minimum size is %"PRIu64" bytes."), low);
+				ui_warnx(_("Minimum size is %ju bytes."), (uintmax_t) low);
 				rc = -ERANGE;
 			}
 			if (user > up && pwr && user < up + (1ULL << pwr * 10))
@@ -1972,7 +1972,7 @@ static int ui_get_size(struct cfdisk *cf,	/* context */
 				user = up;
 
 			if (user > up) {
-				ui_warnx(_("Maximum size is %"PRIu64" bytes."), up);
+				ui_warnx(_("Maximum size is %ju bytes."), (uintmax_t) up);
 				rc = -ERANGE;
 			}
 			if (rc == 0 && insec && expsize)

--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -272,8 +272,8 @@ static int ask_number(struct fdisk_context *cxt,
 			snprintf(prompt, sizeof(prompt), _("%s (%s, default %c): "),
 					q, range, tochar(dflt));
 		else
-			snprintf(prompt, sizeof(prompt), _("%s (%s, default %"PRIu64"): "),
-					q, range, dflt);
+			snprintf(prompt, sizeof(prompt), _("%s (%s, default %ju): "),
+					q, range, (uintmax_t) dflt);
 
 	} else if (dflt >= low && dflt <= high) {
 		if (inchar)
@@ -281,14 +281,14 @@ static int ask_number(struct fdisk_context *cxt,
 					q, tochar(low), tochar(high), tochar(dflt));
 		else
 			snprintf(prompt, sizeof(prompt),
-					_("%s (%"PRIu64"-%"PRIu64", default %"PRIu64"): "),
-					q, low, high, dflt);
+					_("%s (%ju-%ju, default %ju): "),
+					q, (uintmax_t) low, (uintmax_t) high, (uintmax_t) dflt);
 	} else if (inchar)
 		snprintf(prompt, sizeof(prompt), _("%s (%c-%c): "),
 				q, tochar(low), tochar(high));
 	else
-		snprintf(prompt, sizeof(prompt), _("%s (%"PRIu64"-%"PRIu64"): "),
-				q, low, high);
+		snprintf(prompt, sizeof(prompt), _("%s (%ju-%ju): "),
+				q, (uintmax_t) low, (uintmax_t) high);
 
 	do {
 		int rc = get_user_reply(prompt, buf, bufsz);
@@ -339,15 +339,15 @@ static int ask_offset(struct fdisk_context *cxt,
 				q, low, high, base, dflt, range));
 
 	if (range && dflt >= low && dflt <= high)
-		snprintf(prompt, sizeof(prompt), _("%s (%s, default %"PRIu64"): "),
-		         q, range, dflt);
+		snprintf(prompt, sizeof(prompt), _("%s (%s, default %ju): "),
+		         q, range, (uintmax_t) dflt);
 	else if (dflt >= low && dflt <= high)
 		snprintf(prompt, sizeof(prompt),
-		         _("%s (%"PRIu64"-%"PRIu64", default %"PRIu64"): "),
-		         q, low, high, dflt);
+		         _("%s (%ju-%ju, default %ju): "),
+		         q, (uintmax_t) low, (uintmax_t) high, (uintmax_t) dflt);
 	else
-		snprintf(prompt, sizeof(prompt), _("%s (%"PRIu64"-%"PRIu64"): "),
-		         q, low, high);
+		snprintf(prompt, sizeof(prompt), _("%s (%ju-%ju): "),
+		         q, (uintmax_t) low, (uintmax_t) high);
 
 	do {
 		uintmax_t num = 0;
@@ -799,9 +799,9 @@ static int do_discard(struct fdisk_context *cxt, struct fdisk_partition *pa)
 	range[0] = (uint64_t) fdisk_partition_get_start(pa);
 	range[1] = (uint64_t) fdisk_partition_get_size(pa);
 
-	snprintf(buf, sizeof(buf), _("All data in the region (%"PRIu64
-				     "-%"PRIu64") will be lost! Continue?"),
-			range[0], range[0] + range[1] - 1);
+	snprintf(buf, sizeof(buf), _("All data in the region (%ju"
+				     "-%ju) will be lost! Continue?"),
+			(uintmax_t) range[0], (uintmax_t) (range[0] + range[1] - 1));
 
 	range[0] *= (uint64_t) ss;
 	range[1] *= (uint64_t) ss;
@@ -869,7 +869,7 @@ static void discard_freespace(struct fdisk_context *cxt)
 		goto done;
 
 	if (!fdisk_partition_has_size(pa) || !fdisk_partition_has_start(pa)) {
-		fdisk_warnx(cxt, _("Free space %"PRIu64 "has an unspecified range"), n);
+		fdisk_warnx(cxt, _("Free space %ju has an unspecified range"), (uintmax_t) n);
 		goto done;
 	}
 
@@ -999,8 +999,8 @@ static void dump_blkdev(struct fdisk_context *cxt, const char *name,
 {
 	int fd = fdisk_get_devfd(cxt);
 
-	fdisk_info(cxt, _("\n%s: offset = %"PRIu64", size = %zu bytes."),
-			name, offset, size);
+	fdisk_info(cxt, _("\n%s: offset = %ju, size = %zu bytes."),
+			name, (uintmax_t) offset, size);
 
 	assert(fd >= 0);
 

--- a/disk-utils/fsck.cramfs.c
+++ b/disk-utils/fsck.cramfs.c
@@ -202,8 +202,8 @@ static void test_super(int *start)
 
 	/* What are valid superblock sizes? */
 	if (super.size < *start + sizeof(struct cramfs_super))
-		errx(FSCK_EX_UNCORRECTED, _("superblock size (%"PRIu32") too small"),
-		     super.size);
+		errx(FSCK_EX_UNCORRECTED, _("superblock size (%ju) too small"),
+		     (uintmax_t) super.size);
 
 	if (super.flags & CRAMFS_FLAG_FSID_VERSION_2) {
 		if (super.fsid.files == 0)
@@ -242,8 +242,8 @@ static void test_crc(int start)
 			if (tmp < 0)
 				err(FSCK_EX_ERROR, _("cannot read %s"), filename);
 			if (tmp != (ssize_t) super.size)
-				errx(FSCK_EX_ERROR, _("failed to read %"PRIu32" bytes from file %s"),
-					super.size, filename);
+				errx(FSCK_EX_ERROR, _("failed to read %ju bytes from file %s"),
+					(uintmax_t) super.size, filename);
 		}
 	}
 	if (buf != MAP_FAILED) {

--- a/disk-utils/mkfs.bfs.c
+++ b/disk-utils/mkfs.bfs.c
@@ -285,8 +285,9 @@ int main(int argc, char **argv)
 			fprintf(stderr, _("Inodes: %ld (in %llu blocks)\n"),
 				inodes, ino_blocks);
 		fprintf(stderr, _("Blocks: %llu\n"), total_blocks);
-		fprintf(stderr, _("Inode end: %"PRIu32", Data end: %"PRIu32"\n"),
-			le32_to_cpu(sb.s_start) - 1, le32_to_cpu(sb.s_end));
+		fprintf(stderr, _("Inode end: %ju, Data end: %ju\n"),
+			(uintmax_t) le32_to_cpu(sb.s_start) - 1,
+			(uintmax_t) le32_to_cpu(sb.s_end));
 	}
 
 	if (write(fd, &sb, sizeof(sb)) != sizeof(sb))

--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -735,8 +735,8 @@ int main(int argc, char **argv)
 	else if (ctl.npages > sz && !ctl.force)
 		errx(EXIT_FAILURE,
 			_("error: "
-			  "size %llu KiB is larger than device size %"PRIu64" KiB"),
-			ctl.npages * (ctl.pagesize / 1024), sz * (ctl.pagesize / 1024));
+			  "size %llu KiB is larger than device size %ju KiB"),
+			ctl.npages * (ctl.pagesize / 1024), (uintmax_t) (sz * (ctl.pagesize / 1024)));
 
 	if (ctl.npages < MIN_GOODPAGES)
 		errx(EXIT_FAILURE,
@@ -788,8 +788,8 @@ int main(int argc, char **argv)
 	strsz = size_to_human_string(SIZE_SUFFIX_SPACE | SIZE_SUFFIX_3LETTER, sz);
 
 	if (!ctl.quiet)
-		printf(_("Setting up swapspace version %d, size = %s (%"PRIu64" bytes)\n"),
-			version, strsz, sz);
+		printf(_("Setting up swapspace version %d, size = %s (%ju bytes)\n"),
+			version, strsz, (uintmax_t) sz);
 	free(strsz);
 
 	set_signature(&ctl);

--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -1417,9 +1417,9 @@ static int command_discard_free(struct sfdisk *sf, int argc, char **argv)
 		range[0] = (uint64_t) fdisk_partition_get_start(pa);
 		range[1] = (uint64_t) fdisk_partition_get_size(pa);
 
-		fdisk_info(sf->cxt, _("Discarding region %"PRIu64
-					     "-%"PRIu64""),
-				range[0], range[0] + range[1] - 1);
+		fdisk_info(sf->cxt, _("Discarding region %ju-%ju"),
+				(uintmax_t) range[0],
+				(uintmax_t) (range[0] + range[1] - 1));
 
 		range[0] *= ss;
 		range[1] *= ss;

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -555,7 +555,7 @@ int strtimespec_iso(const struct timespec *ts, int flags, char *buf, size_t bufs
 	if (rc)
 		return format_iso_time(&tm, ts->tv_nsec, flags, buf, bufsz);
 
-	warnx(_("time %"PRId64" is out of range."), (int64_t)(ts->tv_sec));
+	warnx(_("time %jd is out of range."), (intmax_t)(ts->tv_sec));
 	return -1;
 }
 
@@ -590,7 +590,7 @@ int strtime_iso(const time_t *t, int flags, char *buf, size_t bufsz)
 	if (rc)
 		return format_iso_time(&tm, 0, flags, buf, bufsz);
 
-	warnx(_("time %"PRId64" is out of range."), (int64_t)*t);
+	warnx(_("time %jd is out of range."), (intmax_t)*t);
 	return -1;
 }
 

--- a/libblkid/samples/topology.c
+++ b/libblkid/samples/topology.c
@@ -54,8 +54,8 @@ int main(int argc, char *argv[])
 				blkid_topology_get_physical_sector_size(tp));
 		printf("\tdax support          : %lu\n",
 				blkid_topology_get_dax(tp));
-		printf("\tdiskseq              : %"PRIu64"\n",
-				blkid_topology_get_diskseq(tp));
+		printf("\tdiskseq              : %ju\n",
+				(uintmax_t) blkid_topology_get_diskseq(tp));
 	}
 
 	/*

--- a/libfdisk/src/gpt.c
+++ b/libfdisk/src/gpt.c
@@ -951,9 +951,9 @@ static int valid_pmbr(struct fdisk_context *cxt)
 		uint64_t sz_lba = (uint64_t) le32_to_cpu(pmbr->partition_record[part].size_in_lba);
 		if (sz_lba != cxt->total_sectors - 1ULL && sz_lba != 0xFFFFFFFFULL) {
 
-			fdisk_warnx(cxt, _("GPT PMBR size mismatch (%"PRIu64" != %"PRIu64") "
+			fdisk_warnx(cxt, _("GPT PMBR size mismatch (%ju != %ju) "
 					   "will be corrected by write."),
-					sz_lba, cxt->total_sectors - (uint64_t) 1);
+					(uintmax_t) sz_lba, (uintmax_t) (cxt->total_sectors - (uint64_t) 1));
 
 			/* Note that gpt_write_pmbr() overwrites PMBR, but we want to keep it valid already
 			 * in memory too to disable warnings when valid_pmbr() called next time */
@@ -2815,13 +2815,13 @@ static int gpt_check_table_overlap(struct fdisk_context *cxt,
 		if (!gpt_entry_is_used(e))
 		        continue;
 		if (gpt_partition_start(e) < first_usable) {
-			fdisk_warnx(cxt, _("Partition #%zu out of range (minimal start is %"PRIu64" sectors)"),
-		                    i + 1, first_usable);
+			fdisk_warnx(cxt, _("Partition #%zu out of range (minimal start is %ju sectors)"),
+		                    i + 1, (uintmax_t) first_usable);
 			rc = -EINVAL;
 		}
 		if (gpt_partition_end(e) > last_usable) {
-			fdisk_warnx(cxt, _("Partition #%zu out of range (maximal end is %"PRIu64" sectors)"),
-		                    i + 1, last_usable - (uint64_t) 1);
+			fdisk_warnx(cxt, _("Partition #%zu out of range (maximal end is %ju sectors)"),
+		                    i + 1, (uintmax_t) (last_usable - (uint64_t) 1));
 			rc = -EINVAL;
 		}
 	}
@@ -2921,8 +2921,8 @@ int fdisk_gpt_set_npartitions(struct fdisk_context *cxt, uint32_t nents)
 	/* update library info */
 	cxt->label->nparts_max = gpt_get_nentries(gpt);
 
-	fdisk_info(cxt, _("Partition table length changed from %"PRIu32" to %"PRIu32"."),
-			old_nents, nents);
+	fdisk_info(cxt, _("Partition table length changed from %ju to %ju."),
+			(uintmax_t) old_nents, (uintmax_t) nents);
 
 	fdisk_label_set_changed(cxt->label, 1);
 	return 0;
@@ -3031,8 +3031,8 @@ int fdisk_gpt_set_partition_attrs(
 		return -EINVAL;
 
 	gpt_get_entry(gpt, partnum)->attrs = cpu_to_le64(attrs);
-	fdisk_info(cxt, _("The attributes on partition %zu changed to 0x%016" PRIx64 "."),
-			partnum + 1, attrs);
+	fdisk_info(cxt, _("The attributes on partition %zu changed to 0x%016jx."),
+			partnum + 1, (uintmax_t) attrs);
 
 	gpt_recompute_crc(gpt->pheader, gpt->ents);
 	gpt_recompute_crc(gpt->bheader, gpt->ents);

--- a/libfdisk/src/sun.c
+++ b/libfdisk/src/sun.c
@@ -6,7 +6,6 @@
  *   Merged with fdisk for other architectures, aeb, June 1998.
  *   Arnaldo Carvalho de Melo <acme@conectiva.com.br> Mar 1999, Internationalization
  */
-#include <inttypes.h>
 #include <stdio.h>		/* stderr */
 #include <stdlib.h>		/* qsort */
 #include <string.h>		/* strstr */
@@ -151,8 +150,8 @@ static int sun_probe_label(struct fdisk_context *cxt)
 		fdisk_apply_user_device_properties(cxt);
 
 	if (be32_to_cpu(sunlabel->vtoc.version) != SUN_VTOC_VERSION) {
-		fdisk_warnx(cxt, _("Detected sun disklabel with wrong version [%"PRIu32"]."),
-			be32_to_cpu(sunlabel->vtoc.version));
+		fdisk_warnx(cxt, _("Detected sun disklabel with wrong version [%ju]."),
+			(uintmax_t) be32_to_cpu(sunlabel->vtoc.version));
 		need_fixing = 1;
 	}
 	if (be32_to_cpu(sunlabel->vtoc.sanity) != SUN_VTOC_SANITY) {

--- a/misc-utils/copyfilerange.c
+++ b/misc-utils/copyfilerange.c
@@ -133,23 +133,24 @@ static void copy_range(struct rangeitem *range) {
 	uintmax_t remaining = range->length;
 
 	if (range->in_offset > range->in_st_size)
-		errx(EXIT_FAILURE, _("%s offset %"PRId64" is beyond file size of %"PRId64""),
-		                     range->in_filename, range->in_offset, range->in_st_size);
+		errx(EXIT_FAILURE, _("%s offset %jd is beyond file size of %jd"),
+		                     range->in_filename, (intmax_t) range->in_offset, (intmax_t) range->in_st_size);
 
 	while (remaining > 0) {
 		const size_t chunk = remaining > SIZE_MAX ? SIZE_MAX : remaining;
 		if (verbose)
-			printf("copy_file_range %s to %s %"PRId64":%"PRId64":%zu\n",
+			printf("copy_file_range %s to %s %jd:%jd:%zu\n",
 			       range->in_filename, range->out_filename,
-			       range->in_offset, range->out_offset, chunk);
+			       (intmax_t) range->in_offset, (intmax_t) range->out_offset, chunk);
 
 		const ssize_t copied = copy_file_range(range->in_fd, &range->in_offset,
 		                                       range->out_fd, &range->out_offset, chunk, 0);
 		if (copied < 0)
-			errx(EXIT_FAILURE, _("failed to copy range %"PRId64":%"PRId64":%ju "
+			errx(EXIT_FAILURE, _("failed to copy range %jd:%jd:%ju "
 			                     "from %s to %s with %ju remaining: %m\n"),
-			                     range->in_offset, range->out_offset, range->length,
-			                     range->in_filename, range->out_filename, remaining);
+			                     (intmax_t) range->in_offset, (intmax_t) range->out_offset,
+								 range->length, range->in_filename,
+								 range->out_filename, remaining);
 		if (copied == 0)
 			break;
 

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -424,10 +424,10 @@ static void print_stats(void)
 	jlog(SUMMARY, printf("%-25s %s", _("Saved:"), ssz));
 	free(ssz);
 
-	jlog(SUMMARY, printf(_("%-25s %"PRId64".%06"PRId64" seconds"),
+	jlog(SUMMARY, printf(_("%-25s %jd.%06jd seconds"),
 				_("Duration:"),
-				(int64_t) delta.tv_sec,
-				(int64_t) delta.tv_usec));
+				(intmax_t) delta.tv_sec,
+				(intmax_t) delta.tv_usec));
 }
 
 /**

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -454,7 +454,7 @@ static void server_loop(const char *socket_path, const char *pidfile_path,
 		}
 		if (ret == 0) {		/* true when poll() times out */
 			if (uuidd_cxt->debug)
-				fprintf(stderr, _("timeout [%"PRIu32" sec]\n"), uuidd_cxt->timeout);
+				fprintf(stderr, _("timeout [%ju sec]\n"), (uintmax_t) uuidd_cxt->timeout);
 			all_done(uuidd_cxt, EXIT_SUCCESS);
 		}
 		if (pfd[POLLFD_SIGNAL].revents != 0)

--- a/misc-utils/waitpid.c
+++ b/misc-utils/waitpid.c
@@ -74,8 +74,8 @@ static inline int get_pidfd(const struct waitpid_control *ctl, struct process_in
 	if (pi->pidfd_ino) {
 		fd = ul_get_valid_pidfd(pi->pid, pi->pidfd_ino);
 		if (fd < 0 && ctl->verbose)
-			warnx(_("pidfd inode %"PRIu64" not found for PID %d"),
-					pi->pidfd_ino, pi->pid);
+			warnx(_("pidfd inode %ju not found for PID %d"),
+					(uintmax_t) pi->pidfd_ino, pi->pid);
 	} else {
 		fd = pidfd_open(pi->pid, 0);
 	}

--- a/schedutils/uclampset.c
+++ b/schedutils/uclampset.c
@@ -96,8 +96,8 @@ static void show_uclamp_pid_info(pid_t pid, char *cmd)
 	else
 		comm = pid_get_cmdname(pid);
 
-	printf(_("%s (%d) util_clamp: min: %"PRIu32" max: %"PRIu32"\n"),
-	       comm ? : "unknown", pid, sa.sched_util_min, sa.sched_util_max);
+	printf(_("%s (%d) util_clamp: min: %ju max: %ju\n"),
+	       comm ? : "unknown", pid, (uintmax_t) sa.sched_util_min, (uintmax_t) sa.sched_util_max);
 
 	if (!cmd)
 		free(comm);

--- a/sys-utils/blkdiscard.c
+++ b/sys-utils/blkdiscard.c
@@ -62,13 +62,13 @@ static void print_stats(int act, char *path, uint64_t stats[])
 {
 	switch (act) {
 	case ACT_ZEROOUT:
-		printf(_("%s: Zero-filled %" PRIu64 " bytes from the offset %" PRIu64"\n"), \
-			path, stats[1], stats[0]);
+		printf(_("%s: Zero-filled %ju bytes from the offset %ju\n"), \
+			path, (uintmax_t) stats[1], (uintmax_t) stats[0]);
 		break;
 	case ACT_SECURE:
 	case ACT_DISCARD:
-		printf(_("%s: Discarded %" PRIu64 " bytes from the offset %" PRIu64"\n"), \
-			path, stats[1], stats[0]);
+		printf(_("%s: Discarded %ju bytes from the offset %ju\n"), \
+			path, (uintmax_t) stats[1], (uintmax_t) stats[0]);
 		break;
 	}
 }
@@ -248,8 +248,8 @@ int main(int argc, char **argv)
 
 	/* check offset alignment to the sector size */
 	if (range[0] % secsize)
-		errx(EXIT_FAILURE, _("%s: offset %" PRIu64 " is not aligned "
-			 "to sector size %i"), path, range[0], secsize);
+		errx(EXIT_FAILURE, _("%s: offset %ju is not aligned "
+			 "to sector size %i"), path, (uintmax_t) range[0], secsize);
 
 	/* is the range end behind the end of the device ?*/
 	if (range[0] > blksize)
@@ -262,8 +262,8 @@ int main(int argc, char **argv)
 
 	/* check length alignment to the sector size */
 	if (range[1] % secsize)
-		errx(EXIT_FAILURE, _("%s: length %" PRIu64 " is not aligned "
-			 "to sector size %i"), path, range[1], secsize);
+		errx(EXIT_FAILURE, _("%s: length %ju is not aligned "
+			 "to sector size %i"), path, (uintmax_t) range[1], secsize);
 #ifdef HAVE_LIBBLKID
 	if (force) {
 		if (!quiet)

--- a/sys-utils/blkpr.c
+++ b/sys-utils/blkpr.c
@@ -209,7 +209,7 @@ static int do_pr_read_keys(int fd)
 
 	if (pr_rk.num_keys) {
 		for (uint32_t i = 0; i < pr_rk.num_keys; i++) {
-			printf(_("%#" PRIx64 "\n"), (uint64_t)keys[i]);
+			printf(_("%#jx\n"), (uintmax_t)keys[i]);
 		}
 	} else {
 		printf(_("No registered keys\n"));
@@ -247,7 +247,7 @@ static int do_pr_read_reservation(int fd)
 	type_str = type_to_str(pr_type, ARRAY_SIZE(pr_type), pr_rr.type);
 
 	if (pr_rr.key) {
-		printf(_("Key: %#" PRIx64 "\n"), (uint64_t)pr_rr.key);
+		printf(_("Key: %#jx\n"), (uintmax_t)pr_rr.key);
 		printf(_("Generation: %#x\n"), pr_rr.generation);
 		printf(_("Type: %s\n"), type_str);
 	} else {

--- a/sys-utils/blkzone.c
+++ b/sys-utils/blkzone.c
@@ -264,8 +264,8 @@ static int blkzone_report(struct blkzone_control *ctl)
 			err(EXIT_FAILURE, _("%s: BLKREPORTZONE ioctl failed"), ctl->devname);
 
 		if (ctl->verbose)
-			printf(_("Found %"PRIu32" zones from 0x%"PRIx64"\n"),
-				zi->nr_zones, ctl->offset);
+			printf(_("Found %ju zones from 0x%jx\n"),
+				(uintmax_t) zi->nr_zones, (uintmax_t) ctl->offset);
 
 		if (!zi->nr_zones)
 			break;
@@ -303,18 +303,18 @@ static int blkzone_report(struct blkzone_control *ctl)
 			if (only_capacity_sum) {
 				capacity_sum += cap;
 			} else if (has_zone_capacity(zi)) {
-				printf(_("  start: 0x%09"PRIx64", len 0x%06"PRIx64
-					", cap 0x%06"PRIx64", wptr %s"
+				printf(_("  start: 0x%09jx, len 0x%06jx"
+					", cap 0x%06jx, wptr %s"
 					" reset:%u non-seq:%u, zcond:%2u(%s) [type: %u(%s)]\n"),
-					start, len, cap, wp_str,
+					(uintmax_t) start, (uintmax_t) len, (uintmax_t) cap, wp_str,
 					entry.reset, entry.non_seq,
 					cond, condition_str[cond & (ARRAY_SIZE(condition_str) - 1)],
 					type, type_text[type]);
 			} else {
-				printf(_("  start: 0x%09"PRIx64", len 0x%06"PRIx64
+				printf(_("  start: 0x%09jx, len 0x%06jx"
 					", wptr %s"
 					" reset:%u non-seq:%u, zcond:%2u(%s) [type: %u(%s)]\n"),
-					start, len, wp_str,
+					(uintmax_t) start, (uintmax_t) len, wp_str,
 					entry.reset, entry.non_seq,
 					cond, condition_str[cond & (ARRAY_SIZE(condition_str) - 1)],
 					type, type_text[type]);
@@ -327,7 +327,7 @@ static int blkzone_report(struct blkzone_control *ctl)
 	}
 
 	if (only_capacity_sum)
-		printf(_("0x%09"PRIx64"\n"), capacity_sum);
+		printf(_("0x%09jx\n"), (uintmax_t) capacity_sum);
 
 	free(zi);
 	close(fd);
@@ -352,9 +352,9 @@ static int blkzone_action(struct blkzone_control *ctl)
 	fd = init_device(ctl, O_WRONLY | (ctl->force ? 0 : O_EXCL));
 
 	if (ctl->offset % zonesize )
-		errx(EXIT_FAILURE, _("%s: offset %" PRIu64 " is not aligned "
+		errx(EXIT_FAILURE, _("%s: offset %ju is not aligned "
 			"to zone size %lu"),
-			ctl->devname, ctl->offset, zonesize);
+			ctl->devname, (uintmax_t) ctl->offset, zonesize);
 
 	if (ctl->offset > ctl->total_sectors)
 		errx(EXIT_FAILURE, _("%s: offset is greater than device size"), ctl->devname);
@@ -371,9 +371,9 @@ static int blkzone_action(struct blkzone_control *ctl)
 	if (ctl->length &&
 	   (zlen % zonesize) &&
 	    ctl->offset + zlen != ctl->total_sectors)
-		errx(EXIT_FAILURE, _("%s: number of sectors %" PRIu64 " is not aligned "
+		errx(EXIT_FAILURE, _("%s: number of sectors %ju is not aligned "
 			"to zone size %lu"),
-			ctl->devname, ctl->length, zonesize);
+			ctl->devname, (uintmax_t) ctl->length, zonesize);
 
 	za.sector = ctl->offset;
 	za.nr_sectors = zlen;
@@ -382,11 +382,11 @@ static int blkzone_action(struct blkzone_control *ctl)
 		err(EXIT_FAILURE, _("%s: %s ioctl failed"),
 		    ctl->devname, ctl->command->ioctl_name);
 	else if (ctl->verbose)
-		printf(_("%s: successful %s of zones in range from %" PRIu64 ", to %" PRIu64),
+		printf(_("%s: successful %s of zones in range from %ju, to %ju"),
 			ctl->devname,
 			ctl->command->name,
-			ctl->offset,
-			ctl->offset + zlen);
+			(uintmax_t) ctl->offset,
+			(uintmax_t) ctl->offset + zlen);
 	close(fd);
 	return 0;
 }

--- a/sys-utils/chmem.c
+++ b/sys-utils/chmem.c
@@ -105,8 +105,8 @@ static void idxtostr(struct chmem_desc *desc, uint64_t idx, char *buf, size_t bu
 	start = idx * desc->block_size;
 	end = start + desc->block_size - 1;
 	snprintf(buf, bufsz,
-		 _("Memory Block %"PRIu64" (0x%016"PRIx64"-0x%016"PRIx64")"),
-		 idx, start, end);
+		 _("Memory Block %ju (0x%016jx-0x%016jx)"),
+		 (uintmax_t) idx, (uintmax_t) start, (uintmax_t) end);
 }
 
 static bool chmem_memmap_enabled(struct chmem_desc *desc)

--- a/sys-utils/flock.c
+++ b/sys-utils/flock.c
@@ -424,10 +424,10 @@ int main(int argc, char *argv[])
 
 		gettime_monotonic(&time_done);
 		timersub(&time_done, &time_start, &delta);
-		printf(_("%s: getting lock took %"PRId64".%06"PRId64" seconds\n"),
+		printf(_("%s: getting lock took %jd.%06jd seconds\n"),
 		       program_invocation_short_name,
-		       (int64_t) delta.tv_sec,
-		       (int64_t) delta.tv_usec);
+		       (intmax_t) delta.tv_sec,
+		       (intmax_t) delta.tv_usec);
 	}
 	status = EX_OK;
 

--- a/sys-utils/fstrim.c
+++ b/sys-utils/fstrim.c
@@ -140,12 +140,12 @@ static int fstrim_filesystem(struct fstrim_control *ctl, const char *path, const
 				(uint64_t) range.len);
 		if (devname)
 			/* TRANSLATORS: The standard value here is a very large number. */
-			printf(_("%s: %s (%" PRIu64 " bytes) trimmed on %s\n"),
-				path, str, (uint64_t) range.len, devname);
+			printf(_("%s: %s (%ju bytes) trimmed on %s\n"),
+				path, str, (uintmax_t) range.len, devname);
 		else
 			/* TRANSLATORS: The standard value here is a very large number. */
-			printf(_("%s: %s (%" PRIu64 " bytes) trimmed\n"),
-				path, str, (uint64_t) range.len);
+			printf(_("%s: %s (%ju bytes) trimmed\n"),
+				path, str, (uintmax_t) range.len);
 
 		free(str);
 	}

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -274,10 +274,10 @@ static int read_adjtime(const struct hwclock_control *ctl,
 	}
 
 	if (ctl->verbose) {
-		printf(_("Last drift adjustment done at %"PRId64" seconds after 1969\n"),
-		       (int64_t)adjtime_p->last_adj_time);
-		printf(_("Last calibration done at %"PRId64" seconds after 1969\n"),
-		       (int64_t)adjtime_p->last_calib_time);
+		printf(_("Last drift adjustment done at %jd seconds after 1969\n"),
+		       (intmax_t)adjtime_p->last_adj_time);
+		printf(_("Last calibration done at %jd seconds after 1969\n"),
+		       (intmax_t)adjtime_p->last_calib_time);
 		printf(_("Hardware clock is on %s time\n"),
 		       (adjtime_p->local_utc ==
 			LOCAL) ? _("local") : (adjtime_p->local_utc ==
@@ -362,9 +362,9 @@ mktime_tz(const struct hwclock_control *ctl, struct tm tm,
 		valid = 1;
 		if (ctl->verbose)
 			printf(_("Hw clock time : %4d/%.2d/%.2d %.2d:%.2d:%.2d = "
-				 "%"PRId64" seconds since 1969\n"), tm.tm_year + 1900,
+				 "%jd seconds since 1969\n"), tm.tm_year + 1900,
 			       tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min,
-			       tm.tm_sec, (int64_t)*systime_p);
+			       tm.tm_sec, (intmax_t)*systime_p);
 	}
 	return valid;
 }
@@ -415,9 +415,9 @@ set_hardware_clock(const struct hwclock_control *ctl, const time_t newtime)
 
 	if (ctl->verbose)
 		printf(_("Setting Hardware Clock to %.2d:%.2d:%.2d "
-			 "= %"PRId64" seconds since 1969\n"),
+			 "= %jd seconds since 1969\n"),
 		       new_broken_time.tm_hour, new_broken_time.tm_min,
-		       new_broken_time.tm_sec, (int64_t)newtime);
+		       new_broken_time.tm_sec, (intmax_t)newtime);
 
 	if (!ctl->testing)
 		ur->set_hardware_clock(ctl, &new_broken_time);
@@ -570,9 +570,9 @@ set_hardware_clock_exact(const struct hwclock_control *ctl,
 		if (ticksize < 0) {
 			if (ctl->verbose)
 				printf(_("time jumped backward %.6f seconds "
-					 "to %"PRId64".%06"PRId64" - retargeting\n"),
-				       ticksize, (int64_t)nowsystime.tv_sec,
-				       (int64_t)nowsystime.tv_usec);
+					 "to %jd.%06jd - retargeting\n"),
+				       ticksize, (intmax_t)nowsystime.tv_sec,
+				       (intmax_t)nowsystime.tv_usec);
 			/* The retarget is handled at the end of the loop. */
 		} else if (deltavstarget < 0) {
 			/* deltavstarget < 0 if current time < target time */
@@ -591,12 +591,12 @@ set_hardware_clock_exact(const struct hwclock_control *ctl,
 			 * aim for the next opportunity.
 			 */
 			if (ctl->verbose)
-				printf(_("missed it - %"PRId64".%06"PRId64" is too far "
-					 "past %"PRId64".%06"PRId64" (%.6f > %.6f)\n"),
-				       (int64_t)nowsystime.tv_sec,
-				       (int64_t)nowsystime.tv_usec,
-				       (int64_t)targetsystime.tv_sec,
-				       (int64_t)targetsystime.tv_usec,
+				printf(_("missed it - %jd.%06jd is too far "
+					 "past %jd.%06jd (%.6f > %.6f)\n"),
+				       (intmax_t)nowsystime.tv_sec,
+				       (intmax_t)nowsystime.tv_usec,
+				       (intmax_t)targetsystime.tv_sec,
+				       (intmax_t)targetsystime.tv_usec,
 				       deltavstarget,
 				       target_time_tolerance_secs);
 			target_time_tolerance_secs += tolerance_incr_secs;
@@ -618,14 +618,14 @@ set_hardware_clock_exact(const struct hwclock_control *ctl,
 		    + round(time_diff(&nowsystime, &refsystime)
 			    - delay /* don't count this */);
 	if (ctl->verbose)
-		printf(_("%"PRId64".%06"PRId64" is close enough to %"PRId64".%06"PRId64" (%.6f < %.6f)\n"
-			 "Set RTC to %"PRId64" (%"PRId64" + %d; refsystime = %"PRId64".%06"PRId64")\n"),
-		       (int64_t)nowsystime.tv_sec, (int64_t)nowsystime.tv_usec,
-		       (int64_t)targetsystime.tv_sec, (int64_t)targetsystime.tv_usec,
+		printf(_("%jd.%06jd is close enough to %jd.%06jd (%.6f < %.6f)\n"
+			 "Set RTC to %jd (%jd + %d; refsystime = %jd.%06jd)\n"),
+		       (intmax_t)nowsystime.tv_sec, (intmax_t)nowsystime.tv_usec,
+		       (intmax_t)targetsystime.tv_sec, (intmax_t)targetsystime.tv_usec,
 		       deltavstarget, target_time_tolerance_secs,
-		       (int64_t)newhwtime, (int64_t)sethwtime,
-		       (int)((int64_t)newhwtime - (int64_t)sethwtime),
-		       (int64_t)refsystime.tv_sec, (int64_t)refsystime.tv_usec);
+		       (intmax_t)newhwtime, (intmax_t)sethwtime,
+		       (int)((intmax_t)newhwtime - (intmax_t)sethwtime),
+		       (intmax_t)refsystime.tv_sec, (intmax_t)refsystime.tv_usec);
 
 	set_hardware_clock(ctl, newhwtime);
 }
@@ -724,9 +724,9 @@ set_system_clock(const struct hwclock_control *ctl,
 			       minuteswest);
 
 		if (ctl->hctosys)
-			printf(_("Calling settimeofday(%"PRId64".%06"PRId64", NULL) "
+			printf(_("Calling settimeofday(%jd.%06jd, NULL) "
 				 "to set the System time.\n"),
-			       (int64_t)newtime.tv_sec, (int64_t)newtime.tv_usec);
+			       (intmax_t)newtime.tv_sec, (intmax_t)newtime.tv_usec);
 	}
 
 	if (!ctl->testing) {
@@ -869,12 +869,12 @@ calculate_adjustment(const struct hwclock_control *ctl,
 	tdrift_p->tv_usec = (exact_adjustment -
 				 (double)tdrift_p->tv_sec) * 1E6;
 	if (ctl->verbose) {
-		printf(P_("Time since last adjustment is %"PRId64" second\n",
-			"Time since last adjustment is %"PRId64" seconds\n",
-		       ((int64_t)systime - (int64_t)last_time)),
-		       ((int64_t)systime - (int64_t)last_time));
-		printf(_("Calculated Hardware Clock drift is %"PRId64".%06"PRId64" seconds\n"),
-		       (int64_t)tdrift_p->tv_sec, (int64_t)tdrift_p->tv_usec);
+		printf(P_("Time since last adjustment is %jd second\n",
+			"Time since last adjustment is %jd seconds\n",
+		       ((intmax_t)systime - (intmax_t)last_time)),
+		       ((intmax_t)systime - (intmax_t)last_time));
+		printf(_("Calculated Hardware Clock drift is %jd.%06jd seconds\n"),
+		       (intmax_t)tdrift_p->tv_sec, (intmax_t)tdrift_p->tv_usec);
 	}
 }
 
@@ -1041,8 +1041,8 @@ manipulate_clock(const struct hwclock_control *ctl, const time_t set_time,
 		hclocktime = time_inc(hclocktime, (double)
 				      -(tdrift.tv_sec + tdrift.tv_usec / 1E6));
 		if (ctl->verbose) {
-			printf(_("Target date:   %"PRId64"\n"), (int64_t)set_time);
-			printf(_("Predicted RTC: %"PRId64"\n"), (int64_t)hclocktime.tv_sec);
+			printf(_("Target date:   %jd\n"), (intmax_t)set_time);
+			printf(_("Predicted RTC: %jd\n"), (intmax_t)hclocktime.tv_sec);
 		}
 		return display_time(hclocktime);
 	}
@@ -1590,8 +1590,8 @@ int main(int argc, char **argv)
 
 	if (ctl.verbose) {
 		out_version();
-		printf(_("System Time: %"PRId64".%06"PRId64"\n"),
-		       (int64_t)startup_time.tv_sec, (int64_t)startup_time.tv_usec);
+		printf(_("System Time: %jd.%06jd\n"),
+		       (intmax_t)startup_time.tv_sec, (intmax_t)startup_time.tv_usec);
 	}
 
 	if (!ctl.systz && !ctl.predict)

--- a/sys-utils/ipcs.c
+++ b/sys-utils/ipcs.c
@@ -612,9 +612,9 @@ static void print_shm(int shmid, int unit)
 	       shmdata->shm_perm.mode & 0777);
 	ipc_print_size(unit, unit == IPC_UNIT_HUMAN ? _("size=") : _("bytes="),
 		       shmdata->shm_segsz, "\t", 0);
-	printf(_("lpid=%d\tcpid=%d\tnattch=%"PRIu64"\n"),
+	printf(_("lpid=%d\tcpid=%d\tnattch=%ju\n"),
 	       shmdata->shm_lprid, shmdata->shm_cprid,
-	       shmdata->shm_nattch);
+	       (uintmax_t) shmdata->shm_nattch);
 	printf(_("att_time=%-26.24s\n"),
 	       shmdata->shm_atim ? ctime64(&(shmdata->shm_atim)) : _("Not set"));
 	printf(_("det_time=%-26.24s\n"),

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -1122,9 +1122,9 @@ static void print_summary(struct lscpu_cxt *cxt)
 			snprintf(field, sizeof(field), hierarchic ? _("%s:") : _("%s cache:"), name);
 			if (cxt->bytes)
 				add_summary_sprint(tb, sec, field,
-						P_("%" PRIu64 " (%d instance)",
-						   "%" PRIu64 " (%d instances)", n),
-						sz, n);
+						P_("%ju (%d instance)",
+						   "%ju (%d instances)", n),
+						(uintmax_t) sz, n);
 			else {
 				char *tmp = size_to_human_string(
 						SIZE_SUFFIX_3LETTER |

--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -252,8 +252,8 @@ static void open_target_fd_by_nsid(int *fd, const char *idstr)
 
 	*fd = open_by_handle_at(nsfs_fd, fh, O_RDONLY);
 	if (*fd < 0)
-		err(EXIT_FAILURE, _("cannot open namespace of id %"PRIu64),
-		    ns_id);
+		err(EXIT_FAILURE, _("cannot open namespace of id %ju"),
+		    (uintmax_t) ns_id);
 }
 #endif /* USE_NAMESPACE_ID_SUPPORT */
 

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -560,11 +560,11 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 
 	if (ctl.verbose)
-		printf(_("alarm %"PRId64", sys_time %"PRId64", "
-			 "rtc_time %"PRId64", seconds %"PRId64"\n"),
-				(int64_t) alarm, (int64_t) ctl.sys_time,
-				(int64_t) ctl.rtc_time,
-				(int64_t) seconds);
+		printf(_("alarm %jd, sys_time %jd, "
+			 "rtc_time %jd, seconds %jd\n"),
+				(intmax_t) alarm, (intmax_t) ctl.sys_time,
+				(intmax_t) ctl.rtc_time,
+				(intmax_t) seconds);
 
 	if (suspend != DISABLE_MODE && suspend != SHOW_MODE) {
 		/* perform alarm setup when the show or disable modes are not set */

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -692,7 +692,7 @@ static int callback_log_stream_activity(void *data, int fd, char *buf, size_t bu
 	/* check output limit */
 	if (ctl->maxsz != 0 && ctl->outsz >= ctl->maxsz) {
 		if (!ctl->quiet)
-			printf(_("Script terminated, max output files size %"PRIu64" exceeded.\n"), ctl->maxsz);
+			printf(_("Script terminated, max output files size %ju exceeded.\n"), (uintmax_t) ctl->maxsz);
 		DBG(IO, ul_debug("output size %"PRIu64", exceeded limit %"PRIu64, ctl->outsz, ctl->maxsz));
 		logging_done(ctl, _("max output size exceeded"));
 		return 1;


### PR DESCRIPTION
Cast to intmax_t/uintmax_t and use their specifiers in translated message to keep message IDs stable as pointed out by Thomas Weißschuh.

Based on discussion in https://github.com/util-linux/util-linux/pull/4230, partially reverts some lines from https://github.com/util-linux/util-linux/pull/4184, otherwise fixes already offending formatters.

Searched for `"\s*PRI` and checked the lines. Hopefully all spotted.

CC: @t-8ch