### PR TITLE
treewide: use bash from PATH

### DIFF
--- a/.github/workflows/cibuild-setup-ubuntu.sh
+++ b/.github/workflows/cibuild-setup-ubuntu.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-     
+#!/usr/bin/env bash
+
 set -ex
 
 export DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/cibuild.sh
+++ b/.github/workflows/cibuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/misc-utils/getopt-example.bash
+++ b/misc-utils/getopt-example.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A small example script for using the getopt(1) program.
 # This script will only work with bash(1).

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/bitops/swapbytes
+++ b/tests/ts/bitops/swapbytes
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/bits/bits
+++ b/tests/ts/bits/bits
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/ts/blkdiscard/offsets
+++ b/tests/ts/blkdiscard/offsets
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2014 Federico Simoncelli <fsimonce@redhat.com>

--- a/tests/ts/blkid/cache
+++ b/tests/ts/blkid/cache
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2009 Karel Zak <kzak@redhat.com>

--- a/tests/ts/blkid/dm-err
+++ b/tests/ts/blkid/dm-err
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2016 Karel Zak <kzak@redhat.com>

--- a/tests/ts/blkid/low-probe
+++ b/tests/ts/blkid/low-probe
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2009 Karel Zak <kzak@redhat.com>

--- a/tests/ts/blkid/lowprobe-pt
+++ b/tests/ts/blkid/lowprobe-pt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2009 Karel Zak <kzak@redhat.com>

--- a/tests/ts/blkid/md-raid0-whole
+++ b/tests/ts/blkid/md-raid0-whole
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>

--- a/tests/ts/blkid/md-raid1-part
+++ b/tests/ts/blkid/md-raid1-part
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>

--- a/tests/ts/blkid/md-raid1-whole
+++ b/tests/ts/blkid/md-raid1-whole
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>

--- a/tests/ts/blkid/offset
+++ b/tests/ts/blkid/offset
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/blkid/options
+++ b/tests/ts/blkid/options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2026 Christian Goeschel Ndjomouo <cgoesc2@wgu.edu>

--- a/tests/ts/blkid/output
+++ b/tests/ts/blkid/output
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2024 Thomas Weißschuh <thomas.weissschuh@linutronix.de>

--- a/tests/ts/blkid/pt-details
+++ b/tests/ts/blkid/pt-details
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/blkid/topology
+++ b/tests/ts/blkid/topology
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2022 Thomas Weißschuh <thomas@t-8ch.de>

--- a/tests/ts/blkid/usages
+++ b/tests/ts/blkid/usages
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/build-sys/config
+++ b/tests/ts/build-sys/config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2011 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/cal/bigyear
+++ b/tests/ts/cal/bigyear
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/cal/color
+++ b/tests/ts/cal/color
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/cal/colorw
+++ b/tests/ts/cal/colorw
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/cal/column
+++ b/tests/ts/cal/column
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007-2018 Karel Zak <kzak@redhat.com>

--- a/tests/ts/cal/jan1753
+++ b/tests/ts/cal/jan1753
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/cal/month
+++ b/tests/ts/cal/month
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007-2018 Karel Zak <kzak@redhat.com>

--- a/tests/ts/cal/sep1752
+++ b/tests/ts/cal/sep1752
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/cal/vertical
+++ b/tests/ts/cal/vertical
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007-2018 Karel Zak <kzak@redhat.com>

--- a/tests/ts/cal/weekarg
+++ b/tests/ts/cal/weekarg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/cal/weeknum
+++ b/tests/ts/cal/weeknum
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/cal/year
+++ b/tests/ts/cal/year
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007-2018 Karel Zak <kzak@redhat.com>

--- a/tests/ts/chfn/gecos
+++ b/tests/ts/chfn/gecos
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2019 Radka Skvarilova <rskvaril@redhat.com>

--- a/tests/ts/chfn/input
+++ b/tests/ts/chfn/input
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Christian Goeschel Ndjomouo <cgoesc2@wgu.edu>
 #

--- a/tests/ts/choom/choom
+++ b/tests/ts/choom/choom
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/chrt/chrt
+++ b/tests/ts/chrt/chrt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/chrt/chrt-non-root
+++ b/tests/ts/chrt/chrt-non-root
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/col/io
+++ b/tests/ts/col/io
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2020 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/col/multibyte
+++ b/tests/ts/col/multibyte
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/col/newlines
+++ b/tests/ts/col/newlines
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2020 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/col/options
+++ b/tests/ts/col/options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2020 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/colcrt/functional
+++ b/tests/ts/colcrt/functional
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/colcrt/regressions
+++ b/tests/ts/colcrt/regressions
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/colrm/rm2-2
+++ b/tests/ts/colrm/rm2-2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2011 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/column/ansiescape
+++ b/tests/ts/column/ansiescape
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2024 Juarez Rudsatz <juarezr@gmail.com>

--- a/tests/ts/column/columnate
+++ b/tests/ts/column/columnate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2011 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/column/invalid-multibyte
+++ b/tests/ts/column/invalid-multibyte
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2014 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/column/multi-file
+++ b/tests/ts/column/multi-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2011 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/column/table
+++ b/tests/ts/column/table
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2011 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/copyfilerange/copyfilerange
+++ b/tests/ts/copyfilerange/copyfilerange
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Dick Marinus <dick@mrns.nl>
 #

--- a/tests/ts/coresched/coresched
+++ b/tests/ts/coresched/coresched
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: EUPL-1.2
 #
 # This file is part of util-linux

--- a/tests/ts/cramfs/doubles
+++ b/tests/ts/cramfs/doubles
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2011 Karel Zak <kzak@redhat.com>

--- a/tests/ts/cramfs/fsck-bad-header
+++ b/tests/ts/cramfs/fsck-bad-header
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/cramfs/fsck-endianness
+++ b/tests/ts/cramfs/fsck-endianness
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/cramfs/mkfs
+++ b/tests/ts/cramfs/mkfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/cramfs/mkfs-endianness
+++ b/tests/ts/cramfs/mkfs-endianness
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/dmesg/cid-json
+++ b/tests/ts/dmesg/cid-json
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/cid-kmsg-colors
+++ b/tests/ts/dmesg/cid-kmsg-colors
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/cid-kmsg-console-levels
+++ b/tests/ts/dmesg/cid-kmsg-console-levels
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/cid-kmsg-decode
+++ b/tests/ts/dmesg/cid-kmsg-decode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/cid-kmsg-delta
+++ b/tests/ts/dmesg/cid-kmsg-delta
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/cid-kmsg-facilities
+++ b/tests/ts/dmesg/cid-kmsg-facilities
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/cid-kmsg-indentation
+++ b/tests/ts/dmesg/cid-kmsg-indentation
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/cid-kmsg-json
+++ b/tests/ts/dmesg/cid-kmsg-json
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/cid-kmsg-limit
+++ b/tests/ts/dmesg/cid-kmsg-limit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/colors
+++ b/tests/ts/dmesg/colors
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/console-levels
+++ b/tests/ts/dmesg/console-levels
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/decode
+++ b/tests/ts/dmesg/decode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/delta
+++ b/tests/ts/dmesg/delta
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/facilities
+++ b/tests/ts/dmesg/facilities
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/indentation
+++ b/tests/ts/dmesg/indentation
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/json
+++ b/tests/ts/dmesg/json
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/kmsg-file
+++ b/tests/ts/dmesg/kmsg-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/limit
+++ b/tests/ts/dmesg/limit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/dmesg/timestamp-format
+++ b/tests/ts/dmesg/timestamp-format
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/eject/umount
+++ b/tests/ts/eject/umount
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="umount"

--- a/tests/ts/enosys/enosys
+++ b/tests/ts/enosys/enosys
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2022 Thomas Weißschuh <thomas@t-8ch.de>
 #

--- a/tests/ts/exch/exch
+++ b/tests/ts/exch/exch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/fadvise/drop
+++ b/tests/ts/fadvise/drop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="drop page caches related to a file"

--- a/tests/ts/fallocate/fallocate
+++ b/tests/ts/fallocate/fallocate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/fdisk/align-512-4K
+++ b/tests/ts/fdisk/align-512-4K
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/align-512-4K-63
+++ b/tests/ts/fdisk/align-512-4K-63
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/align-512-4K-md
+++ b/tests/ts/fdisk/align-512-4K-md
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/align-512-512
+++ b/tests/ts/fdisk/align-512-512
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/align-512-512-topology
+++ b/tests/ts/fdisk/align-512-512-topology
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/bsd
+++ b/tests/ts/fdisk/bsd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/fdisk/gpt
+++ b/tests/ts/fdisk/gpt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/fdisk/gpt-resize
+++ b/tests/ts/fdisk/gpt-resize
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/id
+++ b/tests/ts/fdisk/id
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/mbr-dos-mode
+++ b/tests/ts/fdisk/mbr-dos-mode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/mbr-logical-ebr-gap
+++ b/tests/ts/fdisk/mbr-logical-ebr-gap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="MBR - reserve EBR gap"
 . "$TS_TOPDIR"/functions.sh

--- a/tests/ts/fdisk/mbr-nondos-mode
+++ b/tests/ts/fdisk/mbr-nondos-mode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/mbr-sort
+++ b/tests/ts/fdisk/mbr-sort
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/oddinput
+++ b/tests/ts/fdisk/oddinput
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fdisk/resize
+++ b/tests/ts/fdisk/resize
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/fdisk/sunlabel
+++ b/tests/ts/fdisk/sunlabel
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/fincore/count
+++ b/tests/ts/fincore/count
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="count file contents in core"

--- a/tests/ts/findmnt/df-options
+++ b/tests/ts/findmnt/df-options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/findmnt/filter
+++ b/tests/ts/findmnt/filter
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/findmnt/filterQ
+++ b/tests/ts/findmnt/filterQ
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/findmnt/listmount
+++ b/tests/ts/findmnt/listmount
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/findmnt/outputs
+++ b/tests/ts/findmnt/outputs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/findmnt/target
+++ b/tests/ts/findmnt/target
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/flock/flock
+++ b/tests/ts/flock/flock
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/flock/range-lock
+++ b/tests/ts/flock/range-lock
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/fsck/ismounted
+++ b/tests/ts/fsck/ismounted
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2009 Karel Zak <kzak@redhat.com>
 #

--- a/tests/ts/fuzzers/test_blkid_fuzz
+++ b/tests/ts/fuzzers/test_blkid_fuzz
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/fuzzers/test_fdisk_script_fuzz
+++ b/tests/ts/fuzzers/test_fdisk_script_fuzz
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/fuzzers/test_last_fuzz
+++ b/tests/ts/fuzzers/test_last_fuzz
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/fuzzers/test_mount_fuzz
+++ b/tests/ts/fuzzers/test_mount_fuzz
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/getino/getino
+++ b/tests/ts/getino/getino
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/getopt/basic
+++ b/tests/ts/getopt/basic
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/getopt/options
+++ b/tests/ts/getopt/options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/hardlink/options
+++ b/tests/ts/hardlink/options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2018 Ruediger Meier <ruediger.meier@ga-group.nl>
 #

--- a/tests/ts/hexdump/format-strings
+++ b/tests/ts/hexdump/format-strings
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/hexdump/highlighting
+++ b/tests/ts/hexdump/highlighting
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/hwclock/show
+++ b/tests/ts/hwclock/show
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>

--- a/tests/ts/hwclock/systohc
+++ b/tests/ts/hwclock/systohc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/ionice/ionice
+++ b/tests/ts/ionice/ionice
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/ipcs/functions.sh
+++ b/tests/ts/ipcs/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/ipcs/headers
+++ b/tests/ts/ipcs/headers
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/ipcs/limits
+++ b/tests/ts/ipcs/limits
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/ipcs/limits2
+++ b/tests/ts/ipcs/limits2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/ipcs/mk-rm-msg
+++ b/tests/ts/ipcs/mk-rm-msg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/ipcs/mk-rm-sem
+++ b/tests/ts/ipcs/mk-rm-sem
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/ipcs/mk-rm-shm
+++ b/tests/ts/ipcs/mk-rm-shm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/isosize/print-size
+++ b/tests/ts/isosize/print-size
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/kill/all_processes
+++ b/tests/ts/kill/all_processes
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/kill/decode
+++ b/tests/ts/kill/decode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/kill/name_to_number
+++ b/tests/ts/kill/name_to_number
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/kill/options
+++ b/tests/ts/kill/options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/kill/pidfdino
+++ b/tests/ts/kill/pidfdino
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/kill/print_pid
+++ b/tests/ts/kill/print_pid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/kill/queue
+++ b/tests/ts/kill/queue
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/lib/pidutils
+++ b/tests/ts/lib/pidutils
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/lib/procfs
+++ b/tests/ts/lib/procfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Thomas Weißschuh <thomas@t-8ch.de>
 #

--- a/tests/ts/lib/timeutils
+++ b/tests/ts/lib/timeutils
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/tests/ts/libfdisk/gpt
+++ b/tests/ts/libfdisk/gpt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/libfdisk/mkpart
+++ b/tests/ts/libfdisk/mkpart
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/libfdisk/mkpart-full
+++ b/tests/ts/libfdisk/mkpart-full
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/liblastlog2/dlopen
+++ b/tests/ts/liblastlog2/dlopen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="dlopen"

--- a/tests/ts/liblastlog2/pam_lastlog2_output
+++ b/tests/ts/liblastlog2/pam_lastlog2_output
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="pam_lastlog2_output"

--- a/tests/ts/liblastlog2/remove_entry
+++ b/tests/ts/liblastlog2/remove_entry
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="remove_entry"

--- a/tests/ts/liblastlog2/rename_user
+++ b/tests/ts/liblastlog2/rename_user
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="rename_user"

--- a/tests/ts/liblastlog2/sqlite3_time
+++ b/tests/ts/liblastlog2/sqlite3_time
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="sqlite3_time"

--- a/tests/ts/liblastlog2/write_read_user
+++ b/tests/ts/liblastlog2/write_read_user
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="write_read_user"

--- a/tests/ts/liblastlog2/y2038_ll2_read_all
+++ b/tests/ts/liblastlog2/y2038_ll2_read_all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="y2038_ll2_read_all"

--- a/tests/ts/libmount/context
+++ b/tests/ts/libmount/context
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/context-py
+++ b/tests/ts/libmount/context-py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/context-utab
+++ b/tests/ts/libmount/context-utab
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/context-utab-py
+++ b/tests/ts/libmount/context-utab-py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 TS_TOPDIR="${0%/*}/../.."

--- a/tests/ts/libmount/debug
+++ b/tests/ts/libmount/debug
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2014 Ondrej Oprala <ooprala@redhat.com
 

--- a/tests/ts/libmount/lock
+++ b/tests/ts/libmount/lock
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/loop
+++ b/tests/ts/libmount/loop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2016 Stanislav Brabec <sbrabec@suse.cz>

--- a/tests/ts/libmount/loop-overlay
+++ b/tests/ts/libmount/loop-overlay
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2016 Stanislav Brabec <sbrabec@suse.cz>

--- a/tests/ts/libmount/optlist
+++ b/tests/ts/libmount/optlist
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/optstr
+++ b/tests/ts/libmount/optstr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/tabdiff
+++ b/tests/ts/libmount/tabdiff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2011 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/tabfiles
+++ b/tests/ts/libmount/tabfiles
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/tabfiles-py
+++ b/tests/ts/libmount/tabfiles-py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/tabfiles-tags
+++ b/tests/ts/libmount/tabfiles-tags
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="tags"

--- a/tests/ts/libmount/tabfiles-tags-py
+++ b/tests/ts/libmount/tabfiles-tags-py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="tags-py"

--- a/tests/ts/libmount/update
+++ b/tests/ts/libmount/update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/update-py
+++ b/tests/ts/libmount/update-py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libmount/utils
+++ b/tests/ts/libmount/utils
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/libsmartcols/continuous-json
+++ b/tests/ts/libsmartcols/continuous-json
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/libsmartcols/filter
+++ b/tests/ts/libsmartcols/filter
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/libsmartcols/fromfile
+++ b/tests/ts/libsmartcols/fromfile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/libsmartcols/termreduce-loop
+++ b/tests/ts/libsmartcols/termreduce-loop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/libsmartcols/title
+++ b/tests/ts/libsmartcols/title
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/line/line
+++ b/tests/ts/line/line
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/logger/errors
+++ b/tests/ts/logger/errors
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2015 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/logger/formats
+++ b/tests/ts/logger/formats
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2015 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/logger/journald
+++ b/tests/ts/logger/journald
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2015 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/logger/options
+++ b/tests/ts/logger/options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2015 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/login/islocal
+++ b/tests/ts/login/islocal
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2008 James Youngman <jay@gnu.org>

--- a/tests/ts/login/logindefs
+++ b/tests/ts/login/logindefs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2011 Karel Zak <kzak@redhat.com>
 #

--- a/tests/ts/look/separator
+++ b/tests/ts/look/separator
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/losetup/losetup
+++ b/tests/ts/losetup/losetup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2013 Karel Zak <kzak@redhat.com>

--- a/tests/ts/losetup/losetup-blkdev
+++ b/tests/ts/losetup/losetup-blkdev
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2013 Karel Zak <kzak@redhat.com>

--- a/tests/ts/losetup/losetup-loop
+++ b/tests/ts/losetup/losetup-loop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2016 Stanislav Brabec <sbrabec@suse.cz>

--- a/tests/ts/lsblk/lsblk
+++ b/tests/ts/lsblk/lsblk
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2018 Karel Zak <kzak@redhat.com>
 #

--- a/tests/ts/lsblk/mk-input.sh
+++ b/tests/ts/lsblk/mk-input.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2018 Karel Zak <kzak@redhat.com>
 #

--- a/tests/ts/lsclocks/lsclocks
+++ b/tests/ts/lsclocks/lsclocks
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>
 #

--- a/tests/ts/lscpu/lscpu
+++ b/tests/ts/lscpu/lscpu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2008 Cai Qian <qcai@redhat.com>
 #

--- a/tests/ts/lscpu/mk-input.sh
+++ b/tests/ts/lscpu/mk-input.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2008-2009 Karel Zak <kzak@redhat.com>
 #

--- a/tests/ts/lsfd/assoc-pidfs
+++ b/tests/ts/lsfd/assoc-pidfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2026 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-ainodeclass
+++ b/tests/ts/lsfd/column-ainodeclass
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-deleted
+++ b/tests/ts/lsfd/column-deleted
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-kthread
+++ b/tests/ts/lsfd/column-kthread
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-mntid
+++ b/tests/ts/lsfd/column-mntid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-mntid-nonroot
+++ b/tests/ts/lsfd/column-mntid-nonroot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-name
+++ b/tests/ts/lsfd/column-name
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-source
+++ b/tests/ts/lsfd/column-source
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-source-btrfs
+++ b/tests/ts/lsfd/column-source-btrfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-source-with-root
+++ b/tests/ts/lsfd/column-source-with-root
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-type
+++ b/tests/ts/lsfd/column-type
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/column-xmode
+++ b/tests/ts/lsfd/column-xmode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/error-eaccess
+++ b/tests/ts/lsfd/error-eaccess
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/error-eperm
+++ b/tests/ts/lsfd/error-eperm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/filter-broken-exp
+++ b/tests/ts/lsfd/filter-broken-exp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/filter-floating-point-nums
+++ b/tests/ts/lsfd/filter-floating-point-nums
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-bpf-map
+++ b/tests/ts/lsfd/mkfds-bpf-map
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-bpf-prog
+++ b/tests/ts/lsfd/mkfds-bpf-prog
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-cdev-tun
+++ b/tests/ts/lsfd/mkfds-cdev-tun
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-directory
+++ b/tests/ts/lsfd/mkfds-directory
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-eventfd
+++ b/tests/ts/lsfd/mkfds-eventfd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-eventpoll
+++ b/tests/ts/lsfd/mkfds-eventpoll
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-foreign-sockets
+++ b/tests/ts/lsfd/mkfds-foreign-sockets
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-inotify
+++ b/tests/ts/lsfd/mkfds-inotify
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-inotify-btrfs
+++ b/tests/ts/lsfd/mkfds-inotify-btrfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-mapped-packet-socket
+++ b/tests/ts/lsfd/mkfds-mapped-packet-socket
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-mmap-masked-file
+++ b/tests/ts/lsfd/mkfds-mmap-masked-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-mqueue
+++ b/tests/ts/lsfd/mkfds-mqueue
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-multiplexing
+++ b/tests/ts/lsfd/mkfds-multiplexing
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-netlink-groups
+++ b/tests/ts/lsfd/mkfds-netlink-groups
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-netlink-protocol
+++ b/tests/ts/lsfd/mkfds-netlink-protocol
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-netns
+++ b/tests/ts/lsfd/mkfds-netns
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-pidfd
+++ b/tests/ts/lsfd/mkfds-pidfd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-ping
+++ b/tests/ts/lsfd/mkfds-ping
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-pipe-no-fork
+++ b/tests/ts/lsfd/mkfds-pipe-no-fork
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-pty
+++ b/tests/ts/lsfd/mkfds-pty
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-raw
+++ b/tests/ts/lsfd/mkfds-raw
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-raw6
+++ b/tests/ts/lsfd/mkfds-raw6
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-ro-block-device
+++ b/tests/ts/lsfd/mkfds-ro-block-device
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-ro-regular-file
+++ b/tests/ts/lsfd/mkfds-ro-regular-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-rw-character-device
+++ b/tests/ts/lsfd/mkfds-rw-character-device
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-signalfd
+++ b/tests/ts/lsfd/mkfds-signalfd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-socketpair
+++ b/tests/ts/lsfd/mkfds-socketpair
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-symlink
+++ b/tests/ts/lsfd/mkfds-symlink
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-tcp
+++ b/tests/ts/lsfd/mkfds-tcp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-tcp-bare
+++ b/tests/ts/lsfd/mkfds-tcp-bare
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2026 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-tcp6
+++ b/tests/ts/lsfd/mkfds-tcp6
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-timerfd
+++ b/tests/ts/lsfd/mkfds-timerfd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-timerfd-alarm
+++ b/tests/ts/lsfd/mkfds-timerfd-alarm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-udp
+++ b/tests/ts/lsfd/mkfds-udp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-udp6
+++ b/tests/ts/lsfd/mkfds-udp6
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-unix-dgram
+++ b/tests/ts/lsfd/mkfds-unix-dgram
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-unix-in-netns
+++ b/tests/ts/lsfd/mkfds-unix-in-netns
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-unix-stream
+++ b/tests/ts/lsfd/mkfds-unix-stream
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-unix-stream-requiring-sockdiag
+++ b/tests/ts/lsfd/mkfds-unix-stream-requiring-sockdiag
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2022 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mkfds-vsock
+++ b/tests/ts/lsfd/mkfds-vsock
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/mount-over-same-path
+++ b/tests/ts/lsfd/mount-over-same-path
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2026 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/option-hyperlink
+++ b/tests/ts/lsfd/option-hyperlink
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/option-inet
+++ b/tests/ts/lsfd/option-inet
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/option-pid
+++ b/tests/ts/lsfd/option-pid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsfd/option-summary
+++ b/tests/ts/lsfd/option-summary
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lslocks/filter
+++ b/tests/ts/lslocks/filter
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lslocks/lslocks
+++ b/tests/ts/lslocks/lslocks
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2023 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lslogins/checkuser
+++ b/tests/ts/lslogins/checkuser
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="read logins"

--- a/tests/ts/lslogins/json_mode
+++ b/tests/ts/lslogins/json_mode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="test JSON output mode"

--- a/tests/ts/lsmem/lsmem
+++ b/tests/ts/lsmem/lsmem
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/lsmem/mk-input.sh
+++ b/tests/ts/lsmem/mk-input.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script makes a copy of relevant files from /sys.
 # The files are useful for lsmem(1) regression tests.

--- a/tests/ts/lsns/filedesc
+++ b/tests/ts/lsns/filedesc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsns/filter
+++ b/tests/ts/lsns/filter
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsns/ioctl_ns
+++ b/tests/ts/lsns/ioctl_ns
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsns/netns-from-sock
+++ b/tests/ts/lsns/netns-from-sock
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsns/netnsid
+++ b/tests/ts/lsns/netnsid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2017 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsns/netnsid-for-persistent-namespaces
+++ b/tests/ts/lsns/netnsid-for-persistent-namespaces
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/lsns/nsfs
+++ b/tests/ts/lsns/nsfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2017 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/mcookie/mcookie
+++ b/tests/ts/mcookie/mcookie
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/md5/md5
+++ b/tests/ts/md5/md5
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2009 Karel Zak <kzak@redhat.com>

--- a/tests/ts/minix/fsck
+++ b/tests/ts/minix/fsck
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2009 Karel Zak <kzak@redhat.com>
 #

--- a/tests/ts/minix/fsck-images
+++ b/tests/ts/minix/fsck-images
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/minix/mkfs
+++ b/tests/ts/minix/mkfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2009 Karel Zak <kzak@redhat.com>
 #

--- a/tests/ts/misc/boilerplate
+++ b/tests/ts/misc/boilerplate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>
 #

--- a/tests/ts/misc/canonicalize
+++ b/tests/ts/misc/canonicalize
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2025 Karel Zak <kzak@redhat.com>
 #

--- a/tests/ts/misc/colors
+++ b/tests/ts/misc/colors
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/ts/misc/configs
+++ b/tests/ts/misc/configs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/misc/mbsencode
+++ b/tests/ts/misc/mbsencode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2018 Vaclav Dolezal <vdolezal@redhat.com>

--- a/tests/ts/misc/optstr
+++ b/tests/ts/misc/optstr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="optstr"

--- a/tests/ts/misc/strtobool
+++ b/tests/ts/misc/strtobool
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2026 Karel Zak <kzak@redhat.com>

--- a/tests/ts/misc/strtosize
+++ b/tests/ts/misc/strtosize
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2010 Karel Zak <kzak@redhat.com>

--- a/tests/ts/misc/time_t
+++ b/tests/ts/misc/time_t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>
 #

--- a/tests/ts/mkswap/mkswap
+++ b/tests/ts/mkswap/mkswap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2022 Thomas Weißschuh <thomas@t-8ch.de>

--- a/tests/ts/more/regexp
+++ b/tests/ts/more/regexp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/more/squeeze
+++ b/tests/ts/more/squeeze
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/mount/complex
+++ b/tests/ts/mount/complex
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2022 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/devname
+++ b/tests/ts/mount/devname
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/dm-verity
+++ b/tests/ts/mount/dm-verity
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2021 Vojtech Eichler <veichler@redhat.com>

--- a/tests/ts/mount/fallback
+++ b/tests/ts/mount/fallback
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fstab-fallback"

--- a/tests/ts/mount/fslists
+++ b/tests/ts/mount/fslists
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2014 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-all
+++ b/tests/ts/mount/fstab-all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2019 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/mount/fstab-bind
+++ b/tests/ts/mount/fstab-bind
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fstab-bind"

--- a/tests/ts/mount/fstab-broken
+++ b/tests/ts/mount/fstab-broken
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-btrfs
+++ b/tests/ts/mount/fstab-btrfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2016 Stanislav Brabec <sbrabec@suse.cz>

--- a/tests/ts/mount/fstab-devname
+++ b/tests/ts/mount/fstab-devname
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-devname2label
+++ b/tests/ts/mount/fstab-devname2label
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-devname2uuid
+++ b/tests/ts/mount/fstab-devname2uuid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-label
+++ b/tests/ts/mount/fstab-label
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-label2devname
+++ b/tests/ts/mount/fstab-label2devname
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-label2uuid
+++ b/tests/ts/mount/fstab-label2uuid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-loop
+++ b/tests/ts/mount/fstab-loop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2016 Stanislav Brabec <sbrabec@suse.cz>

--- a/tests/ts/mount/fstab-none
+++ b/tests/ts/mount/fstab-none
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="none"

--- a/tests/ts/mount/fstab-symlink
+++ b/tests/ts/mount/fstab-symlink
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-uuid
+++ b/tests/ts/mount/fstab-uuid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-uuid2devname
+++ b/tests/ts/mount/fstab-uuid2devname
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/fstab-uuid2label
+++ b/tests/ts/mount/fstab-uuid2label
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/label
+++ b/tests/ts/mount/label
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/move
+++ b/tests/ts/mount/move
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/regfile
+++ b/tests/ts/mount/regfile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2011 Karel Zak <kzak@redhat.com>
 # This file is part of util-linux.

--- a/tests/ts/mount/remount
+++ b/tests/ts/mount/remount
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/set_ugid_mode
+++ b/tests/ts/mount/set_ugid_mode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: 0BSD
 
 

--- a/tests/ts/mount/shared-subtree
+++ b/tests/ts/mount/shared-subtree
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="shared-subtree"

--- a/tests/ts/mount/special
+++ b/tests/ts/mount/special
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>
@@ -28,7 +28,7 @@ ts_check_test_command "$TS_CMD_UMOUNT"
 ts_skip_nonroot
 
 cat > $MOUNTER <<\EOF
-#!/bin/bash
+#!/usr/bin/env bash
 # This util-linux regression test component
 # It's safe to remove me...
 #
@@ -62,7 +62,7 @@ ts_init_subtest "missing-options"
 grep -q 'nodev[[:space:]]*tmpfs' /proc/filesystems
 if [ "$?" == "0" ]; then
 cat > $MOUNTER <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 # This util-linux regression test component
 # It's safe to remove me...
 #

--- a/tests/ts/mount/subdir
+++ b/tests/ts/mount/subdir
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2022 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/umount-alltargets
+++ b/tests/ts/mount/umount-alltargets
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2013 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/mount/umount-recursive
+++ b/tests/ts/mount/umount-recursive
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2012 Karel Zak <kzak@redhat.com>
 

--- a/tests/ts/mount/uuid
+++ b/tests/ts/mount/uuid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mount/xnocanon
+++ b/tests/ts/mount/xnocanon
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2024 Karel Zak <kzak@redhat.com>

--- a/tests/ts/mountpoint/mountpoint
+++ b/tests/ts/mountpoint/mountpoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="mountpoint"

--- a/tests/ts/namei/logic
+++ b/tests/ts/namei/logic
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/nsenter/enter-via-socket
+++ b/tests/ts/nsenter/enter-via-socket
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/partx/partx
+++ b/tests/ts/partx/partx
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2010 Davidlohr Bueso <dave@gnu.org>

--- a/tests/ts/partx/partx-image
+++ b/tests/ts/partx/partx-image
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2010 Davidlohr Bueso <dave@gnu.org>

--- a/tests/ts/paths/built-in
+++ b/tests/ts/paths/built-in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/pipesz/pipesz
+++ b/tests/ts/pipesz/pipesz
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/prlimit/pidfd_ino
+++ b/tests/ts/prlimit/pidfd_ino
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/rename/basic
+++ b/tests/ts/rename/basic
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2014 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/rename/exit_codes
+++ b/tests/ts/rename/exit_codes
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2014 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/rename/overwrite
+++ b/tests/ts/rename/overwrite
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2017 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/rename/subdir
+++ b/tests/ts/rename/subdir
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2014 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/rename/symlink
+++ b/tests/ts/rename/symlink
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2014 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/rev/rev
+++ b/tests/ts/rev/rev
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/schedutils/cpuset
+++ b/tests/ts/schedutils/cpuset
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/script/buffering-race
+++ b/tests/ts/script/buffering-race
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/script/options
+++ b/tests/ts/script/options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/script/race
+++ b/tests/ts/script/race
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/script/replay
+++ b/tests/ts/script/replay
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/setarch/pid-without-show
+++ b/tests/ts/setarch/pid-without-show
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/setarch/setarch
+++ b/tests/ts/setarch/setarch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/setarch/show-with-pid
+++ b/tests/ts/setarch/show-with-pid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2025 Masatake YAMATO <yamato@redhat.com>
 #

--- a/tests/ts/setpgid/setpgid
+++ b/tests/ts/setpgid/setpgid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/setpriv/landlock
+++ b/tests/ts/setpriv/landlock
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>
 #

--- a/tests/ts/setpriv/seccomp
+++ b/tests/ts/setpriv/seccomp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>
 #

--- a/tests/ts/setsid/setsid
+++ b/tests/ts/setsid/setsid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/sfdisk/dos
+++ b/tests/ts/sfdisk/dos
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/sfdisk/dump
+++ b/tests/ts/sfdisk/dump
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/sfdisk/gpt
+++ b/tests/ts/sfdisk/gpt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/sfdisk/movedata
+++ b/tests/ts/sfdisk/movedata
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/sfdisk/resize
+++ b/tests/ts/sfdisk/resize
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/sfdisk/script
+++ b/tests/ts/sfdisk/script
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This file is part of util-linux.

--- a/tests/ts/sfdisk/wipe
+++ b/tests/ts/sfdisk/wipe
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of util-linux.
 #

--- a/tests/ts/sha1/sha1
+++ b/tests/ts/sha1/sha1
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2009 Karel Zak <kzak@redhat.com>

--- a/tests/ts/su/environ
+++ b/tests/ts/su/environ
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2024 Karel Zak <kzak@redhat.com>
 #

--- a/tests/ts/su/group
+++ b/tests/ts/su/group
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/su/shell
+++ b/tests/ts/su/shell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/swaplabel/swaplabel
+++ b/tests/ts/swaplabel/swaplabel
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/swapon/devname
+++ b/tests/ts/swapon/devname
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/swapon/fixpgsz
+++ b/tests/ts/swapon/fixpgsz
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fix page size"

--- a/tests/ts/swapon/fixsig
+++ b/tests/ts/swapon/fixsig
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="fix signature"

--- a/tests/ts/swapon/label
+++ b/tests/ts/swapon/label
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/swapon/uuid
+++ b/tests/ts/swapon/uuid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2007 Karel Zak <kzak@redhat.com>

--- a/tests/ts/ul/basic
+++ b/tests/ts/ul/basic
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2020 Sami Kerola <kerolasa@iki.fi>

--- a/tests/ts/ul/ul
+++ b/tests/ts/ul/ul
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/unshare/clear-env
+++ b/tests/ts/unshare/clear-env
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/unshare/forward-signals
+++ b/tests/ts/unshare/forward-signals
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2026 util-linux contributors

--- a/tests/ts/unshare/forward-signals-kill-child
+++ b/tests/ts/unshare/forward-signals-kill-child
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2026 util-linux contributors

--- a/tests/ts/utmp/last
+++ b/tests/ts/utmp/last
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/utmp/last-ipv6
+++ b/tests/ts/utmp/last-ipv6
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/utmp/utmpdump-circle
+++ b/tests/ts/utmp/utmpdump-circle
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/utmp/utmpdump-subsecond
+++ b/tests/ts/utmp/utmpdump-subsecond
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/utmp/utmpdump-tobin
+++ b/tests/ts/utmp/utmpdump-tobin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/utmp/utmpdump-tobin-ipv6
+++ b/tests/ts/utmp/utmpdump-tobin-ipv6
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/utmp/utmpdump-totxt
+++ b/tests/ts/utmp/utmpdump-totxt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/utmp/utmpdump-totxt-ipv6
+++ b/tests/ts/utmp/utmpdump-totxt-ipv6
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/uuid/namespace
+++ b/tests/ts/uuid/namespace
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2009 Karel Zak <kzak@redhat.com>

--- a/tests/ts/uuid/uuid_parser
+++ b/tests/ts/uuid/uuid_parser
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/uuidd/uuidd
+++ b/tests/ts/uuidd/uuidd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/uuidgen/oids
+++ b/tests/ts/uuidgen/oids
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/uuidgen/uuidgen
+++ b/tests/ts/uuidgen/uuidgen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/uuidparse/time
+++ b/tests/ts/uuidparse/time
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/uuidparse/uuidparse
+++ b/tests/ts/uuidparse/uuidparse
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/waitpid/pidfd-ino
+++ b/tests/ts/waitpid/pidfd-ino
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/waitpid/waitpid
+++ b/tests/ts/waitpid/waitpid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2022 Thomas Weißschuh <thomas@t-8ch.de>
 #

--- a/tests/ts/whereis/whereis
+++ b/tests/ts/whereis/whereis
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tests/ts/wipefs/signatures
+++ b/tests/ts/wipefs/signatures
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (C) 2023 Thomas Weißschuh <thomas@t-8ch.de>

--- a/tests/ts/wipefs/wipefs
+++ b/tests/ts/wipefs/wipefs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TS_TOPDIR="${0%/*}/../.."
 TS_DESC="wipefs"

--- a/tools/all_errnos
+++ b/tools/all_errnos
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Derived from all_syscalls.
 

--- a/tools/all_syscalls
+++ b/tools/all_syscalls
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail

--- a/tools/checkadoc-missing.sh
+++ b/tools/checkadoc-missing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2021 Karel Zak <kzak@redhat.com>
 # based on checkman.sh from Sami Kerola <kerolasa@iki.fi>

--- a/tools/checkadoc-repeat.sh
+++ b/tools/checkadoc-repeat.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e		# exit on errors
 set -o pipefail	# exit if pipe writer fails

--- a/tools/checkcompletion.sh
+++ b/tools/checkcompletion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This script verifies bash-completion consistency by checking:

--- a/tools/checkmanpage.sh
+++ b/tools/checkmanpage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tools/checktarball-meson.sh
+++ b/tools/checktarball-meson.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/tools/checkusage.sh
+++ b/tools/checkusage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## This script is potentially dangerous! Don't run it on
 ## arbitrary commands.

--- a/tools/get-options.sh
+++ b/tools/get-options.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #

--- a/tools/git-grouped-log
+++ b/tools/git-grouped-log
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/tools/git-tp-sync
+++ b/tools/git-tp-sync
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/tools/git-version-bump
+++ b/tools/git-version-bump
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/tools/git-version-next
+++ b/tools/git-version-next
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/testcoverage.sh
+++ b/tools/testcoverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of util-linux.
 #


### PR DESCRIPTION
The system shell at /bin/bash may not be sufficient. Look it up from $PATH, so the user can override it.