### PR TITLE
flock: re-enable the initial shell selection logic

### DIFF
--- a/sys-utils/flock.c
+++ b/sys-utils/flock.c
@@ -330,7 +330,7 @@ int main(int argc, char *argv[])
 				     _("%s requires exactly one command argument"),
 				     argv[optind + 1]);
 			cmd_argv = sh_c_argv;
-			cmd_argv[0] = (char *)ul_default_shell(0, NULL);
+			cmd_argv[0] = (char *)ul_default_shell(UL_SHELL_NOPWD, NULL);
 			cmd_argv[1] = "-c";
 			cmd_argv[2] = argv[optind + 2];
 			cmd_argv[3] = NULL;


### PR DESCRIPTION
Commit 6651ae5 added /etc/passwd to the list of shells to choose from before falling back to _PATH_BSHELL. This introduced a regression as some tools dont expect this behavior and assume that unsetting SHELLS is enough.

To re-establish the old behavior we can pass the UL_SHELL_NOPWD flag to the ul_default_shell() helper to ignore shells in /etc/passwd.

Addresses: #4242