### PR TITLE
docs: update shell selection documentation after ul_default_shell() changes

### DIFF
--- a/sys-utils/flock.1.adoc
+++ b/sys-utils/flock.1.adoc
@@ -56,7 +56,7 @@ The third form uses an open file by its file descriptor _number_. See the exampl
 == OPTIONS
 
 *-c*, *--command* _command_::
-Pass a single _command_, without arguments, to the shell with *-c*.
+Pass a single _command_, without arguments, to the shell with *-c*. See *SHELL* in the *ENVIRONMENT* section.
 
 *-E*, *--conflict-exit-code* _number_::
 The exit status used when the *-n* option is in use, and the conflicting lock exists, or the *-w* option is in use, and the timeout is reached. The default value is *1*. The _number_ has to be in the range of 0 to 255.
@@ -103,6 +103,11 @@ include::man-common/help-version.adoc[]
 The command uses <sysexits.h> exit status values for everything, except when using either of the options *-n* or *-w* which report a failure to acquire the lock with an exit status given by the *-E* option, or 1 by default. The exit status given by *-E* has to be in the range of 0 to 255.
 
 When using the _command_ variant, and executing the child worked, then the exit status is that of the child command.
+
+== ENVIRONMENT
+
+*SHELL*::
+The shell used for *-c* _command_ execution. If *SHELL* is not set, _/bin/sh_ is used as the fallback. The user's passwd(5) shell is not consulted, as the command is executed non-interactively.
 
 == NOTES
 

--- a/sys-utils/nsenter.1.adoc
+++ b/sys-utils/nsenter.1.adoc
@@ -16,7 +16,7 @@ nsenter - run program in different namespaces
 
 == DESCRIPTION
 
-The *nsenter* command executes _program_ in the namespace(s) that are specified in the command-line options (described below). If _program_ is not given, then "$\{SHELL}" is run (default: _/bin/sh_).
+The *nsenter* command executes _program_ in the namespace(s) that are specified in the command-line options (described below). If _program_ is not given, then "$\{SHELL}" is run. If *SHELL* is not set, the shell from the user's passwd(5) entry is used. If no shell is defined there either, _/bin/sh_ is used as the fallback.
 
 Enterable namespaces are:
 
@@ -157,6 +157,11 @@ Set the SELinux security context used for executing a new process according to t
 Add the initiated process to the cgroup of the target process.
 
 include::man-common/help-version.adoc[]
+
+== ENVIRONMENT
+
+*SHELL*::
+The default shell to run when no _program_ is specified. If *SHELL* is not set, the shell from the user's passwd(5) entry is used. If no shell is defined there either, _/bin/sh_ is used as the fallback.
 
 == NOTES
 

--- a/sys-utils/unshare.1.adoc
+++ b/sys-utils/unshare.1.adoc
@@ -16,7 +16,7 @@ unshare - run program in new namespaces
 
 == DESCRIPTION
 
-The *unshare* command creates new namespaces (as specified by the command-line options described below) and then executes the specified _program_. If _program_ is not given, then "${SHELL}" is run (default: _/bin/sh_).
+The *unshare* command creates new namespaces (as specified by the command-line options described below) and then executes the specified _program_. If _program_ is not given, then "${SHELL}" is run. If *SHELL* is not set, the shell from the user's passwd(5) entry is used. If no shell is defined there either, _/bin/sh_ is used as the fallback.
 
 By default, a new namespace persists only as long as it has member processes. A new namespace can be made persistent even when it has no member processes by bind mounting /proc/_pid_/ns/_type_ files to a filesystem path. A namespace that has been made persistent in this way can subsequently be entered with *nsenter*(1) even after the _program_ terminates (except PID namespaces where a permanently running init process is required). Once a persistent namespace is no longer needed, it can be unpersisted by using *umount*(8) to remove the bind mount. See the *EXAMPLES* section for more details.
 
@@ -171,6 +171,11 @@ Set the offset of *CLOCK_BOOTTIME* which will be used in the entered time namesp
 Do not pass the environment variables of the calling process to the unshared process.
 
 include::man-common/help-version.adoc[]
+
+== ENVIRONMENT
+
+*SHELL*::
+The default shell to run when no _program_ is specified. If *SHELL* is not set, the shell from the user's passwd(5) entry is used. If no shell is defined there either, _/bin/sh_ is used as the fallback.
 
 == NOTES
 

--- a/term-utils/script.1.adoc
+++ b/term-utils/script.1.adoc
@@ -133,7 +133,7 @@ Upon receiving *SIGUSR1*, *script* immediately flushes the output files.
 Enable script debug output.
 
 *SHELL*::
-Override the default shell. If *SHELL* is not set, the Bourne shell is assumed. (Most shells set this variable automatically).
+Override the default shell. If *SHELL* is not set, the shell from the user's passwd(5) entry is used. If no shell is defined there either, _/bin/sh_ is used as the fallback.
 
 *ULPTY_DEBUG*=all::
 Enable pty debug output.

--- a/term-utils/scriptlive.1.adoc
+++ b/term-utils/scriptlive.1.adoc
@@ -19,7 +19,7 @@ scriptlive - re-run session typescripts, using timing information
 
 This program re-runs a typescript, using stdin typescript and timing information to ensure that input happens in the same rhythm as it originally appeared when the script was recorded.
 
-The *session is executed* in a newly created pseudoterminal with the user's $SHELL (or defaults to _/bin/bash_).
+The *session is executed* in a newly created pseudoterminal with the user's $SHELL, the shell from the user's passwd(5) entry, or _/bin/sh_ as the fallback.
 
 *Be careful!* The typescript may contain arbitrary commands. It is
 recommended to use *"scriptreplay --stream in --log-in typescript"*
@@ -65,6 +65,9 @@ Set the maximum delay between updates to _number_ of seconds. The argument is a 
 include::man-common/help-version.adoc[]
 
 == ENVIRONMENT
+
+*SHELL*::
+Override the default shell. If *SHELL* is not set, the shell from the user's passwd(5) entry is used. If no shell is defined there either, _/bin/sh_ is used as the fallback.
 
 *SCRIPTREPLAY_DEBUG*=all::
 Enable scriptreplay debug output.

--- a/text-utils/more.1.adoc
+++ b/text-utils/more.1.adoc
@@ -194,7 +194,7 @@ Equivalent to MORESECURE.
 Disable exit-on-eof (see option *-e* for more details).
 
 *SHELL*::
-Override the default shell.
+Override the default shell. If *SHELL* is not set, the shell from the user's passwd(5) entry is used. If no shell is defined there either, _/bin/sh_ is used as the fallback.
 
 *TERM*::
 Specify the terminal type used by *more* to get the terminal characteristics necessary to manipulate the screen.


### PR DESCRIPTION
After ul_default_shell() was introduced to unify shell resolution (#3865), the man pages were not updated to reflect the new fallback order ($SHELL → passwd(5) → /bin/sh).
                                                                                               
This branch updates documentation for all affected tools:
  - script(1), scriptlive(1), more(1):  update SHELL description in ENVIRONMENT section
  - unshare(1), nsenter(1), flock(1): add missing ENVIRONMENT section with SHELL entry        
  - flock(1): document that passwd(5) is not consulted for non-interactive -c execution
                                                                     
Addresses: #4242
