### PR TITLE
use pkg-config variables for external libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1103,8 +1103,8 @@ AS_IF([test "x$with_audit" = xno], [
   )
   AS_IF([test "x$have_audit" = xyes], [
     AC_DEFINE([HAVE_LIBAUDIT], [1], [Define if audit is available])
-    AM_CONDITIONAL([HAVE_AUDIT], [true])
   ])
+  AM_CONDITIONAL([HAVE_AUDIT], [test "x$have_audit" = xyes])
 ])
 AC_SUBST([AUDIT_LIBS])
 
@@ -1123,8 +1123,8 @@ AS_IF([test "x$with_udev" = xno], [
   )
   AS_IF([test "x$have_udev" = xyes], [
     AC_DEFINE([HAVE_LIBUDEV], [1], [Define if udev is available])
-    AM_CONDITIONAL([HAVE_UDEV], [true])
   ])
+  AM_CONDITIONAL([HAVE_UDEV], [test "x$have_udev" = xyes])
 ])
 AC_SUBST([UDEV_LIBS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1103,15 +1103,21 @@ AC_ARG_WITH([udev], AS_HELP_STRING([--without-udev], [compile without udev suppo
   [], [with_udev=auto]
 )
 
+have_udev=no
 AS_IF([test "x$with_udev" = xno], [
   AM_CONDITIONAL([HAVE_UDEV], [false])
 ], [
-  UL_CHECK_LIB([udev], [udev_new])
+  PKG_CHECK_MODULES([UDEV], [libudev], [have_udev=yes], [have_udev=no])
   AS_CASE([$with_udev:$have_udev],
     [yes:no],
       [AC_MSG_ERROR([udev selected but libudev not found])]
   )
+  AS_IF([test "x$have_udev" = xyes], [
+    AC_DEFINE([HAVE_LIBUDEV], [1], [Define if udev is available])
+    AM_CONDITIONAL([HAVE_UDEV], [true])
+  ])
 ])
+AC_SUBST([UDEV_LIBS])
 
 
 dnl wide-char ncurses

--- a/configure.ac
+++ b/configure.ac
@@ -1678,12 +1678,14 @@ AC_ARG_WITH([cap_ng],
   AS_HELP_STRING([--without-cap-ng], [compile without libcap-ng]),
   [], [with_cap_ng=auto]
 )
+have_cap_ng=no
 AS_IF([test "x$with_cap_ng" = xno], [
   AM_CONDITIONAL([HAVE_CAP_NG], [false])
-  have_cap_ng=no
 ],[
-  UL_CHECK_LIB([cap-ng], [capng_apply], [cap_ng])
+  PKG_CHECK_MODULES([CAP_NG], [libcap-ng], [have_cap_ng=yes], [have_cap_ng=no])
+  AM_CONDITIONAL([HAVE_CAP_NG], [test "x$have_cap_ng" = xyes])
 ])
+AC_SUBST([CAP_NG_LIBS])
 
 
 AC_ARG_ENABLE([setpriv],

--- a/configure.ac
+++ b/configure.ac
@@ -1752,9 +1752,11 @@ AC_ARG_WITH([libz],
   AS_HELP_STRING([--without-libz], [compile without libz]),
   [], [with_libz=auto]
 )
-AS_IF([test "x$with_libz" = xno], [have_z=no], [
-  AC_CHECK_LIB([z], [crc32], [have_z=yes], [have_z=no])
+have_z=no
+AS_IF([test "x$with_libz" = xno], [], [
+  PKG_CHECK_MODULES([Z], [zlib], [have_z=yes], [have_z=no])
 ])
+AC_SUBST([Z_LIBS])
 
 AC_ARG_WITH([libmagic],
   AS_HELP_STRING([--without-libmagic], [compile without libmagic]),

--- a/configure.ac
+++ b/configure.ac
@@ -1089,15 +1089,21 @@ AC_ARG_WITH([audit],
   [], [with_audit=no]
 )
 
+have_audit=no
 AS_IF([test "x$with_audit" = xno], [
   AM_CONDITIONAL([HAVE_AUDIT], [false])
 ], [
-  UL_CHECK_LIB([audit], [audit_log_user_message])
+  PKG_CHECK_MODULES([AUDIT], [audit], [have_audit=yes], [have_audit=no])
   AS_CASE([$with_audit:$have_audit],
     [yes:no],
-      [AC_MSG_ERROR([Audit selected but libaudit not found (or does not support audit_log_user_message())])]
+      [AC_MSG_ERROR([Audit selected but libaudit not found])]
   )
+  AS_IF([test "x$have_audit" = xyes], [
+    AC_DEFINE([HAVE_LIBAUDIT], [1], [Define if audit is available])
+    AM_CONDITIONAL([HAVE_AUDIT], [true])
+  ])
 ])
+AC_SUBST([AUDIT_LIBS])
 
 AC_ARG_WITH([udev], AS_HELP_STRING([--without-udev], [compile without udev support]),
   [], [with_udev=auto]

--- a/configure.ac
+++ b/configure.ac
@@ -747,11 +747,14 @@ AS_IF([test "x$ul_cv_syscall_statmount" = xno ||
    ])
 
 
-AC_CHECK_FUNCS([isnan], [],
-	[AC_CHECK_LIB([m], [isnan], [MATH_LIBS="-lm"])]
-	[AC_CHECK_LIB([m], [__isnan], [MATH_LIBS="-lm"])]
-)
+AC_CHECK_LIB([m], [floor], [MATH_LIBS="-lm"])
 AC_SUBST([MATH_LIBS])
+
+AC_CHECK_FUNCS([isnan], [],
+	[AC_CHECK_LIB([m], [isnan], [ISNAN_LIBS="-lm"])]
+	[AC_CHECK_LIB([m], [__isnan], [ISNAN_LIBS="-lm"])]
+)
+AC_SUBST([ISNAN_LIBS])
 
 
 dnl lib/mononotic.c may require -lrt

--- a/disk-utils/Makemodule.am
+++ b/disk-utils/Makemodule.am
@@ -71,7 +71,7 @@ mkswap_CFLAGS += -I$(ul_libblkid_incdir)
 mkswap_LDADD += libblkid.la
 endif
 if HAVE_SELINUX
-mkswap_LDADD += -lselinux
+mkswap_LDADD += $(SELINUX_LIBS)
 mkswap_SOURCES += \
 	lib/selinux-utils.c \
 	include/selinux-utils.h

--- a/disk-utils/Makemodule.am
+++ b/disk-utils/Makemodule.am
@@ -122,13 +122,13 @@ sbin_PROGRAMS += fsck.cramfs
 MANPAGES += disk-utils/fsck.cramfs.8
 dist_noinst_DATA += disk-utils/fsck.cramfs.8.adoc
 fsck_cramfs_SOURCES = disk-utils/fsck.cramfs.c $(cramfs_common_sources)
-fsck_cramfs_LDADD = $(LDADD) -lz libcommon.la
+fsck_cramfs_LDADD = $(LDADD) $(Z_LIBS) libcommon.la
 
 sbin_PROGRAMS += mkfs.cramfs
 MANPAGES += disk-utils/mkfs.cramfs.8
 dist_noinst_DATA += disk-utils/mkfs.cramfs.8.adoc
 mkfs_cramfs_SOURCES = disk-utils/mkfs.cramfs.c $(cramfs_common_sources)
-mkfs_cramfs_LDADD = $(LDADD) -lz libcommon.la
+mkfs_cramfs_LDADD = $(LDADD) $(Z_LIBS) libcommon.la
 endif
 
 if BUILD_FDFORMAT

--- a/lib/Makemodule.am
+++ b/lib/Makemodule.am
@@ -252,5 +252,5 @@ test_logindefs_SOURCES = lib/logindefs.c
 test_logindefs_CPPFLAGS = -DTEST_PROGRAM $(AM_CPPFLAGS)
 test_logindefs_LDADD = $(LDADD) libcommon.la
 if HAVE_ECONF
-test_logindefs_LDADD += -leconf
+test_logindefs_LDADD += $(ECONF_LIBS)
 endif

--- a/lib/Makemodule.am
+++ b/lib/Makemodule.am
@@ -183,7 +183,7 @@ test_pty_SOURCES = lib/pty-session.c \
 		   include/pty-session.h \
 		   lib/monotonic.c
 test_pty_CFLAGS = $(AM_CFLAGS) -DTEST_PROGRAM_PTY
-test_pty_LDADD = $(LDADD) libcommon.la $(MATH_LIBS) $(REALTIME_LIBS) -lutil
+test_pty_LDADD = $(LDADD) libcommon.la $(REALTIME_LIBS) -lutil
 endif
 
 if LINUX

--- a/libblkid/src/Makemodule.am
+++ b/libblkid/src/Makemodule.am
@@ -120,7 +120,7 @@ endif
 
 libblkid_la_LIBADD = libcommon.la
 if HAVE_ECONF
-libblkid_la_LIBADD += -leconf
+libblkid_la_LIBADD += $(ECONF_LIBS)
 endif
 
 EXTRA_libblkid_la_DEPENDENCIES = \

--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -71,7 +71,7 @@ if HAVE_SELINUX
 login_LDADD += -lselinux
 endif
 if HAVE_ECONF
-login_LDADD += -leconf
+login_LDADD += $(ECONF_LIBS)
 endif
 endif # BUILD_LOGIN
 
@@ -149,7 +149,7 @@ chfn_CFLAGS = $(chfn_chsh_cflags)
 chfn_LDFLAGS = $(chfn_chsh_ldflags)
 chfn_LDADD = $(LDADD) $(chfn_chsh_ldadd)
 if HAVE_ECONF
-chfn_LDADD += -leconf
+chfn_LDADD += $(ECONF_LIBS)
 endif
 
 chsh_SOURCES = login-utils/chsh.c lib/shells.c $(chfn_chsh_sources)
@@ -157,7 +157,7 @@ chsh_CFLAGS = $(chfn_chsh_cflags)
 chsh_LDFLAGS = $(chfn_chsh_ldflags)
 chsh_LDADD = $(LDADD) $(chfn_chsh_ldadd)
 if HAVE_ECONF
-chsh_LDADD += -leconf
+chsh_LDADD += $(ECONF_LIBS)
 endif
 endif # BUILD_CHFN_CHSH
 
@@ -185,7 +185,7 @@ su_SOURCES += lib/pty-session.c \
 su_LDADD += -lutil $(REALTIME_LIBS)
 endif
 if HAVE_ECONF
-su_LDADD += -leconf
+su_LDADD += $(ECONF_LIBS)
 endif
 endif # BUILD_SU
 
@@ -211,7 +211,7 @@ runuser_SOURCES += lib/pty-session.c \
 runuser_LDADD += -lutil $(REALTIME_LIBS)
 endif
 if HAVE_ECONF
-runuser_LDADD += -leconf
+runuser_LDADD += $(ECONF_LIBS)
 endif
 endif # BUILD_RUNUSER
 
@@ -247,7 +247,7 @@ lslogins_LDADD += $(SYSTEMD_LIBS) $(SYSTEMD_JOURNAL_LIBS)
 lslogins_CFLAGS += $(SYSTEMD_CFLAGS) $(SYSTEMD_JOURNAL_CFLAGS)
 endif
 if HAVE_ECONF
-lslogins_LDADD += -leconf
+lslogins_LDADD += $(ECONF_LIBS)
 endif
 if BUILD_LIBLASTLOG2
 lslogins_CFLAGS += -I$(ul_liblastlog2_incdir)

--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -43,7 +43,7 @@ if HAVE_LIBCRYPT
 sulogin_LDADD += -lcrypt
 endif
 if HAVE_SELINUX
-sulogin_LDADD += -lselinux
+sulogin_LDADD += $(SELINUX_LIBS)
 endif
 
 check_PROGRAMS += test_consoles
@@ -68,7 +68,7 @@ if HAVE_AUDIT
 login_LDADD += -laudit
 endif
 if HAVE_SELINUX
-login_LDADD += -lselinux
+login_LDADD += $(SELINUX_LIBS)
 endif
 if HAVE_ECONF
 login_LDADD += $(ECONF_LIBS)
@@ -138,7 +138,7 @@ if HAVE_SELINUX
 chfn_chsh_sources += \
 	lib/selinux-utils.c \
 	include/selinux-utils.h
-chfn_chsh_ldadd += -lselinux
+chfn_chsh_ldadd += $(SELINUX_LIBS)
 endif
 
 chfn_SOURCES = \
@@ -240,7 +240,7 @@ lslogins_SOURCES = \
 lslogins_LDADD = $(LDADD) libcommon.la libsmartcols.la
 lslogins_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
 if HAVE_SELINUX
-lslogins_LDADD += -lselinux
+lslogins_LDADD += $(SELINUX_LIBS)
 endif
 if HAVE_SYSTEMD
 lslogins_LDADD += $(SYSTEMD_LIBS) $(SYSTEMD_JOURNAL_LIBS)
@@ -266,7 +266,7 @@ vipw_SOURCES = \
 	login-utils/setpwnam.h
 vipw_LDADD = $(LDADD) libcommon.la
 if HAVE_SELINUX
-vipw_LDADD += -lselinux
+vipw_LDADD += $(SELINUX_LIBS)
 endif
 install-exec-hook-vipw::
 	cd $(DESTDIR)$(usrsbin_execdir) && ln -sf vipw vigr

--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -65,7 +65,7 @@ if HAVE_LINUXPAM
 login_LDADD += -lpam_misc
 endif
 if HAVE_AUDIT
-login_LDADD += -laudit
+login_LDADD += $(AUDIT_LIBS)
 endif
 if HAVE_SELINUX
 login_LDADD += $(SELINUX_LIBS)

--- a/lsblk-cmd/Makemodule.am
+++ b/lsblk-cmd/Makemodule.am
@@ -12,7 +12,7 @@ lsblk_LDADD = $(LDADD) libblkid.la libmount.la libcommon.la \
 		libsmartcols.la libtcolors.la
 lsblk_CFLAGS = $(AM_CFLAGS) -I$(ul_libblkid_incdir) -I$(ul_libmount_incdir) -I$(ul_libsmartcols_incdir)
 if HAVE_UDEV
-lsblk_LDADD += -ludev
+lsblk_LDADD += $(UDEV_LIBS)
 endif
 endif # BUILD_LSBLK
 

--- a/meson.build
+++ b/meson.build
@@ -3600,8 +3600,7 @@ if have_pty
     c_args : ['-DTEST_PROGRAM_PTY'],
     include_directories : dir_include,
     link_with : [lib_common],
-    dependencies : [lib_m,
-                    realtime_libs,
+    dependencies : [realtime_libs,
                     lib_util],
     build_by_default: program_tests)
   if not is_disabler(exe)

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -205,7 +205,7 @@ findmnt_SOURCES = misc-utils/findmnt.c \
 		  misc-utils/findmnt-verify.c \
 		  misc-utils/findmnt.h
 if HAVE_UDEV
-findmnt_LDADD += -ludev
+findmnt_LDADD += $(UDEV_LIBS)
 endif
 endif # BUILD_FINDMNT
 

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -94,7 +94,7 @@ usrbin_exec_PROGRAMS += lastlog2
 MANPAGES += misc-utils/lastlog2.8
 dist_noinst_DATA += misc-utils/lastlog2.8.adoc
 lastlog2_SOURCES = misc-utils/lastlog2.c lib/strutils.c
-lastlog2_LDADD = $(LDADD) liblastlog2.la -lsqlite3
+lastlog2_LDADD = $(LDADD) liblastlog2.la $(SQLITE3_LIBS)
 lastlog2_CFLAGS = $(AM_CFLAGS) -I$(ul_liblastlog2_incdir)
 systemdsystemunit_DATA += \
 	misc-utils/lastlog2-import.service

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -565,7 +565,7 @@ if USE_HWCLOCK_GPLv3_DATETIME
 hwclock_SOURCES += \
 	sys-utils/hwclock-parse-date.y
 endif
-hwclock_LDADD = $(LDADD) libcommon.la -lm
+hwclock_LDADD = $(LDADD) libcommon.la $(MATH_LIBS)
 hwclock_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/sys-utils
 if USE_HWCLOCK_CMOS
 hwclock_SOURCES += \

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -583,7 +583,7 @@ hwclock_SOURCES += \
 	lib/monotonic.c
 endif
 if HAVE_AUDIT
-hwclock_LDADD += -laudit
+hwclock_LDADD += $(AUDIT_LIBS)
 endif
 endif # BUILD_HWCLOCK
 

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -598,7 +598,7 @@ dist_noinst_HEADERS += sys-utils/setpriv-landlock.h
 if HAVE_LINUX_LANDLOCK_H
 setpriv_SOURCES += sys-utils/setpriv-landlock.c
 endif
-setpriv_LDADD = $(LDADD) -lcap-ng libcommon.la
+setpriv_LDADD = $(LDADD) $(CAP_NG_LIBS) libcommon.la
 if HAVE_ECONF
 setpriv_LDADD += $(ECONF_LIBS)
 endif

--- a/term-utils/Makemodule.am
+++ b/term-utils/Makemodule.am
@@ -7,7 +7,7 @@ script_SOURCES = term-utils/script.c \
 		 include/pty-session.h \
 		 lib/monotonic.c
 script_CFLAGS = $(AM_CFLAGS) -Wno-format-y2k
-script_LDADD = $(LDADD) libcommon.la $(MATH_LIBS) $(REALTIME_LIBS) -lutil
+script_LDADD = $(LDADD) libcommon.la $(ISNAN_LIBS) $(REALTIME_LIBS) -lutil
 if HAVE_UTEMPTER
 script_LDADD += -lutempter
 endif
@@ -25,7 +25,7 @@ dist_noinst_DATA += term-utils/scriptreplay.1.adoc
 scriptreplay_SOURCES = term-utils/scriptreplay.c \
 		       term-utils/script-playutils.c \
 		       term-utils/script-playutils.h
-scriptreplay_LDADD = $(LDADD) libcommon.la $(MATH_LIBS)
+scriptreplay_LDADD = $(LDADD) libcommon.la $(ISNAN_LIBS)
 endif # BUILD_SCRIPTREPLAY
 
 if BUILD_SCRIPTLIVE
@@ -38,7 +38,7 @@ scriptlive_SOURCES = term-utils/scriptlive.c \
 		       lib/pty-session.c \
 		       include/pty-session.h \
 		       lib/monotonic.c
-scriptlive_LDADD = $(LDADD) libcommon.la $(MATH_LIBS) $(REALTIME_LIBS) -lutil
+scriptlive_LDADD = $(LDADD) libcommon.la $(ISNAN_LIBS) $(REALTIME_LIBS) -lutil
 endif # BUILD_SCRIPTLIVE
 
 

--- a/term-utils/Makemodule.am
+++ b/term-utils/Makemodule.am
@@ -59,7 +59,7 @@ if BSD
 agetty_LDADD += -lutil
 endif
 if HAVE_ECONF
-agetty_LDADD += -leconf
+agetty_LDADD += $(ECONF_LIBS)
 endif
 if HAVE_SYSTEMD
 agetty_LDADD += $(SYSTEMD_LIBS)

--- a/tests/helpers/Makemodule.am
+++ b/tests/helpers/Makemodule.am
@@ -58,7 +58,7 @@ endif
 if HAVE_CAP_NG
 check_PROGRAMS += test_cap
 test_cap_SOURCES = tests/helpers/test_cap.c
-test_cap_LDADD = -lcap-ng
+test_cap_LDADD = $(CAP_NG_LIBS)
 endif
 
 check_PROGRAMS += test_open_twice


### PR DESCRIPTION
  Cleanup hardcoded `-l<lib>` flags in Makemodule.am files, replacing them with                
  proper variables from pkg-config or configure.ac detection.                                  
                                                                                               
  **Use existing `_LIBS` variables from `PKG_CHECK_MODULES`:**                                 
  - `$(ECONF_LIBS)` instead of `-leconf` (9 occurrences)
  - `$(SELINUX_LIBS)` instead of `-lselinux` (6 occurrences)                                   
  - `$(SQLITE3_LIBS)` instead of `-lsqlite3` (1 occurrence)
                                                                                               
  **Switch library detection from `UL_CHECK_LIB`/`AC_CHECK_LIB` to `PKG_CHECK_MODULES`:**      
  - libudev — replaces `-ludev` with `$(UDEV_LIBS)`                                            
  - libaudit — replaces `-laudit` with `$(AUDIT_LIBS)`                                         
  - libcap-ng — replaces `-lcap-ng` with `$(CAP_NG_LIBS)`                                      
  - zlib — replaces `-lz` with `$(Z_LIBS)`                                                     
                                                                                               
  **Fix libm handling:**                                                                       
  - Split `MATH_LIBS` into two variables to match meson's `lib_m`/`math_libs` pattern:         
    - `MATH_LIBS` — unconditional `-lm` (for `floor`, `round`, etc.)                           
    - `ISNAN_LIBS` — conditional `-lm` only when `isnan` is not in libc                        
  - Remove unnecessary libm dependency from test_pty (both autotools and meson)                

Not converted: `-lpam`/`-lpam_misc`, `-lslang`, `-lcrypt`, `-lutil`, `-lutempter`, `-ldl`
(missing pkg-config modules or some extra checks necessary).