### PR TITLE
lsfd: ignore too large integer read from /proc/PID/syscall

### DIFF
--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -1942,7 +1942,8 @@ static void mark_poll_fds_as_multiplexed(char *buf,
 	if (sscanf(buf, "%lx %lx", &fds, &nfds) != 2)
 		return;
 
-	if (nfds == 0)
+	if (nfds <= 0)
+		/* Unexpected value */
 		return;
 
 	local.iov_len = sizeof(struct pollfd) * nfds;
@@ -1987,7 +1988,8 @@ static void mark_select_fds_as_multiplexed(char *buf,
 	if (sscanf(buf, "%lx %lx %lx %lx", &nfds, fds + 0, fds + 1, fds + 2) != 4)
 		return;
 
-	if (nfds == 0)
+	if (nfds <= 0)
+		/* Unexpected value */
 		return;
 
 	for (int i = 0; i < 3; i++) {

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -1932,6 +1932,7 @@ static void mark_poll_fds_as_multiplexed(char *buf,
 {
 	long fds;
 	long nfds;
+	long max_nfds;
 
 	struct iovec  local;
 	struct iovec  remote;
@@ -1946,8 +1947,15 @@ static void mark_poll_fds_as_multiplexed(char *buf,
 		/* Unexpected value */
 		return;
 
+	max_nfds = sysconf (_SC_OPEN_MAX);
+	if (max_nfds >= 0 && nfds > max_nfds)
+		return;
+
 	local.iov_len = sizeof(struct pollfd) * nfds;
-	local.iov_base = xmalloc(local.iov_len);
+	local.iov_base = malloc(local.iov_len);
+	if (!local.iov_base)
+		goto out;
+
 	remote.iov_len = local.iov_len;
 	remote.iov_base = (void *)fds;
 

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -2010,7 +2010,7 @@ static void mark_select_fds_as_multiplexed(char *buf,
 
 	n = process_vm_readv(pid, local, 3, remote, 3, 0);
 	if (n < 0 || n != expected_n)
-			return;
+		return;
 
 	list_for_each (f, &proc->files) {
 		struct file *file = list_entry(f, struct file, files);


### PR DESCRIPTION
Fixes https://github.com/util-linux/util-linux/issues/4168

