### PR TITLE
Remove extra newlines from error/warning messages

### DIFF
--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -725,7 +725,7 @@ static void determine_device_blocks(struct fs_control *ctl, const struct stat *s
 		ctl->fs_blocks = dev_blocks;
 	else if (dev_blocks < ctl->fs_blocks)
 		errx(MKFS_EX_ERROR,
-		     _("%s: requested blocks (%llu) exceeds available (%llu) blocks\n"),
+		     _("%s: requested blocks (%llu) exceeds available (%llu) blocks"),
 		     ctl->device_name, ctl->fs_blocks, dev_blocks);
 	if (ctl->fs_blocks < 10)
 		errx(MKFS_EX_ERROR, _("%s: number of blocks too small"), ctl->device_name);

--- a/libblkid/samples/partitions.c
+++ b/libblkid/samples/partitions.c
@@ -38,15 +38,15 @@ int main(int argc, char *argv[])
 	/* Binary interface */
 	ls = blkid_probe_get_partitions(pr);
 	if (!ls)
-		errx(EXIT_FAILURE, "%s: failed to read partitions\n", devname);
+		errx(EXIT_FAILURE, "%s: failed to read partitions", devname);
 
 	/*
 	 * Print info about the primary (root) partition table
 	 */
 	root_tab = blkid_partlist_get_table(ls);
 	if (!root_tab)
-		errx(EXIT_FAILURE, "%s: does not contains any "
-				 "known partition table\n", devname);
+		errx(EXIT_FAILURE, "%s: does not contain any "
+				 "known partition table", devname);
 
 	printf("size: %jd, sector size: %u, PT: %s, offset: %jd, id=%s\n---\n",
 		(intmax_t)blkid_probe_get_size(pr),

--- a/libmount/src/lock.c
+++ b/libmount/src/lock.c
@@ -332,7 +332,8 @@ static void clean_lock(void)
 
 static void __attribute__((__noreturn__)) sig_handler(int sig)
 {
-	errx(EXIT_FAILURE, "\n%d: catch signal: %s\n", getpid(), strsignal(sig));
+	ul_sig_printf("\n%d: caught signal %d\n", getpid(), sig);
+	_exit(EXIT_FAILURE);
 }
 
 static int test_lock(struct libmnt_test *ts __attribute__((unused)),

--- a/login-utils/sulogin-consoles.c
+++ b/login-utils/sulogin-consoles.c
@@ -112,7 +112,7 @@ void emergency_do_mounts(void)
 	}
 
 	if (stat("/", &rt) != 0) {
-		warn("cannot get file status of root file system\n");
+		warn("cannot get file status of root file system");
 		return;
 	}
 

--- a/login-utils/sulogin-consoles.c
+++ b/login-utils/sulogin-consoles.c
@@ -815,8 +815,10 @@ int main(int argc, char *argv[])
 		fd = STDIN_FILENO;
 	}
 
-	if (!name)
-		errx(EXIT_FAILURE, "usage: %s [<tty>]\n", program_invocation_short_name);
+	if (!name) {
+		fprintf(stderr, "usage: %s [<tty>]\n", program_invocation_short_name);
+		return EXIT_FAILURE;
+	}
 
 	INIT_LIST_HEAD(&consoles);
 	re = detect_consoles(name, fd, &consoles);

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -600,7 +600,7 @@ static struct passwd *getrootpwent(int try_manually)
 	 * If the encrypted password is valid or not found, return.
 	 */
 	if (p == NULL) {
-		warnx(_("%s: no entry for root\n"), _PATH_PASSWD);
+		warnx(_("%s: no entry for root"), _PATH_PASSWD);
 		return &pwd;
 	}
 	if (valid(pwd.pw_passwd))

--- a/misc-utils/copyfilerange.c
+++ b/misc-utils/copyfilerange.c
@@ -148,7 +148,7 @@ static void copy_range(struct rangeitem *range) {
 						range->out_fd, &range->out_offset, chunk, 0);
 		if (copied < 0)
 			errx(EXIT_FAILURE, _("failed to copy range %jd:%jd:%ju "
-						"from %s to %s with %ju remaining: %m\n"),
+						"from %s to %s with %ju remaining: %m"),
 						(intmax_t) range->in_offset, (intmax_t) range->out_offset,
 								range->length, range->in_filename,
 								range->out_filename, remaining);
@@ -162,7 +162,7 @@ static void copy_range(struct rangeitem *range) {
 static void handle_range(char* str, struct rangeitem *range)
 {
 	if (parse_range(str, range) != 0)
-		errx(EXIT_FAILURE, _("invalid range format: %s\n"), str);
+		errx(EXIT_FAILURE, _("invalid range format: %s"), str);
 
 	if (!range->length)
 		range->length = range->in_st_size - range->in_offset;

--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -365,7 +365,7 @@ static void changer_select(const struct eject_control *ctl)
 	if (ioctl(ctl->fd, CDROMLOADFROMSLOT, ctl->c_arg) != 0)
 		err(EXIT_FAILURE, _("CD-ROM load from slot command failed"));
 #else
-	warnx(_("IDE/ATAPI CD-ROM changer not supported by this kernel\n") );
+	warnx(_("IDE/ATAPI CD-ROM changer not supported by this kernel") );
 #endif
 }
 
@@ -385,7 +385,7 @@ static void close_tray(int fd)
 	if (status != 0)
 		err(EXIT_FAILURE, _("CD-ROM tray close command failed"));
 #else
-	warnx(_("CD-ROM tray close command not supported by this kernel\n"));
+	warnx(_("CD-ROM tray close command not supported by this kernel"));
 #endif
 }
 

--- a/sys-utils/wdctl.c
+++ b/sys-utils/wdctl.c
@@ -381,7 +381,7 @@ static int show_flags(struct wd_control *ctl, struct wd_device *wd, uint32_t wan
 	}
 
 	if (flags)
-		warnx(_("%s: unknown flags 0x%x\n"), wd->devpath, flags);
+		warnx(_("%s: unknown flags 0x%x"), wd->devpath, flags);
 
 	scols_print_table(table);
 	rc = 0;


### PR DESCRIPTION
The `errx`/`warnx` functions add a newline by themselves. Adding one to the message thus leads to two in output.
This covers tools which are installed but also test and sample code.

Some examples how to trigger these messages (excluded are sample tools, test tools, eject, wdctl, one feature of sulogin):

```
$ touch a b
$ copyfilerange a b 0:9223372036854775808:1
copyfilerange: invalid range format: 0:9223372036854775808:1

$ copyfilerange a b 0:9223372036854775806:1
copyfilerange: failed to copy range 0:9223372036854775806:1 from a to b with 1 remaining: File too large

$ _
```

```
$ mkfs.minix /dev/null 1234
mkfs.minix: /dev/null: requested blocks (1234) exceeds available (15) blocks

$ _
```

The `sulogin` one takes a bit more preparation:
1. Verify that `systemd` is not used in /etc/nsswitch.conf for `passwd`
2. Temporarily remove `root:` from /etc/passswd
3. Run sulogin
```
$ sulogin -e
sulogin: /etc/passwd: no entry for root

Press Enter for system maintenance
(or press Control-D to continue):
```