### PR TITLE
mkfs.cramfs: Improve file size check

### DIFF
--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -363,7 +363,7 @@ static unsigned int parse_directory(struct entry *root_entry, const char *name, 
 			entry->size = parse_directory(root_entry, path, &entry->child, fslen_ub);
 		} else if (S_ISREG(st.st_mode)) {
 			entry->path = xstrdup(path);
-			if (entry->size >= (1 << CRAMFS_SIZE_WIDTH)) {
+			if (st.st_size >= (1 << CRAMFS_SIZE_WIDTH)) {
 				warn_size = 1;
 				entry->size = (1 << CRAMFS_SIZE_WIDTH) - 1;
 			}


### PR DESCRIPTION
Check `st.st_size` (off_t) for actual file size instead of the possibly already truncated `entry->size` (unsigned int) value. Otherwise files larger than 4 GB might be silently truncated.

Proof of Concept:
1. Create a directory containing a file slightly larger than 4 GB
```
BASE=$(mktemp -d)
mkdir $BASE/dir
fallocate -o 4294967296 -l 1 $BASE/dir/input
```
2. Create a cramfs image
```
mkfs.cramfs -E $BASE/dir $BASE/cramfs.iso
```
Output is:
```
mkfs.cramfs: warning: gids truncated to 8 bits.  (This may be a security concern.)
```
Expected output is:
```
mkfs.cramfs: warning: file sizes truncated to 16MB (minus 1 byte).
mkfs.cramfs: warning: gids truncated to 8 bits.  (This may be a security concern.)
```