### PR TITLE
pidfd-utils: Fix pidfd_get_inode declaration

### DIFF
--- a/include/pidfd-utils.h
+++ b/include/pidfd-utils.h
@@ -12,6 +12,8 @@
 # include <sys/pidfd.h>
 #endif
 
+#include <stdint.h>
+
 /*
  * pidfd ioctls
  *
@@ -100,7 +102,7 @@ static inline int pidfd_getfd(int pidfd __attribute__((unused)),
 #endif
 
 int pfd_is_pidfs(int pidfd);
-ino_t pidfd_get_inode(int pidfd);
+uint64_t pidfd_get_inode(int pidfd);
 
 #ifdef USE_PIDFD_INO_SUPPORT
 int ul_get_valid_pidfd_or_err(pid_t pid, uint64_t pidfd_ino);


### PR DESCRIPTION
The `pidfd_get_inode` function returns a `uint64_t`, not an `ino_t`.

Spotted while trying to compile util-linux on a 32 bit system with `./configure --disable-largefile --disable-year2038`, since `ino_t` is a 32 bit value then.