### PR TITLE
fallocate: Improve range checks

### DIFF
--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -371,7 +371,7 @@ int main(int argc, char **argv)
 	int	mode = 0;
 	int	dig = 0;
 	int	posix = 0;
-	off_t	length = -2;
+	off_t	length = -1;
 	off_t	offset = 0;
 
 	static const struct option longopts[] = {
@@ -421,12 +421,16 @@ int main(int argc, char **argv)
 			break;
 		case 'l':
 			length = cvtnum(optarg);
+			if (length < 0)
+				err(EXIT_FAILURE, _("invalid length"));
 			break;
 		case 'n':
 			mode |= FALLOC_FL_KEEP_SIZE;
 			break;
 		case 'o':
 			offset = cvtnum(optarg);
+			if (offset < 0)
+				err(EXIT_FAILURE, _("invalid offset"));
 			break;
 		case 'p':
 			mode |= FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
@@ -466,19 +470,15 @@ int main(int argc, char **argv)
 
 	if (dig || report) {
 		/* for --dig-holes and --report-holes the default is analyze all file */
-		if (length == -2)
-			length = 0;
 		if (length < 0)
-			errx(EXIT_FAILURE, _("invalid length"));
+			length = 0;
 	} else {
 		/* it's safer to require the range specification (--length --offset) */
-		if (length == -2)
+		if (length < 0)
 			errx(EXIT_FAILURE, _("no length argument specified"));
-		if (length <= 0)
+		if (length == 0)
 			errx(EXIT_FAILURE, _("invalid length"));
 	}
-	if (offset < 0)
-		errx(EXIT_FAILURE, _("invalid offset"));
 
 	/* O_CREAT makes sense only for the default fallocate(2) behavior
 	 * when mode is no specified and new space is allocated */

--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -5,9 +5,6 @@
  * Written by Eric Sandeen <sandeen@redhat.com>
  *            Karel Zak <kzak@redhat.com>
  *
- * cvtnum routine taken from xfsprogs,
- * Copyright (c) 2003-2005 Silicon Graphics, Inc.
- *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation.

--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -498,23 +498,23 @@ int main(int argc, char **argv)
 			char *str = size_to_human_string(SIZE_SUFFIX_3LETTER | SIZE_SUFFIX_SPACE, length);
 
 			if (mode & FALLOC_FL_PUNCH_HOLE)
-				fprintf(stdout, _("%s: %s (%ju bytes) hole created.\n"),
-								filename, str, length);
+				fprintf(stdout, _("%s: %s (%jd bytes) hole created.\n"),
+								filename, str, (intmax_t) length);
 			else if (mode & FALLOC_FL_COLLAPSE_RANGE)
-				fprintf(stdout, _("%s: %s (%ju bytes) removed.\n"),
-								filename, str, length);
+				fprintf(stdout, _("%s: %s (%jd bytes) removed.\n"),
+								filename, str, (intmax_t) length);
 			else if (mode & FALLOC_FL_INSERT_RANGE)
-				fprintf(stdout, _("%s: %s (%ju bytes) inserted.\n"),
-								filename, str, length);
+				fprintf(stdout, _("%s: %s (%jd bytes) inserted.\n"),
+								filename, str, (intmax_t) length);
 			else if (mode & FALLOC_FL_ZERO_RANGE)
-				fprintf(stdout, _("%s: %s (%ju bytes) zeroed.\n"),
-								filename, str, length);
+				fprintf(stdout, _("%s: %s (%jd bytes) zeroed.\n"),
+								filename, str, (intmax_t) length);
 			else if (mode & FALLOC_FL_WRITE_ZEROES)
-				fprintf(stdout, _("%s: %s (%ju bytes) written as zeroes.\n"),
-								filename, str, length);
+				fprintf(stdout, _("%s: %s (%jd bytes) written as zeroes.\n"),
+								filename, str, (intmax_t) length);
 			else
-				fprintf(stdout, _("%s: %s (%ju bytes) allocated.\n"),
-								filename, str, length);
+				fprintf(stdout, _("%s: %s (%jd bytes) allocated.\n"),
+								filename, str, (intmax_t) length);
 			free(str);
 		}
 	}

--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -108,14 +108,18 @@ static void __attribute__((__noreturn__)) usage(void)
 	exit(EXIT_SUCCESS);
 }
 
-static loff_t cvtnum(char *s)
+static off_t cvtnum(char *s)
 {
 	uintmax_t x;
 
 	if (strtosize(s, &x))
 		return -1LL;
+	if (x > (uintmax_t) SINT_MAX(off_t)) {
+		errno = ERANGE;
+		return -1;
+	}
 
-	return x;
+	return (off_t) x;
 }
 
 static void xfallocate(int fd, int mode, off_t offset, off_t length)
@@ -367,8 +371,8 @@ int main(int argc, char **argv)
 	int	mode = 0;
 	int	dig = 0;
 	int	posix = 0;
-	loff_t	length = -2LL;
-	loff_t	offset = 0;
+	off_t	length = -2;
+	off_t	offset = 0;
 
 	static const struct option longopts[] = {
 	    { "help",           no_argument,       NULL, 'h' },
@@ -462,13 +466,13 @@ int main(int argc, char **argv)
 
 	if (dig || report) {
 		/* for --dig-holes and --report-holes the default is analyze all file */
-		if (length == -2LL)
+		if (length == -2)
 			length = 0;
 		if (length < 0)
 			errx(EXIT_FAILURE, _("invalid length"));
 	} else {
 		/* it's safer to require the range specification (--length --offset) */
-		if (length == -2LL)
+		if (length == -2)
 			errx(EXIT_FAILURE, _("no length argument specified"));
 		if (length <= 0)
 			errx(EXIT_FAILURE, _("invalid length"));

--- a/sys-utils/fallocate.c
+++ b/sys-utils/fallocate.c
@@ -479,6 +479,10 @@ int main(int argc, char **argv)
 		if (length == 0)
 			errx(EXIT_FAILURE, _("invalid length"));
 	}
+	if (length > SINT_MAX(off_t) - offset) {
+		errno = ERANGE;
+		err(EXIT_FAILURE, _("invalid range specified"));
+	}
 
 	/* O_CREAT makes sense only for the default fallocate(2) behavior
 	 * when mode is no specified and new space is allocated */


### PR DESCRIPTION
Verify that given arguments fit into `off_t` variables and that `offset + length` does not trigger integer overflows.
Get rid of `loff_t`, use `intmax_t` and appropriate format string modifiers, and use util-linux' internal functionality for range checks.

While at it, clarify that the `cvtnum` function cannot be covered by xfsprogs' copyright anymore because the implementation has been replaced a long time ago.

Proof of Concepts:
1. Run on 64 bit (ideally compile with ubsan)
```
$ fallocate -l 18446744073709551614 /tmp/poc
fallocate: no length argument specified
$ fallocate -r -o 100 -l 9223372036854775807 /tmp/poc
sys-utils/fallocate.c:248:8: runtime error: signed integer overflow: 100 + 9223372036854775807 cannot be represented in type 'long int'
```
2. Run on 32 bit with 32 bit `off_t` (`./configure --disable-largefile --disable-year2038`)
```
$ fallocate -vl 4294967297 /tmp/poc
/tmp/poc: 4 GiB (4294967297 bytes) allocated.
$ ls -l /tmp/poc
-rw-r--r--. 1 user group 1 Apr 18 17:31 /tmp/poc
```