### PR TITLE
hexdump: Cast %ll argument to long long

### DIFF
--- a/text-utils/hexdump-display.c
+++ b/text-utils/hexdump-display.c
@@ -277,7 +277,7 @@ print(struct hexdump_pr *pr, unsigned char *bp) {
 
 	switch(pr->flags) {
 	case F_ADDRESS:
-		printf(pr->fmt, address);
+		printf(pr->fmt, (long long) address);
 		break;
 	case F_BPAD:
 		printf(pr->fmt, "");


### PR DESCRIPTION
Cast off_t for F_ADDRESS to long long. In most cases, this should be actually unsigned long long due to %llx or %llo, but since %lld is also available and off_t is signed, keep it at that.

In theory, this might fix very intelligent static analysers which notice that off_t is long int but %ll expects long long, but in reality, this fixes 32 bit off_t builds. Without this, wrong addresses are shown.

The F_ADRESS counter part is located here:
https://github.com/util-linux/util-linux/blob/dcc5161240fe3b5c993297880432e150ff124f3b/text-utils/hexdump-parse.c#L360-L366