### PR TITLE
fix manpages term inconsistencies

### DIFF
--- a/disk-utils/fsck.cramfs.8.adoc
+++ b/disk-utils/fsck.cramfs.8.adoc
@@ -8,7 +8,7 @@
 
 == NAME
 
-fsck.cramfs - fsck compressed ROM file system
+fsck.cramfs - fsck compressed ROM filesystem
 
 == SYNOPSIS
 
@@ -16,7 +16,7 @@ fsck.cramfs - fsck compressed ROM file system
 
 == DESCRIPTION
 
-*fsck.cramfs* is used to check the cramfs file system.
+*fsck.cramfs* is used to check the cramfs filesystem.
 
 == OPTIONS
 
@@ -27,7 +27,7 @@ Enable verbose messaging.
 Use this blocksize, defaults to page size. Must be equal to what was set at creation time. Only used for *--extract*.
 
 *--extract*[**=**_directory_]::
-Test to uncompress the whole file system. Optionally extract contents of the _file_ to _directory_.
+Test to uncompress the whole filesystem. Optionally extract contents of the _file_ to _directory_.
 
 *-a*::
 This option is silently ignored.
@@ -42,7 +42,7 @@ include::man-common/help-version.adoc[]
 *0*::
 success
 *4*::
-file system was left uncorrected
+filesystem was left uncorrected
 *8*::
 operation error, such as unable to allocate memory
 *16*::

--- a/disk-utils/fsck.minix.8.adoc
+++ b/disk-utils/fsck.minix.8.adoc
@@ -59,7 +59,7 @@ Perform automatic repairs. This option implies *--repair* and serves to answer a
 Be verbose.
 
 *-s*, *--super*::
-Output super-block information.
+Output superblock information.
 
 *-m*, *--uncleared*::
 Activate MINIX-like "mode not cleared" warnings.

--- a/disk-utils/mkfs.cramfs.8.adoc
+++ b/disk-utils/mkfs.cramfs.8.adoc
@@ -8,7 +8,7 @@
 
 == NAME
 
-mkfs.cramfs - make compressed ROM file system
+mkfs.cramfs - make compressed ROM filesystem
 
 == SYNOPSIS
 
@@ -16,19 +16,19 @@ mkfs.cramfs - make compressed ROM file system
 
 == DESCRIPTION
 
-Files on cramfs file systems are zlib-compressed one page at a time to allow random read access. The metadata is not compressed, but is expressed in a terse representation that is more space-efficient than conventional file systems.
+Files on cramfs filesystems are zlib-compressed one page at a time to allow random read access. The metadata is not compressed, but is expressed in a terse representation that is more space-efficient than conventional filesystems.
 
-The file system is intentionally read-only to simplify its design; random write access for compressed files is difficult to implement. cramfs ships with a utility (*mkcramfs*(8)) to pack files into new cramfs images.
+The filesystem is intentionally read-only to simplify its design; random write access for compressed files is difficult to implement. cramfs ships with a utility (*mkcramfs*(8)) to pack files into new cramfs images.
 
 File sizes are limited to less than 16 MB.
 
-Maximum file system size is a little under 272 MB. (The last file on the file system must begin before the 256 MB block, but can extend past it.)
+Maximum filesystem size is a little under 272 MB. (The last file on the filesystem must begin before the 256 MB block, but can extend past it.)
 
 == ARGUMENTS
 
 The _directory_ is simply the root of the directory tree that we want to generate a compressed filesystem out of.
 
-The _file_ will contain the cram file system, which later can be mounted.
+The _file_ will contain the cram filesystem, which later can be mounted.
 
 == OPTIONS
 
@@ -42,16 +42,16 @@ Treat all warnings as errors, which are reflected as command exit status.
 Use defined block size, which has to be divisible by page size.
 
 *-e* _edition_::
-Use defined file system edition number in superblock.
+Use defined filesystem edition number in superblock.
 
 *-N* *big*|*little*|*host*::
 Use the specified endianness. The default is *host*.
 
 *-i* _file_::
-Insert a _file_ to cramfs file system.
+Insert a _file_ to cramfs filesystem.
 
 *-n* _name_::
-Set name of the cramfs file system.
+Set name of the cramfs filesystem.
 
 *-p*::
 Pad by 512 bytes for boot code.

--- a/disk-utils/mkfs.minix.8.adoc
+++ b/disk-utils/mkfs.minix.8.adoc
@@ -38,7 +38,7 @@ The _device_ is usually of the following form:
 
 The device may be a block device or an image file of one, but this is not enforced. Expect not much fun on a character device :-).
 
-The _size-in-blocks_ parameter is the desired size of the file system, in blocks. It is present only for backwards compatibility. If omitted the size will be determined automatically. Only block counts strictly greater than 10 and strictly less than 65536 are allowed.
+The _size-in-blocks_ parameter is the desired size of the filesystem, in blocks. It is present only for backwards compatibility. If omitted the size will be determined automatically. Only block counts strictly greater than 10 and strictly less than 65536 are allowed.
 
 == OPTIONS
 
@@ -46,7 +46,7 @@ The _size-in-blocks_ parameter is the desired size of the file system, in blocks
 Check the device for bad blocks before creating the filesystem. If any are found, the count is printed.
 
 *-n*, *--namelength* _length_::
-Specify the maximum length of filenames. Currently, the only allowable values are 14 and 30 for file system versions 1 and 2. Version 3 allows only value 60. The default is 30.
+Specify the maximum length of filenames. Currently, the only allowable values are 14 and 30 for filesystem versions 1 and 2. Version 3 allows only value 60. The default is 30.
 
 *--lock*[**=**_mode_]::
 Use an exclusive BSD lock for the device or file that is operated upon.

--- a/disk-utils/raw.8.adoc
+++ b/disk-utils/raw.8.adoc
@@ -24,7 +24,7 @@ raw - bind a Linux raw character device
 
 *raw* is used to bind a Linux raw character device to a block device. Any block device may be used: at the time of binding, the device driver does not even have to be accessible (it may be loaded on demand as a kernel module later).
 
-*raw* is used in two modes: it either sets raw device bindings, or it queries existing bindings. When setting a raw device, _/dev/raw/raw<N>_ is the device name of an existing raw device node in the filesystem. The block device to which it is to be bound can be specified either in terms of its _major_ and _minor_ device numbers, or as a path name _/dev/<blockdev>_ to an existing block device file.
+*raw* is used in two modes: it either sets raw device bindings, or it queries existing bindings. When setting a raw device, _/dev/raw/raw<N>_ is the device name of an existing raw device node in the filesystem. The block device to which it is to be bound can be specified either in terms of its _major_ and _minor_ device numbers, or as a pathname _/dev/<blockdev>_ to an existing block device file.
 
 The bindings already in existence can be queried with the *-q* option, which is used either with a raw device filename to query that one device, or with the *-a* option to query all bound raw devices.
 

--- a/disk-utils/sfdisk.8.adoc
+++ b/disk-utils/sfdisk.8.adoc
@@ -156,7 +156,7 @@ not the last partition in the partition table. See also *-N* for addressing a
 specific entry in the partition table.
 
 *-b*, *--backup*::
-Back up the current partition table sectors before starting the partitioning. The default backup file name is _~/sfdisk-<device>-<offset>.bak_; to use another name see option *-O*, *--backup-file*. See section *BACKING UP THE PARTITION TABLE* for more details.
+Back up the current partition table sectors before starting the partitioning. The default backup filename is _~/sfdisk-<device>-<offset>.bak_; to use another name see option *-O*, *--backup-file*. See section *BACKING UP THE PARTITION TABLE* for more details.
 
 *--bytes*::
 Print SIZE in bytes rather than in human readable format.
@@ -188,12 +188,12 @@ Do not check through the re-read-partition-table ioctl whether the device is in 
 Don't tell the kernel about partition changes. This option is recommended together with *--no-reread* to modify a partition on used disk. The modified partition should not be used (e.g., mounted).
 
 *-O*, *--backup-file* _path_::
-Override the default backup file name. Note that the device name and offset are always appended to the file name.
+Override the default backup filename. Note that the device name and offset are always appended to the filename.
 
 *--move-data*[**=**__path__]::
 Move data after partition relocation, for example when moving the beginning of a partition to another place on the disk. The size of the partition has to remain the same, the new and old location may overlap. This option requires option *-N* in order to be processed on one specific partition only.
 +
-The optional _path_ specifies log file name. The log file contains information about all read/write operations on the partition data. The word "@default" as a _path_ forces *sfdisk* to use _~/sfdisk-<devname>.move_ for the log. The log is optional since v2.35.
+The optional _path_ specifies log filename. The log file contains information about all read/write operations on the partition data. The word "@default" as a _path_ forces *sfdisk* to use _~/sfdisk-<devname>.move_ for the log. The log is optional since v2.35.
 +
 Note that this operation is risky and not atomic. *Don't forget to backup your data!*
 +

--- a/libblkid/libblkid.3.adoc
+++ b/libblkid/libblkid.3.adoc
@@ -35,7 +35,7 @@ The high-level part of the library keeps information about block devices in a ca
 
 In situations where one is getting information about a single known device, it does not impact performance whether the cache is used or not (unless you are not able to read the block device directly).
 
-The high-level part of the library supports two methods to determine *LABEL/UUID*. It reads information directly from a block device or reads information from /dev/disk/by-* udev symlinks. The udev is preferred method by default.
+The high-level part of the library supports two methods to determine *LABEL/UUID*. It reads information directly from a block device or reads information from /dev/disk/by-* udev symbolic links. The udev is preferred method by default.
 
 If you are dealing with multiple devices, use of the cache is highly recommended (even if empty) as devices will be scanned at most one time and the on-disk cache will be updated if possible.
 

--- a/libblkid/libblkid.3.adoc
+++ b/libblkid/libblkid.3.adoc
@@ -47,7 +47,7 @@ The standard location of the _/etc/blkid.conf_ config file can be overridden by 
 
 == TAGS
 
-All available tags are listed below. Not all tags are supported for all file systems. To enable a tag, set one of the following flags with *blkid_probe_set_superblocks_flags*():
+All available tags are listed below. Not all tags are supported for all filesystems. To enable a tag, set one of the following flags with *blkid_probe_set_superblocks_flags*():
 
 BLKID_SUBLKS_TYPE::
 
@@ -100,11 +100,11 @@ BLKID_SUBLKS_FSINFO::
 
 - FSLASTBLOCK - last fsblock/total number of fsblocks
 
-- FSBLOCKSIZE - file system block size
+- FSBLOCKSIZE - filesystem block size
 
 The following tags are always enabled::
 
-- BLOCK_SIZE - minimal block size accessible by file system
+- BLOCK_SIZE - minimal block size accessible by filesystem
 
 - MOUNT - cluster mount name (ocfs only)
 

--- a/libblkid/libblkid.3.adoc
+++ b/libblkid/libblkid.3.adoc
@@ -87,7 +87,7 @@ BLKID_SUBLKS_VERSION::
 
 BLKID_SUBLKS_MAGIC::
 
-- SBMAGIC - super block magic string
+- SBMAGIC - superblock magic string
 
 - SBMAGIC_OFFSET - offset of SBMAGIC
 

--- a/libuuid/man/uuid_time.3.adoc
+++ b/libuuid/man/uuid_time.3.adoc
@@ -56,7 +56,7 @@ The *uuid_time*() function extracts the time at which the supplied time-based UU
 
 == RETURN VALUE
 
-The time at which the UUID was created, in seconds since January 1, 1970 GMT (the epoch), is returned (see *time*(2)). The time at which the UUID was created, in seconds and microseconds since the epoch, is also stored in the location pointed to by _ret_tv_ (see *gettimeofday*(2)).
+The time at which the UUID was created, in seconds since January 1, 1970 GMT (the Epoch), is returned (see *time*(2)). The time at which the UUID was created, in seconds and microseconds since the Epoch, is also stored in the location pointed to by _ret_tv_ (see *gettimeofday*(2)).
 
 == AUTHORS
 

--- a/login-utils/chsh.1.adoc
+++ b/login-utils/chsh.1.adoc
@@ -52,7 +52,7 @@ older versions used the now-deprecated *-v*).
 
 *chsh* will accept the full pathname of any executable file on the system.
 
-The default behavior for non-root users is to accept only shells listed in the _/etc/shells_ file, and issue a warning for root user. It can also be configured at compile-time to only issue a warning for all users.
+The default behavior for unprivileged users is to accept only shells listed in the _/etc/shells_ file, and issue a warning for root user. It can also be configured at compile-time to only issue a warning for all users.
 
 == EXIT STATUS
 

--- a/login-utils/last.1.adoc
+++ b/login-utils/last.1.adoc
@@ -56,7 +56,7 @@ The pseudo user *reboot* logs in each time the system is rebooted. Thus *last re
 Display the hostname in the last column. Useful in combination with the *-d* option.
 
 *-d*, *--dns*::
-For non-local logins, Linux stores not only the host name of the remote host, but its IP number as well. This option translates the IP number back into a hostname.
+For non-local logins, Linux stores not only the hostname of the remote host, but its IP number as well. This option translates the IP number back into a hostname.
 
 *-f*, *--file* _file_::
 Tell *last* to use a specific _file_ instead of _/var/log/wtmp_. The *-f* option

--- a/login-utils/nologin.8.adoc
+++ b/login-utils/nologin.8.adoc
@@ -54,7 +54,7 @@ include::man-common/help-version.adoc[]
 
 *nologin* is a per-account way to disable login (usually used for system accounts like http or ftp). *nologin* uses _/etc/nologin.txt_ as an optional source for a non-default message, the login access is always refused independently of the file.
 
-*pam_nologin*(8) PAM module usually prevents all non-root users from logging into the system. *pam_nologin*(8) functionality is controlled by _/var/run/nologin_ or the _/etc/nologin_ file.
+*pam_nologin*(8) PAM module usually prevents all unprivileged users from logging into the system. *pam_nologin*(8) functionality is controlled by _/var/run/nologin_ or the _/etc/nologin_ file.
 
 == HISTORY
 

--- a/login-utils/runuser.1.adoc
+++ b/login-utils/runuser.1.adoc
@@ -57,12 +57,12 @@ Start the shell as a login shell with an environment similar to a real login:
 Preserve the entire environment, i.e., do not set *HOME*, *SHELL*, *USER* or *LOGNAME*. The option is ignored if the option *--login* is specified.
 
 *-P*, *--pty*::
-Create a pseudo-terminal for the session. The independent terminal provides better security as the user does not share a terminal with the original session.
+Create a pseudoterminal for the session. The independent terminal provides better security as the user does not share a terminal with the original session.
 Please note security advice about TIOCSTI vulnerability below.
 +
-The entire session can also be moved to the background (e.g., *runuser --pty* *-u* _user_ *--* _command_ *&*). If the pseudo-terminal is enabled, then *runuser* works as a proxy between the sessions (sync stdin and stdout).
+The entire session can also be moved to the background (e.g., *runuser --pty* *-u* _user_ *--* _command_ *&*). If the pseudoterminal is enabled, then *runuser* works as a proxy between the sessions (sync stdin and stdout).
 +
-This feature is mostly designed for interactive sessions. If the standard input is not a terminal, but for example a pipe (e.g., *echo "date" | runuser --pty -u* _user_), then the *ECHO* flag for the pseudo-terminal is disabled to avoid messy output.
+This feature is mostly designed for interactive sessions. If the standard input is not a terminal, but for example a pipe (e.g., *echo "date" | runuser --pty -u* _user_), then the *ECHO* flag for the pseudoterminal is disabled to avoid messy output.
 
 *-s*, *--shell*=_shell_::
 Run the specified _shell_ instead of the default. The shell to run is selected according to the following rules, in order:
@@ -143,7 +143,7 @@ global logindef config file
 
 == SECURITY NOTES
 
-If *runuser* shares a terminal with the original session, it is potentially vulnerable to privilege escalation through TIOCSTI/TIOCLINUX ioctl command injection. There are two built-in ways to prevent this: Either you can use *runuser* with the *-c* option, which starts a new session via *setsid*(2) without a controlling terminal. Or, if your use case requires a controlling terminal, for example an interactive session, you can instruct *runuser* to use a pseudo terminal with the *--pty* or *-P* option.
+If *runuser* shares a terminal with the original session, it is potentially vulnerable to privilege escalation through TIOCSTI/TIOCLINUX ioctl command injection. There are two built-in ways to prevent this: Either you can use *runuser* with the *-c* option, which starts a new session via *setsid*(2) without a controlling terminal. Or, if your use case requires a controlling terminal, for example an interactive session, you can instruct *runuser* to use a pseudoterminal with the *--pty* or *-P* option.
 
 == HISTORY
 

--- a/login-utils/su.1.adoc
+++ b/login-utils/su.1.adoc
@@ -65,12 +65,12 @@ PAM) from this point of view. You need to use tools like *systemd-run*(1) or
 Preserve the entire environment, i.e., do not set *HOME*, *SHELL*, *USER* or *LOGNAME*. This option is ignored if the option *--login* is specified.
 
 *-P*, *--pty*::
-Create a pseudo-terminal for the session. The independent terminal provides better security as the user does not share a terminal with the original session.
+Create a pseudoterminal for the session. The independent terminal provides better security as the user does not share a terminal with the original session.
 Please note security advice about TIOCSTI vulnerability below.
 +
-The entire session can also be moved to the background (e.g., *su --pty* **-** __user__ *-c* _application_ *&*). If the pseudo-terminal is enabled, then *su* works as a proxy between the sessions (sync stdin and stdout).
+The entire session can also be moved to the background (e.g., *su --pty* **-** __user__ *-c* _application_ *&*). If the pseudoterminal is enabled, then *su* works as a proxy between the sessions (sync stdin and stdout).
 +
-This feature is mostly designed for interactive sessions. If the standard input is not a terminal, but for example a pipe (e.g., *echo "date" | su --pty*), then the *ECHO* flag for the pseudo-terminal is disabled to avoid messy output.
+This feature is mostly designed for interactive sessions. If the standard input is not a terminal, but for example a pipe (e.g., *echo "date" | su --pty*), then the *ECHO* flag for the pseudoterminal is disabled to avoid messy output.
 
 *-s*, *--shell* __shell__::
 Run the specified _shell_ instead of the default. If the target user has a restricted shell (i.e., not listed in _/etc/shells_), the *--shell* option and the *SHELL* environment variables are ignored unless the calling user is root.
@@ -156,7 +156,7 @@ global logindef config file
 
 == SECURITY NOTES
 
-If *su* shares a terminal with the original session, it is potentially vulnerable to privilege escalation through TIOCSTI/TIOCLINUX ioctl command injection. There are two built-in ways to prevent this: Either you can use *su* with the *-c* option, which starts a new session via *setsid*(2) without a controlling terminal. Or, if your use case requires a controlling terminal, for example an interactive session, you can instruct *su* to use a pseudo terminal with the *--pty* or *-P* option.
+If *su* shares a terminal with the original session, it is potentially vulnerable to privilege escalation through TIOCSTI/TIOCLINUX ioctl command injection. There are two built-in ways to prevent this: Either you can use *su* with the *-c* option, which starts a new session via *setsid*(2) without a controlling terminal. Or, if your use case requires a controlling terminal, for example an interactive session, you can instruct *su* to use a pseudoterminal with the *--pty* or *-P* option.
 
 For security reasons, *su* always logs failed log-in attempts to the _btmp_ file, but it does not write to the _lastlog_ file at all. This solution can be used to control *su* behavior by PAM configuration. If you want to use the *pam_lastlog*(8) module to print warning message about failed log-in attempts then *pam_lastlog*(8) has to be configured to update the _lastlog_ file as well. For example by:
 

--- a/lsfd-cmd/lsfd.1.adoc
+++ b/lsfd-cmd/lsfd.1.adoc
@@ -268,7 +268,7 @@ KNAME <``string``>::
 //
 // Not only u but also p is decorated with underline.
 //
-Raw file name extracted from
+Raw filename extracted from
 from ``/proc/``_pid_``/fd/``_fd_ or ``/proc/``_pid_``/map_files/``_region_.
 
 KTHREAD <``boolean``>::
@@ -685,7 +685,7 @@ Do the same in an alternative way: ::
 # lsfd -Q 'ASSOC eq "exe"'
 ....
 
-Do the same but print only file names: ::
+Do the same but print only filenames: ::
 ....
 # lsfd -o NAME -Q 'ASSOC eq "exe"' | sort -u
 ....

--- a/lsfd-cmd/lsfd.1.adoc
+++ b/lsfd-cmd/lsfd.1.adoc
@@ -175,7 +175,7 @@ COMMAND <``string``>::
 Command of the process opening the file.
 
 DELETED <``boolean``>::
-Reachability from the file system.
+Reachability from the filesystem.
 
 DEV <``string``>::
 ID of the device containing the file.
@@ -375,7 +375,7 @@ state=_SOCK.STATE_[ path=_UNIX.PATH_] type=_SOCK.TYPE_
 ____
 Note that `(deleted)` markers are removed from this column.
 Refer to _KNAME_, _DELETED_, or _XMODE_ to know the
-readability of the file from the file system.
+readability of the file from the filesystem.
 ____
 
 NETLINK.GROUPS <``number``>::
@@ -617,7 +617,7 @@ opened of mapped for writing. This is also in _MODE_.
 mapped for executing the code. This is also in _MODE_.
 +
 [-D]:::
-deleted from  the file system. See also _DELETED_.
+deleted from  the filesystem. See also _DELETED_.
 +
 [-Ll]:::
 locked or leased. _l_ represents a read, a shared lock or a read lease.

--- a/misc-utils/blkid.8.adoc
+++ b/misc-utils/blkid.8.adoc
@@ -74,7 +74,7 @@ Look up only one device that matches the search parameter specified with the *--
 This option forces *blkid* to use udev when used for LABEL or UUID tokens in *--match-token*. The goal is to provide output consistent with other utils (like *mount*(8), etc.) on systems where the same tag is used for multiple devices.
 
 *-L*, *--label* _label_::
-Look up the device that uses this filesystem _label_; this is equal to **--list-one --output device --match-token LABEL=**__label__. This lookup method is able to reliably use /dev/disk/by-label udev symlinks (dependent on a setting in _/etc/blkid.conf_). Avoid using the symlinks directly; it is not reliable to use the symlinks without verification. The *--label* option works on systems with and without udev.
+Look up the device that uses this filesystem _label_; this is equal to **--list-one --output device --match-token LABEL=**__label__. This lookup method is able to reliably use /dev/disk/by-label udev symbolic links (dependent on a setting in _/etc/blkid.conf_). Avoid using the symbolic links directly; it is not reliable to use the symbolic links without verification. The *--label* option works on systems with and without udev.
 +
 Unfortunately, the original *blkid*(8) from e2fsprogs uses the *-L* option as a synonym for *-o list*. For better portability, use **-l -o device -t LABEL=**__label__ and *-o list* in your scripts rather than the *-L* option.
 
@@ -164,13 +164,13 @@ If an ambivalent probing result was detected by low-level probing mode (*-p*), a
 The standard location of the _/etc/blkid.conf_ config file can be overridden by the environment variable *BLKID_CONF*. The following options control the libblkid library:
 
 _SEND_UEVENT=<yes|not>_::
-Sends uevent when _/dev/disk/by-{label,uuid,partuuid,partlabel}/_ symlink does not match with LABEL, UUID, PARTUUID or PARTLABEL on the device. Default is "yes".
+Sends uevent when _/dev/disk/by-{label,uuid,partuuid,partlabel}/_ symbolic link does not match with LABEL, UUID, PARTUUID or PARTLABEL on the device. Default is "yes".
 
 _CACHE_FILE=<path>_::
 Overrides the standard location of the cache file. This setting can be overridden by the environment variable *BLKID_FILE*. Default is _/run/blkid/blkid.tab_, or _/etc/blkid.tab_ on systems without a _/run_ directory.
 
 _EVALUATE=<methods>_::
-Defines LABEL and UUID evaluation method(s). Currently, the libblkid library supports the "udev" and "scan" methods. More than one method may be specified in a comma-separated list. Default is "udev,scan". The "udev" method uses udev _/dev/disk/by-*_ symlinks and the "scan" method scans all block devices from the _/proc/partitions_ file.
+Defines LABEL and UUID evaluation method(s). Currently, the libblkid library supports the "udev" and "scan" methods. More than one method may be specified in a comma-separated list. Default is "udev,scan". The "udev" method uses udev _/dev/disk/by-*_ symbolic links and the "scan" method scans all block devices from the _/proc/partitions_ file.
 
 == ENVIRONMENT
 

--- a/misc-utils/blkid.8.adoc
+++ b/misc-utils/blkid.8.adoc
@@ -32,7 +32,7 @@ The *blkid* program is the command-line interface to working with the *libblkid*
 *It is recommended to use* *lsblk*(8) *command to get information about block devices, or lsblk --fs to get an overview of filesystems, or* *findmnt*(8) *to search in already mounted filesystems.*
 
 ____
-*lsblk*(8) provides more information, better control on output formatting, easy to use in scripts and it does not require root permissions to get actual information. *blkid* reads information directly from devices and for non-root users it returns cached unverified information. *blkid* is mostly designed for system services and to test *libblkid*(3) functionality.
+*lsblk*(8) provides more information, better control on output formatting, easy to use in scripts and it does not require root permissions to get actual information. *blkid* reads information directly from devices and for unprivileged users it returns cached unverified information. *blkid* is mostly designed for system services and to test *libblkid*(3) functionality.
 ____
 
 When _device_ is specified, tokens from only this device are displayed. It is possible to specify multiple _device_ arguments on the command line. If none is given, all partitions or unpartitioned devices which appear in _/proc/partitions_ are shown, if they are recognized.

--- a/misc-utils/fadvise.1.adoc
+++ b/misc-utils/fadvise.1.adoc
@@ -25,7 +25,7 @@ that is for predeclaring an access pattern for file data.
 
 *-d*, *--fd* _file-descriptor_::
 Apply the advice to the file specified with the file descriptor instead
-of open a file specified with a file name.
+of open a file specified with a filename.
 
 *-a*, *--advice* _advice_::
 See the command output with *--help* option for available values for

--- a/misc-utils/getopt.1.adoc
+++ b/misc-utils/getopt.1.adoc
@@ -83,7 +83,7 @@ Each parameter not starting with a '*-*', and not a required argument of a previ
 
 Output is generated for each element described in the previous section. Output is done in the same order as the elements are specified in the input, except for non-option parameters. Output can be done in _compatible_ (_unquoted_) mode, or in such way that whitespace and other special characters within arguments and non-option parameters are preserved (see *QUOTING*). When the output is processed in the shell script, it will seem to be composed of distinct elements that can be processed one by one (by using the shift command in most shell languages). This is imperfect in unquoted mode, as elements can be split at unexpected places if they contain whitespace or special characters.
 
-If there are problems parsing the parameters, for example because a required argument is not found or an option is not recognized, an error will be reported on stderr, there will be no output for the offending element, and a non-zero error status is returned.
+If there are problems parsing the parameters, for example because a required argument is not found or an option is not recognized, an error will be reported on stderr, there will be no output for the offending element, and a nonzero error status is returned.
 
 For a short option, a single '*-*' and the option character are generated as one parameter. If the option has an argument, the next parameter will be the argument. If the option takes an optional argument, but none was found, the next parameter will be generated but be empty in quoting mode, but no second parameter will be generated in unquoted (compatible) mode. Note that many other *getopt*(1) implementations do not support optional arguments.
 

--- a/misc-utils/kill.1.adoc
+++ b/misc-utils/kill.1.adoc
@@ -33,7 +33,7 @@ The command *kill* sends the specified _signal_ to the specified processes or pr
 
 If no signal is specified, the *TERM* signal is sent. The default action for this signal is to terminate the process. This signal should be used in preference to the *KILL* signal (number 9), since a process may install a handler for the TERM signal in order to perform clean-up steps before terminating in an orderly fashion. If a process does not terminate after a *TERM* signal has been sent, then the *KILL* signal may be used; be aware that the latter signal cannot be caught, and so does not give the target process the opportunity to perform any clean-up before terminating.
 
-Most modern shells have a builtin *kill* command, with a usage rather similar to that of the command described here. The *--all*, *--pid*, and *--queue* options, and the possibility to specify processes by command name, are local extensions.
+Most modern shells have a built-in *kill* command, with a usage rather similar to that of the command described here. The *--all*, *--pid*, and *--queue* options, and the possibility to specify processes by command name, are local extensions.
 
 If _signal_ is 0, then no actual signal is sent, but error checking is still performed.
 
@@ -132,7 +132,7 @@ partial success (when more than one process specified)
 
 Although it is possible to specify the TID (thread ID, see *gettid*(2)) of one of the threads in a multithreaded process as the argument of *kill*, the signal is nevertheless directed to the process (i.e., the entire thread group). In other words, it is not possible to send a signal to an explicitly selected thread in a multithreaded process. The signal will be delivered to an arbitrarily selected thread in the target process that is not blocking the signal. For more details, see *signal*(7) and the description of *CLONE_THREAD* in *clone*(2).
 
-Various shells provide a builtin *kill* command that is preferred in relation to the *kill*(1) executable described by this manual. The easiest way to ensure one is executing the command described in this page is to use the full path when calling the command, for example: */bin/kill --version*
+Various shells provide a built-in *kill* command that is preferred in relation to the *kill*(1) executable described by this manual. The easiest way to ensure one is executing the command described in this page is to use the full path when calling the command, for example: */bin/kill --version*
 
 == AUTHORS
 

--- a/misc-utils/kill.1.adoc
+++ b/misc-utils/kill.1.adoc
@@ -46,7 +46,7 @@ Each _PID_ can be expressed in one of the following ways:
 _n_;;
 where _n_ is larger than 0. The process with PID _n_ is signaled.
 *0*;;
-All processes in the current process group are signaled.
+All processes in the calling process group are signaled.
 *-1*;;
 All processes with a PID larger than 1 are signaled.
 **-**__n__;;

--- a/misc-utils/namei.1.adoc
+++ b/misc-utils/namei.1.adoc
@@ -63,7 +63,7 @@ Use the long listing format (same as *-m -o -v*).
 Show the mode bits of each file type in the style of *ls*(1), for example 'rwxr-xr-x'.
 
 *-n*, *--nosymlinks*::
-Don't follow symlinks.
+Don't follow symbolic links.
 
 *-o*, *--owners*::
 Show owner and group name of each file.

--- a/misc-utils/rename.1.adoc
+++ b/misc-utils/rename.1.adoc
@@ -29,7 +29,7 @@ rename - rename files
 == OPTIONS
 
 *-s*, *--symlink*::
-Do not rename a symlink but change where it points.
+Do not rename a symbolic link but change where it points.
 
 *-v*, *--verbose*::
 Show which files were renamed, if any.
@@ -44,7 +44,7 @@ Replace all occurrences of _substring_ rather than only the first one.
 Replace the last occurrence of _substring_ rather than the first one.
 
 *-o*, *--no-overwrite*::
-Do not overwrite existing files. When *--symlink* is active, do not overwrite symlinks pointing to existing targets.
+Do not overwrite existing files. When *--symlink* is active, do not overwrite symbolic links pointing to existing targets.
 
 *-i*, *--interactive*::
 Ask before overwriting existing files.

--- a/misc-utils/rename.1.adoc
+++ b/misc-utils/rename.1.adoc
@@ -53,7 +53,7 @@ include::man-common/help-version.adoc[]
 
 == WARNING
 
-The renaming has no safeguards by default or without any one of the options *--no-overwrite*, *--interactive* or *--no-act*. If the user has permission to rewrite file names, the command will perform the action without any questions. For example, the result can be quite drastic when the command is run as root in the _/lib_ directory. Always make a backup before running the command, unless you truly know what you are doing.
+The renaming has no safeguards by default or without any one of the options *--no-overwrite*, *--interactive* or *--no-act*. If the user has permission to rewrite filenames, the command will perform the action without any questions. For example, the result can be quite drastic when the command is run as root in the _/lib_ directory. Always make a backup before running the command, unless you truly know what you are doing.
 
 == EDGE CASES
 

--- a/schedutils/taskset.1.adoc
+++ b/schedutils/taskset.1.adoc
@@ -45,7 +45,7 @@ taskset - set or retrieve a process's CPU affinity
 
 The *taskset* command is used to set or retrieve the CPU affinity of a running process given its _pid_, or to launch a new _command_ with a given CPU affinity. CPU affinity is a scheduler property that "bonds" a process to a given set of CPUs on the system. The Linux scheduler will honor the given CPU affinity and the process will not run on any other CPUs. Note that the Linux scheduler also supports natural CPU affinity: the scheduler attempts to keep processes on the same CPU as long as practical for performance reasons. Therefore, forcing a specific CPU affinity is useful only in certain applications.   The affinity of some processes like kernel per-CPU threads cannot be set.
 
-The CPU affinity is represented as a bitmask, with the lowest order bit corresponding to the first logical CPU and the highest order bit corresponding to the last logical CPU. Not all CPUs may exist on a given system but a mask may specify more CPUs than are present. A retrieved mask will reflect only the bits that correspond to CPUs physically on the system. If an invalid mask is given (i.e., one that corresponds to no valid CPUs on the current system) an error is returned. The masks may be specified in hexadecimal (with or without a leading "0x"), or as a CPU list with the *--cpu-list* option. For example,
+The CPU affinity is represented as a bit mask, with the lowest order bit corresponding to the first logical CPU and the highest order bit corresponding to the last logical CPU. Not all CPUs may exist on a given system but a mask may specify more CPUs than are present. A retrieved mask will reflect only the bits that correspond to CPUs physically on the system. If an invalid mask is given (i.e., one that corresponds to no valid CPUs on the current system) an error is returned. The masks may be specified in hexadecimal (with or without a leading "0x"), or as a CPU list with the *--cpu-list* option. For example,
 
 *0x00000001*::
 is processor #0,
@@ -73,7 +73,7 @@ When *taskset* returns, it is guaranteed that the given program has been schedul
 Set or retrieve the CPU affinity of all the tasks (threads) for a given PID.
 
 *-c*, *--cpu-list*::
-Interpret _mask_ as numerical list of processors instead of a bitmask. Numbers are separated by commas and may include ranges. For example: *0,5,8-11*.
+Interpret _mask_ as numerical list of processors instead of a bit mask. Numbers are separated by commas and may include ranges. For example: *0,5,8-11*.
 
 *-p*, *--pid*::
 Operate on an existing PID and do not launch a new task.

--- a/sys-utils/flock.1.adoc
+++ b/sys-utils/flock.1.adoc
@@ -108,7 +108,7 @@ When using the _command_ variant, and executing the child worked, then the exit 
 
 *flock* does not detect deadlock. See *flock*(2) for details.
 
-Some file systems (e. g. NFS and CIFS) have a limited implementation of *flock*(2) and flock may always fail. For details see *flock*(2), *nfs*(5) and *mount.cifs*(8). Depending on mount options, flock can always fail there.
+Some filesystems (e. g. NFS and CIFS) have a limited implementation of *flock*(2) and flock may always fail. For details see *flock*(2), *nfs*(5) and *mount.cifs*(8). Depending on mount options, flock can always fail there.
 
 == EXAMPLES
 

--- a/sys-utils/fstab.5.adoc
+++ b/sys-utils/fstab.5.adoc
@@ -80,7 +80,7 @@ It's also possible to use *PARTUUID=* and *PARTLABEL=*. These partitions identif
 
 See *mount*(8), *blkid*(8) or *lsblk*(8) for more details about device identifiers.
 
-Note that *mount*(8) uses UUIDs as strings. The string representation of the UUID should be based on lowercase characters. But when specifying the volume ID of FAT or NTFS filesystems upper case characters are used (e.g UUID="A40D-85E7" or UUID="61DB7756DB7779B3").
+Note that *mount*(8) uses UUIDs as strings. The string representation of the UUID should be based on lowercase characters. But when specifying the volume ID of FAT or NTFS filesystems uppercase characters are used (e.g UUID="A40D-85E7" or UUID="61DB7756DB7779B3").
 
 === The second field (_fs_file_).
 

--- a/sys-utils/fstab.5.adoc
+++ b/sys-utils/fstab.5.adoc
@@ -80,7 +80,7 @@ It's also possible to use *PARTUUID=* and *PARTLABEL=*. These partitions identif
 
 See *mount*(8), *blkid*(8) or *lsblk*(8) for more details about device identifiers.
 
-Note that *mount*(8) uses UUIDs as strings. The string representation of the UUID should be based on lower case characters. But when specifying the volume ID of FAT or NTFS file systems upper case characters are used (e.g UUID="A40D-85E7" or UUID="61DB7756DB7779B3").
+Note that *mount*(8) uses UUIDs as strings. The string representation of the UUID should be based on lower case characters. But when specifying the volume ID of FAT or NTFS filesystems upper case characters are used (e.g UUID="A40D-85E7" or UUID="61DB7756DB7779B3").
 
 === The second field (_fs_file_).
 

--- a/sys-utils/fstab.5.adoc
+++ b/sys-utils/fstab.5.adoc
@@ -80,7 +80,7 @@ It's also possible to use *PARTUUID=* and *PARTLABEL=*. These partitions identif
 
 See *mount*(8), *blkid*(8) or *lsblk*(8) for more details about device identifiers.
 
-Note that *mount*(8) uses UUIDs as strings. The string representation of the UUID should be based on lower case characters. But when specifying the volume ID of FAT or NTFS filesystems upper case characters are used (e.g UUID="A40D-85E7" or UUID="61DB7756DB7779B3").
+Note that *mount*(8) uses UUIDs as strings. The string representation of the UUID should be based on lowercase characters. But when specifying the volume ID of FAT or NTFS filesystems upper case characters are used (e.g UUID="A40D-85E7" or UUID="61DB7756DB7779B3").
 
 === The second field (_fs_file_).
 

--- a/sys-utils/fstrim.8.adoc
+++ b/sys-utils/fstrim.8.adoc
@@ -67,7 +67,7 @@ Verbose execution. With this option *fstrim* will output the number of bytes pas
 *fstrim* will report the same potential discard bytes each time, but only sectors which had been written to between the discards would actually be discarded by the storage device. Further, the kernel block layer reserves the right to adjust the discard ranges to fit raid stripe geometry, non-trim capable devices in a LVM setup, etc. These reductions would not be reflected in fstrim_range.len (the *--length* option).
 
 *--quiet-unsupported*::
-Suppress error messages if trim operation (ioctl) is unsupported. This option is meant to be used in *systemd* service file or in *cron*(8) scripts to hide warnings that are result of known problems, such as NTFS driver reporting _Bad file descriptor_ when device is mounted read-only, or lack of file system support for ioctl _FITRIM_ call. This option also cleans exit status when unsupported filesystem specified on *fstrim* command line.
+Suppress error messages if trim operation (ioctl) is unsupported. This option is meant to be used in *systemd* service file or in *cron*(8) scripts to hide warnings that are result of known problems, such as NTFS driver reporting _Bad file descriptor_ when device is mounted read-only, or lack of filesystem support for ioctl _FITRIM_ call. This option also cleans exit status when unsupported filesystem specified on *fstrim* command line.
 
 include::man-common/help-version.adoc[]
 

--- a/sys-utils/hwclock.8.adoc
+++ b/sys-utils/hwclock.8.adoc
@@ -79,7 +79,7 @@ The kernel also keeps a timezone value, the *--hctosys* function sets it to the 
 +
 When used in a startup script, making the *--hctosys* function the first caller of *settimeofday*(2) from boot, it will set the NTP '11 minute mode' timescale via the _persistent_clock_is_local_ kernel variable. If the Hardware Clock's timescale configuration is changed then a reboot is required to inform the kernel. See the discussion below, under *Automatic Hardware Clock Synchronization by the Kernel*.
 +
-This is a good function to use in one of the system startup scripts before the file systems are mounted read/write.
+This is a good function to use in one of the system startup scripts before the filesystems are mounted read/write.
 +
 This function should never be used on a running system. Jumping system time will cause problems, such as corrupted filesystem timestamps. Also, if something has changed the Hardware Clock, like NTP's '11 minute mode', then *--hctosys* will set the time incorrectly by including drift compensation.
 +

--- a/sys-utils/hwclock.8.adoc
+++ b/sys-utils/hwclock.8.adoc
@@ -151,7 +151,7 @@ This option is meaningful for ISA compatible machines in the x86 and x86_64 fami
 This option is required when using the *--setepoch* function. The minimum _year_ value is 1900. The maximum is system dependent (*ULONG_MAX - 1*).
 
 *-f*, **--rtc=**__filename__::
-Override *hwclock*'s default rtc device file name. Otherwise it will use the first one found in this order: _/dev/rtc_, _/dev/rtc0_, _/dev/misc/rtc_. For *IA-64:* _/dev/efirtc_ _/dev/misc/efirtc_
+Override *hwclock*'s default rtc device filename. Otherwise it will use the first one found in this order: _/dev/rtc_, _/dev/rtc0_, _/dev/misc/rtc_. For *IA-64:* _/dev/efirtc_ _/dev/misc/efirtc_
 
 *-l*, *--localtime*; *-u*, *--utc*::
 Indicate which timescale the Hardware Clock is set to.

--- a/sys-utils/hwclock.8.adoc
+++ b/sys-utils/hwclock.8.adoc
@@ -198,13 +198,13 @@ There are two types of date-time clocks:
 
 On an ISA compatible system, this clock is specified as part of the ISA standard. A control program can read or set this clock only to a whole second, but it can also detect the edges of the 1 second clock ticks, so the clock actually has virtually infinite precision.
 
-This clock is commonly called the hardware clock, the real time clock, the RTC, the BIOS clock, and the CMOS clock. Hardware Clock, in its capitalized form, was coined for use by *hwclock*. The Linux kernel also refers to it as the persistent clock.
+This clock is commonly called the hardware clock, the real-time clock, the RTC, the BIOS clock, and the CMOS clock. Hardware Clock, in its capitalized form, was coined for use by *hwclock*. The Linux kernel also refers to it as the persistent clock.
 
-Some non-ISA systems have a few real time clocks with only one of them having its own power domain. A very low power external I2C or SPI clock chip might be used with a backup battery as the hardware clock to initialize a more functional integrated real-time clock which is used for most other purposes.
+Some non-ISA systems have a few real-time clocks with only one of them having its own power domain. A very low power external I2C or SPI clock chip might be used with a backup battery as the hardware clock to initialize a more functional integrated real-time clock which is used for most other purposes.
 
 *The System Clock:* This clock is part of the Linux kernel and is driven by a timer interrupt. (On an ISA machine, the timer interrupt is part of the ISA standard.) It has meaning only while Linux is running on the machine. The System Time is the number of seconds since 00:00:00 January 1, 1970 UTC (or more succinctly, the number of seconds since 1969 UTC). The System Time is not an integer, though. It has virtually infinite precision.
 
-The System Time is the time that matters. The Hardware Clock's basic purpose is to keep time when Linux is not running so that the System Clock can be initialized from it at boot. Note that in DOS, for which ISA was designed, the Hardware Clock is the only real time clock.
+The System Time is the time that matters. The Hardware Clock's basic purpose is to keep time when Linux is not running so that the System Clock can be initialized from it at boot. Note that in DOS, for which ISA was designed, the Hardware Clock is the only real-time clock.
 
 It is important that the System Time not have any discontinuities such as would happen if you used the *date*(1) program to set it while the system is running. You can, however, do whatever you want to the Hardware Clock while the system is running, and the next time Linux starts up, it will do so with the adjusted time from the Hardware Clock. Note: currently this is not possible on most systems because *hwclock --systohc* is called at shutdown.
 

--- a/sys-utils/losetup.8.adoc
+++ b/sys-utils/losetup.8.adoc
@@ -54,7 +54,7 @@ The loop device setup is not an atomic operation when used with *--find*, and *l
 The _size_ and _offset_ arguments may be followed by the multiplicative suffixes KiB (=1024), MiB (=1024*1024), and so on for GiB, TiB, PiB, EiB, ZiB and YiB (the "iB" is optional, e.g., "K" has the same meaning as "KiB") or the suffixes KB (=1000), MB (=1000*1000), and so on for GB, TB, PB, EB, ZB and YB.
 
 *-a*, *--all*::
-Show the status of all loop devices. Note that not all information is accessible for non-root users. See also *--list*. The old output format (as printed without *--list*) is deprecated.
+Show the status of all loop devices. Note that not all information is accessible for unprivileged users. See also *--list*. The old output format (as printed without *--list*) is deprecated.
 
 *-d*, *--detach* _loopdev_...::
 Detach the file or device associated with the specified loop device(s). Note that since Linux v3.7 kernel uses "lazy device destruction". The detach operation does not return *EBUSY* error anymore if device is actively used by system, but it is marked by autoclear flag and destroyed later. Even if the device is not used, the loop device can be destroyed later. If you need to wait for a complete removal of the loop device, call *udevadm settle* after *losetup*.

--- a/sys-utils/lsns.8.adoc
+++ b/sys-utils/lsns.8.adoc
@@ -30,7 +30,7 @@ The default output is subject to change. So whenever possible, you should avoid 
 
 The *NSFS* column, printed when *net* is specified for the *--type* option, is special; it uses multi-line cells. Use the option *--nowrap* to switch to ","-separated single-line representation.
 
-Note that *lsns* reads information directly from the _/proc_ filesystem and for non-root users it may return incomplete information. The current _/proc_ filesystem may be unshared and affected by a PID namespace (see *unshare --mount-proc* for more details). *lsns* is not able to see persistent namespaces without processes where the namespace instance is held by a bind mount to /proc/_pid_/ns/_type_.
+Note that *lsns* reads information directly from the _/proc_ filesystem and for unprivileged users it may return incomplete information. The current _/proc_ filesystem may be unshared and affected by a PID namespace (see *unshare --mount-proc* for more details). *lsns* is not able to see persistent namespaces without processes where the namespace instance is held by a bind mount to /proc/_pid_/ns/_type_.
 
 == OPTIONS
 

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1212,7 +1212,7 @@ Files with the Windows-specific SYSTEM (FILE_ATTRIBUTE_SYSTEM) attribute will be
 Updates the Windows-specific HIDDEN (FILE_ATTRIBUTE_HIDDEN) attribute when creating and moving or renaming files. Files whose names start with a dot will have the HIDDEN attribute set and files whose names do not start with a dot will have it unset.
 
 **windows_names**::
-Prevents the creation of files and directories with a name not allowed by Windows, either because it contains some not allowed character (which are the characters “ * / : < > ? \ | and those whose code is less than 0x20), because the name (with or without extension) is a reserved file name (CON, AUX, NUL, PRN, LPT1-9, COM1-9) or because the last character is a space or a dot. Existing such files can still be read and renamed.
+Prevents the creation of files and directories with a name not allowed by Windows, either because it contains some not allowed character (which are the characters “ * / : < > ? \ | and those whose code is less than 0x20), because the name (with or without extension) is a reserved filename (CON, AUX, NUL, PRN, LPT1-9, COM1-9) or because the last character is a space or a dot. Existing such files can still be read and renamed.
 
 **discard**::
 Enable support of the TRIM command for improved performance on delete operations, which is recommended for use with the solid-state drives (SSD).
@@ -1372,7 +1372,7 @@ Instructs version 3.6 reiserfs software to mount a version 3.5 filesystem, using
 Choose which hash function reiserfs will use to find files within directories.
 +
 *rupasov*;;
-A hash invented by Yury Yu. Rupasov. It is fast and preserves locality, mapping lexicographically close file names to close hash values. This option should not be used, as it causes a high probability of hash collisions.
+A hash invented by Yury Yu. Rupasov. It is fast and preserves locality, mapping lexicographically close filenames to close hash values. This option should not be used, as it causes a high probability of hash collisions.
 
 *tea*;;
 A Davis-Meyer function implemented by Jeremy Fitzhardinge. It uses hash permuting bits in the name. It gets high randomness and, therefore, low probability of hash collisions at some CPU cost. This may be used if *EHASHCOLLISION* errors are experienced with the r5 hash.

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -879,7 +879,7 @@ Set the permission mask for ADFS 'owner' permissions and 'other' permissions, re
 === Mount options for affs
 
 **uid=**__value__ and **gid=**__value__::
-Set the owner and group of the root of the filesystem (default: uid=gid=0, but with option *uid* or *gid* without specified value, the UID and GID of the current process are taken).
+Set the owner and group of the root of the filesystem (default: uid=gid=0, but with option *uid* or *gid* without specified value, the UID and GID of the calling process are taken).
 
 **setuid=**__value__ and **setgid=**__value__::
 Set the owner and group of all files.
@@ -975,7 +975,7 @@ Set the umask applied to regular files only. The default is the umask of the cur
 This option controls the permission check of mtime/atime.  Possible values:
 
 *20*;;
-If the current process is in the group of the file's group ID,
+If the calling process is in the group of the file's group ID,
 you can change the timestamp.
 +
 *2*;;
@@ -985,7 +985,7 @@ Other users can change the timestamp.
 The default is set from the above *dmask* option. (If the directory
 is writable, *utime*(2) is also allowed.  That is: ~dmask & 022.)
  +
-Normally *utime*(2) checks that the current process is the owner of the
+Normally *utime*(2) checks that the calling process is the owner of the
 file, or that it has the *CAP_FOWNER* capability. But FAT filesystems
 don't have UID/GID on disk, so the normal check is too inflexible.
 With this option you can relax it.

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1045,7 +1045,7 @@ To maintain backward compatibility, *-o nfs* is also accepted, defaulting to *st
 This option disables the conversion of timestamps between local time (as used by Windows on FAT) and UTC (which Linux uses internally). This is particularly useful when mounting devices (like digital cameras) that are set to UTC in order to avoid the pitfalls of local time.
 
 **time_offset=**__minutes__::
-Set offset for conversion of timestamps from local time used by FAT to UTC. I.e., _minutes_ will be subtracted from each timestamp to convert it to UTC used internally by Linux. This is useful when the time zone set in the kernel via *settimeofday*(2) is not the time zone used by the filesystem. Note that this option still does not provide correct time stamps in all cases in presence of DST - time stamps in a different DST setting will be off by one hour.
+Set offset for conversion of timestamps from local time used by FAT to UTC. I.e., _minutes_ will be subtracted from each timestamp to convert it to UTC used internally by Linux. This is useful when the timezone set in the kernel via *settimeofday*(2) is not the timezone used by the filesystem. Note that this option still does not provide correct timestamps in all cases in presence of DST - timestamps in a different DST setting will be off by one hour.
 
 *quiet*::
 Turn on the _quiet_ flag. Attempts to chown or chmod files do not return errors, although they fail. Use with caution!

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1181,7 +1181,7 @@ These options are accepted but ignored.
 
 === Mount options for msdos
 
-See mount options for fat. If the _msdos_ filesystem detects an inconsistency, it reports an error and sets the file system read-only. The filesystem can be made writable again by remounting it.
+See mount options for fat. If the _msdos_ filesystem detects an inconsistency, it reports an error and sets the filesystem read-only. The filesystem can be made writable again by remounting it.
 
 === Mount options for ncpfs
 

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -926,18 +926,18 @@ Sets the mode of the mountpoint.
 
 === Mount options for devpts
 
-The devpts filesystem is a pseudo filesystem, traditionally mounted on _/dev/pts_. In order to acquire a pseudo terminal, a process opens _/dev/ptmx_; the number of the pseudo terminal is then made available to the process and the pseudo terminal slave can be accessed as _/dev/pts/_<number>.
+The devpts filesystem is a pseudo filesystem, traditionally mounted on _/dev/pts_. In order to acquire a pseudoterminal, a process opens _/dev/ptmx_; the number of the pseudoterminal is then made available to the process and the pseudoterminal slave can be accessed as _/dev/pts/_<number>.
 
 **uid=**__value__ and **gid=**__value__::
-This sets the owner or the group of newly created pseudo terminals to the specified values. When nothing is specified, they will be set to the UID and GID of the creating process. For example, if there is a tty group with GID 5, then *gid=5* will cause newly created pseudo terminals to belong to the tty group.
+This sets the owner or the group of newly created pseudoterminals to the specified values. When nothing is specified, they will be set to the UID and GID of the creating process. For example, if there is a tty group with GID 5, then *gid=5* will cause newly created pseudoterminals to belong to the tty group.
 
 **mode=**__value__::
-Set the mode of newly created pseudo terminals to the specified value. The default is 0600. A value of *mode=620* and *gid=5* makes "mesg y" the default on newly created pseudo terminals.
+Set the mode of newly created pseudoterminals to the specified value. The default is 0600. A value of *mode=620* and *gid=5* makes "mesg y" the default on newly created pseudoterminals.
 
 *newinstance*::
-Create a private instance of the devpts filesystem, such that indices of pseudo terminals allocated in this new instance are independent of indices created in other instances of devpts.
+Create a private instance of the devpts filesystem, such that indices of pseudoterminals allocated in this new instance are independent of indices created in other instances of devpts.
 +
-All mounts of devpts without this *newinstance* option share the same set of pseudo terminal indices (i.e., legacy mode). Each mount of devpts with the *newinstance* option has a private set of pseudo terminal indices.
+All mounts of devpts without this *newinstance* option share the same set of pseudoterminal indices (i.e., legacy mode). Each mount of devpts with the *newinstance* option has a private set of pseudoterminal indices.
 +
 This option is mainly used to support containers in the Linux kernel. It is implemented in Linux kernel versions starting with 2.6.29. Further, this mount option is valid only if *CONFIG_DEVPTS_MULTIPLE_INSTANCES* is enabled in the kernel configuration.
 +

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -126,7 +126,7 @@ The command *lsblk --fs* provides an overview of filesystems, LABELs and UUIDs o
 
 Don't forget that there is no guarantee that UUIDs and labels are really unique, especially if you move, share or copy the device. Use *lsblk -o +UUID,PARTUUID* to verify that the UUIDs are really unique in your system.
 
-The recommended setup is to use tags (e.g. *UUID*=_uuid_) rather than _/dev/disk/by-{label,uuid,id,partuuid,partlabel}_ udev symlinks in the _/etc/fstab_ file. Tags are more readable, robust and portable. The *mount*(8) command internally uses udev symlinks, so the use of symlinks in _/etc/fstab_ has no advantage over tags. For more details see *libblkid*(3).
+The recommended setup is to use tags (e.g. *UUID*=_uuid_) rather than _/dev/disk/by-{label,uuid,id,partuuid,partlabel}_ udev symbolic links in the _/etc/fstab_ file. Tags are more readable, robust and portable. The *mount*(8) command internally uses udev symbolic links, so the use of symbolic links in _/etc/fstab_ has no advantage over tags. For more details see *libblkid*(3).
 
 The _proc_ filesystem is not associated with a special device, and when mounting it, an arbitrary keyword - for example, __proc__ - can be used instead of a device specification. (The customary choice _none_ is less fortunate: the error message 'none already mounted' from *mount* can be confusing.)
 
@@ -144,7 +144,7 @@ ____
 
 When mounting a filesystem mentioned in _fstab_ or _mtab_, it suffices to specify on the command line only the device, or only the mount point.
 
-The programs *mount* and *umount*(8) traditionally maintained a list of currently mounted filesystems in the file _/etc/mtab_. The support for regular classic _/etc/mtab_ is completely disabled at compile time by default, because on current Linux systems it is better to make _/etc/mtab_ a symlink to _/proc/mounts_ instead. The regular _mtab_ file maintained in userspace cannot reliably work with namespaces, containers and other advanced Linux features. If the regular _mtab_ support is enabled, then it's possible to use the file as well as the symlink.
+The programs *mount* and *umount*(8) traditionally maintained a list of currently mounted filesystems in the file _/etc/mtab_. The support for regular classic _/etc/mtab_ is completely disabled at compile time by default, because on current Linux systems it is better to make _/etc/mtab_ a symbolic link to _/proc/mounts_ instead. The regular _mtab_ file maintained in userspace cannot reliably work with namespaces, containers and other advanced Linux features. If the regular _mtab_ support is enabled, then it's possible to use the file as well as the symbolic link.
 
 If no arguments are given to *mount*, the list of mounted filesystems is printed.
 
@@ -790,9 +790,9 @@ ____
 Allow to make a target directory (mountpoint) if it does not exist yet. The optional argument _mode_ specifies the filesystem access mode used for *mkdir*(2) in octal notation. The default mode is 0755. This functionality is supported only for root users or when *mount* is executed without suid permissions. The option is also supported as *x-mount.mkdir*, but this notation is deprecated since v2.30. See also *--mkdir* command line option.
 
 *X-mount.nocanonicalize*[**=**_type_]::
-Allows disabling of canonicalization for mount source and target paths. By default, the `mount` command resolves all paths to their absolute paths without symlinks. However, this behavior may not be desired in certain situations, such as when binding a mount over a symlink, or a symlink over a directory or another symlink. The optional argument _type_ can be either "source" or "target" (mountpoint). If no _type_ is specified, then canonicalization is disabled for both types. This mount option does not affect the conversion of source tags (e.g. *LABEL=* or *UUID=*) and _fstab_ processing.
+Allows disabling of canonicalization for mount source and target paths. By default, the `mount` command resolves all paths to their absolute paths without symbolic links. However, this behavior may not be desired in certain situations, such as when binding a mount over a symbolic link, or a symbolic link over a directory or another symbolic link. The optional argument _type_ can be either "source" or "target" (mountpoint). If no _type_ is specified, then canonicalization is disabled for both types. This mount option does not affect the conversion of source tags (e.g. *LABEL=* or *UUID=*) and _fstab_ processing.
 +
-The command-line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but for backward compatibility, it does not modify *open_tree*(2) syscall flags and does not allow the bind-mount over a symlink use case.
+The command-line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but for backward compatibility, it does not modify *open_tree*(2) syscall flags and does not allow the bind-mount over a symbolic link use case.
 +
 Note that *mount*(8) still sanitizes and canonicalizes the source and target paths specified on the command line by non-root users, regardless of the X-mount.nocanonicalize setting.
 
@@ -843,7 +843,7 @@ The user namespace will then be attached to the mount and the ID-mapping of the 
 For example, *X-mount.idmap=/proc/PID/ns/user* will attach the user namespace of the process PID to the mount.
 
 *nosymfollow*::
-Do not follow symlinks when resolving paths. Symlinks can still be created, and *readlink*(1), *readlink*(2), *realpath*(1), and *realpath*(3) all still work properly.
+Do not follow symbolic links when resolving paths. Symbolic links can still be created, and *readlink*(1), *readlink*(2), *realpath*(1), and *realpath*(3) all still work properly.
 
 == FILESYSTEM-SPECIFIC MOUNT OPTIONS
 
@@ -1776,13 +1776,13 @@ _/run/mount_::
 libmount private runtime directory
 
 _/etc/mtab_::
-table of mounted filesystems or symlink to _/proc/mounts_
+table of mounted filesystems or symbolic link to _/proc/mounts_
 
 _/etc/mtab~_::
-lock file (unused on systems with _mtab_ symlink)
+lock file (unused on systems with _mtab_ symbolic link)
 
 _/etc/mtab.tmp_::
-temporary file (unused on systems with _mtab_ symlink)
+temporary file (unused on systems with _mtab_ symbolic link)
 
 _/etc/filesystems_::
 a list of filesystem types to try
@@ -1799,7 +1799,7 @@ Some Linux filesystems don't support *-o sync* and *-o dirsync* (the ext2, ext3,
 
 The *-o remount* may not be able to change mount parameters (all _ext2fs_-specific parameters, except *sb*, are changeable with a remount, for example, but you can't change *gid* or *umask* for the _fatfs_).
 
-It is possible that the files _/etc/mtab_ and _/proc/mounts_ don't match on systems with a regular _mtab_ file. The first file is based only on the *mount* command options, but the content of the second file also depends on the kernel and others settings (e.g. on a remote NFS server -- in certain cases the *mount* command may report unreliable information about an NFS mount point and the _/proc/mount_ file usually contains more reliable information.) This is another reason to replace the _mtab_ file with a symlink to the _/proc/mounts_ file.
+It is possible that the files _/etc/mtab_ and _/proc/mounts_ don't match on systems with a regular _mtab_ file. The first file is based only on the *mount* command options, but the content of the second file also depends on the kernel and others settings (e.g. on a remote NFS server -- in certain cases the *mount* command may report unreliable information about an NFS mount point and the _/proc/mount_ file usually contains more reliable information.) This is another reason to replace the _mtab_ file with a symbolic link to the _/proc/mounts_ file.
 
 Checking files on NFS filesystems referenced by file descriptors (i.e. the *fcntl* and *ioctl* families of functions) may lead to inconsistent results due to the lack of a consistency check in the kernel even if the *noac* mount option is used.
 

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -162,7 +162,7 @@ ____
 *mount /dev/foo /dir*
 ____
 
-This default behaviour can be changed by using the *--options-source-force* command-line option to always read configuration from _fstab_. For non-root users *mount* always reads the _fstab_ configuration.
+This default behaviour can be changed by using the *--options-source-force* command-line option to always read configuration from _fstab_. For unprivileged users *mount* always reads the _fstab_ configuration.
 
 === Non-superuser mounts
 
@@ -180,9 +180,9 @@ ____
 *mount /cd*
 ____
 
-Note that *mount* is very strict about non-root users and all paths specified on command line are verified before _fstab_ is parsed or a helper program is executed. It's strongly recommended to use a valid mountpoint to specify filesystem, otherwise *mount* may fail. For example it's a bad idea to use NFS or CIFS source on command line.
+Note that *mount* is very strict about unprivileged users and all paths specified on command line are verified before _fstab_ is parsed or a helper program is executed. It's strongly recommended to use a valid mountpoint to specify filesystem, otherwise *mount* may fail. For example it's a bad idea to use NFS or CIFS source on command line.
 
-Since util-linux 2.35, *mount* does not exit when user permissions are inadequate according to libmount's internal security rules. Instead, it drops suid permissions and continues as regular non-root user. This behavior supports use-cases where root permissions are not necessary (e.g., fuse filesystems, user namespaces, etc).
+Since util-linux 2.35, *mount* does not exit when user permissions are inadequate according to libmount's internal security rules. Instead, it drops suid permissions and continues as regular unprivileged user. This behavior supports use-cases where root permissions are not necessary (e.g., fuse filesystems, user namespaces, etc).
 
 For more details, see *fstab*(5). Only the user that mounted a filesystem can unmount it again. If any user should be able to unmount it, then use *users* instead of *user* in the _fstab_ line. The *owner* option is similar to the *user* option, with the restriction that the user must be the owner of the special file. This may be useful e.g. for _/dev/fd_ if a login script makes the console user owner of this device. The *group* option is similar, with the restriction that the user must be a member of the group of the special file.
 
@@ -345,7 +345,7 @@ Note that *mount* does not pass this option to the **/sbin/mount.**__type__ help
 Ensures that the filesystem is mounted as a unique instance and that the
 filesystem superblock is not reused by the kernel. The filesystem may be reused
 later if mounted without the option. The option affects only the current mount
-and is allowed for non-root users as well.
+and is allowed for unprivileged users as well.
 +
 See also the **--onlyonce** option. The difference between *--onlyonce* and
 *--exclusive* is that "onlyonce" ensures the same source is not mounted on the
@@ -794,7 +794,7 @@ Allows disabling of canonicalization for mount source and target paths. By defau
 +
 The command-line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but for backward compatibility, it does not modify *open_tree*(2) syscall flags and does not allow the bind-mount over a symbolic link use case.
 +
-Note that *mount*(8) still sanitizes and canonicalizes the source and target paths specified on the command line by non-root users, regardless of the X-mount.nocanonicalize setting.
+Note that *mount*(8) still sanitizes and canonicalizes the source and target paths specified on the command line by unprivileged users, regardless of the X-mount.nocanonicalize setting.
 
 *X-mount.noloop*::
 Do not create and mount a loop device, even if the source of the mount is a regular file.

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -111,7 +111,7 @@ Human readable filesystem identifier. See also *-L*.
 UUID=__uuid__::
 Filesystem universally unique identifier. The format of the UUID is usually a series of hex digits separated by hyphens. See also *-U*.
 +
-Note that *mount* uses UUIDs as strings. The UUIDs from the command line or from *fstab*(5) are not converted to internal binary representation. The string representation of the UUID should be based on lower case characters.
+Note that *mount* uses UUIDs as strings. The UUIDs from the command line or from *fstab*(5) are not converted to internal binary representation. The string representation of the UUID should be based on lowercase characters.
 
 PARTLABEL=__label__::
 Human readable partition identifier. This identifier is independent on filesystem and does not change by *mkfs* or *mkswap* operations. It's supported for example for GUID Partition Tables (GPT).
@@ -994,7 +994,7 @@ With this option you can relax it.
 Three different levels of pickiness can be chosen:
 
 *r*[*elaxed*];;
-Upper and lower case are accepted and equivalent, long name parts are truncated (e.g. _verylongname.foobar_ becomes _verylong.foo_), leading and embedded spaces are accepted in each name part (name and extension).
+Uppercase and lowercase are accepted and equivalent, long name parts are truncated (e.g. _verylongname.foobar_ becomes _verylong.foo_), leading and embedded spaces are accepted in each name part (name and extension).
 
 *n*[*ormal*];;
 Like "relaxed", but many special characters (*, ?, <, spaces, etc.) are rejected. This is the default.
@@ -1099,7 +1099,7 @@ Set the owner and group of all files. (Default: the UID and GID of the current p
 Set the umask (the bit mask of the permissions that are *not* present). The default is the umask of the current process. The value is given in octal.
 
 *case=*{**lower**|*asis*}::
-Convert all files names to lower case, or leave them. (Default: *case=lower*.)
+Convert all files names to lowercase, or leave them. (Default: *case=lower*.)
 
 **conv=**__mode__::
 This option is obsolete and may fail or being ignored.
@@ -1122,13 +1122,13 @@ Disable the use of Rock Ridge extensions, even if available. Cf. *map*.
 Disable the use of Microsoft Joliet extensions, even if available. Cf. *map*.
 
 *check=*{*r*[*elaxed*]|*s*[*trict*]}::
-With *check=relaxed*, a filename is first converted to lower case before doing the lookup. This is probably only meaningful together with *norock* and *map=normal*. (Default: *check=strict*.)
+With *check=relaxed*, a filename is first converted to lowercase before doing the lookup. This is probably only meaningful together with *norock* and *map=normal*. (Default: *check=strict*.)
 
 **uid=**__value__ and **gid=**__value__::
 Give all files in the filesystem the indicated user or group id, possibly overriding the information found in the Rock Ridge extensions. (Default: *uid=0,gid=0*.)
 
 *map=*{*n*[*ormal*]|*o*[*ff*]|*a*[*corn*]}::
-For non-Rock Ridge volumes, normal name translation maps upper to lower case ASCII, drops a trailing ';1', and converts ';' to '.'. With *map=off* no name translation is done. See *norock*. (Default: *map=normal*.) *map=acorn* is like *map=normal* but also apply Acorn extensions if present.
+For non-Rock Ridge volumes, normal name translation maps upper to lowercase ASCII, drops a trailing ';1', and converts ';' to '.'. With *map=off* no name translation is done. See *norock*. (Default: *map=normal*.) *map=acorn* is like *map=normal* but also apply Acorn extensions if present.
 
 **mode=**__value__::
 For non-Rock Ridge volumes, give all files the indicated mode. (Default: read and execute permission for everybody.) Octal mode values require a leading 0.
@@ -1602,13 +1602,13 @@ UTF8 is the filesystem safe 8-bit encoding of Unicode that is used by the consol
 Defines the behavior for creation and display of filenames which fit into 8.3 characters. If a long name for a file exists, it will always be the preferred one for display. There are four __mode__s:
 
 *lower*;;
-Force the short name to lower case upon display; store a long name when the short name is not all upper case.
+Force the short name to lowercase upon display; store a long name when the short name is not all upper case.
 
 *win95*;;
 Force the short name to upper case upon display; store a long name when the short name is not all upper case.
 
 *winnt*;;
-Display the short name as is; store a long name when the short name is not all lower case or all upper case.
+Display the short name as is; store a long name when the short name is not all lowercase or all upper case.
 
 *mixed*;;
 Display the short name as is; store a long name when the short name is not all upper case. This mode is the default since Linux 2.6.32.

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -963,7 +963,7 @@ Set blocksize (default 512). This option is obsolete.
 Set the owner and group of all files. (Default: the UID and GID of the current process.)
 
 **umask=**__value__::
-Set the umask (the bitmask of the permissions that are *not* present). The default is the umask of the current process. The value is given in octal.
+Set the umask (the bit mask of the permissions that are *not* present). The default is the umask of the current process. The value is given in octal.
 
 **dmask=**__value__::
 Set the umask applied to directories only. The default is the umask of the current process. The value is given in octal.
@@ -1096,7 +1096,7 @@ Don't complain about invalid mount options.
 Set the owner and group of all files. (Default: the UID and GID of the current process.)
 
 **umask=**__value__::
-Set the umask (the bitmask of the permissions that are *not* present). The default is the umask of the current process. The value is given in octal.
+Set the umask (the bit mask of the permissions that are *not* present). The default is the umask of the current process. The value is given in octal.
 
 *case=*{**lower**|*asis*}::
 Convert all files names to lower case, or leave them. (Default: *case=lower*.)

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -1111,7 +1111,7 @@ Do not abort mounting when certain consistency checks fail.
 
 ISO 9660 is a standard describing a filesystem structure to be used on CD-ROMs. (This filesystem type is also seen on some DVDs. See also the _udf_ filesystem.)
 
-Normal _iso9660_ filenames appear in an 8.3 format (i.e., DOS-like restrictions on filename length), and in addition all characters are in upper case. Also there is no field for file ownership, protection, number of links, provision for block/character devices, etc.
+Normal _iso9660_ filenames appear in an 8.3 format (i.e., DOS-like restrictions on filename length), and in addition all characters are in uppercase. Also there is no field for file ownership, protection, number of links, provision for block/character devices, etc.
 
 Rock Ridge is an extension to iso9660 that provides all of these UNIX-like features. Basically there are extensions to each directory record that supply all of the additional information, and when Rock Ridge is in use, the filesystem is indistinguishable from a normal UNIX filesystem (except that it is read-only, of course).
 
@@ -1602,16 +1602,16 @@ UTF8 is the filesystem safe 8-bit encoding of Unicode that is used by the consol
 Defines the behavior for creation and display of filenames which fit into 8.3 characters. If a long name for a file exists, it will always be the preferred one for display. There are four __mode__s:
 
 *lower*;;
-Force the short name to lowercase upon display; store a long name when the short name is not all upper case.
+Force the short name to lowercase upon display; store a long name when the short name is not all uppercase.
 
 *win95*;;
-Force the short name to upper case upon display; store a long name when the short name is not all upper case.
+Force the short name to uppercase upon display; store a long name when the short name is not all uppercase.
 
 *winnt*;;
-Display the short name as is; store a long name when the short name is not all lowercase or all upper case.
+Display the short name as is; store a long name when the short name is not all lowercase or all uppercase.
 
 *mixed*;;
-Display the short name as is; store a long name when the short name is not all upper case. This mode is the default since Linux 2.6.32.
+Display the short name as is; store a long name when the short name is not all uppercase. This mode is the default since Linux 2.6.32.
 
 === Mount options for usbfs
 

--- a/sys-utils/mountpoint.1.adoc
+++ b/sys-utils/mountpoint.1.adoc
@@ -35,7 +35,7 @@ Do not follow symbolic link if it the last element of the _directory_ path.
 Show the major/minor numbers of the given blockdevice on standard output.
 
 *--show*::
-Print the mountpoint path for the given path. This resolves the given directory or file to its actual mountpoint, which is useful with bind mounts, symlinks, or paths within filesystems. This option requires kernel support for the *statmount*(2) system call (Linux 6.8 and newer). On older kernels, this option will fail with an error message.
+Print the mountpoint path for the given path. This resolves the given directory or file to its actual mountpoint, which is useful with bind mounts, symbolic links, or paths within filesystems. This option requires kernel support for the *statmount*(2) system call (Linux 6.8 and newer). On older kernels, this option will fail with an error message.
 
 include::man-common/help-version.adoc[]
 

--- a/sys-utils/pivot_root.8.adoc
+++ b/sys-utils/pivot_root.8.adoc
@@ -16,7 +16,7 @@ pivot_root - change the root filesystem
 
 == DESCRIPTION
 
-*pivot_root* moves the root file system of the current process to the directory _put_old_ and makes _new_root_ the new root file system. Since *pivot_root*(8) simply calls *pivot_root*(2), we refer to the man page of the latter for further details.
+*pivot_root* moves the root filesystem of the current process to the directory _put_old_ and makes _new_root_ the new root filesystem. Since *pivot_root*(8) simply calls *pivot_root*(2), we refer to the man page of the latter for further details.
 
 Note that, depending on the implementation of *pivot_root*, root and current working directory of the caller may or may not change. The following is a sequence for invoking *pivot_root* that works in either case, assuming that *pivot_root* and *chroot* are in the current *PATH*:
 
@@ -28,7 +28,7 @@ exec chroot . command
 
 Note that *chroot* must be available under the old root and under the new root, because *pivot_root* may or may not have implicitly changed the root directory of the shell.
 
-Note that *exec chroot* changes the running executable, which is necessary if the old root directory should be unmounted afterwards. Also note that standard input, output, and error may still point to a device on the old root file system, keeping it busy. They can easily be changed when invoking *chroot* (see below; note the absence of leading slashes to make it work whether *pivot_root* has changed the shell's root or not).
+Note that *exec chroot* changes the running executable, which is necessary if the old root directory should be unmounted afterwards. Also note that standard input, output, and error may still point to a device on the old root filesystem, keeping it busy. They can easily be changed when invoking *chroot* (see below; note the absence of leading slashes to make it work whether *pivot_root* has changed the shell's root or not).
 
 == OPTIONS
 
@@ -36,7 +36,7 @@ include::man-common/help-version.adoc[]
 
 == EXAMPLE
 
-Change the root file system to _/dev/hda1_ from an interactive shell:
+Change the root filesystem to _/dev/hda1_ from an interactive shell:
 
 ....
 mount /dev/hda1 /new-root
@@ -46,7 +46,7 @@ exec chroot . sh <dev/console >dev/console 2>&1
 umount /old-root
 ....
 
-Mount the new root file system over NFS from 10.0.0.1:/my_root and run *init*:
+Mount the new root filesystem over NFS from 10.0.0.1:/my_root and run *init*:
 
 ....
 ifconfig lo 127.0.0.1 up   # for portmap

--- a/sys-utils/pivot_root.8.adoc
+++ b/sys-utils/pivot_root.8.adoc
@@ -16,7 +16,7 @@ pivot_root - change the root filesystem
 
 == DESCRIPTION
 
-*pivot_root* moves the root filesystem of the current process to the directory _put_old_ and makes _new_root_ the new root filesystem. Since *pivot_root*(8) simply calls *pivot_root*(2), we refer to the man page of the latter for further details.
+*pivot_root* moves the root filesystem of the calling process to the directory _put_old_ and makes _new_root_ the new root filesystem. Since *pivot_root*(8) simply calls *pivot_root*(2), we refer to the man page of the latter for further details.
 
 Note that, depending on the implementation of *pivot_root*, root and current working directory of the caller may or may not change. The following is a sequence for invoking *pivot_root* that works in either case, assuming that *pivot_root* and *chroot* are in the current *PATH*:
 

--- a/sys-utils/prlimit.1.adoc
+++ b/sys-utils/prlimit.1.adoc
@@ -130,7 +130,7 @@ Display the limits of the RSS, and set the soft and hard limits for the number o
 Modify only the soft limit for the number of processes.
 
 *prlimit --pid $$ --nproc=unlimited*::
-Set for the current process both the soft and ceiling values for the number of processes to unlimited.
+Set for the calling process both the soft and ceiling values for the number of processes to unlimited.
 
 *prlimit --cpu=10 sort -u hugefile*::
 Set both the soft and hard CPU time limit to ten seconds and run *sort*(1).

--- a/sys-utils/rtcwake.8.adoc
+++ b/sys-utils/rtcwake.8.adoc
@@ -55,7 +55,7 @@ Examples of the **+**_number_[*smhd*] format are: *+5m*, *+6h*, *+2d*.
 The unit specifier may be longer: *+5min*, *+6hours*, *+2days*.
 
 *-d*, *--device* _device_::
-Use the specified _device_ instead of *rtc0* as realtime clock. This option is only relevant if your system has more than one RTC. You may specify *rtc1*, *rtc2*, ... here.
+Use the specified _device_ instead of *rtc0* as real-time clock. This option is only relevant if your system has more than one RTC. You may specify *rtc1*, *rtc2*, ... here.
 
 *-l*, *--local*::
 Assume that the hardware clock is set to local time, regardless of the contents of the _adjtime_ file.

--- a/sys-utils/umount.8.adoc
+++ b/sys-utils/umount.8.adoc
@@ -61,7 +61,7 @@ Unmount all mountpoints in the current mount namespace for the specified filesys
 *-c*, *--no-canonicalize*::
 Do not canonicalize paths. The paths canonicalization is based on *stat*(2) and *readlink*(2) system calls. These system calls may hang in some cases (for example on NFS if server is not available). The option has to be used with canonical path to the mount point.
 +
-This option is silently ignored by *umount* for non-root users.
+This option is silently ignored by *umount* for unprivileged users.
 +
 For more details about this option see the *mount*(8) man page. Note that *umount* does not pass this option to the **/sbin/umount.**__type__ helpers.
 
@@ -123,7 +123,7 @@ Normally, only the superuser can umount filesystems. However, when _fstab_ conta
 
 Since version 2.34 the *umount* command can be used to perform umount operation also for fuse filesystems if kernel mount table contains user's ID. In this case _fstab_ *user=* mount option is not required.
 
-Since version 2.35 *umount* command does not exit when user permissions are inadequate by internal *libmount* security rules. It drops suid permissions and continue as regular non-root user. This can be used to support use-cases where root permissions are not necessary (e.g., fuse filesystems, user namespaces, etc).
+Since version 2.35 *umount* command does not exit when user permissions are inadequate by internal *libmount* security rules. It drops suid permissions and continue as regular unprivileged user. This can be used to support use-cases where root permissions are not necessary (e.g., fuse filesystems, user namespaces, etc).
 
 == LOOP DEVICE
 

--- a/sys-utils/umount.8.adoc
+++ b/sys-utils/umount.8.adoc
@@ -56,7 +56,7 @@ Note that a filesystem cannot be unmounted when it is 'busy' - for example, when
 All of the filesystems described in _/proc/self/mountinfo_ (or in deprecated _/etc/mtab_) are unmounted, except the proc, devfs, devpts, sysfs, rpc_pipefs and nfsd filesystems. This list of the filesystems may be replaced by *--types* umount option.
 
 *-A*, *--all-targets*::
-Unmount all mountpoints in the current mount namespace for the specified filesystem. The filesystem can be specified by one of the mountpoints or the device name (or UUID, etc.). When this option is used together with *--recursive*, then all nested mounts within the filesystem are recursively unmounted. This option is only supported on systems where _/etc/mtab_ is a symlink to _/proc/mounts_.
+Unmount all mountpoints in the current mount namespace for the specified filesystem. The filesystem can be specified by one of the mountpoints or the device name (or UUID, etc.). When this option is used together with *--recursive*, then all nested mounts within the filesystem are recursively unmounted. This option is only supported on systems where _/etc/mtab_ is a symbolic link to _/proc/mounts_.
 
 *-c*, *--no-canonicalize*::
 Do not canonicalize paths. The paths canonicalization is based on *stat*(2) and *readlink*(2) system calls. These system calls may hang in some cases (for example on NFS if server is not available). The option has to be used with canonical path to the mount point.
@@ -74,7 +74,7 @@ Causes everything to be done except for the actual system call or umount helper 
 *-f*, *--force*::
 Force an unmount (in case of an unreachable NFS system).
 +
-Note that this option does not guarantee that umount command does not hang. It's strongly recommended to use absolute paths without symlinks to avoid unwanted *readlink*(2) and *stat*(2) system calls on unreachable NFS in *umount*.
+Note that this option does not guarantee that umount command does not hang. It's strongly recommended to use absolute paths without symbolic links to avoid unwanted *readlink*(2) and *stat*(2) system calls on unreachable NFS in *umount*.
 
 *-i*, *--internal-only*::
 Do not call the **/sbin/umount.**__filesystem__ helper even if it exists. By default such a helper program is called if it exists.
@@ -199,7 +199,7 @@ Override the default location of the _fstab_ file (ignored for *suid*).
 == FILES
 
 _/etc/mtab_::
-table of mounted filesystems (deprecated and usually replaced by symlink to _/proc/mounts_)
+table of mounted filesystems (deprecated and usually replaced by symbolic link to _/proc/mounts_)
 
 _/etc/fstab_::
 table of known filesystems

--- a/sys-utils/zramctl.8.adoc
+++ b/sys-utils/zramctl.8.adoc
@@ -32,7 +32,7 @@ Set up a zram device: ::
 
 *zramctl* is used to quickly set up zram device parameters, to reset zram devices, and to query the status of used zram devices.
 
-If no option is given, all non-zero size zram devices are shown.
+If no option is given, all nonzero size zram devices are shown.
 
 Use *--help* to get an overview of the supported output columns and their descriptions.
 

--- a/term-utils/agetty.8.adoc
+++ b/term-utils/agetty.8.adoc
@@ -359,7 +359,7 @@ The baud-rate detection feature (the *--extract-baud* option) requires that the 
 
 == DIAGNOSTICS
 
-Depending on how the program was configured, all diagnostics are written to the console device or reported via the *syslog*(3) facility. Error messages are produced if the _port_ argument does not specify a terminal device; if there is no utmp entry for the current process (System V only); and so on.
+Depending on how the program was configured, all diagnostics are written to the console device or reported via the *syslog*(3) facility. Error messages are produced if the _port_ argument does not specify a terminal device; if there is no utmp entry for the calling process (System V only); and so on.
 
 == AUTHORS
 

--- a/term-utils/agetty.8.adoc
+++ b/term-utils/agetty.8.adoc
@@ -35,7 +35,7 @@ This program does not use the _/etc/gettydefs_ (System V) or _/etc/gettytab_ (Su
 == ARGUMENTS
 
 _port_::
-A path name relative to the _/dev_ directory. If a "-" is specified, *agetty* assumes that its standard input is already connected to a tty port and that a connection to a remote user has already been established.
+A pathname relative to the _/dev_ directory. If a "-" is specified, *agetty* assumes that its standard input is already connected to a tty port and that a connection to a remote user has already been established.
 +
 Under System V, a "-" _port_ argument should be preceded by a "--".
 

--- a/term-utils/setterm.1.adoc
+++ b/term-utils/setterm.1.adoc
@@ -89,7 +89,7 @@ Sets the terminal's rendering options to the default values.
 Writes a snapshot of the virtual console with the given number to the file specified with the *--file* option, overwriting its contents; the default is _screen.dump_. Without an argument, it dumps the current virtual console. This overrides *--append*.
 
 *--file* _filename_::
-Sets the snapshot filename for any *--dump* or *--append* options on the same command line. If this option is not present, the default is _screen.dump_ in the current directory. A path name that exceeds the system maximum will be truncated, see *PATH_MAX* from _linux/limits.h_ for the value.
+Sets the snapshot filename for any *--dump* or *--append* options on the same command line. If this option is not present, the default is _screen.dump_ in the current directory. A pathname that exceeds the system maximum will be truncated, see *PATH_MAX* from _linux/limits.h_ for the value.
 
 *--foreground* __8-color__|**default**::
 Sets the foreground text color.

--- a/term-utils/setterm.1.adoc
+++ b/term-utils/setterm.1.adoc
@@ -89,7 +89,7 @@ Sets the terminal's rendering options to the default values.
 Writes a snapshot of the virtual console with the given number to the file specified with the *--file* option, overwriting its contents; the default is _screen.dump_. Without an argument, it dumps the current virtual console. This overrides *--append*.
 
 *--file* _filename_::
-Sets the snapshot file name for any *--dump* or *--append* options on the same command line. If this option is not present, the default is _screen.dump_ in the current directory. A path name that exceeds the system maximum will be truncated, see *PATH_MAX* from _linux/limits.h_ for the value.
+Sets the snapshot filename for any *--dump* or *--append* options on the same command line. If this option is not present, the default is _screen.dump_ in the current directory. A path name that exceeds the system maximum will be truncated, see *PATH_MAX* from _linux/limits.h_ for the value.
 
 *--foreground* __8-color__|**default**::
 Sets the foreground text color.

--- a/text-utils/more.1.adoc
+++ b/text-utils/more.1.adoc
@@ -158,7 +158,7 @@ Go to kth next file. Defaults to 1.
 Go to kth previous file. Defaults to 1.
 
 *:f*::
-Display current file name and line number.
+Display current filename and line number.
 
 *.*::
 Repeat previous command.


### PR DESCRIPTION
This PR aims at following some of the suggestions described in the Linux manpages conventions that address technical terms which should be avoided and replaced with preferred alternatives.

The list of these terms can be found [here](https://man7.org/linux/man-pages/man7/man-pages.7.html); in the discussions `Preferred terms` and `Terms to avoid`. 