### PR TITLE
[po-man] Add missing languages to po4a.cfg

### DIFF
--- a/po-man/po4a.cfg
+++ b/po-man/po4a.cfg
@@ -1,4 +1,4 @@
-[po4a_langs] cs de es fr ko pl pt_BR ro sr uk
+[po4a_langs] ar cs de es fr ko pl pt_BR ro sr sv uk
 [po4a_paths] util-linux-man.pot $lang:$lang.po
 
 [type:asciidoc] ../man-common/annotate.adoc      $lang:$lang/man-common/annotate.adoc    opt:"--keep 0"


### PR DESCRIPTION
I was wondering why the Arabic and Swedish man pages are not shipped with the `util-linux-i18n` package on Fedora. The reason was that during the sync with GNU TP, the files have been fetched, but not enabled in the po4a configuration.

Moreover, I propose to cherry-pick this commit into `stable/v2.42` to also enable the missing languages for inclusion in util-linux-2.42.1.