### PR TITLE
agetty: add support for more systemd credentials

### DIFF
--- a/term-utils/agetty.8.adoc
+++ b/term-utils/agetty.8.adoc
@@ -349,6 +349,37 @@ _/etc/inittab_::
 
 If set, configures *agetty* to automatically log in the specified user without asking for a username or password, similarly to the *--autologin* option.
 
+*agetty.delay* (unsigned integer)::
+
+If set, configures *agetty* to sleep for a specified number of seconds before opening the tty. Similar to the *--delay* option.
+
+*agetty.hangup* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to do a virtual hangup of the specified terminal. Similar to the *--hangup* option.
+
+*agetty.nice* (signed integer)::
+
+If set, configures *agetty* to run the login program with the specified priority. Similar to the *--nice* option.
+
+*agetty.noclear* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to not clear the screen before prompting for the login name. Similar to the *--noclear* option.
+
+*agetty.nohints* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to not print hints about Num, Caps and Scroll Locks. Similar to the *--nohints* option.
+
+*agetty.nohostname* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to show no hostname. Similar to the *--nohostname* option.
+
+*agetty.noissue* (boolean)::
+
+If set to a positive boolean value, configures *agetty* to not show contents of _/etc/issue_ before writing the login prompt. Similar to the *--noissue* option.
+
+Boolean credentials accept the following positive values: "1", "y", "t", "yes", "true", "on", "enable",
+and negative values: "0", "n", "f", "no", "false", "off", "disable". The values are case insensitive.
+
 == BUGS
 
 The baud-rate detection feature (the *--extract-baud* option) requires that *agetty* be scheduled soon enough after completion of a dial-in call (within 30 ms with modems that talk at 2400 baud). For robustness, always use the *--extract-baud* option in combination with a multiple baud rate command-line argument, so that BREAK processing is enabled.

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -3094,6 +3094,20 @@ static void reload_agettys(void)
 #endif
 }
 
+static int cred_read_str(struct path_cxt *pc, const char *name,
+			 struct options *op, size_t offset)
+{
+	char *str = NULL, **dest;
+
+	if (ul_path_read_string(pc, &str, name) < 0)
+		return -1;
+
+	dest = (char **) ((char *) op + offset);
+	free(*dest);
+	*dest = str;
+	return 0;
+}
+
 static void load_credentials(struct options *op)
 {
 	char *env;
@@ -3118,13 +3132,9 @@ static void load_credentials(struct options *op)
 	}
 
 	while ((d = xreaddir(dir))) {
-		char *str;
-
-		if (strcmp(d->d_name, "agetty.autologin") == 0) {
-			ul_path_read_string(pc, &str, d->d_name);
-			free(op->autolog);
-			op->autolog = str;
-		}
+		if (strcmp(d->d_name, "agetty.autologin") == 0)
+			cred_read_str(pc, d->d_name, op,
+				      offsetof(struct options, autolog));
 	}
 	closedir(dir);
 }

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -3145,6 +3145,28 @@ static int cred_read_num(struct path_cxt *pc, const char *name,
 	return rc;
 }
 
+static int cred_read_bool(struct path_cxt *pc, const char *name,
+			  int *flags, int flag, int invert)
+{
+	char *str = NULL;
+	bool res;
+	int rc;
+
+	if (ul_path_read_string(pc, &str, name) < 0)
+		return -1;
+
+	rc = ul_strtobool(str, &res);
+	if (rc)
+		log_warn(_("invalid '%s' credential value"), name);
+	else if (res != invert)
+		*flags |= flag;
+	else
+		*flags &= ~flag;
+
+	free(str);
+	return rc;
+}
+
 static void load_credentials(struct options *op)
 {
 	char *env;

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -3108,6 +3108,43 @@ static int cred_read_str(struct path_cxt *pc, const char *name,
 	return 0;
 }
 
+static int cred_read_num(struct path_cxt *pc, const char *name,
+			 struct options *op, size_t offset, int type)
+{
+	char *str = NULL;
+	int rc;
+
+	if (ul_path_read_string(pc, &str, name) < 0)
+		return -1;
+
+	switch (type) {
+	case 'u':
+	{
+		uint32_t num;
+		rc = ul_strtou32(str, &num, 10);
+		if (rc == 0)
+			*((unsigned int *) ((char *) op + offset)) = num;
+		break;
+	}
+	case 'd':
+	{
+		int32_t num;
+		rc = ul_strtos32(str, &num, 10);
+		if (rc == 0)
+			*((int *) ((char *) op + offset)) = num;
+		break;
+	}
+	default:
+		rc = -EINVAL;
+		break;
+	}
+
+	if (rc)
+		log_warn(_("invalid '%s' credential value"), name);
+	free(str);
+	return rc;
+}
+
 static void load_credentials(struct options *op)
 {
 	char *env;

--- a/term-utils/agetty.c
+++ b/term-utils/agetty.c
@@ -3194,6 +3194,27 @@ static void load_credentials(struct options *op)
 		if (strcmp(d->d_name, "agetty.autologin") == 0)
 			cred_read_str(pc, d->d_name, op,
 				      offsetof(struct options, autolog));
+		else if (strcmp(d->d_name, "agetty.delay") == 0)
+			cred_read_num(pc, d->d_name, op,
+				      offsetof(struct options, delay), 'u');
+		else if (strcmp(d->d_name, "agetty.nice") == 0)
+			cred_read_num(pc, d->d_name, op,
+				      offsetof(struct options, nice), 'd');
+		else if (strcmp(d->d_name, "agetty.hangup") == 0)
+			cred_read_bool(pc, d->d_name,
+				       &op->flags, F_HANGUP, 0);
+		else if (strcmp(d->d_name, "agetty.noclear") == 0)
+			cred_read_bool(pc, d->d_name,
+				       &op->flags, F_NOCLEAR, 0);
+		else if (strcmp(d->d_name, "agetty.nohints") == 0)
+			cred_read_bool(pc, d->d_name,
+				       &op->flags, F_NOHINTS, 0);
+		else if (strcmp(d->d_name, "agetty.nohostname") == 0)
+			cred_read_bool(pc, d->d_name,
+				       &op->flags, F_NOHOSTNAME, 0);
+		else if (strcmp(d->d_name, "agetty.noissue") == 0)
+			cred_read_bool(pc, d->d_name,
+				       &op->flags, F_ISSUE, 1);
 	}
 	closedir(dir);
 }


### PR DESCRIPTION
  Reimplementation of #4057 with a cleaner architecture.                                                 
                                                                                                         
  Instead of open-coding read/parse/assign/free for each credential, this introduces three reusable
  helpers:                                                                                               
                  
  - `cred_read_str()` — reads a credential into a char * struct member (via offsetof())                    
  - `cred_read_num()` — reads and parses a numeric credential, with a type selector ('u' for unsigned, 'd'
  for signed) extensible for future types                                                                
  - `cred_read_bool()` — reads and parses a boolean credential using ul_strtobool(), with an invert flag
  for "noissue"-style semantics where true clears the flag                                               
                  
  The existing agetty.autologin handling is refactored to use cred_read_str(), and the following new     
  credentials are added:
                                                                                                         
  - agetty.delay (unsigned int) — --delay
  - agetty.hangup (boolean) — --hangup
  - agetty.nice (signed int) — --nice
  - agetty.noclear (boolean) — --noclear                                                                 
  - agetty.nohints (boolean) — --nohints
  - agetty.nohostname (boolean) — --nohostname                                                           
  - agetty.noissue (boolean) — --noissue                                                                 
                                                                                                         
  Closes: #2255                                                                                          
  Supersedes: #4057

