### PR TITLE
mkfs.cramfs: Consider -i/-p argument sizes only once

### DIFF
--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -761,10 +761,6 @@ int main(int argc, char **argv)
 			break;
 		case 'i':
 			opt_image = optarg;
-			if (lstat(opt_image, &st) < 0)
-				err(MKFS_EX_USAGE, _("stat of %s failed"), opt_image);
-			image_length = st.st_size; /* may be padded later */
-			fslen_ub += (image_length + 3); /* 3 is for padding */
 			break;
 		case 'l':
 			lockmode = "1";
@@ -803,6 +799,12 @@ int main(int argc, char **argv)
 	dirname = argv[optind];
 	outfile = argv[optind + 1];
 
+	if (opt_image != NULL) {
+		if (lstat(opt_image, &st) < 0)
+			err(MKFS_EX_USAGE, _("stat of %s failed"), opt_image);
+		image_length = st.st_size; /* may be padded later */
+		fslen_ub += (image_length + 3); /* 3 is for padding */
+	}
 	fslen_ub += opt_pad;
 
 	if (blksize == 0)

--- a/disk-utils/mkfs.cramfs.c
+++ b/disk-utils/mkfs.cramfs.c
@@ -779,7 +779,6 @@ int main(int argc, char **argv)
 			break;
 		case 'p':
 			opt_pad = PAD_SIZE;
-			fslen_ub += PAD_SIZE;
 			break;
 		case 's':
 			/* old option, ignored */
@@ -803,6 +802,8 @@ int main(int argc, char **argv)
 	}
 	dirname = argv[optind];
 	outfile = argv[optind + 1];
+
+	fslen_ub += opt_pad;
 
 	if (blksize == 0)
 		blksize = getpagesize();


### PR DESCRIPTION
Padding is only added once to the image, but if `-p` is specified multiple times, padding is added to estimated size over and over.
The same is true for `-i` files. Only the last supplied file is added, but every time, the file size is added to estimated size.

Proof of Concept:
1. Create 16 MB file
```
BASE=$(mktemp -d)
mkdir $BASE/in
fallocate -o 16777215 -l 1 $BASE/ifile
```
2. Specify the file 20 times with `-i` argument
```
mkfs.cramfs $(python -c 'print(20*"-i '$BASE'/ifile ")') $BASE/in $BASE/out
```
```
mkfs.cramfs: warning: guestimate of required size (upper bound) is 320MB, but maximum image size is 272MB.  We might die prematurely.
```

No warning should be shown instead.