### PR TITLE
last: fix phantom detection for unset loginuid and X11 sessions

### DIFF
--- a/include/c.h
+++ b/include/c.h
@@ -655,6 +655,10 @@ static inline int fputsln(const char *s, FILE *stream) {
 #define SINT_MIN(t) (-SINT_MAX(t) - (t)1)
 #define MAX_OF_UINT_TYPE(t) ~((t)0)
 
+#ifndef INVALID_UID
+# define INVALID_UID ((uid_t) -1)
+#endif
+
 #ifndef HAVE_REALLOCARRAY
 static inline void *reallocarray(void *ptr, size_t nmemb, size_t size)
 {

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -649,7 +649,7 @@ static int is_phantom(const struct last_control *ctl, struct utmpx *ut)
 		if (fscanf(f, "%u", &loginuid) != 1)
 			ret = 1;
 		fclose(f);
-		if (!ret && pw->pw_uid != loginuid)
+		if (!ret && loginuid != INVALID_UID && pw->pw_uid != loginuid)
 			return 1;
 	} else {
 		struct stat st;
@@ -657,11 +657,13 @@ static int is_phantom(const struct last_control *ctl, struct utmpx *ut)
 
 		mem2strcpy(utline, ut->ut_line, sizeof(ut->ut_line), sizeof(utline));
 
-		snprintf(path, sizeof(path), "/dev/%s", utline);
-		if (stat(path, &st))
-			return 1;
-		if (pw->pw_uid != st.st_uid)
-			return 1;
+		if (utline[0] != ':') {
+			snprintf(path, sizeof(path), "/dev/%s", utline);
+			if (stat(path, &st))
+				return 1;
+			if (pw->pw_uid != st.st_uid)
+				return 1;
+		}
 	}
 	return ret;
 }


### PR DESCRIPTION
Don't mark a session as phantom when /proc/pid/loginuid exists but has not been set by pam_loginuid.so (contains the kernel's unset sentinel value 4294967295).

Skip the /dev/ tty stat() check when the utline starts with ':' (traditional X11 session registration by xdm/sessreg).

Based on a patch by glangshaw.

Fixes: https://github.com/util-linux/util-linux/issues/4295