### PR TITLE
fix build with libeconf

### DIFF
--- a/include/shells.h
+++ b/include/shells.h
@@ -6,8 +6,16 @@
 
 #include <pwd.h>
 
+#if defined (HAVE_LIBECONF) && defined (USE_VENDORDIR)
+# include <libeconf.h>
+#endif
+
 #define UL_SHELL_NOENV  (1 << 0)
 #define UL_SHELL_NOPWD  (1 << 1)
+
+#if defined (HAVE_LIBECONF) && defined (USE_VENDORDIR)
+econf_file *open_etc_shells(void);
+#endif
 
 extern void print_shells(FILE *out, const char *format);
 extern int is_known_shell(const char *shell_name);

--- a/lib/Makemodule.am
+++ b/lib/Makemodule.am
@@ -37,7 +37,6 @@ libcommon_la_SOURCES = \
 	lib/randutils.c \
 	lib/sha1.c \
 	lib/sha256.c \
-	lib/shells.c \
 	lib/signames.c \
 	lib/strutils.c \
 	lib/strv.c \
@@ -66,6 +65,16 @@ if HAVE_DIRFD
 libcommon_la_SOURCES += lib/path.c
 libcommon_la_SOURCES += lib/sysfs.c
 libcommon_la_SOURCES += lib/procfs.c
+endif
+endif
+
+EXTRA_LTLIBRARIES += libcommon_shells.la
+libcommon_shells_la_CFLAGS = $(AM_CFLAGS)
+libcommon_shells_la_SOURCES = \
+	lib/shells.c
+if HAVE_ECONF
+if USE_VENDORDIR
+libcommon_shells_la_LIBADD = $(ECONF_LIBS)
 endif
 endif
 

--- a/lib/Makemodule.am
+++ b/lib/Makemodule.am
@@ -68,6 +68,14 @@ libcommon_la_SOURCES += lib/procfs.c
 endif
 endif
 
+EXTRA_LTLIBRARIES += libcommon_logindefs.la
+libcommon_logindefs_la_CFLAGS = $(AM_CFLAGS)
+libcommon_logindefs_la_SOURCES = \
+	lib/logindefs.c
+if HAVE_ECONF
+libcommon_logindefs_la_LIBADD = $(ECONF_LIBS)
+endif
+
 EXTRA_LTLIBRARIES += libcommon_shells.la
 libcommon_shells_la_CFLAGS = $(AM_CFLAGS)
 libcommon_shells_la_SOURCES = \

--- a/lib/shells.c
+++ b/lib/shells.c
@@ -15,7 +15,7 @@
 #include "shells.h"
 
 #if defined (HAVE_LIBECONF) && defined (USE_VENDORDIR)
-static econf_file *open_etc_shells(void)
+econf_file *open_etc_shells(void)
 {
 	econf_err error;
 	econf_file *key_file = NULL;

--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -60,7 +60,7 @@ dist_noinst_DATA += login-utils/login.1.adoc
 login_SOURCES = \
 	login-utils/login.c \
 	lib/logindefs.c
-login_LDADD = $(LDADD) libcommon.la -lpam
+login_LDADD = $(LDADD) libcommon.la libcommon_shells.la -lpam
 if HAVE_LINUXPAM
 login_LDADD += -lpam_misc
 endif
@@ -69,9 +69,6 @@ login_LDADD += $(AUDIT_LIBS)
 endif
 if HAVE_SELINUX
 login_LDADD += $(SELINUX_LIBS)
-endif
-if HAVE_ECONF
-login_LDADD += $(ECONF_LIBS)
 endif
 endif # BUILD_LOGIN
 

--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -58,9 +58,8 @@ bin_PROGRAMS += login
 MANPAGES += login-utils/login.1
 dist_noinst_DATA += login-utils/login.1.adoc
 login_SOURCES = \
-	login-utils/login.c \
-	lib/logindefs.c
-login_LDADD = $(LDADD) libcommon.la libcommon_shells.la -lpam
+	login-utils/login.c
+login_LDADD = $(LDADD) libcommon.la libcommon_logindefs.la libcommon_shells.la -lpam
 if HAVE_LINUXPAM
 login_LDADD += -lpam_misc
 endif
@@ -140,22 +139,16 @@ endif
 
 chfn_SOURCES = \
 	login-utils/chfn.c \
-	lib/logindefs.c \
 	$(chfn_chsh_sources)
 chfn_CFLAGS = $(chfn_chsh_cflags)
 chfn_LDFLAGS = $(chfn_chsh_ldflags)
-chfn_LDADD = $(LDADD) $(chfn_chsh_ldadd)
-if HAVE_ECONF
-chfn_LDADD += $(ECONF_LIBS)
-endif
+chfn_LDADD = $(LDADD) $(chfn_chsh_ldadd) libcommon_logindefs.la
 
-chsh_SOURCES = login-utils/chsh.c lib/shells.c $(chfn_chsh_sources)
+chsh_SOURCES = login-utils/chsh.c \
+	$(chfn_chsh_sources)
 chsh_CFLAGS = $(chfn_chsh_cflags)
 chsh_LDFLAGS = $(chfn_chsh_ldflags)
-chsh_LDADD = $(LDADD) $(chfn_chsh_ldadd)
-if HAVE_ECONF
-chsh_LDADD += $(ECONF_LIBS)
-endif
+chsh_LDADD = $(LDADD) $(chfn_chsh_ldadd) libcommon_logindefs.la libcommon_shells.la
 endif # BUILD_CHFN_CHSH
 
 
@@ -166,12 +159,10 @@ dist_noinst_DATA += login-utils/su.1.adoc
 su_SOURCES = \
 	login-utils/su.c \
 	login-utils/su-common.c \
-	login-utils/su-common.h \
-	lib/logindefs.c \
-	lib/shells.c
+	login-utils/su-common.h
 su_CFLAGS = $(SUID_CFLAGS) $(AM_CFLAGS)
 su_LDFLAGS = $(SUID_LDFLAGS) $(AM_LDFLAGS)
-su_LDADD = $(LDADD) libcommon.la -lpam
+su_LDADD = $(LDADD) libcommon.la libcommon_logindefs.la libcommon_shells.la -lpam
 if HAVE_LINUXPAM
 su_LDADD += -lpam_misc
 endif
@@ -180,9 +171,6 @@ su_SOURCES += lib/pty-session.c \
       include/pty-session.h \
       lib/monotonic.c
 su_LDADD += -lutil $(REALTIME_LIBS)
-endif
-if HAVE_ECONF
-su_LDADD += $(ECONF_LIBS)
 endif
 endif # BUILD_SU
 
@@ -194,10 +182,8 @@ dist_noinst_DATA += login-utils/runuser.1.adoc
 runuser_SOURCES = \
 	login-utils/runuser.c \
 	login-utils/su-common.c \
-	login-utils/su-common.h \
-	lib/logindefs.c \
-	lib/shells.c
-runuser_LDADD = $(LDADD) libcommon.la -lpam
+	login-utils/su-common.h
+runuser_LDADD = $(LDADD) libcommon.la libcommon_logindefs.la libcommon_shells.la -lpam
 if HAVE_LINUXPAM
 runuser_LDADD += -lpam_misc
 endif
@@ -206,9 +192,6 @@ runuser_SOURCES += lib/pty-session.c \
 	include/pty-session.h \
 	lib/monotonic.c
 runuser_LDADD += -lutil $(REALTIME_LIBS)
-endif
-if HAVE_ECONF
-runuser_LDADD += $(ECONF_LIBS)
 endif
 endif # BUILD_RUNUSER
 
@@ -232,9 +215,8 @@ usrbin_exec_PROGRAMS += lslogins
 MANPAGES += login-utils/lslogins.1
 dist_noinst_DATA += login-utils/lslogins.1.adoc
 lslogins_SOURCES = \
-	login-utils/lslogins.c \
-	lib/logindefs.c
-lslogins_LDADD = $(LDADD) libcommon.la libsmartcols.la
+	login-utils/lslogins.c
+lslogins_LDADD = $(LDADD) libcommon.la libcommon_logindefs.la libsmartcols.la
 lslogins_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
 if HAVE_SELINUX
 lslogins_LDADD += $(SELINUX_LIBS)
@@ -242,9 +224,6 @@ endif
 if HAVE_SYSTEMD
 lslogins_LDADD += $(SYSTEMD_LIBS) $(SYSTEMD_JOURNAL_LIBS)
 lslogins_CFLAGS += $(SYSTEMD_CFLAGS) $(SYSTEMD_JOURNAL_CFLAGS)
-endif
-if HAVE_ECONF
-lslogins_LDADD += $(ECONF_LIBS)
 endif
 if BUILD_LIBLASTLOG2
 lslogins_CFLAGS += -I$(ul_liblastlog2_incdir)

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -86,6 +86,10 @@
 
 #include "logindefs.h"
 
+#if defined (HAVE_LIBECONF) && defined (USE_VENDORDIR)
+# include "shells.h"
+#endif
+
 #define LOGIN_MAX_TRIES        3
 #define LOGIN_EXIT_TIMEOUT     5
 #define LOGIN_TIMEOUT          60

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -20,7 +20,7 @@ usrbin_exec_PROGRAMS += flock
 MANPAGES += sys-utils/flock.1
 dist_noinst_DATA += sys-utils/flock.1.adoc
 flock_SOURCES = sys-utils/flock.c lib/monotonic.c lib/timer.c
-flock_LDADD = $(LDADD) libcommon.la $(REALTIME_LIBS)
+flock_LDADD = $(LDADD) libcommon.la libcommon_shells.la $(REALTIME_LIBS)
 endif
 
 if BUILD_CHOOM
@@ -523,7 +523,7 @@ dist_noinst_DATA += sys-utils/unshare.1.adoc
 unshare_SOURCES = sys-utils/unshare.c \
 		  lib/caputils.c \
 		  lib/exec_shell.c
-unshare_LDADD = $(LDADD) libcommon.la
+unshare_LDADD = $(LDADD) libcommon.la libcommon_shells.la
 unshare_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 
 if HAVE_STATIC_UNSHARE
@@ -541,7 +541,7 @@ MANPAGES += sys-utils/nsenter.1
 dist_noinst_DATA += sys-utils/nsenter.1.adoc
 nsenter_SOURCES = sys-utils/nsenter.c lib/exec_shell.c \
 		  lib/caputils.c
-nsenter_LDADD = $(LDADD) libcommon.la $(SELINUX_LIBS)
+nsenter_LDADD = $(LDADD) libcommon.la libcommon_shells.la $(SELINUX_LIBS)
 
 if HAVE_STATIC_NSENTER
 usrbin_exec_PROGRAMS += nsenter.static

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -593,14 +593,10 @@ usrbin_exec_PROGRAMS += setpriv
 MANPAGES += sys-utils/setpriv.1
 dist_noinst_DATA += sys-utils/setpriv.1.adoc
 setpriv_SOURCES = sys-utils/setpriv.c \
-		  lib/caputils.c \
-		  lib/logindefs.c
+		  lib/caputils.c
 dist_noinst_HEADERS += sys-utils/setpriv-landlock.h
 if HAVE_LINUX_LANDLOCK_H
 setpriv_SOURCES += sys-utils/setpriv-landlock.c
 endif
-setpriv_LDADD = $(LDADD) $(CAP_NG_LIBS) libcommon.la
-if HAVE_ECONF
-setpriv_LDADD += $(ECONF_LIBS)
-endif
+setpriv_LDADD = $(LDADD) $(CAP_NG_LIBS) libcommon.la libcommon_logindefs.la
 endif # BUILD_SETPRIV

--- a/term-utils/Makemodule.am
+++ b/term-utils/Makemodule.am
@@ -46,20 +46,16 @@ if BUILD_AGETTY
 sbin_PROGRAMS += agetty
 MANPAGES += term-utils/agetty.8
 dist_noinst_DATA += term-utils/agetty.8.adoc
-agetty_SOURCES = term-utils/agetty.c \
-		 lib/logindefs.c
+agetty_SOURCES = term-utils/agetty.c
 if USE_PLYMOUTH_SUPPORT
 agetty_SOURCES += lib/plymouth-ctrl.c
 endif
 if LINUX
 agetty_SOURCES += lib/netlink.c lib/netaddrq.c
 endif
-agetty_LDADD = $(LDADD) libcommon.la
+agetty_LDADD = $(LDADD) libcommon.la libcommon_logindefs.la
 if BSD
 agetty_LDADD += -lutil
-endif
-if HAVE_ECONF
-agetty_LDADD += $(ECONF_LIBS)
 endif
 if HAVE_SYSTEMD
 agetty_LDADD += $(SYSTEMD_LIBS)

--- a/term-utils/Makemodule.am
+++ b/term-utils/Makemodule.am
@@ -7,7 +7,7 @@ script_SOURCES = term-utils/script.c \
 		 include/pty-session.h \
 		 lib/monotonic.c
 script_CFLAGS = $(AM_CFLAGS) -Wno-format-y2k
-script_LDADD = $(LDADD) libcommon.la $(ISNAN_LIBS) $(REALTIME_LIBS) -lutil
+script_LDADD = $(LDADD) libcommon.la libcommon_shells.la $(ISNAN_LIBS) $(REALTIME_LIBS) -lutil
 if HAVE_UTEMPTER
 script_LDADD += -lutempter
 endif
@@ -38,7 +38,7 @@ scriptlive_SOURCES = term-utils/scriptlive.c \
 		       lib/pty-session.c \
 		       include/pty-session.h \
 		       lib/monotonic.c
-scriptlive_LDADD = $(LDADD) libcommon.la $(ISNAN_LIBS) $(REALTIME_LIBS) -lutil
+scriptlive_LDADD = $(LDADD) libcommon.la libcommon_shells.la $(ISNAN_LIBS) $(REALTIME_LIBS) -lutil
 endif # BUILD_SCRIPTLIVE
 
 

--- a/text-utils/Makemodule.am
+++ b/text-utils/Makemodule.am
@@ -98,7 +98,7 @@ MANPAGES += text-utils/more.1
 dist_noinst_DATA += text-utils/more.1.adoc
 more_SOURCES = text-utils/more.c
 more_CFLAGS = $(AM_CFLAGS) $(BSD_WARN_CFLAGS)
-more_LDADD = $(LDADD) $(MAGIC_LIBS) libcommon.la
+more_LDADD = $(LDADD) $(MAGIC_LIBS) libcommon.la libcommon_shells.la
 if HAVE_TINFO
 more_LDADD += $(TINFO_LIBS)
 more_LDADD += $(TINFO_CFLAGS)


### PR DESCRIPTION
Building with libeconf fails. Fix the build:
- Add missing includes.
- Make open_etc_shells() public, as required by login.c.
- shells.c requires linking against libeconf. To prevent linking of all binaries with libeconf, split shells.c out of libcommon to libecommon and use it only if it is really needed.