### PR TITLE
tests: fix remaining shellcheck warnings

### DIFF
--- a/tests/ts/fsck/ismounted
+++ b/tests/ts/fsck/ismounted
@@ -28,7 +28,7 @@ ts_skip_nonroot
 ts_check_losetup
 ts_check_prog "mkfs.ext2"
 
-> "$TS_OUTPUT"
+: > "$TS_OUTPUT"
 
 ts_device_init
 DEVICE=$TS_LODEV

--- a/tests/ts/libmount/lock
+++ b/tests/ts/libmount/lock
@@ -28,7 +28,7 @@ NLOOPS=1000
 NPROCESSES=50
 
 
-> "$TS_OUTPUT".debug
+: > "$TS_OUTPUT".debug
 echo 0 > "$TS_OUTPUT"
 SYNCTIME=$(( $(date +%s) + 5 ))
 

--- a/tests/ts/mount/fstab-all
+++ b/tests/ts/mount/fstab-all
@@ -118,7 +118,7 @@ ts_finalize_subtest
 
 ts_init_subtest "relative-path"
 cd "$TS_OUTDIR" > /dev/null
-$TS_CMD_MOUNT --all --fstab $(basename "${TS_FSTAB}") >> "$TS_OUTPUT" 2>> "$TS_ERRLOG" \
+$TS_CMD_MOUNT --all --fstab "$(basename "${TS_FSTAB}")" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG" \
 			|| ts_log "mount failed"
 udevadm settle
 $TS_CMD_UMOUNT ${MOUNTPOINT}{A,B,C,D} || ts_log "umount failed"

--- a/tests/ts/mount/fstab-devname
+++ b/tests/ts/mount/fstab-devname
@@ -44,7 +44,7 @@ ts_fstab_add $DEVICE
 ts_init_subtest "mountpoint"
 $TS_CMD_MOUNT --fstab "$TS_FSTAB" $MOUNTPOINT >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_is_mounted $DEVICE || ts_log "Cannot find $DEVICE in /proc/mounts"
-$TS_CMD_UMOUNT $DEVICE || >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+$TS_CMD_UMOUNT $DEVICE >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_finalize_subtest
 
 ts_init_subtest "device-name"


### PR DESCRIPTION
 - fstab-devname: remove broken '|| >>' pattern (SC2188), the bare redirection after || has no command
 - fstab-all: quote $(basename ...) to prevent word splitting (SC2046)
 - libmount/lock, fsck/ismounted: use ':' no-op with bare file truncation redirections (SC2188)