### PR TITLE
chrt: Add support for (GRUB) bandwidth reclaim

### DIFF
--- a/bash-completion/chrt
+++ b/bash-completion/chrt
@@ -26,6 +26,7 @@ _chrt_module()
 				--max
 				--other
 				--pid
+				--reclaim-grub
 				--reset-on-fork
 				--rr
 				--sched-deadline

--- a/schedutils/chrt.1.adoc
+++ b/schedutils/chrt.1.adoc
@@ -81,6 +81,9 @@ Specifies period parameter for *SCHED_DEADLINE* policy (Linux-specific). Note th
 *-D*, *--sched-deadline* _nanoseconds_::
 Specifies deadline parameter for *SCHED_DEADLINE* policy (Linux-specific).
 
+*-G*, *--reclaim-grub*::
+Enables GRUB (Greedy Reclamation of Unused Bandwidth) algorithm. Linux-specific, supported since 4.13.
+
 *-R*, *--reset-on-fork*::
 Use *SCHED_RESET_ON_FORK* or *SCHED_FLAG_RESET_ON_FORK* flag. Linux-specific, supported since 2.6.31.
 +

--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -46,6 +46,7 @@ struct chrt_ctl {
 	uint64_t runtime;			/* --sched-* options */
 	uint64_t deadline;
 	uint64_t period;
+	uint64_t sched_flags;			/* For sched_attr->sched_flags member */
 
 	unsigned int all_tasks : 1,		/* all threads of the PID */
 		     reset_on_fork : 1,		/* SCHED_RESET_ON_FORK or SCHED_FLAG_RESET_ON_FORK */
@@ -79,6 +80,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_("Scheduling options:\n"), out);
 	fputs(_(" -R, --reset-on-fork       set reset-on-fork flag\n"), out);
+	fputs(_(" -G, --reclaim-grub        set SCHED_FLAG_RECLAIM\n"), out);
 	fputs(_(" -T, --sched-runtime <ns>  runtime parameter for DEADLINE\n"), out);
 	fputs(_(" -P, --sched-period <ns>   period parameter for DEADLINE\n"), out);
 	fputs(_(" -D, --sched-deadline <ns> deadline parameter for DEADLINE\n"), out);
@@ -359,6 +361,7 @@ static int set_sched_one(struct chrt_ctl *ctl, pid_t pid)
 	sa.sched_runtime  = ctl->runtime;
 	sa.sched_period   = ctl->period;
 	sa.sched_deadline = ctl->deadline;
+	sa.sched_flags    = ctl->sched_flags;
 
 # ifdef SCHED_FLAG_RESET_ON_FORK
 	/* Don't use SCHED_RESET_ON_FORK for sched_setattr()! */
@@ -417,6 +420,7 @@ int main(int argc, char **argv)
 		{ "sched-period",   required_argument, NULL, 'P' },
 		{ "sched-deadline", required_argument, NULL, 'D' },
 		{ "reset-on-fork",  no_argument,       NULL, 'R' },
+		{ "reclaim-grub",   no_argument,       NULL, 'G' },
 		{ "verbose",	no_argument, NULL, 'v' },
 		{ "version",	no_argument, NULL, 'V' },
 		{ NULL,		no_argument, NULL, 0 }
@@ -427,7 +431,7 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	close_stdout_atexit();
 
-	while((c = getopt_long(argc, argv, "+abdD:efiphmoP:T:rRvV", longopts, NULL)) != -1)
+	while((c = getopt_long(argc, argv, "+abdD:efiphmoP:T:rRGvV", longopts, NULL)) != -1)
 	{
 		switch (c) {
 		case 'a':
@@ -459,6 +463,11 @@ int main(int argc, char **argv)
 			break;
 		case 'R':
 			ctl->reset_on_fork = 1;
+			break;
+		case 'G':
+#ifdef SCHED_FLAG_RECLAIM
+			ctl->sched_flags |= SCHED_FLAG_RECLAIM;
+#endif
 			break;
 		case 'i':
 #ifdef SCHED_IDLE
@@ -547,6 +556,12 @@ int main(int argc, char **argv)
 	if ((ctl->deadline || ctl->period) && ctl->policy != SCHED_DEADLINE)
 		errx(EXIT_FAILURE, _("--sched-{deadline,period} options are "
 				     "supported for SCHED_DEADLINE only"));
+#ifndef HAVE_SCHED_SETATTR
+	if (ctl->sched_flags & SCHED_FLAG_RECLAIM)
+		errx(EXIT_FAILURE, _("SCHED_FLAG_RECLAIM is unsupported"));
+#endif
+	if ((ctl->sched_flags & SCHED_FLAG_RECLAIM) && ctl->policy != SCHED_DEADLINE)
+		errx(EXIT_FAILURE, _("--reclaim-grub is only supported for SCHED_DEADLINE"));
 	if (ctl->policy == SCHED_DEADLINE) {
 		/* The basic rule is runtime <= deadline <= period, so we can
 		 * make deadline and runtime optional on command line. Note we

--- a/tests/helpers/test_strerror.c
+++ b/tests/helpers/test_strerror.c
@@ -26,6 +26,7 @@ static struct {
 	E(EINVAL),
 	E(ERANGE),
 	E(EPERM),
+	E(EACCES),
 };
 
 int main(int argc, const char *argv[])

--- a/tests/ts/getino/getino
+++ b/tests/ts/getino/getino
@@ -19,6 +19,13 @@ TS_DESC="getino"
 
 . "$TS_TOPDIR/functions.sh"
 ts_init "$*"
+ts_skip_nonroot
+
+ts_check_test_command "$TS_CMD_GETINO"
+ts_check_test_command "$TS_CMD_UNSHARE"
+ts_check_test_command "$TS_CMD_RUNUSER"
+ts_check_test_command "$TS_HELPER_STRERROR"
+ts_check_prog "stat"
 
 # make sure we do not use shell built-in command
 if [ "$TS_USE_SYSTEM_COMMANDS" == "yes" ]; then
@@ -31,8 +38,6 @@ fi
 if ts_kernel_ver_lt 6 9; then
 	TS_KNOWN_FAIL="yes"
 fi
-
-ts_check_test_command "$TS_CMD_GETINO"
 
 ts_init_subtest "single-pid"
 if "$TS_CMD_GETINO" 1 &>/dev/null; then
@@ -58,5 +63,76 @@ if [ -n "$res" ]; then
   echo "ok" > "$TS_OUTPUT"
 fi
 ts_finalize_subtest
+
+ts_init_subtest "ipcns"
+ts_ipc_ns=$("$TS_CMD_GETINO" --ipcns $$ 2>>"$TS_ERRLOG")
+unshare_ipc_ns=$("$TS_CMD_UNSHARE" --ipc bash -c "$TS_CMD_GETINO --ipcns \$\$" 2>>"$TS_ERRLOG")
+if (( ts_ipc_ns == unshare_ipc_ns )); then
+  ts_failed_subtest "IPC namespace unchanged"
+fi
+ts_finalize_subtest
+
+ts_init_subtest "netns"
+ts_net_ns=$("$TS_CMD_GETINO" --netns $$ 2>>"$TS_ERRLOG")
+unshare_net_ns=$("$TS_CMD_UNSHARE" --net bash -c "$TS_CMD_GETINO --netns \$\$" 2>>"$TS_ERRLOG")
+if (( ts_net_ns == unshare_net_ns )); then
+  ts_failed_subtest "network namespace unchanged"
+fi
+ts_finalize_subtest
+
+ts_init_subtest "mntns"
+ts_mnt_ns=$("$TS_CMD_GETINO" --mntns $$ 2>>"$TS_ERRLOG")
+unshare_mnt_ns=$("$TS_CMD_UNSHARE" --mount bash -c "$TS_CMD_GETINO --mntns \$\$" 2>>"$TS_ERRLOG")
+if (( ts_mnt_ns == unshare_mnt_ns )); then
+  ts_failed_subtest "mount namespace unchanged"
+fi
+ts_finalize_subtest
+
+ts_init_subtest "utsns"
+ts_uts_ns=$("$TS_CMD_GETINO" --utsns $$ 2>>"$TS_ERRLOG")
+unshare_uts_ns=$("$TS_CMD_UNSHARE" --uts bash -c "$TS_CMD_GETINO --utsns \$\$" 2>>"$TS_ERRLOG")
+if (( ts_uts_ns == unshare_uts_ns )); then
+  ts_failed_subtest "UTS namespace unchanged"
+fi
+ts_finalize_subtest
+
+ts_init_subtest "timens"
+ts_time_ns=$("$TS_CMD_GETINO" --timens $$ 2>>"$TS_ERRLOG")
+unshare_time_ns=$("$TS_CMD_UNSHARE" --time bash -c "$TS_CMD_GETINO --timens \$\$" 2>>"$TS_ERRLOG")
+if (( ts_time_ns == unshare_time_ns )); then
+  ts_failed_subtest "time namespace unchanged"
+fi
+ts_finalize_subtest
+
+ts_init_subtest "pidns"
+ts_pid_ns=$("$TS_CMD_GETINO" --pidns $$ 2>>"$TS_ERRLOG")
+unshare_pid_ns=$("$TS_CMD_UNSHARE" --pid --fork bash -c "$TS_CMD_GETINO --pidns \$\$" 2>>"$TS_ERRLOG")
+if (( ts_pid_ns == unshare_pid_ns )); then
+  ts_failed_subtest "pid namespace unchanged"
+fi
+ts_finalize_subtest
+
+ts_init_subtest "cgroupns"
+ts_cgroup_ns=$("$TS_CMD_GETINO" --cgroupns $$ 2>>"$TS_ERRLOG")
+unshare_cgroup_ns=$("$TS_CMD_UNSHARE" --cgroup bash -c "$TS_CMD_GETINO --cgroupns \$\$" 2>>"$TS_ERRLOG")
+if (( ts_cgroup_ns == unshare_cgroup_ns )); then
+  ts_failed_subtest "cgroup namespace unchanged"
+fi
+ts_finalize_subtest
+
+ts_init_subtest "userns"
+getino_owner="$(stat --format=%U "$TS_CMD_GETINO")"
+ts_user_ns=$("$TS_CMD_GETINO" --userns $$ 2>>"$TS_ERRLOG")
+unshare_user_ns=$("$TS_CMD_RUNUSER" --user "$getino_owner" -- \
+                    "$TS_CMD_UNSHARE" --user \
+                      bash -c "$TS_CMD_GETINO --userns \$\$" 2>>"$TS_ERRLOG")
+
+if grep "$("$TS_HELPER_STRERROR" EACCES)" "$TS_ERRLOG" &>/dev/null; then
+  ts_skip_subtest "missing permissions to obtain user namespace"
+else
+  (( ts_user_ns == unshare_user_ns )) && ts_failed_subtest "user namespace unchanged"
+fi
+ts_finalize_subtest
+
 
 ts_finalize


### PR DESCRIPTION
The SCHED_DEADLINE policy supports the (GRUB) Greedy Reclamation of Unused Bandwidth algorithm. This allows tasks to reclaim bandwidth that are left over by other deadline tasks that finish their work early, or voluntarily yield the cpu.

Currently, chrt has no way to set the SCHED_FLAG_RECLAIM bit in the sched_flags field of the sched_attr structure.

Add -G/--reclaim-grub option to allow users to toggle this feature using the deadline scheduling class.