### PR TITLE
more: align MORE_SHELL_LINES semantics with less(1)

### DIFF
--- a/text-utils/more.1.adoc
+++ b/text-utils/more.1.adoc
@@ -185,7 +185,7 @@ Specify favored options for *more*.
 Run *more* in "secure" mode. See SECURITY for details.
 
 *MORE_SHELL_LINES*::
-Specify the _number_ of lines per screenful. It has the same effect as the *-n* and *--lines* options. See in OPTIONS for details. Also, note that the environment variable's value will be overridden if any of these options are set.
+Specify the _number_ of lines the shell prompt occupies on the terminal screen. If this value is set, the _number_ of lines for the shell prompt is subtracted from the number of lines used to print a page on the screen. The value must be greater than zero and less than the current number of lines per screen; otherwise it is silently ignored. This is useful in situations where the printed page has to remain on the screen after exiting *more*(1) without scrolling up too much as the shell prints a new prompt.
 
 *PAGERSECURE*::
 Equivalent to MORESECURE.

--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -2144,12 +2144,6 @@ int main(int argc, char **argv)
 	if (getenv("MORESECURE") || getenv("PAGERSECURE"))
 		ctl.is_secure = 1;
 
-	if ((s = getenv("MORE_SHELL_LINES")) && isdigit_string(s)) {
-		uint16_t x = 0;
-		if (ul_strtou16(s, (uint16_t *) &x, 10) == 0)
-			ctl.lines_per_screen = x;
-	}
-
 	if ((s = getenv("MORE")) != NULL)
 		env_argscan(&ctl, s);
 
@@ -2186,6 +2180,15 @@ int main(int argc, char **argv)
 	}
 	if (ctl.lines_per_screen == 0)
 		ctl.lines_per_screen = ctl.lines_per_page - 1;
+
+	if ((s = getenv("MORE_SHELL_LINES")) && isdigit_string(s)) {
+		uint16_t x = 0;
+		if (ul_strtou16(s, (uint16_t *) &x, 10) == 0
+		    && x > 0
+		    && x < (uint16_t) ctl.lines_per_screen)
+			ctl.lines_per_screen -= x;
+	}
+
 	left = ctl.lines_per_screen;
 	if (ctl.num_files > 1)
 		ctl.print_banner = 1;


### PR DESCRIPTION
Change MORE_SHELL_LINES to subtract lines from lines_per_screen (like LESS_SHELL_LINES in less(1)) rather than setting the absolute number of lines per screenful.

The block is moved after lines_per_screen is finalized (either from the default lines_per_page - 1 or from an explicit -n/--lines), so it correctly adjusts both cases. Values that are zero or would exceed lines_per_screen are silently ignored.

Addresses: https://github.com/util-linux/util-linux/issues/3476