### PR TITLE
tests: enforce ts_init_subtest/ts_finalize_subtest pairing

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -193,6 +193,9 @@ function ts_runs_on_qemu {
 function ts_failed_subtest {
 	local msg="FAILED"
 	local ret=1
+
+	TS_SUBFAILED="yes"
+
 	if [ "$TS_KNOWN_FAIL" = "yes" ]; then
 		msg="KNOWN FAILED"
 		ret=0
@@ -458,7 +461,13 @@ function ts_init_env {
 
 function ts_init_subtest {
 
+	if [ -n "$TS_SUBNAME" ]; then
+		ts_failed "BUG: subtest '$TS_SUBNAME' not finalized"
+	fi
+
 	TS_SUBNAME="$1"
+	TS_SUBFAILED=""
+	TS_SUBSKIPPED=""
 	ts_init_core_subtest_env
 	TS_NSUBTESTS=$(( $TS_NSUBTESTS + 1 ))
 
@@ -632,12 +641,18 @@ function tt_gen_mem_report {
 function ts_finalize_subtest {
 	local res=0
 
-	ts_gen_diff
-	if [ $? -eq 1 ]; then
-		ts_failed_subtest "$1"
+	if [ "$TS_SUBSKIPPED" = "yes" ]; then
+		:
+	elif [ "$TS_SUBFAILED" = "yes" ]; then
 		res=1
 	else
-		ts_report_ok "$(tt_gen_mem_report "$1")"
+		ts_gen_diff
+		if [ $? -eq 1 ]; then
+			ts_failed_subtest "$1"
+			res=1
+		else
+			ts_report_ok "$(tt_gen_mem_report "$1")"
+		fi
 	fi
 
 	[ $res -ne 0 ] && TS_NSUBFAILED=$(( $TS_NSUBFAILED + 1 ))
@@ -649,10 +664,8 @@ function ts_finalize_subtest {
 }
 
 function ts_skip_subtest {
+	TS_SUBSKIPPED="yes"
 	ts_report_skip "$1"
-	# reset environment back to parental test
-	ts_init_core_env
-
 }
 
 # Specify the kernel version X.Y.Z you wish to compare against like:
@@ -678,6 +691,10 @@ function ts_kernel_ver_lt {
 
 function ts_finalize {
 	ts_cleanup_on_exit
+
+	if [ -n "$TS_SUBNAME" ]; then
+		ts_failed "BUG: subtest '$TS_SUBNAME' not finalized"
+	fi
 
 	if [ $TS_NSUBTESTS -ne 0 ]; then
 		if ! ts_gen_diff || [ $TS_NSUBFAILED -ne 0 ]; then

--- a/tests/ts/chrt/all-tasks
+++ b/tests/ts/chrt/all-tasks
@@ -93,9 +93,8 @@ else
     else
         echo "retrieved real-time scheduling attributes for all tasks" >"$TS_OUTPUT"
     fi
-
-    ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 
 ts_init_subtest "set-attributes"
@@ -133,9 +132,8 @@ else
     else
         echo "set real-time scheduling attributes for all tasks" >>"$TS_OUTPUT"
     fi
-
-    ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 
 ts_finalize

--- a/tests/ts/chrt/chrt
+++ b/tests/ts/chrt/chrt
@@ -32,6 +32,7 @@ function skip_policy {
 	$TS_CMD_CHRT --max | grep $1 | grep 'priority' &> /dev/null
 	if [ $? == 1 ]; then
 		ts_skip_subtest "unsupported"
+		ts_finalize_subtest
 		return 1
 	fi
 	return 0
@@ -40,6 +41,7 @@ function skip_policy {
 function skip_kernel_lt {
 	if ts_kernel_ver_lt $1 $2 $3; then
 		ts_skip_subtest "kernel version must be >= $1.$2.$3"
+		ts_finalize_subtest
 		return 1
 	fi
 
@@ -50,6 +52,7 @@ function skip_kernel_ge {
 	ts_kernel_ver_lt $1 $2 $3
 	if [ $? == 1 ]; then
 		ts_skip_subtest "kernel version must be < $1.$2.$3"
+		ts_finalize_subtest
 		return 1
 	fi
 

--- a/tests/ts/chrt/chrt-non-root
+++ b/tests/ts/chrt/chrt-non-root
@@ -32,6 +32,7 @@ function skip_policy {
 	$TS_CMD_CHRT --max | grep $1 | grep 'priority' &> /dev/null
 	if [ $? == 1 ]; then
 		ts_skip_subtest "unsupported"
+		ts_finalize_subtest
 		return 1
 	fi
 	return 0

--- a/tests/ts/findmnt/filterQ
+++ b/tests/ts/findmnt/filterQ
@@ -73,5 +73,6 @@ ts_finalize_subtest
 ts_init_subtest "options-no-multi"
 $TS_CMD_FINDMNT --filter 'OPTIONS =~ "\<nosuid\>" && OPTIONS =~ "\<nodev\>" && OPTIONS =~ "\<blkio\>"' --kernel --tab-file "$TS_SELF/files/mountinfo" &> "$TS_OUTPUT"
 echo rc=$? >> "$TS_OUTPUT"
+ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/findmnt/outputs
+++ b/tests/ts/findmnt/outputs
@@ -126,8 +126,8 @@ else
     # This should not return anything
     $TS_CMD_FINDMNT --output TARGET --nocanonicalize "$TEST_LINK" >>"$TS_OUTPUT" 2>>"$TS_ERRLOG"
     rm -f "$TEST_LINK"
-    ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 ts_init_subtest "default"
 $TS_CMD_FINDMNT --tab-file "$TS_SELF/files/mountinfo" &> "$TS_OUTPUT"

--- a/tests/ts/libmount/loop
+++ b/tests/ts/libmount/loop
@@ -93,8 +93,8 @@ else
 	$TS_CMD_UMOUNT "$TS_MOUNTPOINT" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 	udevadm settle
 	ts_log "Success"
-	ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 ts_init_subtest "reuse"
 [ -d "$TS_MOUNTPOINT" ] || mkdir -p $TS_MOUNTPOINT

--- a/tests/ts/libmount/utils
+++ b/tests/ts/libmount/utils
@@ -55,18 +55,18 @@ ts_finalize_subtest
 ts_init_subtest "mountpoint"
 if [ -d /proc ]; then
 	ts_run $TESTPROG --mountpoint /proc &> "$TS_OUTPUT"
-	ts_finalize_subtest
 else
 	ts_skip_subtest "no /proc"
 fi
+ts_finalize_subtest
 
 ts_init_subtest "mountpoint-subdir"
 if [ -d /proc/sys/kernel ]; then
 	ts_run $TESTPROG --mountpoint /proc/sys/kernel &> "$TS_OUTPUT"
-	ts_finalize_subtest
 else
 	ts_skip_subtest "no /proc"
 fi
+ts_finalize_subtest
 
 ts_init_subtest "mountpoint-root"
 ts_run $TESTPROG --mountpoint / &> "$TS_OUTPUT"

--- a/tests/ts/losetup/losetup-loop
+++ b/tests/ts/losetup/losetup-loop
@@ -217,8 +217,8 @@ else
 	$TS_CMD_LOSETUP -d "$LODEV"
 	$TS_CMD_LOSETUP -d "$LODEVR" >/dev/null 2>&1
 	ts_log "Success"
-	ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 udevadm settle
 
@@ -238,8 +238,8 @@ else
 	$TS_CMD_LOSETUP -d "$LODEV"
 	$TS_CMD_LOSETUP -d "$LODEVR" >/dev/null 2>&1
 	ts_log "Success"
-	ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 udevadm settle
 

--- a/tests/ts/lsclocks/lsclocks
+++ b/tests/ts/lsclocks/lsclocks
@@ -47,20 +47,20 @@ ts_init_subtest dynamic
 if [ -c /dev/ptp0 ] && [ -r /dev/ptp0 ]; then
 	"$TS_CMD_LSCLOCKS" $NO_DISCOVER --dynamic-clock /dev/ptp0 --output TYPE,ID,CLOCK,NAME \
 		| tail -1 > "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-	ts_finalize_subtest
 else
 	ts_skip_subtest "/dev/ptp0 not usable"
 fi
+ts_finalize_subtest
 
 ts_init_subtest rtc
 
 if [ -c /dev/rtc0 ] && [ -r /dev/rtc0 ]; then
 	"$TS_CMD_LSCLOCKS" $NO_DISCOVER --rtc /dev/rtc0 --output TYPE,ID,CLOCK,NAME \
 		| tail -1 > "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-	ts_finalize_subtest
 else
 	ts_skip_subtest "/dev/rtc0 not usable"
 fi
+ts_finalize_subtest
 
 ts_init_subtest cpu
 

--- a/tests/ts/lsfd/column-ainodeclass
+++ b/tests/ts/lsfd/column-ainodeclass
@@ -48,12 +48,14 @@ for C in pidfd inotify; do
 
     if [ "$C-$RC" == "pidfd-$TS_EXIT_NOTSUPP" ]; then
 	ts_skip_subtest "pidfd_open(2) is not available"
+	ts_finalize_subtest
 	continue
     fi
 
     STTYPE="$(head -n1 "$TS_OUTPUT" | awk '{print $2}')"
     if [ "$C-$STTYPE" == "pidfd-REG" ]; then
 	ts_skip_subtest "pidfd is from pidfs instead of anon inode"
+	ts_finalize_subtest
 	continue
     fi
 

--- a/tests/ts/lsfd/column-name
+++ b/tests/ts/lsfd/column-name
@@ -70,6 +70,7 @@ for C in ro-regular-file pidfd socketpair; do
 
     if [ "$C-$RC" == "pidfd-$TS_EXIT_NOTSUPP" ]; then
 	ts_skip_subtest "pidfd_open(2) is not available"
+	ts_finalize_subtest
 	continue
     fi
 

--- a/tests/ts/lsfd/column-type
+++ b/tests/ts/lsfd/column-type
@@ -56,6 +56,7 @@ for C in ro-regular-file pidfd inotify socketpair; do
 
     if [ "$C-$RC" == "pidfd-$TS_EXIT_NOTSUPP" ]; then
 	ts_skip_subtest "pidfd_open(2) is not available"
+	ts_finalize_subtest
 	continue
     fi
 

--- a/tests/ts/lsfd/column-xmode
+++ b/tests/ts/lsfd/column-xmode
@@ -151,6 +151,7 @@ for m in flock-sh posix-r- ofd-r-; do
     RC=$?
     if [ "$RC" == "$TS_EXIT_NOTSUPP" ]; then
 	ts_skip_subtest	"$m lock is not available"
+	ts_finalize_subtest
 	continue
     fi
     ts_finalize_subtest
@@ -187,6 +188,7 @@ for m in flock-ex posix--w posix-rw  ofd--w ofd-rw lease-w; do
     RC=$?
     if [ "$RC" == "$TS_EXIT_NOTSUPP" ]; then
 	ts_skip_subtest	"$m lock is not available"
+	ts_finalize_subtest
 	continue
     fi
     ts_finalize_subtest

--- a/tests/ts/lsfd/column-xmode
+++ b/tests/ts/lsfd/column-xmode
@@ -99,8 +99,8 @@ else
 	fi
     } > "$TS_OUTPUT" 2>&1
     wait "${MKFDS_PID}"
-    ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 ts_init_subtest "XMODE-x-bit"
 if [ "$QEMU_USER" == "1" ]; then
@@ -117,8 +117,8 @@ else
 	fi
     } > "$TS_OUTPUT" 2>&1
     wait "${MKFDS_PID}"
-    ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 FILE=./test_mkfds_make_regular_file
 EXPR='(FD == '"$FD"')'

--- a/tests/ts/lsfd/mkfds-multiplexing
+++ b/tests/ts/lsfd/mkfds-multiplexing
@@ -38,6 +38,7 @@ for multiplexer in pselect6 select poll ppoll; do
     ts_init_subtest "${multiplexer}"
     if ! "$TS_HELPER_MKFDS" -W | grep -q "^$multiplexer\$"; then
 	ts_skip_subtest "the multiplexer ${multiplexer} is not available"
+	ts_finalize_subtest
 	continue
     fi
 
@@ -52,6 +53,7 @@ for multiplexer in pselect6 select poll ppoll; do
 	    kill -CONT "${PID}"
 	    wait "${MKFDS_PID}"
 	    ts_skip_subtest "cannot open /proc/${PID}/syscall"
+	    ts_finalize_subtest
 	    continue
 	fi
 	syscall_n=$(cut -f1 -d' ' <<< "$syscall_line")
@@ -61,6 +63,7 @@ for multiplexer in pselect6 select poll ppoll; do
 	    kill -CONT "${PID}"
 	    wait "${MKFDS_PID}"
 	    ts_skip_subtest "incorrect syscall number in /proc/${PID}/syscall"
+	    ts_finalize_subtest
 	    continue
 	fi
 

--- a/tests/ts/lsfd/mkfds-socketpair
+++ b/tests/ts/lsfd/mkfds-socketpair
@@ -71,6 +71,7 @@ mkfds_socketpair_stream_endpoint()
     ts_init_subtest "STREAM-ENDPOINT"
     if [ "$QEMU_USER" == "1" ]; then
 	ts_skip_subtest "running under qemu-user emulation"
+	ts_finalize_subtest
 	return
     fi
     {
@@ -93,6 +94,7 @@ mkfds_socketpair_stream_shutdown_state()
     ts_init_subtest "STREAM-SHUTDOWN-STATE"
     if [ "$QEMU_USER" == "1" ]; then
 	ts_skip_subtest "running under qemu-user emulation"
+	ts_finalize_subtest
 	return
     fi
     {
@@ -115,6 +117,7 @@ mkfds_socketpair_stream_endpoint_halfclose()
     ts_init_subtest "STREAM-ENDPOINT-halfclose"
     if [ "$QEMU_USER" == "1" ]; then
 	ts_skip_subtest "running under qemu-user emulation"
+	ts_finalize_subtest
 	return
     fi
     {

--- a/tests/ts/lsfd/mkfds-unix-dgram
+++ b/tests/ts/lsfd/mkfds-unix-dgram
@@ -102,8 +102,8 @@ else
 	fi
 	wait "${MKFDS_PID}"
     } > "$TS_OUTPUT" 2>&1
-    ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 ts_init_subtest "UNIX.IPEEER-column"
 if ! lsfd_check_sockdiag --subtest unix; then
@@ -139,7 +139,7 @@ else
 	fi
 	wait "${MKFDS_PID}"
     } > "$TS_OUTPUT" 2>&1
-    ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/lsfd/mkfds-unix-in-netns
+++ b/tests/ts/lsfd/mkfds-unix-in-netns
@@ -103,6 +103,7 @@ for t in stream dgram seqpacket; do
     } > "$TS_OUTPUT" 2>&1
     if [ "$RC" == "$EPERM" ]; then
 	ts_skip_subtest "unshare(2) is not permitted on this platform"
+	ts_finalize_subtest
 	continue
     fi
     ts_finalize_subtest

--- a/tests/ts/misc/canonicalize
+++ b/tests/ts/misc/canonicalize
@@ -67,11 +67,10 @@ if id $uid &>/dev/null; then
 			--inh-caps=-all --reset-env \
 			-- $TESTPROG ${BASE}/root-sym/foo \
 		| sed "s:${BASE}::g" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-
-	ts_finalize_subtest
 else
 	ts_skip_subtest "nobody user is missing"
 fi
+ts_finalize_subtest
 
 
 # cleanup

--- a/tests/ts/misc/mbsencode
+++ b/tests/ts/misc/mbsencode
@@ -58,28 +58,28 @@ ts_finalize_subtest
 ts_init_subtest "invalid-ascii"
 if [ "$HAVE_WIDECHAR" = true ]; then
 	$TS_HELPER_MBSENCODE --invalid "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-	ts_finalize_subtest
 else
 	ts_skip_subtest 'No widechar support'
 fi
+ts_finalize_subtest
 
 ts_init_subtest "safe-utf8"
 if [ "$HAVE_WIDECHAR" = true ]; then
 	LC_ALL=C.UTF-8 \
 	$TS_HELPER_MBSENCODE --safe "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-	ts_finalize_subtest
 else
 	ts_skip_subtest 'No widechar support'
 fi
+ts_finalize_subtest
 
 ts_init_subtest "invalid-utf8"
 if [ "$HAVE_WIDECHAR" = true ]; then
 	LC_ALL=C.UTF-8 \
 	$TS_HELPER_MBSENCODE --invalid "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-	ts_finalize_subtest
 else
 	ts_skip_subtest 'No widechar support'
 fi
+ts_finalize_subtest
 
 ts_finalize
 

--- a/tests/ts/mount/special
+++ b/tests/ts/mount/special
@@ -87,12 +87,12 @@ EOF
 		$TS_CMD_UMOUNT "$mountpoint"
 		unset LIBMOUNT_UTAB
 		rm -f $MOUNTER
-		ts_finalize_subtest
 	else
 		ts_skip_subtest "tmpfs not mounted"
 	fi
 else
 	ts_skip_subtest "tmpfs unsupported"
 fi
+ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/runuser/options
+++ b/tests/ts/runuser/options
@@ -39,9 +39,8 @@ unset -v UL_TEST_VAR
 
 if grep "$($TS_HELPER_STRERROR ENOTTY)" "$TS_ERRLOG"; then
     ts_skip_subtest "failed to launch login session: ENOTTY"
-else
-    ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 
 ts_init_subtest "preserve-environment"
@@ -101,8 +100,7 @@ ps --version >/dev/null
 if ! compare_ptys; then
     ts_skip_subtest "$errmsg"
     unset -v errmsg
-else
-    ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/unshare/env
+++ b/tests/ts/unshare/env
@@ -31,9 +31,8 @@ unset -v UL_TEST_ENV
 
 if grep -q "$($TS_HELPER_STRERROR EPERM)" "$TS_OUTPUT" "$TS_ERRLOG"; then
         ts_skip_subtest "missing permissions"
-else
-        ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 
 ts_init_subtest "whitelist-env"
@@ -43,8 +42,7 @@ export UL_TEST_ENV2=bar
 
 if grep -q "$($TS_HELPER_STRERROR EPERM)" "$TS_OUTPUT" "$TS_ERRLOG"; then
         ts_skip_subtest "missing permissions"
-else
-        ts_finalize_subtest
 fi
+ts_finalize_subtest
 
 ts_finalize


### PR DESCRIPTION
 Every subtest must now be a proper `ts_init_subtest` / `ts_finalize_subtest` block. Previously, 
  `ts_failed_subtest` and `ts_skip_subtest` were used as terminal actions *instead of*            
  `ts_finalize_subtest`, which forced every callsite into an if/else structure and made it easy to
   introduce bugs where both FAILED and OK were reported for the same subtest (as seen in #4315). 
                                                                                                  
  ### Framework changes (`tests/functions.sh`)

  - Add `TS_SUBFAILED` and `TS_SUBSKIPPED` flags, set by `ts_failed_subtest` and `ts_skip_subtest`
   respectively, cleared by `ts_init_subtest`
  - `ts_finalize_subtest` checks these flags before running `ts_gen_diff` — if the subtest was
  already marked as failed or skipped, it respects that status instead of unconditionally         
  comparing output
  - Remove `ts_init_core_env` from `ts_skip_subtest` — environment reset is now handled           
  exclusively by `ts_finalize_subtest`                                                            
  - Add runtime guards: both `ts_init_subtest` and `ts_finalize` call `ts_failed` if `TS_SUBNAME`
  is still set from a previous subtest that was never finalized — this makes missing              
  `ts_finalize_subtest` calls a hard test failure, detectable in CI
                                                                                                  
  ### Callsite fixes (21 files)                                                                   
   
  All existing callers updated to ensure every subtest is a proper init/finalize block:           
  - **if/else branches**: move `ts_finalize_subtest` after the entire block instead of only in the
   success branch                                                                                 
  - **loops with `continue`**: add `ts_finalize_subtest` before `continue`
  - **functions with early `return`**: add `ts_finalize_subtest` before `return`                  
                                                                                                  
  ### Pre-existing bug found                                                                      
                                                                                                  
  The runtime guard immediately caught a missing `ts_finalize_subtest` in                         
  `tests/ts/findmnt/filterQ` (subtest "options-no-multi").
