### PR TITLE
docs: clarify wipefs --force description for partition-table signatures

### DIFF
--- a/misc-utils/wipefs.8.adoc
+++ b/misc-utils/wipefs.8.adoc
@@ -50,7 +50,7 @@ partitions.
 Create a signature backup to the file _wipefs-<devname>-<offset>.bak_ in _$HOME_ or the directory specified as the optional argument. For more details see the *EXAMPLE* section.
 
 *-f*, *--force*::
-Force erasure, even if the filesystem is mounted. This is required in order to erase a partition-table signature on a block device.
+Force erasure, even if the filesystem is mounted. This is also required in order to erase a nested partition-table signature on a non-whole disk device.
 
 *-J*, *--json*::
 Use JSON output format.


### PR DESCRIPTION
## Summary
- Fix misleading description of `--force` in wipefs(8) man page
- The current text claims `--force` "is required in order to erase a partition-table signature on a block device", but according to the source code (`do_wipe()` in `wipefs.c`), `--force` is only needed for **nested** partition tables on **non-whole-disk** devices
- The example `wipefs --all --backup /dev/sdb` works correctly without `--force` because it operates on a whole-disk device
- Updated text now says "a nested partition-table signature on a non-whole disk device", consistent with the note earlier in the man page

Fixes #2447