### PR TITLE
tests: skip fallocate/zero-range test when /proc/sys/vm/drop_caches is not writable

### DIFF
--- a/tests/ts/fallocate/zero-range
+++ b/tests/ts/fallocate/zero-range
@@ -20,6 +20,7 @@ TS_DESC="zero-range"
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
 ts_skip_nonroot
+[ -w /proc/sys/vm/drop_caches ] || ts_skip "/proc/sys/vm/drop_caches not writable"
 
 ts_check_test_command "$TS_CMD_FALLOCATE"
 ts_check_test_command "$TS_CMD_FINDMNT"


### PR DESCRIPTION
The build (compat, ubuntu:18.04) CI job runs inside a Docker container where /proc/sys/vm/drop_caches is read-only. Falling back to fallocate --report-holes with stale VFS cache yields 0 holes instead of 1, causing the test to fail.