### PR TITLE
CI: replace ntp with ntpsec

### DIFF
--- a/.github/workflows/cibuild-setup-ubuntu.sh
+++ b/.github/workflows/cibuild-setup-ubuntu.sh
@@ -18,7 +18,7 @@ PACKAGES=(
 	libudev-dev
 	gtk-doc-tools
 	mdadm
-	ntp
+	ntpsec
 	socat
 	asciidoctor
 	meson


### PR DESCRIPTION
The ntp package has been removed from Ubuntu repositories. Use ntpsec as a replacement to provide the sntp command needed by tests/ts/hwclock/systohc.