### PR TITLE
CI: (getino) skip namespace subtests when not supported

### DIFF
--- a/tests/ts/getino/getino
+++ b/tests/ts/getino/getino
@@ -64,75 +64,107 @@ if [ -n "$res" ]; then
 fi
 ts_finalize_subtest
 
-$TS_CMD_UNSHARE --ipc true &> /dev/null || ts_skip "no namespace support"
+"$TS_CMD_GETINO" --ipcns $$ > /dev/null 2>&1 || ts_skip "namespace ioctl not supported"
 
 ts_init_subtest "ipcns"
-ts_ipc_ns=$("$TS_CMD_GETINO" --ipcns $$ 2>>"$TS_ERRLOG")
-unshare_ipc_ns=$("$TS_CMD_UNSHARE" --ipc bash -c "$TS_CMD_GETINO --ipcns \$\$" 2>>"$TS_ERRLOG")
-if (( ts_ipc_ns == unshare_ipc_ns )); then
-  ts_failed_subtest "IPC namespace unchanged"
+if [ -r /proc/self/ns/ipc ]; then
+  ts_ipc_ns=$("$TS_CMD_GETINO" --ipcns $$ 2>>"$TS_ERRLOG")
+  unshare_ipc_ns=$("$TS_CMD_UNSHARE" --ipc bash -c "$TS_CMD_GETINO --ipcns \$\$" 2>>"$TS_ERRLOG")
+  if (( ts_ipc_ns == unshare_ipc_ns )); then
+    ts_failed_subtest "IPC namespace unchanged"
+  fi
+else
+  ts_skip_subtest "no IPC namespace support"
 fi
 ts_finalize_subtest
 
 ts_init_subtest "netns"
-ts_net_ns=$("$TS_CMD_GETINO" --netns $$ 2>>"$TS_ERRLOG")
-unshare_net_ns=$("$TS_CMD_UNSHARE" --net bash -c "$TS_CMD_GETINO --netns \$\$" 2>>"$TS_ERRLOG")
-if (( ts_net_ns == unshare_net_ns )); then
-  ts_failed_subtest "network namespace unchanged"
+if [ -r /proc/self/ns/net ]; then
+  ts_net_ns=$("$TS_CMD_GETINO" --netns $$ 2>>"$TS_ERRLOG")
+  unshare_net_ns=$("$TS_CMD_UNSHARE" --net bash -c "$TS_CMD_GETINO --netns \$\$" 2>>"$TS_ERRLOG")
+  if (( ts_net_ns == unshare_net_ns )); then
+    ts_failed_subtest "network namespace unchanged"
+  fi
+else
+  ts_skip_subtest "no network namespace support"
 fi
 ts_finalize_subtest
 
 ts_init_subtest "mntns"
-ts_mnt_ns=$("$TS_CMD_GETINO" --mntns $$ 2>>"$TS_ERRLOG")
-unshare_mnt_ns=$("$TS_CMD_UNSHARE" --mount bash -c "$TS_CMD_GETINO --mntns \$\$" 2>>"$TS_ERRLOG")
-if (( ts_mnt_ns == unshare_mnt_ns )); then
-  ts_failed_subtest "mount namespace unchanged"
+if [ -r /proc/self/ns/mnt ]; then
+  ts_mnt_ns=$("$TS_CMD_GETINO" --mntns $$ 2>>"$TS_ERRLOG")
+  unshare_mnt_ns=$("$TS_CMD_UNSHARE" --mount bash -c "$TS_CMD_GETINO --mntns \$\$" 2>>"$TS_ERRLOG")
+  if (( ts_mnt_ns == unshare_mnt_ns )); then
+    ts_failed_subtest "mount namespace unchanged"
+  fi
+else
+  ts_skip_subtest "no mount namespace support"
 fi
 ts_finalize_subtest
 
 ts_init_subtest "utsns"
-ts_uts_ns=$("$TS_CMD_GETINO" --utsns $$ 2>>"$TS_ERRLOG")
-unshare_uts_ns=$("$TS_CMD_UNSHARE" --uts bash -c "$TS_CMD_GETINO --utsns \$\$" 2>>"$TS_ERRLOG")
-if (( ts_uts_ns == unshare_uts_ns )); then
-  ts_failed_subtest "UTS namespace unchanged"
+if [ -r /proc/self/ns/uts ]; then
+  ts_uts_ns=$("$TS_CMD_GETINO" --utsns $$ 2>>"$TS_ERRLOG")
+  unshare_uts_ns=$("$TS_CMD_UNSHARE" --uts bash -c "$TS_CMD_GETINO --utsns \$\$" 2>>"$TS_ERRLOG")
+  if (( ts_uts_ns == unshare_uts_ns )); then
+    ts_failed_subtest "UTS namespace unchanged"
+  fi
+else
+  ts_skip_subtest "no UTS namespace support"
 fi
 ts_finalize_subtest
 
 ts_init_subtest "timens"
-ts_time_ns=$("$TS_CMD_GETINO" --timens $$ 2>>"$TS_ERRLOG")
-unshare_time_ns=$("$TS_CMD_UNSHARE" --time bash -c "$TS_CMD_GETINO --timens \$\$" 2>>"$TS_ERRLOG")
-if (( ts_time_ns == unshare_time_ns )); then
-  ts_failed_subtest "time namespace unchanged"
+if [ -r /proc/self/ns/time ]; then
+  ts_time_ns=$("$TS_CMD_GETINO" --timens $$ 2>>"$TS_ERRLOG")
+  unshare_time_ns=$("$TS_CMD_UNSHARE" --time bash -c "$TS_CMD_GETINO --timens \$\$" 2>>"$TS_ERRLOG")
+  if (( ts_time_ns == unshare_time_ns )); then
+    ts_failed_subtest "time namespace unchanged"
+  fi
+else
+  ts_skip_subtest "no time namespace support"
 fi
 ts_finalize_subtest
 
 ts_init_subtest "pidns"
-ts_pid_ns=$("$TS_CMD_GETINO" --pidns $$ 2>>"$TS_ERRLOG")
-unshare_pid_ns=$("$TS_CMD_UNSHARE" --pid --fork bash -c "$TS_CMD_GETINO --pidns \$\$" 2>>"$TS_ERRLOG")
-if (( ts_pid_ns == unshare_pid_ns )); then
-  ts_failed_subtest "pid namespace unchanged"
+if [ -r /proc/self/ns/pid ]; then
+  ts_pid_ns=$("$TS_CMD_GETINO" --pidns $$ 2>>"$TS_ERRLOG")
+  unshare_pid_ns=$("$TS_CMD_UNSHARE" --pid --fork bash -c "$TS_CMD_GETINO --pidns \$\$" 2>>"$TS_ERRLOG")
+  if (( ts_pid_ns == unshare_pid_ns )); then
+    ts_failed_subtest "pid namespace unchanged"
+  fi
+else
+  ts_skip_subtest "no PID namespace support"
 fi
 ts_finalize_subtest
 
 ts_init_subtest "cgroupns"
-ts_cgroup_ns=$("$TS_CMD_GETINO" --cgroupns $$ 2>>"$TS_ERRLOG")
-unshare_cgroup_ns=$("$TS_CMD_UNSHARE" --cgroup bash -c "$TS_CMD_GETINO --cgroupns \$\$" 2>>"$TS_ERRLOG")
-if (( ts_cgroup_ns == unshare_cgroup_ns )); then
-  ts_failed_subtest "cgroup namespace unchanged"
+if [ -r /proc/self/ns/cgroup ]; then
+  ts_cgroup_ns=$("$TS_CMD_GETINO" --cgroupns $$ 2>>"$TS_ERRLOG")
+  unshare_cgroup_ns=$("$TS_CMD_UNSHARE" --cgroup bash -c "$TS_CMD_GETINO --cgroupns \$\$" 2>>"$TS_ERRLOG")
+  if (( ts_cgroup_ns == unshare_cgroup_ns )); then
+    ts_failed_subtest "cgroup namespace unchanged"
+  fi
+else
+  ts_skip_subtest "no cgroup namespace support"
 fi
 ts_finalize_subtest
 
 ts_init_subtest "userns"
-getino_owner="$(stat --format=%U "$TS_CMD_GETINO")"
-ts_user_ns=$("$TS_CMD_GETINO" --userns $$ 2>>"$TS_ERRLOG")
-unshare_user_ns=$("$TS_CMD_RUNUSER" --user "$getino_owner" -- \
-                    "$TS_CMD_UNSHARE" --user \
-                      bash -c "$TS_CMD_GETINO --userns \$\$" 2>>"$TS_ERRLOG")
+if [ -r /proc/self/ns/user ]; then
+  getino_owner="$(stat --format=%U "$TS_CMD_GETINO")"
+  ts_user_ns=$("$TS_CMD_GETINO" --userns $$ 2>>"$TS_ERRLOG")
+  unshare_user_ns=$("$TS_CMD_RUNUSER" --user "$getino_owner" -- \
+                      "$TS_CMD_UNSHARE" --user \
+                        bash -c "$TS_CMD_GETINO --userns \$\$" 2>>"$TS_ERRLOG")
 
-if grep "$("$TS_HELPER_STRERROR" EACCES)" "$TS_ERRLOG" &>/dev/null; then
-  ts_skip_subtest "missing permissions to obtain user namespace"
+  if grep "$("$TS_HELPER_STRERROR" EACCES)" "$TS_ERRLOG" &>/dev/null; then
+    ts_skip_subtest "missing permissions to obtain user namespace"
+  else
+    (( ts_user_ns == unshare_user_ns )) && ts_failed_subtest "user namespace unchanged"
+  fi
 else
-  (( ts_user_ns == unshare_user_ns )) && ts_failed_subtest "user namespace unchanged"
+  ts_skip_subtest "no user namespace support"
 fi
 ts_finalize_subtest
 


### PR DESCRIPTION
Skip individual namespace subtests when the corresponding /proc/self/ns/* entry is not readable, indicating that the kernel namespace type is not available (e.g., on QEMU or in restricted containers).