### PR TITLE
liblastlog: (tests) avoid log spam

### DIFF
--- a/tests/expected/liblastlog2/y2038_ll2_read_all
+++ b/tests/expected/liblastlog2/y2038_ll2_read_all
@@ -1,0 +1,2 @@
+Cannot open database (y2038-ll2_read_all.db): unable to open database file
+Returning the correct errno: No such file or directory

--- a/tests/ts/liblastlog2/y2038_ll2_read_all
+++ b/tests/ts/liblastlog2/y2038_ll2_read_all
@@ -8,8 +8,8 @@ ts_init "$*"
 
 ts_check_test_command $TS_HELPER_LIBLASTLOG2_Y2038_LL2_READ_ALL
 
-$TS_HELPER_LIBLASTLOG2_Y2038_LL2_READ_ALL >/dev/null || ts_failed "returned an error"
+$TS_HELPER_LIBLASTLOG2_Y2038_LL2_READ_ALL >/dev/null 2>> "$TS_OUTPUT" || ts_failed "returned an error"
 
-rm y2038-ll2_read_all.db
+rm -f y2038-ll2_read_all.db
 
 ts_finalize


### PR DESCRIPTION
In its current form this test spams the test log with some pointless noise. Redirect the output to a logfile and validate it, too.