### PR TITLE
pipesz: suppress duplicate getopt error on unknown options

### DIFF
--- a/misc-utils/pipesz.c
+++ b/misc-utils/pipesz.c
@@ -228,6 +228,7 @@ int main(int argc, char **argv)
 	close_stdout_atexit();
 
 	/* check for --help or --version */
+	opterr = 0;	/* suppress getopt error for first scan, restored below */
 	while ((c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {
 		switch (c) {
 		case 'h':
@@ -237,6 +238,7 @@ int main(int argc, char **argv)
 		}
 	}
 
+	opterr = 1;	/* re-enable getopt error messages */
 	/* gather normal options */
 	optind = 1;
 	while ((c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {


### PR DESCRIPTION
The main() function scans command-line options in two passes: the first pass checks for --help/--version, and the second processes normal options. When getopt_long encounters an unknown option in the first pass, it prints an error message to stderr. The same error is then printed again during the second pass, resulting in a duplicate "unrecognized option" message.

Fix this by setting opterr=0 before the first scan to suppress getopt error messages, then restoring it after the loop.

Fixes #3817