### PR TITLE
tests: test_scols_termreduce needs libsmartcols

### DIFF
--- a/tests/helpers/Makemodule.am
+++ b/tests/helpers/Makemodule.am
@@ -1,7 +1,9 @@
+if BUILD_LIBSMARTCOLS
 if !OSS_FUZZ
 check_PROGRAMS += test_scols_termreduce
 test_scols_termreduce_SOURCES = tests/helpers/test_scols_termreduce.c
 test_scols_termreduce_LDADD = $(LDADD) libsmartcols.la
+endif
 endif
 
 check_PROGRAMS += test_mbsencode


### PR DESCRIPTION
This helper needs libsmartcols, so it can't be built if util-linux is configured with --disable-libsmartcols. (It's still reasonable to want to run the test suite in this case, for example if you're configuring util-linux to only build libuuid.)