### PR TITLE
libmount: (tests) skip btrfs test if btrfs support is not enabled

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -194,7 +194,7 @@ function ts_runs_on_qemu {
 	return
 }
 
-function ts_failed_subtest {
+function ts_failed {
 	local msg="FAILED"
 	local ret=1
 
@@ -211,12 +211,11 @@ function ts_failed_subtest {
 		ts_report " $msg ($1)"
 	fi
 
-	return $ret
-}
+	if [ -z "$TS_SUBNAME" ]; then
+		exit $ret
+	fi
 
-function ts_failed {
-	ts_failed_subtest "$1"
-	exit $?
+	return $ret
 }
 
 function ts_report_ok {
@@ -652,7 +651,7 @@ function ts_finalize_subtest {
 	else
 		ts_gen_diff
 		if [ $? -eq 1 ]; then
-			ts_failed_subtest "$1"
+			ts_failed "$1"
 			res=1
 		else
 			ts_report_ok "$(tt_gen_mem_report "$1")"

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -153,8 +153,12 @@ function ts_report_skip {
 function ts_skip {
 	ts_report_skip "$1"
 
-	ts_cleanup_on_exit
-	exit 0
+	if [ -n "$TS_SUBNAME" ]; then
+		TS_SUBSKIPPED="yes"
+	else
+		ts_cleanup_on_exit
+		exit 0
+	fi
 }
 
 function ts_skip_nonroot {
@@ -661,11 +665,6 @@ function ts_finalize_subtest {
 	ts_init_core_env
 
 	return $res
-}
-
-function ts_skip_subtest {
-	TS_SUBSKIPPED="yes"
-	ts_report_skip "$1"
 }
 
 # Specify the kernel version X.Y.Z you wish to compare against like:

--- a/tests/ts/chrt/all-tasks
+++ b/tests/ts/chrt/all-tasks
@@ -72,7 +72,7 @@ function search_tids() {
 ts_init_subtest "get-attributes"
 
 if ! start_threads_create 5 5; then
-    ts_failed_subtest "failed to start threads helper program"
+    ts_failed "failed to start threads helper program"
 else
     chrt_output="$("$TS_CMD_CHRT" --all-tasks --pid "$HELPER_PID" 2>>"$TS_ERRLOG"\
                     | sed -E 's/pid ([0-9]*).*/\1/g' | sort | uniq)"
@@ -101,7 +101,7 @@ ts_init_subtest "set-attributes"
 
 PRIORITY=33
 if ! start_threads_create 5 5; then
-    ts_failed_subtest "failed to start threads helper program"
+    ts_failed "failed to start threads helper program"
 else
     # Set the real-time scheduling attributes for all tasks
     "$TS_CMD_CHRT" --all-tasks --fifo --pid "$PRIORITY" "$HELPER_PID" 2>>"$TS_ERRLOG"

--- a/tests/ts/chrt/chrt
+++ b/tests/ts/chrt/chrt
@@ -31,7 +31,7 @@ function do_chrt {
 function skip_policy {
 	$TS_CMD_CHRT --max | grep $1 | grep 'priority' &> /dev/null
 	if [ $? == 1 ]; then
-		ts_skip_subtest "unsupported"
+		ts_skip "unsupported"
 		ts_finalize_subtest
 		return 1
 	fi
@@ -40,7 +40,7 @@ function skip_policy {
 
 function skip_kernel_lt {
 	if ts_kernel_ver_lt $1 $2 $3; then
-		ts_skip_subtest "kernel version must be >= $1.$2.$3"
+		ts_skip "kernel version must be >= $1.$2.$3"
 		ts_finalize_subtest
 		return 1
 	fi
@@ -51,7 +51,7 @@ function skip_kernel_lt {
 function skip_kernel_ge {
 	ts_kernel_ver_lt $1 $2 $3
 	if [ $? == 1 ]; then
-		ts_skip_subtest "kernel version must be < $1.$2.$3"
+		ts_skip "kernel version must be < $1.$2.$3"
 		ts_finalize_subtest
 		return 1
 	fi

--- a/tests/ts/chrt/chrt-non-root
+++ b/tests/ts/chrt/chrt-non-root
@@ -31,7 +31,7 @@ function do_chrt {
 function skip_policy {
 	$TS_CMD_CHRT --max | grep $1 | grep 'priority' &> /dev/null
 	if [ $? == 1 ]; then
-		ts_skip_subtest "unsupported"
+		ts_skip "unsupported"
 		ts_finalize_subtest
 		return 1
 	fi

--- a/tests/ts/findmnt/outputs
+++ b/tests/ts/findmnt/outputs
@@ -119,7 +119,7 @@ ts_init_subtest "canonicalization"
 TEST_LINK="$TS_OUTDIR/fakelink"
 
 if ! ln -s / "$TEST_LINK"; then
-    ts_skip_subtest "failed to create symbolic link to root filesystem"
+    ts_skip "failed to create symbolic link to root filesystem"
 else
     # This return the right mount target
     $TS_CMD_FINDMNT --output TARGET --canonicalize "$TEST_LINK" >>"$TS_OUTPUT" 2>>"$TS_ERRLOG"

--- a/tests/ts/getino/getino
+++ b/tests/ts/getino/getino
@@ -77,7 +77,7 @@ function do_ns_check() {
                                     "$TS_CMD_GETINO --${ns_name}ns \$\$" 2>>"$TS_ERRLOG")
 
     if (( ts_ns_ino == unshare_ns_ino )); then
-      ts_failed_subtest "${ns_name} namespace unchanged (NS ID: $ts_ns_ino)"
+      ts_failed "${ns_name} namespace unchanged (NS ID: $ts_ns_ino)"
     fi
   else
     ts_skip "no ${ns_name} namespace support"
@@ -125,7 +125,7 @@ if [ -r /proc/self/ns/user ]; then
   if grep "$("$TS_HELPER_STRERROR" EACCES)" "$TS_ERRLOG" &>/dev/null; then
     ts_skip "missing permissions to obtain user namespace"
   else
-    (( ts_user_ns == unshare_user_ns )) && ts_failed_subtest "user namespace unchanged"
+    (( ts_user_ns == unshare_user_ns )) && ts_failed "user namespace unchanged"
   fi
 else
   ts_skip "no user namespace support"

--- a/tests/ts/getino/getino
+++ b/tests/ts/getino/getino
@@ -80,7 +80,7 @@ function do_ns_check() {
       ts_failed_subtest "${ns_name} namespace unchanged (NS ID: $ts_ns_ino)"
     fi
   else
-    ts_skip_subtest "no ${ns_name} namespace support"
+    ts_skip "no ${ns_name} namespace support"
   fi
 }
 
@@ -123,12 +123,12 @@ if [ -r /proc/self/ns/user ]; then
                         bash -c "$TS_CMD_GETINO --userns \$\$" 2>>"$TS_ERRLOG")
 
   if grep "$("$TS_HELPER_STRERROR" EACCES)" "$TS_ERRLOG" &>/dev/null; then
-    ts_skip_subtest "missing permissions to obtain user namespace"
+    ts_skip "missing permissions to obtain user namespace"
   else
     (( ts_user_ns == unshare_user_ns )) && ts_failed_subtest "user namespace unchanged"
   fi
 else
-  ts_skip_subtest "no user namespace support"
+  ts_skip "no user namespace support"
 fi
 ts_finalize_subtest
 

--- a/tests/ts/libmount/loop
+++ b/tests/ts/libmount/loop
@@ -84,7 +84,7 @@ ts_finalize_subtest
 ts_init_subtest "o-loop-val"
 if [ "$TS_PARALLEL" = "yes" ]; then
 	# There is a race in $LODEV is usage
-	ts_skip_subtest "no-reentrant"
+	ts_skip "no-reentrant"
 else
 	[ -d "$TS_MOUNTPOINT" ] || mkdir -p $TS_MOUNTPOINT
 	LODEV=$( $TS_CMD_LOSETUP --find 2>> "$TS_OUTPUT" )

--- a/tests/ts/libmount/tabfiles
+++ b/tests/ts/libmount/tabfiles
@@ -83,6 +83,7 @@ sed -i -e 's/fs: 0x.*/fs:/g' "$TS_OUTPUT"
 ts_finalize_subtest
 
 ts_init_subtest "is-mounted-btrfs"
+grep -q '#define HAVE_BTRFS_SUPPORT' ${top_builddir}/config.h || ts_skip_subtest "no btrfs support"
 ts_run $TESTPROG --is-mounted "$TS_SELF/files/fstab_btrfs" "$TS_SELF/files/mountinfo_btrfs" &> "$TS_OUTPUT"
 ts_finalize_subtest
 

--- a/tests/ts/libmount/tabfiles
+++ b/tests/ts/libmount/tabfiles
@@ -83,7 +83,7 @@ sed -i -e 's/fs: 0x.*/fs:/g' "$TS_OUTPUT"
 ts_finalize_subtest
 
 ts_init_subtest "is-mounted-btrfs"
-grep -q '#define HAVE_BTRFS_SUPPORT' ${top_builddir}/config.h || ts_skip "no btrfs support"
+ts_skip_config HAVE_BTRFS_SUPPORT "no btrfs support"
 ts_run $TESTPROG --is-mounted "$TS_SELF/files/fstab_btrfs" "$TS_SELF/files/mountinfo_btrfs" &> "$TS_OUTPUT"
 ts_finalize_subtest
 

--- a/tests/ts/libmount/tabfiles
+++ b/tests/ts/libmount/tabfiles
@@ -83,7 +83,7 @@ sed -i -e 's/fs: 0x.*/fs:/g' "$TS_OUTPUT"
 ts_finalize_subtest
 
 ts_init_subtest "is-mounted-btrfs"
-grep -q '#define HAVE_BTRFS_SUPPORT' ${top_builddir}/config.h || ts_skip_subtest "no btrfs support"
+grep -q '#define HAVE_BTRFS_SUPPORT' ${top_builddir}/config.h || ts_skip "no btrfs support"
 ts_run $TESTPROG --is-mounted "$TS_SELF/files/fstab_btrfs" "$TS_SELF/files/mountinfo_btrfs" &> "$TS_OUTPUT"
 ts_finalize_subtest
 

--- a/tests/ts/libmount/utils
+++ b/tests/ts/libmount/utils
@@ -56,7 +56,7 @@ ts_init_subtest "mountpoint"
 if [ -d /proc ]; then
 	ts_run $TESTPROG --mountpoint /proc &> "$TS_OUTPUT"
 else
-	ts_skip_subtest "no /proc"
+	ts_skip "no /proc"
 fi
 ts_finalize_subtest
 
@@ -64,7 +64,7 @@ ts_init_subtest "mountpoint-subdir"
 if [ -d /proc/sys/kernel ]; then
 	ts_run $TESTPROG --mountpoint /proc/sys/kernel &> "$TS_OUTPUT"
 else
-	ts_skip_subtest "no /proc"
+	ts_skip "no /proc"
 fi
 ts_finalize_subtest
 

--- a/tests/ts/losetup/losetup-loop
+++ b/tests/ts/losetup/losetup-loop
@@ -204,7 +204,7 @@ udevadm settle
 ts_init_subtest "plain-conflict"
 if [ "$TS_PARALLEL" = "yes" ]; then
 	# There is a race in $LODEV is usage
-	ts_skip_subtest "no-reentrant"
+	ts_skip "no-reentrant"
 else
 	LODEV=$( $TS_CMD_LOSETUP --find --nooverlap --show $BACKFILE )
 	if [ -z "$LODEV" ]; then
@@ -225,7 +225,7 @@ udevadm settle
 ts_init_subtest "plain-readonly"
 if [ "$TS_PARALLEL" = "yes" ]; then
 	# There is a race in $LODEV is usage
-	ts_skip_subtest "no-reentrant"
+	ts_skip "no-reentrant"
 else
 	LODEV=$( $TS_CMD_LOSETUP --find --nooverlap --show --read-only $BACKFILE )
 	if [ -z "$LODEV" ]; then

--- a/tests/ts/lsclocks/lsclocks
+++ b/tests/ts/lsclocks/lsclocks
@@ -48,7 +48,7 @@ if [ -c /dev/ptp0 ] && [ -r /dev/ptp0 ]; then
 	"$TS_CMD_LSCLOCKS" $NO_DISCOVER --dynamic-clock /dev/ptp0 --output TYPE,ID,CLOCK,NAME \
 		| tail -1 > "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 else
-	ts_skip_subtest "/dev/ptp0 not usable"
+	ts_skip "/dev/ptp0 not usable"
 fi
 ts_finalize_subtest
 
@@ -58,7 +58,7 @@ if [ -c /dev/rtc0 ] && [ -r /dev/rtc0 ]; then
 	"$TS_CMD_LSCLOCKS" $NO_DISCOVER --rtc /dev/rtc0 --output TYPE,ID,CLOCK,NAME \
 		| tail -1 > "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 else
-	ts_skip_subtest "/dev/rtc0 not usable"
+	ts_skip "/dev/rtc0 not usable"
 fi
 ts_finalize_subtest
 

--- a/tests/ts/lsfd/column-ainodeclass
+++ b/tests/ts/lsfd/column-ainodeclass
@@ -47,14 +47,14 @@ for C in pidfd inotify; do
     } > "$TS_OUTPUT" 2>&1
 
     if [ "$C-$RC" == "pidfd-$TS_EXIT_NOTSUPP" ]; then
-	ts_skip_subtest "pidfd_open(2) is not available"
+	ts_skip "pidfd_open(2) is not available"
 	ts_finalize_subtest
 	continue
     fi
 
     STTYPE="$(head -n1 "$TS_OUTPUT" | awk '{print $2}')"
     if [ "$C-$STTYPE" == "pidfd-REG" ]; then
-	ts_skip_subtest "pidfd is from pidfs instead of anon inode"
+	ts_skip "pidfd is from pidfs instead of anon inode"
 	ts_finalize_subtest
 	continue
     fi

--- a/tests/ts/lsfd/column-name
+++ b/tests/ts/lsfd/column-name
@@ -69,7 +69,7 @@ for C in ro-regular-file pidfd socketpair; do
     RC=$?
 
     if [ "$C-$RC" == "pidfd-$TS_EXIT_NOTSUPP" ]; then
-	ts_skip_subtest "pidfd_open(2) is not available"
+	ts_skip "pidfd_open(2) is not available"
 	ts_finalize_subtest
 	continue
     fi

--- a/tests/ts/lsfd/column-type
+++ b/tests/ts/lsfd/column-type
@@ -55,7 +55,7 @@ for C in ro-regular-file pidfd inotify socketpair; do
     } > "$TS_OUTPUT" 2>&1
 
     if [ "$C-$RC" == "pidfd-$TS_EXIT_NOTSUPP" ]; then
-	ts_skip_subtest "pidfd_open(2) is not available"
+	ts_skip "pidfd_open(2) is not available"
 	ts_finalize_subtest
 	continue
     fi

--- a/tests/ts/lsfd/column-xmode
+++ b/tests/ts/lsfd/column-xmode
@@ -86,9 +86,9 @@ ts_finalize_subtest
 EXPR='(ASSOC == "mem") and (INODE == '"$INO"') and (MODE != "r--") and (MODE != "rw-") and (MODE != "rwx")'
 ts_init_subtest "MODE-x-bit"
 if [ "$QEMU_USER" == "1" ]; then
-    ts_skip_subtest "running under qemu-user emulation"
+    ts_skip "running under qemu-user emulation"
 elif [ "$UID" != "0" ]; then
-    ts_skip_subtest "no root permissions"
+    ts_skip "no root permissions"
 else
     {
 	coproc MKFDS { "$TS_HELPER_MKFDS" ro-regular-file $FD; }
@@ -104,9 +104,9 @@ ts_finalize_subtest
 
 ts_init_subtest "XMODE-x-bit"
 if [ "$QEMU_USER" == "1" ]; then
-    ts_skip_subtest "running under qemu-user emulation"
+    ts_skip "running under qemu-user emulation"
 elif [ "$UID" != "0" ]; then
-    ts_skip_subtest "no root permissions"
+    ts_skip "no root permissions"
 else
     {
 	coproc MKFDS { "$TS_HELPER_MKFDS" ro-regular-file $FD; }
@@ -150,7 +150,7 @@ for m in flock-sh posix-r- ofd-r-; do
     wait "${MKFDS_PID}"
     RC=$?
     if [ "$RC" == "$TS_EXIT_NOTSUPP" ]; then
-	ts_skip_subtest	"$m lock is not available"
+	ts_skip	"$m lock is not available"
 	ts_finalize_subtest
 	continue
     fi
@@ -187,7 +187,7 @@ for m in flock-ex posix--w posix-rw  ofd--w ofd-rw lease-w; do
     wait "${MKFDS_PID}"
     RC=$?
     if [ "$RC" == "$TS_EXIT_NOTSUPP" ]; then
-	ts_skip_subtest	"$m lock is not available"
+	ts_skip	"$m lock is not available"
 	ts_finalize_subtest
 	continue
     fi

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -133,11 +133,11 @@ function lsfd_check_sockdiag
 	    0)
 		return 0;;
 	    "$EPROTONOSUPPORT")
-		ts_skip$suffix "NETLINK_SOCK_DIAG protocol is not supported in socket(2)";;
+		ts_skip "NETLINK_SOCK_DIAG protocol is not supported in socket(2)";;
 	    "$EACCES")
-		ts_skip$suffix "sending a msg via a sockdiag netlink socket is not permitted";;
+		ts_skip "sending a msg via a sockdiag netlink socket is not permitted";;
 	    "$ENOENT")
-		ts_skip$suffix "sockdiag netlink socket is not available";;
+		ts_skip "sockdiag netlink socket is not available";;
 	    *)
 		ts_failed$suffix "failed to create a sockdiag netlink socket $family ($err): $msg";;
 	esac

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -106,11 +106,9 @@ function lsfd_check_mkfds_factory
 function lsfd_check_sockdiag
 {
 	local is_subtest
-	local suffix=
 
 	case "$1" in
 	    (--subtest)
-		suffix=_subtest
 		is_subtest=1
 		shift
 		;;

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -139,7 +139,7 @@ function lsfd_check_sockdiag
 	    "$ENOENT")
 		ts_skip "sockdiag netlink socket is not available";;
 	    *)
-		ts_failed$suffix "failed to create a sockdiag netlink socket $family ($err): $msg";;
+		ts_failed "failed to create a sockdiag netlink socket $family ($err): $msg";;
 	esac
 
 	return 1

--- a/tests/ts/lsfd/mkfds-cdev-tun
+++ b/tests/ts/lsfd/mkfds-cdev-tun
@@ -124,7 +124,7 @@ cdev_tun_test()
 
     ts_init_subtest "$tname"-devnetns
     if [[ -z "${devnetns_available}" ]]; then
-	ts_skip_subtest "no method to access devnetns on this platform"
+	ts_skip "no method to access devnetns on this platform"
     else
 	{
 	    output=$(${TS_CMD_LSFD} -p "${PID}" -n --raw -o TUN.DEVNETNS -Q "${EXPR}")

--- a/tests/ts/lsfd/mkfds-multiplexing
+++ b/tests/ts/lsfd/mkfds-multiplexing
@@ -37,7 +37,7 @@ PID=
 for multiplexer in pselect6 select poll ppoll; do
     ts_init_subtest "${multiplexer}"
     if ! "$TS_HELPER_MKFDS" -W | grep -q "^$multiplexer\$"; then
-	ts_skip_subtest "the multiplexer ${multiplexer} is not available"
+	ts_skip "the multiplexer ${multiplexer} is not available"
 	ts_finalize_subtest
 	continue
     fi
@@ -52,7 +52,7 @@ for multiplexer in pselect6 select poll ppoll; do
 	if [[ "$syscall_status" != 0 ]]; then
 	    kill -CONT "${PID}"
 	    wait "${MKFDS_PID}"
-	    ts_skip_subtest "cannot open /proc/${PID}/syscall"
+	    ts_skip "cannot open /proc/${PID}/syscall"
 	    ts_finalize_subtest
 	    continue
 	fi
@@ -62,7 +62,7 @@ for multiplexer in pselect6 select poll ppoll; do
 	if [[ "$syscall_n" == 0 ]]; then
 	    kill -CONT "${PID}"
 	    wait "${MKFDS_PID}"
-	    ts_skip_subtest "incorrect syscall number in /proc/${PID}/syscall"
+	    ts_skip "incorrect syscall number in /proc/${PID}/syscall"
 	    ts_finalize_subtest
 	    continue
 	fi

--- a/tests/ts/lsfd/mkfds-socketpair
+++ b/tests/ts/lsfd/mkfds-socketpair
@@ -70,7 +70,7 @@ mkfds_socketpair_stream_endpoint()
 {
     ts_init_subtest "STREAM-ENDPOINT"
     if [ "$QEMU_USER" == "1" ]; then
-	ts_skip_subtest "running under qemu-user emulation"
+	ts_skip "running under qemu-user emulation"
 	ts_finalize_subtest
 	return
     fi
@@ -93,7 +93,7 @@ mkfds_socketpair_stream_shutdown_state()
 {
     ts_init_subtest "STREAM-SHUTDOWN-STATE"
     if [ "$QEMU_USER" == "1" ]; then
-	ts_skip_subtest "running under qemu-user emulation"
+	ts_skip "running under qemu-user emulation"
 	ts_finalize_subtest
 	return
     fi
@@ -116,7 +116,7 @@ mkfds_socketpair_stream_endpoint_halfclose()
 {
     ts_init_subtest "STREAM-ENDPOINT-halfclose"
     if [ "$QEMU_USER" == "1" ]; then
-	ts_skip_subtest "running under qemu-user emulation"
+	ts_skip "running under qemu-user emulation"
 	ts_finalize_subtest
 	return
     fi

--- a/tests/ts/lsfd/mkfds-unix-dgram
+++ b/tests/ts/lsfd/mkfds-unix-dgram
@@ -75,10 +75,10 @@ ts_finalize_subtest
 
 ts_init_subtest "ENDPOINTS-column"
 if ! lsfd_check_sockdiag --subtest unix; then
-    # lsfd_check_sockdiag calls ts_skip_subtest or ts_failed_subtest.
+    # lsfd_check_sockdiag calls ts_skip or ts_failed_subtest.
     :
 elif ts_is_in_docker; then
-    ts_skip_subtest "unsupported in docker environment"
+    ts_skip "unsupported in docker environment"
 else
     {
 	coproc MKFDS { "$TS_HELPER_MKFDS" unix-dgram $FDS $FDC \
@@ -107,10 +107,10 @@ ts_finalize_subtest
 
 ts_init_subtest "UNIX.IPEEER-column"
 if ! lsfd_check_sockdiag --subtest unix; then
-    # lsfd_check_sockdiag calls ts_skip_subtest or ts_failed_subtest.
+    # lsfd_check_sockdiag calls ts_skip or ts_failed_subtest.
     :
 elif ts_is_in_docker; then
-    ts_skip_subtest "unsupported in docker environment"
+    ts_skip "unsupported in docker environment"
 else
     {
 	coproc MKFDS { "$TS_HELPER_MKFDS" unix-dgram $FDS $FDC \

--- a/tests/ts/lsfd/mkfds-unix-dgram
+++ b/tests/ts/lsfd/mkfds-unix-dgram
@@ -75,7 +75,7 @@ ts_finalize_subtest
 
 ts_init_subtest "ENDPOINTS-column"
 if ! lsfd_check_sockdiag --subtest unix; then
-    # lsfd_check_sockdiag calls ts_skip or ts_failed_subtest.
+    # lsfd_check_sockdiag calls ts_skip or ts_failed.
     :
 elif ts_is_in_docker; then
     ts_skip "unsupported in docker environment"
@@ -107,7 +107,7 @@ ts_finalize_subtest
 
 ts_init_subtest "UNIX.IPEEER-column"
 if ! lsfd_check_sockdiag --subtest unix; then
-    # lsfd_check_sockdiag calls ts_skip or ts_failed_subtest.
+    # lsfd_check_sockdiag calls ts_skip or ts_failed.
     :
 elif ts_is_in_docker; then
     ts_skip "unsupported in docker environment"

--- a/tests/ts/lsfd/mkfds-unix-in-netns
+++ b/tests/ts/lsfd/mkfds-unix-in-netns
@@ -102,7 +102,7 @@ for t in stream dgram seqpacket; do
 	RC=$?
     } > "$TS_OUTPUT" 2>&1
     if [ "$RC" == "$EPERM" ]; then
-	ts_skip_subtest "unshare(2) is not permitted on this platform"
+	ts_skip "unshare(2) is not permitted on this platform"
 	ts_finalize_subtest
 	continue
     fi

--- a/tests/ts/lsns/ioctl_ns
+++ b/tests/ts/lsns/ioctl_ns
@@ -22,7 +22,7 @@ TS_DESC="ownership and hierarchy"
 ts_init "$*"
 
 # ts_skip_nonroot
-grep -q '#define HAVE_LINUX_NSFS_H' ${top_builddir}/config.h || ts_skip "no ioctl_ns support"
+ts_skip_config HAVE_LINUX_NSFS_H "no ioctl_ns support"
 
 [ -r /proc/self/ns/user ] || ts_skip "no USER namespace kernel support"
 [ -r /proc/self/ns/pid ] || ts_skip "no PID namespace kernel support"

--- a/tests/ts/lsns/nsfs
+++ b/tests/ts/lsns/nsfs
@@ -34,7 +34,7 @@ ts_check_prog "touch"
 ts_check_prog "mkfifo"
 ts_check_prog "sed"
 
-grep -q '#define HAVE_LINUX_NET_NAMESPACE_H' ${top_builddir}/config.h || ts_skip "no netns support"
+ts_skip_config HAVE_LINUX_NET_NAMESPACE_H "no netns support"
 
 if [ "$($TS_HELPER_SYSINFO ns-gettype-ok)" == "0" ]; then
     ts_skip "NS_GET_NSTYPE ioctl cmd not available"

--- a/tests/ts/misc/canonicalize
+++ b/tests/ts/misc/canonicalize
@@ -24,7 +24,7 @@ ts_check_test_command "$TS_CMD_SETPRIV"
 ts_check_test_command "$TS_HELPER_CANONICALIZE"
 
 grep -q 'nodev[[:space:]]*tmpfs' /proc/filesystems || \
-	ts_skip_subtest "tmpfs unsupported"
+	ts_skip "tmpfs unsupported"
 
 mkdir -p $TS_MOUNTPOINT &>  /dev/null
 $TS_CMD_MOUNT -t tmpfs tmpfs $TS_MOUNTPOINT >> "$TS_OUTPUT" 2>> "$TS_ERRLOG" \
@@ -68,7 +68,7 @@ if id $uid &>/dev/null; then
 			-- $TESTPROG ${BASE}/root-sym/foo \
 		| sed "s:${BASE}::g" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 else
-	ts_skip_subtest "nobody user is missing"
+	ts_skip "nobody user is missing"
 fi
 ts_finalize_subtest
 

--- a/tests/ts/misc/mbsencode
+++ b/tests/ts/misc/mbsencode
@@ -56,29 +56,20 @@ $TS_HELPER_MBSENCODE --safe "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_finalize_subtest
 
 ts_init_subtest "invalid-ascii"
-if [ "$HAVE_WIDECHAR" = true ]; then
-	$TS_HELPER_MBSENCODE --invalid "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-else
-	ts_skip 'No widechar support'
-fi
+ts_skip_config HAVE_WIDECHAR 'No widechar support'
+$TS_HELPER_MBSENCODE --invalid "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_finalize_subtest
 
 ts_init_subtest "safe-utf8"
-if [ "$HAVE_WIDECHAR" = true ]; then
-	LC_ALL=C.UTF-8 \
-	$TS_HELPER_MBSENCODE --safe "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-else
-	ts_skip 'No widechar support'
-fi
+ts_skip_config HAVE_WIDECHAR 'No widechar support'
+LC_ALL=C.UTF-8 \
+$TS_HELPER_MBSENCODE --safe "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_finalize_subtest
 
 ts_init_subtest "invalid-utf8"
-if [ "$HAVE_WIDECHAR" = true ]; then
-	LC_ALL=C.UTF-8 \
-	$TS_HELPER_MBSENCODE --invalid "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-else
-	ts_skip 'No widechar support'
-fi
+ts_skip_config HAVE_WIDECHAR 'No widechar support'
+LC_ALL=C.UTF-8 \
+$TS_HELPER_MBSENCODE --invalid "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/misc/mbsencode
+++ b/tests/ts/misc/mbsencode
@@ -59,7 +59,7 @@ ts_init_subtest "invalid-ascii"
 if [ "$HAVE_WIDECHAR" = true ]; then
 	$TS_HELPER_MBSENCODE --invalid "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 else
-	ts_skip_subtest 'No widechar support'
+	ts_skip 'No widechar support'
 fi
 ts_finalize_subtest
 
@@ -68,7 +68,7 @@ if [ "$HAVE_WIDECHAR" = true ]; then
 	LC_ALL=C.UTF-8 \
 	$TS_HELPER_MBSENCODE --safe "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 else
-	ts_skip_subtest 'No widechar support'
+	ts_skip 'No widechar support'
 fi
 ts_finalize_subtest
 
@@ -77,7 +77,7 @@ if [ "$HAVE_WIDECHAR" = true ]; then
 	LC_ALL=C.UTF-8 \
 	$TS_HELPER_MBSENCODE --invalid "${STRINGS[@]}" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 else
-	ts_skip_subtest 'No widechar support'
+	ts_skip 'No widechar support'
 fi
 ts_finalize_subtest
 

--- a/tests/ts/mount/dm-verity
+++ b/tests/ts/mount/dm-verity
@@ -35,7 +35,7 @@ ts_skip_nonroot
 ts_check_prog "mksquashfs"
 ts_check_prog "veritysetup"
 
-grep -q '#define HAVE_CRYPTSETUP' ${top_builddir}/config.h || ts_skip "no dm-verity support"
+ts_skip_config HAVE_CRYPTSETUP "no dm-verity support"
 
 # Make a squashfs and prepare verity device out of it
 mksquashfs $TS_SELF $SQUASHFS &>/dev/null || ts_skip "error: mksquashfs on $TS_SELF"

--- a/tests/ts/mount/special
+++ b/tests/ts/mount/special
@@ -88,10 +88,10 @@ EOF
 		unset LIBMOUNT_UTAB
 		rm -f $MOUNTER
 	else
-		ts_skip_subtest "tmpfs not mounted"
+		ts_skip "tmpfs not mounted"
 	fi
 else
-	ts_skip_subtest "tmpfs unsupported"
+	ts_skip "tmpfs unsupported"
 fi
 ts_finalize_subtest
 

--- a/tests/ts/runuser/options
+++ b/tests/ts/runuser/options
@@ -38,7 +38,7 @@ export UL_TEST_VAR=foo
 unset -v UL_TEST_VAR
 
 if grep "$($TS_HELPER_STRERROR ENOTTY)" "$TS_ERRLOG"; then
-    ts_skip_subtest "failed to launch login session: ENOTTY"
+    ts_skip "failed to launch login session: ENOTTY"
 fi
 ts_finalize_subtest
 
@@ -98,7 +98,7 @@ ts_init_subtest "pty"
 ps --version >/dev/null
 
 if ! compare_ptys; then
-    ts_skip_subtest "$errmsg"
+    ts_skip "$errmsg"
     unset -v errmsg
 fi
 ts_finalize_subtest

--- a/tests/ts/su/group
+++ b/tests/ts/su/group
@@ -52,7 +52,7 @@ ts_init_subtest "primary-login"
                         | grep -o "$grp_name" \
                         | uniq >> "$TS_OUTPUT"
 
-grep -q 'Authentication failure' "$TS_ERRLOG" && ts_skip_subtest "authentication failure"
+grep -q 'Authentication failure' "$TS_ERRLOG" && ts_skip "authentication failure"
 ts_finalize_subtest
 
 ts_init_subtest "supplemental-no-login"
@@ -68,7 +68,7 @@ ts_init_subtest "supplemental-login"
                         | grep -o "$grp_name" \
                         | uniq >> "$TS_OUTPUT"
 
-grep -q 'Authentication failure' "$TS_ERRLOG" && ts_skip_subtest "authentication failure"
+grep -q 'Authentication failure' "$TS_ERRLOG" && ts_skip "authentication failure"
 ts_finalize_subtest
 
 ts_init_subtest "group-id"

--- a/tests/ts/unshare/env
+++ b/tests/ts/unshare/env
@@ -30,7 +30,7 @@ export UL_TEST_ENV=foo
 unset -v UL_TEST_ENV
 
 if grep -q "$($TS_HELPER_STRERROR EPERM)" "$TS_OUTPUT" "$TS_ERRLOG"; then
-        ts_skip_subtest "missing permissions"
+        ts_skip "missing permissions"
 fi
 ts_finalize_subtest
 
@@ -41,7 +41,7 @@ export UL_TEST_ENV2=bar
 "$TS_CMD_UNSHARE" --whitelist-env UL_TEST_ENV1 /bin/bash -c 'echo "${UL_TEST_ENV1}${UL_TEST_ENV2}"' >>"$TS_OUTPUT" 2>>"$TS_ERRLOG"
 
 if grep -q "$($TS_HELPER_STRERROR EPERM)" "$TS_OUTPUT" "$TS_ERRLOG"; then
-        ts_skip_subtest "missing permissions"
+        ts_skip "missing permissions"
 fi
 ts_finalize_subtest
 


### PR DESCRIPTION
btrfs support in libmount is optional. If it is not enabled, the test will fail. Skip the test in that case.

Fixes: 4583d15248fd ("tests: add btrfs RAID is-mounted test for libmount")