### PR TITLE
pam_lastlog2: fix libpam linking in autotools build

### DIFF
--- a/pam_lastlog2/src/Makemodule.am
+++ b/pam_lastlog2/src/Makemodule.am
@@ -11,9 +11,9 @@ pam_lastlog2_la_CFLAGS = \
 	 $(SOLIB_CFLAGS) \
 	 -I$(ul_liblastlog2_incdir)
 
-pam_lastlog2_la_LIBADD = liblastlog2.la
+pam_lastlog2_la_LIBADD = liblastlog2.la -lpam
 
-pam_lastlog2_la_LDFLAGS = $(SOLIB_LDFLAGS) -lpam -module -avoid-version -shared
+pam_lastlog2_la_LDFLAGS = $(SOLIB_LDFLAGS) -module -avoid-version -shared
 if HAVE_VSCRIPT
 pam_lastlog2_la_LDFLAGS += $(VSCRIPT_LDFLAGS),$(top_srcdir)/pam_lastlog2/src/pam_lastlog2.sym
 endif


### PR DESCRIPTION
Move -lpam from LDFLAGS to LIBADD. When -lpam is in LDFLAGS it appears on the linker command line before object files, so the --as-needed linker flag (default on Fedora) discards it before seeing any undefined PAM symbols. This results in pam_lastlog2.so missing libpam.so in its ELF NEEDED entries.

The module then fails to load with dlopen() if the calling process does not itself link against libpam (e.g., systemd in Fedora 44+):

  PAM unable to dlopen(pam_lastlog2.so): undefined symbol: pam_syslog

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2453457