### PR TITLE
lscpu: Fix the model name issue on the Phytium platform

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -280,17 +280,6 @@ static const struct id_part ampere_part[] = {
     { -1, "unknown" },
 };
 
-static const struct id_part ft_part[] = {
-    { 0x303, "FTC310" },
-    { 0x660, "FTC660" },
-    { 0x661, "FTC661" },
-    { 0x662, "FTC662" },
-    { 0x663, "FTC663" },
-    { 0x664, "FTC664" },
-    { 0x862, "FTC862" },
-    { -1, "unknown" },
-};
-
 static const struct id_part ms_part[] = {
     { 0xd49, "Azure-Cobalt-100" },
     { -1, "unknown" },
@@ -324,7 +313,6 @@ static const struct hw_impl hw_implementer[] = {
     { 0x66, faraday_part, "Faraday" },
     { 0x69, intel_part,   "Intel" },
     { 0x6d, ms_part,      "Microsoft" },
-    { 0x70, ft_part,      "Phytium" },
     { 0xc0, ampere_part,  "Ampere" },
     { -1,   unknown_part, "unknown" },
 };


### PR DESCRIPTION
…m platform

Since the Phytium kernel already implements model name, the model name output by lscpu should be retrieved from /proc/cpuinfo instead of beging hardcoded to a specific value directly in the lscpu-arm.c file.