### PR TITLE
pipesz: merge help/version getopt loop into main loop

### DIFF
--- a/misc-utils/pipesz.c
+++ b/misc-utils/pipesz.c
@@ -227,18 +227,6 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 	close_stdout_atexit();
 
-	/* check for --help or --version */
-	while ((c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {
-		switch (c) {
-		case 'h':
-			usage();
-		case 'V':
-			print_version(EXIT_SUCCESS);
-		}
-	}
-
-	/* gather normal options */
-	optind = 1;
 	while ((c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {
 		err_exclusive_options(c, longopts, excl, excl_st);
 
@@ -276,6 +264,11 @@ int main(int argc, char **argv)
 		case 'v':
 			opt_verbose = TRUE;
 			break;
+
+		case 'V':
+			print_version(EXIT_SUCCESS);
+		case 'h':
+			usage();
 		default:
 			errtryhelp(EXIT_FAILURE);
 		}


### PR DESCRIPTION
The main() function scanned command-line options in two passes: the first pass checked for --help/--version, and the second processed normal options. When getopt_long encountered an unknown option in the first pass, it printed an error message. The same error was then printed again during the second pass, resulting in a duplicate "unrecognized option" message.

Fix this by merging the first getopt_long loop into the main one, following the standard util-linux convention.

Fixes: https://github.com/util-linux/util-linux/issues/3817