### PR TITLE
chrt: always use sched_setattr(), cleanup ifdefs

### DIFF
--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -174,11 +174,11 @@ static bool supports_runtime_param(int policy)
 static const char *get_supported_runtime_param_policies(void)
 {
 #if defined(SCHED_BATCH)
-#if defined(SCHED_DEADLINE)
+# if defined(SCHED_DEADLINE)
 	return _("SCHED_OTHER, SCHED_BATCH and SCHED_DEADLINE");
-#else
+# else
 	return _("SCHED_OTHER and SCHED_BATCH");
-#endif /* SCHED_DEADLINE */
+# endif /* SCHED_DEADLINE */
 #elif defined(SCHED_DEADLINE)
 	return _("SCHED_OTHER and SCHED_DEADLINE");
 #else
@@ -232,10 +232,10 @@ static void show_sched_pid_info(struct chrt_ctl *ctl, pid_t pid)
 		reset_on_fork = sa.sched_flags & SCHED_FLAG_RESET_ON_FORK;
 # endif
 		runtime = sa.sched_runtime;
-#ifdef SCHED_DEADLINE
+# ifdef SCHED_DEADLINE
 		deadline = sa.sched_deadline;
 		period = sa.sched_period;
-#endif
+# endif
 	}
 
 	/*
@@ -243,7 +243,7 @@ static void show_sched_pid_info(struct chrt_ctl *ctl, pid_t pid)
 	 */
 fallback:
 	if (errno == ENOSYS)
-#endif
+#endif /* HAVE_SCHED_SETATTR */
 	{
 		struct sched_param sp;
 
@@ -255,10 +255,10 @@ fallback:
 			err(EXIT_FAILURE, _("failed to get pid %d's attributes"), pid);
 		else
 			prio = sp.sched_priority;
-# ifdef SCHED_RESET_ON_FORK
+#ifdef SCHED_RESET_ON_FORK
 		if (policy & SCHED_RESET_ON_FORK)
 			reset_on_fork = 1;
-# endif
+#endif
 	}
 
 	if (ctl->altered)
@@ -362,15 +362,15 @@ static int set_sched_one_by_setscheduler(struct chrt_ctl *ctl, pid_t pid)
 		policy |= SCHED_RESET_ON_FORK;
 # endif
 
-#if defined (__linux__) && defined(SYS_sched_setscheduler)
+# if defined (__linux__) && defined(SYS_sched_setscheduler)
 	/* musl libc returns ENOSYS for its sched_setscheduler library
 	 * function, because the sched_setscheduler Linux kernel system call
 	 * does not conform to Posix; so we use the system call directly
 	 */
 	return syscall(SYS_sched_setscheduler, pid, policy, &sp);
-#else
+# else
 	return sched_setscheduler(pid, policy, &sp);
-#endif
+# endif
 }
 
 
@@ -645,16 +645,16 @@ int main(int argc, char **argv)
 		errx(EXIT_FAILURE, _("--deadline-overrun is only supported for SCHED_DEADLINE"));
 # endif
 
-#ifndef HAVE_SCHED_SETATTR
-# ifdef SCHED_FLAG_UTIL_CLAMP_MIN
+# ifndef HAVE_SCHED_SETATTR
+#  ifdef SCHED_FLAG_UTIL_CLAMP_MIN
 	if (ctl->sched_flags & SCHED_FLAG_UTIL_CLAMP_MIN)
 		errx(EXIT_FAILURE, _("SCHED_FLAG_UTIL_CLAMP_MIN is unsupported"));
-# endif
-# ifdef SCHED_FLAG_UTIL_CLAMP_MAX
+#  endif
+#  ifdef SCHED_FLAG_UTIL_CLAMP_MAX
 	if (ctl->sched_flags & SCHED_FLAG_UTIL_CLAMP_MAX)
 		errx(EXIT_FAILURE, _("SCHED_FLAG_UTIL_CLAMP_MAX is unsupported"));
+#  endif
 # endif
-#endif
 	if (ctl->policy == SCHED_DEADLINE) {
 		/* The basic rule is runtime <= deadline <= period, so we can
 		 * make deadline and runtime optional on command line. Note we

--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -350,6 +350,7 @@ static void show_min_max(void)
 	}
 }
 
+#ifndef HAVE_SCHED_SETATTR
 static int set_sched_one_by_setscheduler(struct chrt_ctl *ctl, pid_t pid)
 {
 	struct sched_param sp = { .sched_priority = ctl->priority };
@@ -373,7 +374,6 @@ static int set_sched_one_by_setscheduler(struct chrt_ctl *ctl, pid_t pid)
 }
 
 
-#ifndef HAVE_SCHED_SETATTR
 static int set_sched_one(struct chrt_ctl *ctl, pid_t pid)
 {
 	return set_sched_one_by_setscheduler(ctl, pid);
@@ -384,10 +384,6 @@ static int set_sched_one(struct chrt_ctl *ctl, pid_t pid)
 {
 	struct sched_attr sa = { .size = sizeof(struct sched_attr) };
 	int ret;
-
-	/* old API is good enough for non-deadline */
-	if (!supports_runtime_param(ctl->policy))
-		return set_sched_one_by_setscheduler(ctl, pid);
 
 	/* not changed by chrt, follow the current setting */
 	sa.sched_nice = getpriority(PRIO_PROCESS, pid);

--- a/schedutils/chrt.c
+++ b/schedutils/chrt.c
@@ -624,37 +624,19 @@ int main(int argc, char **argv)
 	if (ctl->runtime && !supports_runtime_param(ctl->policy))
 		errx(EXIT_FAILURE, _("--sched-runtime option is supported for %s"),
 				     get_supported_runtime_param_policies());
-#ifdef SCHED_DEADLINE
+#ifdef HAVE_SCHED_SETATTR
+# ifdef SCHED_DEADLINE
 	if ((ctl->deadline || ctl->period) && ctl->policy != SCHED_DEADLINE)
 		errx(EXIT_FAILURE, _("--sched-{deadline,period} options are "
 				     "supported for SCHED_DEADLINE only"));
-# ifdef SCHED_FLAG_RECLAIM
-#  ifndef HAVE_SCHED_SETATTR
-	if (ctl->sched_flags & SCHED_FLAG_RECLAIM)
-		errx(EXIT_FAILURE, _("SCHED_FLAG_RECLAIM is unsupported"));
-#  endif
+#  ifdef SCHED_FLAG_RECLAIM
 	if ((ctl->sched_flags & SCHED_FLAG_RECLAIM) && ctl->policy != SCHED_DEADLINE)
 		errx(EXIT_FAILURE, _("--reclaim-grub is only supported for SCHED_DEADLINE"));
-# endif
-# ifdef SCHED_FLAG_DL_OVERRUN
-#  ifndef HAVE_SCHED_SETATTR
-	if (ctl->sched_flags & SCHED_FLAG_DL_OVERRUN)
-		errx(EXIT_FAILURE, _("SCHED_FLAG_DL_OVERRUN is unsupported"));
 #  endif
+#  ifdef SCHED_FLAG_DL_OVERRUN
 	if ((ctl->sched_flags & SCHED_FLAG_DL_OVERRUN) && ctl->policy != SCHED_DEADLINE)
 		errx(EXIT_FAILURE, _("--deadline-overrun is only supported for SCHED_DEADLINE"));
-# endif
-
-# ifndef HAVE_SCHED_SETATTR
-#  ifdef SCHED_FLAG_UTIL_CLAMP_MIN
-	if (ctl->sched_flags & SCHED_FLAG_UTIL_CLAMP_MIN)
-		errx(EXIT_FAILURE, _("SCHED_FLAG_UTIL_CLAMP_MIN is unsupported"));
 #  endif
-#  ifdef SCHED_FLAG_UTIL_CLAMP_MAX
-	if (ctl->sched_flags & SCHED_FLAG_UTIL_CLAMP_MAX)
-		errx(EXIT_FAILURE, _("SCHED_FLAG_UTIL_CLAMP_MAX is unsupported"));
-#  endif
-# endif
 	if (ctl->policy == SCHED_DEADLINE) {
 		/* The basic rule is runtime <= deadline <= period, so we can
 		 * make deadline and runtime optional on command line. Note we
@@ -666,10 +648,27 @@ int main(int argc, char **argv)
 		if (ctl->runtime == 0)
 			ctl->runtime = ctl->deadline;
 	}
-#else /* !SCHED_DEADLINE */
+# endif /* SCHED_DEADLINE */
+#else /* !HAVE_SCHED_SETATTR */
 	if (ctl->deadline || ctl->period)
 		errx(EXIT_FAILURE, _("SCHED_DEADLINE is unsupported"));
-#endif /* SCHED_DEADLINE */
+# ifdef SCHED_FLAG_RECLAIM
+	if (ctl->sched_flags & SCHED_FLAG_RECLAIM)
+		errx(EXIT_FAILURE, _("SCHED_FLAG_RECLAIM is unsupported"));
+# endif
+# ifdef SCHED_FLAG_DL_OVERRUN
+	if (ctl->sched_flags & SCHED_FLAG_DL_OVERRUN)
+		errx(EXIT_FAILURE, _("SCHED_FLAG_DL_OVERRUN is unsupported"));
+# endif
+# ifdef SCHED_FLAG_UTIL_CLAMP_MIN
+	if (ctl->sched_flags & SCHED_FLAG_UTIL_CLAMP_MIN)
+		errx(EXIT_FAILURE, _("SCHED_FLAG_UTIL_CLAMP_MIN is unsupported"));
+# endif
+# ifdef SCHED_FLAG_UTIL_CLAMP_MAX
+	if (ctl->sched_flags & SCHED_FLAG_UTIL_CLAMP_MAX)
+		errx(EXIT_FAILURE, _("SCHED_FLAG_UTIL_CLAMP_MAX is unsupported"));
+# endif
+#endif /* HAVE_SCHED_SETATTR */
 	if (ctl->priority < sched_get_priority_min(ctl->policy) ||
 			sched_get_priority_max(ctl->policy) < ctl->priority)
 		errx(EXIT_FAILURE,


### PR DESCRIPTION
- Remove `sched_setscheduler()` shortcut from the `HAVE_SCHED_SETATTR` code path — `getpriority()` already preserves the nice value, making it unnecessary
- Fix: `--clamp-min`/`--clamp-max` (`SCHED_FLAG_UTIL_CLAMP`, PR #4351) were silently ignored for `SCHED_FIFO` and `SCHED_RR` because those policies were routed through `sched_setscheduler()` which cannot pass `sched_flags`
- Fix preprocessor indentation levels and restructure validation to use `HAVE_SCHED_SETATTR` as a top-level guard with `SCHED_DEADLINE` nested inside


The `sched_setscheduler()` shortcut was added in 2016 (commit 88b60f0bdee6) to avoid resetting the nice value via `sched_setattr()`, which caused `EPERM` for non-root users. The `getpriority()` call added in the same commit already solves this for the `sched_setattr()` path, so the shortcut is dead weight that creates bugs when new `sched_flags` are added.
