### PR TITLE
Fix typo and improve EINVAL error reporting

### DIFF
--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -157,8 +157,12 @@ static int do_rtc_read_ioctl(int rtc_fd, struct tm *tm)
 	rc = ioctl(rtc_fd, RTC_RD_TIME, &rtc_tm);
 
 	if (rc == -1) {
-		warn(_("ioctl(RTC_RD_TIME) to %s to read the time failed"),
-			rtc_dev_name);
+		if (errno == EINVAL)
+			warn(_("ioctl(RTC_RD_TIME) to %s to read the time failed, RTC time may not be set"),
+				rtc_dev_name);
+		else
+			warn(_("ioctl(RTC_RD_TIME) to %s to read the time failed"),
+				rtc_dev_name);
 		return -1;
 	}
 

--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -157,7 +157,7 @@ static int do_rtc_read_ioctl(int rtc_fd, struct tm *tm)
 	rc = ioctl(rtc_fd, RTC_RD_TIME, &rtc_tm);
 
 	if (rc == -1) {
-		warn(_("ioctl(RTC_RD_NAME) to %s to read the time failed"),
+		warn(_("ioctl(RTC_RD_TIME) to %s to read the time failed"),
 			rtc_dev_name);
 		return -1;
 	}

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -174,7 +174,10 @@ static int get_basetimes(struct rtcwake_control *ctl, int fd)
 	 * precisely (+/- a second) as we can read them.
 	 */
 	if (ioctl(fd, RTC_RD_TIME, &rtc) < 0) {
-		warn(_("read rtc time failed"));
+		if (errno == EINVAL)
+			warn(_("read rtc time failed, RTC time may not be set"));
+		else
+			warn(_("read rtc time failed"));
 		return -1;
 	}
 


### PR DESCRIPTION
This series contains two small improvements to RTC error handling in
hwclock and rtcwake.

The first patch fixes a pre-existing typo in the hwclock-rtc error
message where the ioctl name was mistakenly referred to as "RTC_RD_NAME"
instead of "RTC_RD_TIME".

The second patch adds EINVAL-specific handling to both hwclock and
rtcwake. Some RTC drivers (such as rtc-nxp-bbnsm) return EINVAL from
RTC_RD_TIME when the hardware time counter has never been initialized —
a common state on freshly manufactured boards. The previous generic error
message ("Invalid argument") gave no indication of the likely cause. The
new message preserves the device name and strerror output while adding a
hint that the RTC time may not be set. The wording uses "may not be set"
rather than "is not set" because the kernel also translates ENOIOCTLCMD
to EINVAL for drivers that do not implement RTC_RD_TIME, making the two
cases indistinguishable in userspace.