### PR TITLE
libmount: skip srcpath canonicalize in restricted mode

### DIFF
--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -1970,9 +1970,15 @@ int mnt_context_prepare_srcpath(struct libmnt_context *cxt)
 		rc = path ? mnt_fs_set_source(cxt->fs, path) : -MNT_ERR_NOSOURCE;
 
 	} else if (cache && !mnt_fs_is_pseudofs(cxt->fs)
+			 && !mnt_context_is_restricted(cxt)
 			 && !mnt_context_is_xnocanonicalize(cxt, "source")) {
 		/*
 		 * Source is PATH (canonicalize)
+		 *
+		 * CVE-2026-27456 follow-up: in restricted mode the source
+		 * path was already canonicalized in user context by
+		 * sanitize_paths(); a second realpath() here as root would
+		 * reopen the TOCTOU window that hook_loopdev tries to close.
 		 */
 		path = mnt_resolve_path(src, cache);
 		if (path && strcmp(path, src) != 0)


### PR DESCRIPTION
Commit 5e390467 ("loopdev: add LOOPDEV_FL_NOFOLLOW to prevent symlink attacks") closed two of the three TOCTOU windows in mount(8) loop-device setup:

  [USE 1] loopcxt_set_backing_file() canonicalize as root  -> fixed
  [USE 2] loopcxt_setup_device()     open() without NOFOLLOW -> fixed

It missed [USE 0]: mnt_context_prepare_srcpath() also calls mnt_resolve_path() -> canonicalize_path() -> realpath(3) as root, before hook_loopdev runs, and writes the canonicalized path back into cxt->fs->source via mnt_fs_set_source(). If an unprivileged caller wins the race during this realpath() (e.g. by atomically swapping the fstab backing file with a symlink via renameat2(RENAME_EXCHANGE)), the source field becomes the attacker-chosen target path before hook_loopdev's NOFOLLOW handling kicks in. Subsequent open(target, O_NOFOLLOW) does not fail because the target is itself a regular file, not a symlink.

In restricted mode the source path was already canonicalized in user context by sanitize_paths()/ul_canonicalize_path_restricted() in sys-utils/mount.c, so a second canonicalize as root is unnecessary and unsafe. Skip it.