### PR TITLE
fdisk-list: fix memory leak when partition returns empty string

### DIFF
--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -940,8 +940,11 @@ int print_partition_info(struct fdisk_context *cxt)
 		rc = fdisk_partition_to_string(pa, cxt, id, &data);
 		if (rc < 0)
 			goto clean_data;
-		if (!data || !*data)
+		if (!data || !*data) {
+			free(data);
 			continue;
+
+		}
 		fdisk_info(cxt, "%15s: %s", fdisk_field_get_name(fd), data);
 		free(data);
 	}


### PR DESCRIPTION
When fdisk_partition_to_string() successfully returns a non-NULL pointer
but the resulting string is empty (*data == '\0'), the code executes
'continue' without freeing the allocated data buffer, leading to a
memory leak.