### PR TITLE
loopdev: use openat2(RESOLVE_NO_SYMLINKS) for backing file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -347,6 +347,7 @@ AC_CHECK_HEADERS([ \
 	linux/kcmp.h \
 	linux/net_namespace.h \
 	linux/nsfs.h \
+	linux/openat2.h \
 	linux/pr.h \
 	linux/raw.h \
 	linux/seccomp.h \

--- a/include/fileutils.h
+++ b/include/fileutils.h
@@ -64,6 +64,8 @@ static inline int is_same_inode(const int fd, const struct stat *st)
 	return 1;
 }
 
+extern int ul_open_no_symlinks(const char *path, int flags, mode_t mode);
+
 extern int dup_fd_cloexec(int oldfd, int lowfd);
 extern unsigned int get_fd_tabsize(void);
 

--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -11,8 +11,15 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/syscall.h>
 #include <string.h>
 #include <sys/wait.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#ifdef HAVE_LINUX_OPENAT2_H
+# include <linux/openat2.h>
+#endif
 
 #include "c.h"
 #include "all-io.h"
@@ -491,3 +498,20 @@ FILE *fopen_at_no_link(int dir, const char *filename,
 	return fp;
 }
 #endif /* HAVE_OPENAT */
+
+int ul_open_no_symlinks(const char *path, int flags, mode_t mode)
+{
+#if defined(SYS_openat2) && defined(RESOLVE_NO_SYMLINKS)
+	struct open_how how = {
+		.flags = (__u64) flags,
+		.mode = (__u64) mode,
+		.resolve = RESOLVE_NO_SYMLINKS,
+	};
+	int fd = syscall(SYS_openat2, AT_FDCWD, path, &how, sizeof(how));
+
+	/* only fall back to O_NOFOLLOW if the syscall is unavailable */
+	if (fd >= 0 || errno != ENOSYS)
+		return fd;
+#endif
+	return open(path, flags | O_NOFOLLOW, mode);
+}

--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -1398,16 +1398,21 @@ int loopcxt_setup_device(struct loopdev_cxt *lc)
 	if (lc->config.info.lo_flags & LO_FLAGS_DIRECT_IO)
 		flags |= O_DIRECT;
 	if (lc->flags & LOOPDEV_FL_NOFOLLOW)
-		flags |= O_NOFOLLOW;
+		file_fd = ul_open_no_symlinks(lc->filename, mode | flags, 0);
+	else
+		file_fd = open(lc->filename, mode | flags);
 
-	if ((file_fd = open(lc->filename, mode | flags)) < 0) {
-		if (mode != O_RDONLY && (errno == EROFS || errno == EACCES))
-			file_fd = open(lc->filename, (mode = O_RDONLY) | flags);
-
-		if (file_fd < 0) {
-			DBG_OBJ(SETUP, lc, ul_debug("open backing file failed: %m"));
-			return -errno;
-		}
+	if (file_fd < 0 && mode != O_RDONLY
+	    && (errno == EROFS || errno == EACCES)) {
+		mode = O_RDONLY;
+		if (lc->flags & LOOPDEV_FL_NOFOLLOW)
+			file_fd = ul_open_no_symlinks(lc->filename, mode | flags, 0);
+		else
+			file_fd = open(lc->filename, mode | flags);
+	}
+	if (file_fd < 0) {
+		DBG_OBJ(SETUP, lc, ul_debug("open backing file failed: %m"));
+		return -errno;
 	}
 	DBG_OBJ(SETUP, lc, ul_debug("backing file open: OK"));
 

--- a/meson.build
+++ b/meson.build
@@ -123,6 +123,7 @@ headers = '''
         linux/kcmp.h
         linux/net_namespace.h
         linux/nsfs.h
+        linux/openat2.h
         linux/mount.h
         linux/pr.h
         linux/rfkill.h


### PR DESCRIPTION
## Summary

- Add `ul_open_no_symlinks()` helper that uses `openat2(RESOLVE_NO_SYMLINKS)` to reject symlinks at **any** path component, with `O_NOFOLLOW` fallback for older kernels (< 5.6)
- Use it in `lib/loopdev.c` when `LOOPDEV_FL_NOFOLLOW` is set, replacing plain `open(O_NOFOLLOW)` which only protects the last component

The current `O_NOFOLLOW` does not prevent TOCTOU attacks where an intermediate path component is swapped to a symlink via `renameat2(RENAME_EXCHANGE)` between path canonicalization and the `open()` call. `openat2(RESOLVE_NO_SYMLINKS)` closes this gap.

Related: #4378, CVE-2026-27456 (GHSA-qq4x-vfq4-9h9g)