### PR TITLE
fstrim: resolve non-device sources to real block devices

### DIFF
--- a/sys-utils/fstrim.c
+++ b/sys-utils/fstrim.c
@@ -47,6 +47,7 @@
 #include "sysfs.h"
 #include "optutils.h"
 #include "statfs_magic.h"
+#include "mountutils.h"
 
 #include <libmount.h>
 
@@ -367,6 +368,26 @@ static int fstrim_all_from_file(struct fstrim_control *ctl, const char *filename
 			mnt_table_remove_fs(tab, fs);
 			continue;	/* overlaying mount */
 		}
+
+		/* resolve non-device source (e.g. bind mount directory
+		 * path) to real block device via statmount();
+		 * requires mountfd support (mountutils.h) */
+#ifdef STATMOUNT_SB_SOURCE
+		if (is_directory(src, 1)) {
+			char *orig = xstrdup(src);
+
+			mnt_fs_set_source(fs, NULL);
+			src = NULL;
+			if (mnt_fs_fetch_statmount(fs,
+					STATMOUNT_SB_SOURCE) == 0)
+				src = mnt_fs_get_srcpath(fs);
+			if (!src || *src != '/') {
+				mnt_fs_set_source(fs, orig);
+				src = mnt_fs_get_srcpath(fs);
+			}
+			free(orig);
+		}
+#endif
 
 		if (!is_directory(tgt, 1) ||
 		    !has_discard(src, &wholedisk)) {


### PR DESCRIPTION
## Summary
- When fstrim reads fstab entries (`--fstab`, `--listed-in`), bind mount entries use directory paths as sources (e.g. `/data/ssd/ldap`) rather than device names. Source de-duplication compares path strings, so these never match the real device paths (e.g. `/dev/mapper/tika-data--ssd`), causing the same filesystem to be trimmed multiple times.
- Use `statmount(STATMOUNT_SB_SOURCE)` to resolve directory source paths to their real block device before de-duplication. This also correctly handles multi-device filesystems like btrfs where `stat()` does not return a usable device number.

Addresses: https://github.com/util-linux/util-linux/issues/857