### PR TITLE
Avoid busy-loop after terminal input becomes unavailable

### DIFF
--- a/disk-utils/cfdisk.c
+++ b/disk-utils/cfdisk.c
@@ -590,8 +590,13 @@ static int ask_menu(struct fdisk_ask *ask, struct cfdisk *cf)
 
 		if (sig_die)
 			break;
-		if (sig_resize)
+		if (sig_resize) {
 			ui_menu_resize(cf);
+			if (key == ERR)
+				continue;
+		}
+		if (key == ERR)
+			break;
 		if (ui_menu_move(cf, key) == 0)
 			continue;
 
@@ -2039,8 +2044,13 @@ static struct fdisk_parttype *ui_get_parttype(struct cfdisk *cf,
 
 		if (sig_die)
 			break;
-		if (sig_resize)
+		if (sig_resize) {
 			ui_menu_resize(cf);
+			if (key == ERR)
+				continue;
+		}
+		if (key == ERR)
+			break;
 		if (ui_menu_move(cf, key) == 0)
 			continue;
 
@@ -2199,8 +2209,13 @@ static int ui_create_label(struct cfdisk *cf)
 
 		if (sig_die)
 			break;
-		if (sig_resize)
+		if (sig_resize) {
 			ui_menu_resize(cf);
+			if (key == ERR)
+				continue;
+		}
+		if (key == ERR)
+			break;
 		if (ui_menu_move(cf, key) == 0)
 			continue;
 		switch (key) {


### PR DESCRIPTION
I recently debugged a VPS where CPU usage stayed high for several days and the provider's automated fair-use CPU limitation was triggered.

After investigation, the load was caused by a cfdisk process left behind from an interactive web terminal session. The terminal session had already gone away, but cfdisk did not exit. It remained attached to a deleted /dev/pts/* and continued consuming CPU until it was killed manually.

cfdisk is an interactive curses program, so it should normally block while waiting for user input. If the terminal disappears or input becomes unavailable, getch() may return ERR. Some cfdisk menu loops currently pass that value through the normal menu handling path instead of treating it as terminal failure. This patch adds defensive handling for ERR in those loops, while still preserving the existing resize behavior where getch() may be interrupted by SIGWINCH.

The patch also registers SIGHUP with the existing termination handler, so cfdisk can exit cleanly when the controlling terminal is closed.

I do not have a fully reliable standalone reproducer because this happened through a web terminal/PTY session, but the observed state was:
- cfdisk running for several days
- attached to a deleted /dev/pts/*
- no active user interaction
- high CPU usage
- fixed immediately by killing the cfdisk process

This change is intended as a defensive guard. An interactive partitioning tool should not continue running indefinitely if its terminal input is no longer usable.