### PR TITLE
fix: (bash-completion) remove --bit option from bits completion

### DIFF
--- a/bash-completion/bits
+++ b/bash-completion/bits
@@ -11,7 +11,7 @@ _bits_module()
 	esac
 	case $cur in
 	-*)
-		OPTS="--version --help --width --fail-width --mask --grouped-mask --bit --binary --list --expand"
+		OPTS="--version --help --width --fail-width --mask --grouped-mask --binary --list --expand"
 		COMPREPLY=( $(compgen -W "${OPTS[*]}" -- $cur) )
 		return 0
 		;;


### PR DESCRIPTION
The --bit option does not exist in the program, so this fix is correct.

------
<img width="1372" height="896" alt="屏幕截图_20260601_133825" src="https://github.com/user-attachments/assets/8ef4d43b-3915-4173-82fb-82a4bafd772e" />
