### PR TITLE
fix(resize_partition): initialize index to avoid undefined behavior

### DIFF
--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -685,7 +685,7 @@ void resize_partition(struct fdisk_context *cxt)
 	char *query = NULL, *response = NULL, *default_size;
 	struct fdisk_table *tb = NULL;
 	uint64_t max_size, size, secs;
-	size_t i;
+	size_t i = 0;
 	int rc;
 
 	assert(cxt);


### PR DESCRIPTION
In the `resize_partition` function, if `fdisk_ask_partnum()` fails, the 
variable `i` (used to store the partition number) is left uninitialized. 
The code then jumps to the error handling label `err` and uses `i + 1` 
in a warning message.