### PR TITLE
sfdisk: honor --force for "All space for primary partitions is in use"

### DIFF
--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -2503,6 +2503,8 @@ int main(int argc, char *argv[])
 	colors_init(colormode, "sfdisk");
 
 	sfdisk_init(sf);
+	if (sf->force)
+		fdisk_enable_force(sf->cxt, 1);
 	if (bytes)
 		fdisk_set_size_unit(sf->cxt, FDISK_SIZEUNIT_BYTES);
 	if (user_ss)

--- a/libfdisk/docs/libfdisk-sections.txt
+++ b/libfdisk/docs/libfdisk-sections.txt
@@ -334,6 +334,7 @@ fdisk_get_sector_size
 fdisk_get_size_unit
 fdisk_get_unit
 fdisk_get_units_per_sector
+fdisk_enable_force
 fdisk_has_dialogs
 fdisk_has_label
 fdisk_has_protected_bootbits

--- a/libfdisk/src/context.c
+++ b/libfdisk/src/context.c
@@ -383,6 +383,25 @@ int fdisk_has_dialogs(struct fdisk_context *cxt)
 }
 
 /**
+ * fdisk_enable_force:
+ * @cxt: fdisk context
+ * @enable: 1 to enable, 0 to disable
+ *
+ * The flag allows to bypass all consistency checks.
+ *
+ * Returns: 0 on success, < 0 on error.
+ *
+ * Since: 2.43
+ */
+int fdisk_enable_force(struct fdisk_context *cxt, int enable)
+{
+	if (!cxt)
+		return -EINVAL;
+	cxt->force = enable ? 1 : 0;
+	return 0;
+}
+
+/**
  * fdisk_enable_wipe
  * @cxt: fdisk context
  * @enable: 1 or 0

--- a/libfdisk/src/dos.c
+++ b/libfdisk/src/dos.c
@@ -2017,7 +2017,8 @@ static int dos_add_partition(struct fdisk_context *cxt,
 
 				if (pa && fdisk_partition_has_start(pa)) {
 					fdisk_warnx(cxt, "%s", msg);
-					return -EINVAL;
+					if (!cxt->force)
+						return -EINVAL;
 				}
 				fdisk_info(cxt, "%s", msg);
 			}
@@ -2030,7 +2031,8 @@ static int dos_add_partition(struct fdisk_context *cxt,
 			/* TRANSLATORS: Try to keep this within 80 characters. */
 				fdisk_info(cxt, _("To create more partitions, first replace "
 					  "a primary with an extended partition."));
-			return -EINVAL;
+			if (!cxt->force)
+				return -EINVAL;
 		}
 	} else {
 		char hint[BUFSIZ];

--- a/libfdisk/src/fdiskP.h
+++ b/libfdisk/src/fdiskP.h
@@ -404,7 +404,8 @@ struct fdisk_context {
 		     dev_model_probed : 1,	/* tried to read from sys */
 		     is_priv : 1,		/* open by libfdisk */
 		     is_excl : 1,		/* open with O_EXCL */
-		     listonly : 1;		/* list partition, nothing else */
+		     listonly : 1,		/* list partition, nothing else */
+		     force : 1;		/* disable all consistency checking */
 
 	char *collision;			/* name of already existing FS/PT */
 	uint64_t collision_offset;

--- a/libfdisk/src/libfdisk.h.in
+++ b/libfdisk/src/libfdisk.h.in
@@ -204,6 +204,7 @@ int fdisk_is_regfile(struct fdisk_context *cxt);
 int fdisk_device_is_used(struct fdisk_context *cxt);
 
 int fdisk_disable_dialogs(struct fdisk_context *cxt, int disable);
+int fdisk_enable_force(struct fdisk_context *cxt, int enable);
 int fdisk_has_dialogs(struct fdisk_context *cxt);
 
 int fdisk_enable_details(struct fdisk_context *cxt, int enable);

--- a/libfdisk/src/libfdisk.sym
+++ b/libfdisk/src/libfdisk.sym
@@ -336,4 +336,5 @@ FDISK_2_42 {
 FDISK_2_43 {
 	fdisk_script_disable_devnames;
 	fdisk_script_has_devnames;
+	fdisk_enable_force;
 } FDISK_2_42;


### PR DESCRIPTION
## Summary
- `--force` is documented as "disable all consistency checking" but sfdisk still refused to create a partition when all four primary slots were occupied
- Added a `force` bit to `struct fdisk_context` with `fdisk_enable_force()` public API
- Propagated the `sfdisk --force` flag to the libfdisk context
- Made the two "All space for primary partitions" `-EINVAL` returns in `dos_add_partition()` conditional on the force flag

Fixes: #4320

## Test plan
- [ ] `dd if=/dev/zero of=/tmp/part count=1 && echo 1 2 7 - | sfdisk --force /tmp/part` should succeed
- [ ] Without `--force`, the same command should still fail with the existing error
- [ ] Normal partition operations should be unaffected