### PR TITLE
lsblk: truncate long ID-LINK columns

### DIFF
--- a/lsblk-cmd/lsblk.c
+++ b/lsblk-cmd/lsblk.c
@@ -173,8 +173,8 @@ struct colinfo {
 /* columns descriptions */
 static const struct colinfo infos[] = {
 	[COL_ALIOFF] = { "ALIGNMENT", 6, SCOLS_FL_RIGHT, N_("alignment offset"), COLTYPE_NUM },
-	[COL_ID] = { "ID", 0.1, SCOLS_FL_NOEXTREMES, N_("udev ID (based on ID-LINK)") },
-	[COL_IDLINK] = { "ID-LINK", 0.1, SCOLS_FL_NOEXTREMES, N_("the shortest udev /dev/disk/by-id link name") },
+	[COL_ID] = { "ID", 0.1, SCOLS_FL_TRUNC | SCOLS_FL_NOEXTREMES, N_("udev ID (based on ID-LINK)") },
+	[COL_IDLINK] = { "ID-LINK", 0.1, SCOLS_FL_TRUNC | SCOLS_FL_NOEXTREMES, N_("the shortest udev /dev/disk/by-id link name") },
 	[COL_DALIGN] = { "DISC-ALN", 6, SCOLS_FL_RIGHT, N_("discard alignment offset"), COLTYPE_NUM },
 	[COL_DAX] = { "DAX", 1, SCOLS_FL_RIGHT, N_("dax-capable device"), COLTYPE_BOOL },
 	[COL_DGRAN] = { "DISC-GRAN", 6, SCOLS_FL_RIGHT, N_("discard granularity, use <number> if --bytes is given"), COLTYPE_SIZE },


### PR DESCRIPTION
## Summary
- Mark the ID and ID-LINK columns as truncatable so very long udev by-id links do not stretch lsblk's table output.

## Changes
| File | Change |
|------|--------|
| `lsblk-cmd/lsblk.c` | Add `SCOLS_FL_TRUNC` to the ID and ID-LINK column definitions. |

## Test Plan
- [x] `git diff --check`
- [x] Build/run lsblk tests locally (blocked: this environment lacks meson/ninja; `./autogen.sh` also requires bison)

Fixes #4336