### PR TITLE
tests: fix lsfd/mkfds-multiplexing coproc PID handling

### DIFF
--- a/tests/ts/lsfd/mkfds-multiplexing
+++ b/tests/ts/lsfd/mkfds-multiplexing
@@ -45,13 +45,21 @@ for multiplexer in pselect6 select poll ppoll; do
     {
 	coproc MKFDS { "$TS_HELPER_MKFDS" -w "$multiplexer" multiplexing {10..22}; }
     } > "$TS_OUTPUT" 2>&1
+    # bash unsets MKFDS_PID when the coproc terminates; save it
+    MKFDS_CPID=$MKFDS_PID
 
     if read -r -u "${MKFDS[0]}" PID; then
+	if ! kill -0 "$PID" 2>/dev/null; then
+	    wait "$MKFDS_CPID"
+	    ts_skip "the $multiplexer process exited unexpectedly"
+	    ts_finalize_subtest
+	    continue
+	fi
 	syscall_line=$(cat /proc/"${PID}"/syscall 2>> "$TS_OUTPUT")
 	syscall_status=$?
 	if [[ "$syscall_status" != 0 ]]; then
 	    kill -CONT "${PID}"
-	    wait "${MKFDS_PID}"
+	    wait "$MKFDS_CPID"
 	    ts_skip "cannot open /proc/${PID}/syscall"
 	    ts_finalize_subtest
 	    continue
@@ -61,7 +69,7 @@ for multiplexer in pselect6 select poll ppoll; do
 	# on any platforms.
 	if [[ "$syscall_n" == 0 ]]; then
 	    kill -CONT "${PID}"
-	    wait "${MKFDS_PID}"
+	    wait "$MKFDS_CPID"
 	    ts_skip "incorrect syscall number in /proc/${PID}/syscall"
 	    ts_finalize_subtest
 	    continue
@@ -80,7 +88,7 @@ for multiplexer in pselect6 select poll ppoll; do
 	} >> "$TS_OUTPUT" 2>&1
     fi
 
-    wait "${MKFDS_PID}"
+    wait "$MKFDS_CPID"
     ts_finalize_subtest
 done
 


### PR DESCRIPTION
Bash automatically unsets the MKFDS_PID variable when the coproc terminates. If the multiplexer syscall is not available at runtime (e.g., select on ppc64le with kernel 6.18 returns ENOSYS despite __NR_select being defined at compile time), the coproc exits immediately and MKFDS_PID becomes empty, causing:

  wait: '': not a pid or valid job spec

Save MKFDS_PID to a regular variable (MKFDS_CPID) immediately after starting the coproc.

Additionally, add a kill -0 liveness check after reading the PID to detect when the multiplexer process died early (e.g., due to ENOSYS) and skip the subtest cleanly.