### PR TITLE
libfdisk: clamp out-of-range d_npartitions in bsd_readlabel

### DIFF
--- a/libfdisk/src/bsd.c
+++ b/libfdisk/src/bsd.c
@@ -858,9 +858,11 @@ static int bsd_readlabel(struct fdisk_context *cxt)
 		d->d_partitions[t].p_fstype = BSD_FS_UNUSED;
 	}
 
-	if (d->d_npartitions > BSD_MAXPARTITIONS)
+	if (d->d_npartitions > BSD_MAXPARTITIONS) {
 		fdisk_warnx(cxt, _("Too many partitions (%d, maximum is %d)."),
 				d->d_npartitions, BSD_MAXPARTITIONS);
+		d->d_npartitions = BSD_MAXPARTITIONS;
+	}
 
 	/* let's follow in-PT geometry */
 	cxt->geom.sectors = d->d_nsectors;


### PR DESCRIPTION
Reading through the BSD label parser. `d_npartitions` comes straight off disk and is only checked with a warning, never clamped:

    bsd.c:861  if (d->d_npartitions > BSD_MAXPARTITIONS)
    bsd.c:862      fdisk_warnx(cxt, _("Too many partitions ..."));

So the unbounded count survives and lands in `bsd_dkcksum()` on write:

    bsd.c:744  end = (unsigned char *) &lp->d_partitions[lp->d_npartitions];

`d_partitions[]` is 16 entries, 256 bytes. `d_npartitions` is a u16, so a crafted disklabel sets it to 65535 and the checksum loop walks roughly 1 MB past the array; a count of 20 already overshoots by 64 bytes. A read overrun, reachable when the label is written back. ASAN trips inside `bsd_dkcksum`.

Clamp at the warning, the same ceiling sun/sgi/gpt keep on their partition arrays.
