### PR TITLE
asciidoctor: fix encoding error for non-ASCII translations

### DIFF
--- a/tools/asciidoctor-includetracker.rb
+++ b/tools/asciidoctor-includetracker.rb
@@ -17,7 +17,7 @@ module IncludeTracker
       docdir = doc.attributes["docdir"]
       path = target
       file = File.expand_path path, docdir
-      data = File.read file
+      data = File.read file, encoding: 'UTF-8'
       reader.push_include data, file, path, 1, attributes
       doc.attributes["include_dependencies"] << file
       reader


### PR DESCRIPTION
## Summary
- Fix `File.read` in `asciidoctor-includetracker.rb` to explicitly use UTF-8 encoding, preventing build failures when generating man pages from non-ASCII translations (e.g. Arabic)

Fixes: https://github.com/util-linux/util-linux/issues/4409