### PR TITLE
fsck.minix: bound namelen guessed in get_dirsize

### DIFF
--- a/disk-utils/fsck.minix.c
+++ b/disk-utils/fsck.minix.c
@@ -548,7 +548,7 @@ get_dirsize(void) {
 		block = Inode[ROOT_INO].i_zone[0];
 	read_block(block, blk);
 
-	for (size = 16; size + 2 < MINIX_BLOCK_SIZE; size <<= 1) {
+	for (size = 16; size + 2 < MINIX_BLOCK_SIZE && size - 2 <= MINIX_NAME_MAX; size <<= 1) {
 		if (strcmp(blk + size + 2, "..") == 0) {
 			dirsize = size;
 			namelen = size - 2;


### PR DESCRIPTION
Found while feeding crafted minix images to fsck.minix under ASAN:

    AddressSanitizer: global-buffer-overflow
    WRITE of size 509 ... 0 bytes after global variable 'name_list' (size 12800)
      #0 xstrncpy include/strutils.h
      #1 check_file disk-utils/fsck.minix.c:978

get_dirsize() guesses the directory entry name length from the on-disk
root directory. It doubles a candidate size from 16 up to 512 hunting for
the ".." entry, then sets namelen = size - 2. A root block whose first
".." match sits at offset 514 yields namelen 510. MINIX_NAME_MAX is 255
and each name_list row is MINIX_NAME_MAX + 1 bytes, so the
xstrncpy(name_list[name_depth], name, namelen) calls in check_file write
past the array. get_current_name() walks the same oversized namelen.

The bad value is born in get_dirsize, so the bound belongs there.
Stopping the scan once size - 2 would exceed MINIX_NAME_MAX keeps the
guess inside the buffers and leaves the magic-derived default in place.
Real minix directories never need namelen above 60.