### PR TITLE
nsenter: Fix invalid fd check in enter_namespaces

### DIFF
--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -356,7 +356,7 @@ static void enter_namespaces(int pid_fd, int namespaces, bool ignore_errors)
 {
 	struct namespace_file *n =  NULL;
 
-	if (pid_fd) {
+	if (pid_fd >= 0) {
 		int ns = 0;
 		while ((n = next_enabled_nsfile(n, namespaces))) {
 			if (n->fd < 0)


### PR DESCRIPTION
When nsenter is executed with closed stdin, one pid_fd will be 0, which is a valid file descriptor. But with current code namespace switch is skipped, leading to incorrect results.

Fixes: f18be0ca5aa7 ("nsenter: use pidfd to enter target namespaces")