### PR TITLE
fsck.minix: bound auto-detected namelen to MINIX_NAME_MAX

### DIFF
--- a/disk-utils/fsck.minix.c
+++ b/disk-utils/fsck.minix.c
@@ -548,7 +548,7 @@ get_dirsize(void) {
 		block = Inode[ROOT_INO].i_zone[0];
 	read_block(block, blk);
 
-	for (size = 16; size + 2 < MINIX_BLOCK_SIZE; size <<= 1) {
+	for (size = 16; size + 2 < MINIX_BLOCK_SIZE && size - 2 <= MINIX_NAME_MAX; size <<= 1) {
 		if (strcmp(blk + size + 2, "..") == 0) {
 			dirsize = size;
 			namelen = size - 2;


### PR DESCRIPTION
Tracing fsck.minix over a crafted image. get_dirsize() works out the
directory entry size from the root block and sets namelen off it:

    fsck.minix.c:551  for (size = 16; size + 2 < MINIX_BLOCK_SIZE; size <<= 1)
    fsck.minix.c:554      namelen = size - 2;

size doubles 16, 32 ... 512, so namelen reaches 510. That value is then
the destination size given to xstrncpy() for each path component:

    fsck.minix.c:978  xstrncpy(name_list[name_depth], name, namelen);

name_list slots are MINIX_NAME_MAX + 1 = 256 bytes. Put ".." at offset
514 of the root block and namelen comes out 510; a long entry name then
lands ~509 bytes in the 256-byte slot. check_file2() carries the same
call. An out-of-bounds write off an untrusted image.

Bound the probe loop to MINIX_NAME_MAX so namelen cannot exceed the slot.
The real entry sizes (16/32/64) are untouched.
