### PR TITLE
lscpu: show RISC-V MMU mode

### DIFF
--- a/bash-completion/lscpu
+++ b/bash-completion/lscpu
@@ -12,7 +12,7 @@ _lscpu_module()
 			prefix="${cur%$realcur}"
 			OPTS_ALL="CPU CORE SOCKET NODE
 				BOOK DRAWER CACHE POLARIZATION ADDRESS
-				CONFIGURED ONLINE MICROCODE MAXMHZ MINMHZ"
+				CONFIGURED ONLINE MICROCODE MMU MAXMHZ MINMHZ"
 			for WORD in $OPTS_ALL; do
 				if ! [[ $prefix == *"$WORD"* ]]; then
 					OPTS="$WORD ${OPTS:-""}"

--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -105,6 +105,7 @@ void lscpu_unref_cputype(struct lscpu_cputype *ct)
 		free(ct->static_mhz);
 		free(ct->dynamic_mhz);
 		free(ct->isa);
+		free(ct->mmu);
 		free(ct);
 	}
 }
@@ -202,6 +203,7 @@ enum {
 	PAT_VENDOR,
 	PAT_CACHE,
 	PAT_ISA,
+	PAT_MMU,
 };
 
 /*
@@ -243,6 +245,7 @@ static const struct cpuinfo_pattern type_patterns[] =
 	DEF_PAT_CPUTYPE( "max thread id",	PAT_MAX_THREAD_ID, mtid),	/* s390 */
 	DEF_PAT_CPUTYPE( "microcode",	        PAT_MICROCODE, microcode),
 	DEF_PAT_CPUTYPE( "mimpid",		PAT_MODEL,	model),		/* riscv */
+	DEF_PAT_CPUTYPE( "mmu",			PAT_MMU,	mmu),		/* riscv */
 	DEF_PAT_CPUTYPE( "model",		PAT_MODEL,	model),
 	DEF_PAT_CPUTYPE( "model name",		PAT_MODEL_NAME,	modelname),
 	DEF_PAT_CPUTYPE( "mvendorid",		PAT_VENDOR,	vendor),	/* riscv */

--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -104,6 +104,7 @@ void lscpu_unref_cputype(struct lscpu_cputype *ct)
 		free(ct->addrsz);	/* address sizes */
 		free(ct->static_mhz);
 		free(ct->dynamic_mhz);
+		free(ct->isa);
 		free(ct);
 	}
 }

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -973,6 +973,10 @@ print_summary_cputype(struct lscpu_cxt *cxt,
 		lscpu_format_isa_riscv(ct);
 		add_summary_s(tb, sec, _("ISA:"), ct->isa);
 	}
+
+	if (ct->mmu && is_riscv(ct)) {
+		add_summary_s(tb, sec, _("MMU:"), ct->mmu);
+	}
 }
 
 /*

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -101,6 +101,7 @@ enum {
 	COL_CPU_CONFIGURED,
 	COL_CPU_ONLINE,
 	COL_CPU_MICROCODE,
+	COL_CPU_MMU,
 	COL_CPU_MHZ,
 	COL_CPU_SCALMHZ,
 	COL_CPU_MAXMHZ,
@@ -150,6 +151,7 @@ static struct lscpu_coldesc coldescs_cpu[] =
 	[COL_CPU_CONFIGURED]   = { "CONFIGURED", N_("shows if the hypervisor has allocated the CPU"), 0, 0, SCOLS_JSON_BOOLEAN_OPTIONAL },
 	[COL_CPU_ONLINE]       = { "ONLINE", N_("shows if Linux currently makes use of the CPU"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_BOOLEAN_OPTIONAL },
 	[COL_CPU_MICROCODE]    = { "MICROCODE", N_("shows the loaded CPU microcode version"), 0, 0, SCOLS_JSON_STRING },
+	[COL_CPU_MMU]          = { "MMU", N_("shows the RISC-V MMU mode"), 0, 0, SCOLS_JSON_STRING },
 	[COL_CPU_MHZ]          = { "MHZ", N_("shows the current MHz of the CPU"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
 	[COL_CPU_SCALMHZ]      = { "SCALMHZ%", N_("shows scaling percentage of the CPU frequency"), SCOLS_FL_RIGHT, SCOLS_JSON_NUMBER },
 	[COL_CPU_MAXMHZ]       = { "MAXMHZ", N_("shows the maximum MHz of the CPU"), SCOLS_FL_RIGHT, 0, SCOLS_JSON_NUMBER },
@@ -439,6 +441,10 @@ static char *get_cell_data(
 	case COL_CPU_MICROCODE:
 		if (cpu->type && cpu->type->microcode)
 			xstrncpy(buf, cpu->type->microcode, bufsz);
+		break;
+	case COL_CPU_MMU:
+		if (cpu->type && cpu->type->mmu)
+			xstrncpy(buf, cpu->type->mmu, bufsz);
 		break;
 	case COL_CPU_MHZ:
 		if (cpu->mhz_cur_freq)

--- a/sys-utils/lscpu.h
+++ b/sys-utils/lscpu.h
@@ -115,7 +115,8 @@ struct lscpu_cputype {
 
 	size_t nr_socket_on_cluster; /* the number of sockets if the is_cluster is 1 */
 
-	char	*isa;	/* loongarch */
+	char	*isa;	/* loongarch, riscv */
+	char	*mmu;	/* riscv */
 };
 
 /* dispatching modes */

--- a/tests/expected/lscpu/lscpu-rv64-linux
+++ b/tests/expected/lscpu/lscpu-rv64-linux
@@ -5,6 +5,7 @@ Thread(s) per core:  2
 Core(s) per socket:  1
 Socket(s):           1
 ISA:                 rv64imafdc
+MMU:                 sv39
 L1d cache:           64 KiB (2 instances)
 L1i cache:           64 KiB (2 instances)
 L2 cache:            2 MiB (1 instance)

--- a/tests/expected/lscpu/lscpu-rv64-milkvpioneer
+++ b/tests/expected/lscpu/lscpu-rv64-milkvpioneer
@@ -8,6 +8,7 @@ Thread(s) per core:  1
 Core(s) per socket:  64
 Socket(s):           1
 ISA:                 rv64imafdcv
+MMU:                 sv39
 NUMA node(s):        4
 NUMA node0 CPU(s):   0-7,16-23
 NUMA node1 CPU(s):   8-15,24-31

--- a/tests/expected/lscpu/lscpu-rv64-visionfive2
+++ b/tests/expected/lscpu/lscpu-rv64-visionfive2
@@ -9,6 +9,7 @@ Thread(s) per core:  1
 Core(s) per socket:  4
 Socket(s):           1
 ISA:                 rv64imafdc zba zbb zicntr zicsr zifencei zihpm
+MMU:                 sv39
 L1d cache:           128 KiB (4 instances)
 L1i cache:           128 KiB (4 instances)
 L2 cache:            2 MiB (1 instance)


### PR DESCRIPTION
This PR adds support for parsing the RISC-V mmu field from /proc/cpuinfo and displaying it in the lscpu summary output.

On RISC-V systems, the kernel may expose the current address translation mode through the mmu field, such as sv39, sv48, sv57 or none. Showing this field makes the RISC-V-specific lscpu output more complete and useful for system inspection.

This PR also frees the existing cputype ISA string when releasing struct lscpu_cputype.

Tested on a RISC-V system with mmu: sv48.

Before:

ISA:             rv64imafdch ...

After:

ISA:             rv64imafdch ...
MMU:             sv48