### PR TITLE
lslogins: fix lastlog2 tty/host buffer overflow in get_lastlog2

### DIFF
--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -571,7 +571,8 @@ static int get_lastlog2(struct lslogins_control *ctl, const char *user, void *ds
 			return -1;
 		}
 		if (res_tty) {
-			mem2strcpy(dst, res_tty, strlen(res_tty), strlen(res_tty) + 1);
+			mem2strcpy(dst, res_tty, strlen(res_tty),
+					sizeof_member(struct utmpx, ut_line) + 1);
 			free (res_tty);
 		}
 		break;
@@ -584,7 +585,8 @@ static int get_lastlog2(struct lslogins_control *ctl, const char *user, void *ds
 			return -1;
 		}
 		if (res_host) {
-			mem2strcpy(dst, res_host, strlen(res_host), strlen(res_host) + 1);
+			mem2strcpy(dst, res_host, strlen(res_host),
+					sizeof_member(struct utmpx, ut_host) + 1);
 			free(res_host);
 		}
 		break;


### PR DESCRIPTION
Comparing the lastlog2 reader against the wtmp branch in the same function, the last mem2strcpy() argument looked wrong, so I traced it.

1. lslogins allocates user->last_tty and user->last_hostname at sizeof(ut_line)+1 and sizeof(ut_host)+1.
2. get_lastlog2() reads the tty/host for the user from the lastlog2 database; both are unbounded TEXT columns.
3. it then calls mem2strcpy(dst, value, strlen(value), strlen(value) + 1), taking the limit from the source length.
4. mem2strcpy() memsets and copies that many bytes into dst, so the source length defeats the cap and a value wider than the field writes past the heap buffer.

Under ASAN a host longer than 256 bytes gives a heap-buffer-overflow one byte after the 257-byte buffer (the memset). The values reach the database from pam_lastlog2 (PAM_TTY/PAM_RHOST, stored untruncated) or from any database handed to lslogins with --lastlog2-file. Capped the limit to the destination field size, which is what the wtmp and plain-lastlog branches just above already do.