### PR TITLE
mkswap: use fd-based operations to avoid TOCTOU in open_device()

### DIFF
--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -401,13 +401,16 @@ static void open_device(struct mkswap_control *ctl)
 	assert(ctl->devname);
 
 	if (ctl->file) {
-		if (stat(ctl->devname, &ctl->devstat) == 0) {
+		ctl->fd = open(ctl->devname, O_RDWR | O_CREAT, 0600);
+		if (ctl->fd >= 0) {
+			if (fstat(ctl->fd, &ctl->devstat) < 0)
+				err(EXIT_FAILURE, _("stat of %s failed"), ctl->devname);
 			if (!S_ISREG(ctl->devstat.st_mode))
-				err(EXIT_FAILURE, _("cannot create swap file %s: node isn't regular file"), ctl->devname);
-			if (chmod(ctl->devname, 0600) < 0)
+				errx(EXIT_FAILURE, _("cannot create swap file %s: node isn't regular file"), ctl->devname);
+			if ((ctl->devstat.st_mode & 07777) != 0600
+			    && fchmod(ctl->fd, 0600) < 0)
 				err(EXIT_FAILURE, _("cannot set permissions on swap file %s"), ctl->devname);
 		}
-		ctl->fd = open(ctl->devname, O_RDWR | O_CREAT, 0600);
 	} else {
 		if (stat(ctl->devname, &ctl->devstat) < 0)
 			err(EXIT_FAILURE, _("stat of %s failed"), ctl->devname);


### PR DESCRIPTION
Replace path-based `stat()` + `chmod()` with `open()` first, then `fstat()` and `fchmod()` on the file descriptor. This eliminates the TOCTOU race window between checking and modifying the file.

Also skip `fchmod()` when permissions are already 0600.

Note: this is not a security fix — mkswap is not setuid and the reported scenario requires root to operate on a path in a user-writable directory, which is a misconfiguration. This is a code hardening improvement.

*— assisted by Claude Code*