### PR TITLE
unshare: Remove docs comment for removed args on unshare.c's map_ids_from_child

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -670,9 +670,7 @@ static void map_ids_internal(const char *type, int ppid, struct map_range *chain
 /**
  * map_ids_from_child() - Set up a new uid/gid map
  * @fd: The eventfd to wait on
- * @mapuser: The user to map the current user to (or -1)
  * @usermap: The range of UIDs to map (or %NULL)
- * @mapgroup: The group to map the current group to (or -1)
  * @groupmap: The range of GIDs to map (or %NULL)
  *
  * fork_and_wait() for our parent to call sync_with_child() on @fd. Upon


### PR DESCRIPTION
Spotted this while reading the through unshare.c. Looks like the `uid_t mapuesr` and `gid_t mapgroup` were removed [here](https://github.com/util-linux/util-linux/commit/926b207cae709b05ba53acf0ee4b88e529d51729#diff-908b7066a85efa0ed97a8abfc9f707b0a22e6bf176b01a28678c42005e79342dR694), but the comment above wasn't updated.