### PR TITLE
tests: handle ENOSYS in multiplexing syscall tests

### DIFF
--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -78,7 +78,7 @@
 #define EXIT_EPROTONOSUPPORT 20
 #define EXIT_EACCES 21
 #define EXIT_ENOENT 22
-#define EXIT_ENOSYS 23
+/* EXIT_ENOSYS also defined in test_mkfds.h */
 #define EXIT_EADDRNOTAVAIL 24
 #define EXIT_ENODEV 25
 
@@ -4551,8 +4551,11 @@ static void sighandler_nop(int si _U_)
 		SETUP_SIG_HANDLER					\
 									\
 		if (SYSCALL_INVOCATION < 0				\
-		    && errno != EINTR)					\
+		    && errno != EINTR) {				\
+			if (errno == ENOSYS)				\
+				errx(EXIT_ENOSYS, "no syscall: " SYSCALL); \
 			err(EXIT_FAILURE, "failed in " SYSCALL);	\
+		}							\
 	}
 
 DEFUN_WAIT_EVENT_SELECT(default,

--- a/tests/helpers/test_mkfds.h
+++ b/tests/helpers/test_mkfds.h
@@ -23,6 +23,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#define EXIT_ENOSYS 23
+
 enum multiplexing_mode {
    MX_READ   = 1 << 0,
    MX_WRITE  = 1 << 1,
@@ -72,8 +74,11 @@ struct fdesc {
 		SETUP_SIG_HANDLER					\
 									\
 		if (SYSCALL_INVOCATION < 0				\
-		    && errno != EINTR)					\
+		    && errno != EINTR) {				\
+			if (errno == ENOSYS)				\
+				errx(EXIT_ENOSYS, "no syscall: " SYSCALL); \
 			err(EXIT_FAILURE, "failed in " SYSCALL);	\
+		}							\
 		free(pfds);						\
 	}
 

--- a/tests/ts/lsfd/mkfds-multiplexing
+++ b/tests/ts/lsfd/mkfds-multiplexing
@@ -89,6 +89,9 @@ for multiplexer in pselect6 select poll ppoll; do
     fi
 
     wait "$MKFDS_CPID"
+    if [ $? -eq 23 ]; then
+	ts_skip "the $multiplexer syscall is not available (ENOSYS)"
+    fi
     ts_finalize_subtest
 done
 


### PR DESCRIPTION
## Summary
- On ppc64le, `__NR_select` is defined at compile time but the kernel returns
  ENOSYS at runtime, causing the `lsfd/mkfds-multiplexing` test to fail due to
  a race between the helper process dying and the bash script checking its state
- Exit with `EXIT_ENOSYS` (23) from both `DEFUN_WAIT_EVENT_SELECT` and
  `DEFUN_WAIT_EVENT_POLL` macros when the multiplexer syscall returns ENOSYS
- Check the coproc exit code in the bash test and skip the subtest cleanly