### PR TITLE
lscpu: riscv: preserve ISA extension order

### DIFF
--- a/sys-utils/lscpu-riscv.c
+++ b/sys-utils/lscpu-riscv.c
@@ -14,11 +14,6 @@
 #include "strv.h"
 #include "cctype.h"
 
-static int riscv_cmp_func(const void *a, const void *b)
-{
-	return strcmp(*(const char **)a, *(const char **)b);
-}
-
 bool is_riscv(struct lscpu_cputype *ct)
 {
 	const char *base_isa[] = {"rv32", "rv64", "rv128"};
@@ -42,11 +37,7 @@ void lscpu_format_isa_riscv(struct lscpu_cputype *ct)
 
 	split = ul_strv_split(ct->isa, "_");
 
-	/* Sort multi-letter extensions alphabetically */
-	if (ul_strv_length(split) > 1)
-		qsort(&split[1], ul_strv_length(split) - 1, sizeof(char *), riscv_cmp_func);
-
-	/* Keep Base ISA and single-letter extensions at the start */
+	/* Keep the kernel-provided ISA extension order. */
 	strcpy(ct->isa, split[0]);
 
 	for (i = 1; i < ul_strv_length(split); i++) {

--- a/tests/expected/lscpu/lscpu-rv64-visionfive2
+++ b/tests/expected/lscpu/lscpu-rv64-visionfive2
@@ -8,7 +8,7 @@ Model:               0x4210427
 Thread(s) per core:  1
 Core(s) per socket:  4
 Socket(s):           1
-ISA:                 rv64imafdc zba zbb zicntr zicsr zifencei zihpm
+ISA:                 rv64imafdc zicntr zicsr zifencei zihpm zba zbb
 MMU:                 sv39
 L1d cache:           128 KiB (4 instances)
 L1i cache:           128 KiB (4 instances)


### PR DESCRIPTION
The Linux RISC-V UABI documents the canonical ordering of ISA
extension names in /proc/cpuinfo. Since the kernel already provides
the ISA string in that order, lscpu should not reorder the
multi-letter extensions alphabetically.

This change removes the extra sorting step in the RISC-V ISA formatter
and preserves the kernel-provided ISA extension order. The formatter
still replaces underscores with spaces for display.

For example, the VisionFive2 test dump now keeps:

rv64imafdc zicntr zicsr zifencei zihpm zba zbb

instead of reordering it as:

rv64imafdc zba zbb zicntr zicsr zifencei zihpm

Testing:
./tests/run.sh lscpu