### PR TITLE
tests: (lsfd::mkfds-multiplexing,refactor) use ENOSYS connstant

### DIFF
--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -73,15 +73,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#define EXIT_EPERM  18
-#define EXIT_ENOPROTOOPT 19
-#define EXIT_EPROTONOSUPPORT 20
-#define EXIT_EACCES 21
-#define EXIT_ENOENT 22
-/* EXIT_ENOSYS also defined in test_mkfds.h */
-#define EXIT_EADDRNOTAVAIL 24
-#define EXIT_ENODEV 25
-
 #define _U_ __attribute__((__unused__))
 
 static void do_nothing(int signum _U_);

--- a/tests/helpers/test_mkfds.h
+++ b/tests/helpers/test_mkfds.h
@@ -23,7 +23,17 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+/* Update the constants in
+ * tests/ts/lsfd/lsfd-functions.bash when changing
+ * the above error definitions. */
+#define EXIT_EPERM  18
+#define EXIT_ENOPROTOOPT 19
+#define EXIT_EPROTONOSUPPORT 20
+#define EXIT_EACCES 21
+#define EXIT_ENOENT 22
 #define EXIT_ENOSYS 23
+#define EXIT_EADDRNOTAVAIL 24
+#define EXIT_ENODEV 25
 
 enum multiplexing_mode {
    MX_READ   = 1 << 0,

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -16,6 +16,9 @@
 #
 
 # The exit-status used in a test target.
+#
+# Update the above constants when changing
+# the error definitions in tests/helpers/test_mkfds.h.
 readonly EPERM=18
 readonly ENOPROTOOPT=19
 readonly EPROTONOSUPPORT=20

--- a/tests/ts/lsfd/mkfds-multiplexing
+++ b/tests/ts/lsfd/mkfds-multiplexing
@@ -19,6 +19,7 @@ TS_DESC="XMODE.m for classical system calls for multiplexing"
 
 . "$TS_TOPDIR"/functions.sh
 ts_init "$*"
+. "$TS_SELF/lsfd-functions.bash"
 
 ts_check_test_command "$TS_CMD_LSFD"
 ts_check_test_command "$TS_HELPER_MKFDS"
@@ -89,7 +90,7 @@ for multiplexer in pselect6 select poll ppoll; do
     fi
 
     wait "$MKFDS_CPID"
-    if [ $? -eq 23 ]; then
+    if [ $? -eq "$ENOSYS" ]; then
 	ts_skip "the $multiplexer syscall is not available (ENOSYS)"
     fi
     ts_finalize_subtest


### PR DESCRIPTION
Use the ENOSYS constant instead of hard-coding the error number.