### PR TITLE
lscpu: fix NULL+offset dereference in cpuinfo_parse_cache()

### DIFF
--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -530,16 +530,17 @@ static int cpuinfo_parse_cache(struct lscpu_cxt *cxt, int keynum, char *data)
 
 	DBG_OBJ(GATHER, cxt, ul_debug(" parse cpuinfo cache '%s'", data));
 
-	p = strstr(data, "scope=") + 6;
+	p = strstr(data, "scope=");
 	/* Skip private caches, also present in sysfs */
-	if (!p || strncmp(p, "Private", 7) == 0)
+	if (!p || strncmp(p + 6, "Private", 7) == 0)
 		return 0;
 	p = strstr(data, "level=");
 	if (!p || sscanf(p, "level=%d", &level) != 1)
 		return 0;
-	p = strstr(data, "type=") + 5;
-	if (!p || !*p)
+	p = strstr(data, "type=");
+	if (!p || !*(p + 5))
 		return 0;
+	p += 5;
 	type = 0;
 	if (strncmp(p, "Data", 4) == 0)
 		type = 'd';


### PR DESCRIPTION
## Problem

`cpuinfo_parse_cache()` in `sys-utils/lscpu-cputype.c` parses the
s390-style `/proc/cpuinfo` cache lines (format:
`cache<nr> : level=<lvl> type=<type> scope=<scope> size=<size> ...`).

Two fields are fetched with an offset applied **before** the NULL guard:

```c
/* scope= */
p = strstr(data, "scope=") + 6;
if (!p || strncmp(p, "Private", 7) == 0)   /* !p is dead code */
    return 0;

/* type= */
p = strstr(data, "type=") + 5;
if (!p || !*p)                              /* !p is dead code */
    return 0;
```

When `strstr()` returns `NULL` (field absent from the cache line), `p`
becomes `(char *)6` or `(char *)5` — a non-NULL near-zero pointer that
passes the `!p` guard and immediately faults on the subsequent
`strncmp()` or `*p` dereference (CWE-476 / CWE-823).

Reachable via `lscpu -s <sysroot>` with a crafted `proc/cpuinfo`, or
on real hardware/firmware that emits a malformed s390 cache line.

The same function already uses the correct pattern for `level=`, `size=`,
`line_size=`, and `associativity=` — `strstr()` result checked first,
arithmetic applied after:

```c
p = strstr(data, "level=");
if (!p || sscanf(p, "level=%d", &level) != 1)
    return 0;
```

## Fix

Move the offset arithmetic to after the NULL check for both affected
fields, matching the established pattern:

```c
/* scope= */
p = strstr(data, "scope=");
if (!p || strncmp(p + 6, "Private", 7) == 0)
    return 0;

/* type= */
p = strstr(data, "type=");
if (!p || !*(p + 5))
    return 0;
p += 5;
```

No behaviour change when the fields are present. When absent, the
function now returns 0 safely instead of crashing.

## Testing

Built with `./configure --disable-all-programs --enable-libsmartcols --enable-lscpu && make lscpu` — zero errors, zero warnings on the changed translation unit.

Ran a dedicated self-check covering all six cases (missing field, `scope=Private`, `scope=Shared`, missing `type=`, `type=Unified`, `type=Data`) — all pass.