### PR TITLE
fincore: include sys/syscall.h if available

### DIFF
--- a/misc-utils/fincore.c
+++ b/misc-utils/fincore.c
@@ -20,6 +20,9 @@
 
 #include <sys/mman.h>
 #include <sys/stat.h>
+#ifdef HAVE_SYS_SYSCALL_H
+#include <sys/syscall.h>
+#endif
 #include <unistd.h>
 #include <getopt.h>
 #include <stdio.h>


### PR DESCRIPTION
Without sys/syscall.h, we fall back to the hand-brew logic for SYS_cachestat.  The hand-brew code has a special case for Alpha, but there are more cases where cachestat has a different syscall number, for example MIPS.