### PR TITLE
libsmartcols: fix SEGV in filter_compile_param()

### DIFF
--- a/libsmartcols/scols-filter.5.adoc
+++ b/libsmartcols/scols-filter.5.adoc
@@ -111,6 +111,14 @@ long double. The `integer` may be followed by the multiplicative suffixes KiB,
 GiB, TiB, PiB, EiB, ZiB, and YiB (the "iB" is optional, e.g., "K" has the same
 meaning as "KiB").
 
+The filter expression string is limited to 1024 bytes. The number of nodes
+(parameters and operators) in a single expression is limited to 256.
+
+Regular expression patterns used with the `=~` and `!~` operators are limited to
+256 bytes. Patterns with consecutive quantifiers (e.g., `a++`, `a**`) or nested
+group repetitions (e.g., `(a+)+`) are rejected because they can cause excessive
+memory consumption in the POSIX regex compiler.
+
 == AUTHORS
 
 mailto:kzak@redhat.com[Karel Zak]

--- a/libsmartcols/src/Makemodule.am
+++ b/libsmartcols/src/Makemodule.am
@@ -105,6 +105,19 @@ libsmartcols_la_LDFLAGS += -version-info $(LIBSMARTCOLS_VERSION_INFO)
 EXTRA_DIST += \
 	libsmartcols/src/libsmartcols.sym
 
+if FUZZING_ENGINE
+check_PROGRAMS += test_smartcols_fuzz
+
+test_smartcols_fuzz_SOURCES = libsmartcols/src/fuzz.c
+
+# https://google.github.io/oss-fuzz/getting-started/new-project-guide/#Requirements
+nodist_EXTRA_test_smartcols_fuzz_SOURCES = dummy.cxx
+
+test_smartcols_fuzz_CFLAGS = $(sample_scols_cflags) -DFUZZ_TARGET
+test_smartcols_fuzz_LDFLAGS = -static
+test_smartcols_fuzz_LDADD = $(sample_scols_ldadd) libcommon.la $(LIB_FUZZING_ENGINE)
+endif
+
 # move lib from $(usrlib_execdir) to $(libdir) if needed
 install-exec-hook-libsmartcols:
 	if test "$(usrlib_execdir)" != "$(libdir)" -a -f "$(DESTDIR)$(usrlib_execdir)/libsmartcols.so"; then \

--- a/libsmartcols/src/filter-expr.c
+++ b/libsmartcols/src/filter-expr.c
@@ -14,16 +14,24 @@ struct filter_expr {
 };
 
 struct filter_node *filter_new_expr(
-			struct libscols_filter *fltr __attribute__((__unused__)),
+			struct libscols_filter *fltr,
 			enum filter_etype type,
 			struct filter_node *left,
 			struct filter_node *right)
 {
-	struct filter_expr *n = (struct filter_expr *) __filter_new_node(
-					F_NODE_EXPR, sizeof(struct filter_expr));
+	struct filter_expr *n;
 
+	if (fltr && fltr->parsing && fltr->parse_nodes >= SCOLS_FILTER_MAX_NODES) {
+		errno = ERANGE;
+		return NULL;
+	}
+
+	n = (struct filter_expr *) __filter_new_node(
+					F_NODE_EXPR, sizeof(struct filter_expr));
 	if (!n)
 		return NULL;
+	if (fltr && fltr->parsing)
+		fltr->parse_nodes++;
 
 	n->type = type;
 

--- a/libsmartcols/src/filter-param.c
+++ b/libsmartcols/src/filter-param.c
@@ -199,6 +199,16 @@ void filter_free_param(struct filter_param *n)
 	free(n);
 }
 
+void filter_free_params(struct libscols_filter *fltr)
+{
+	while (!list_empty(&fltr->params)) {
+		struct filter_param *n = list_entry(fltr->params.next,
+					struct filter_param, pr_params);
+		filter_unref_node((struct filter_node *) n);
+	}
+	INIT_LIST_HEAD(&fltr->params);
+}
+
 int filter_param_get_datatype(struct filter_param *n)
 {
 	return n ? n->type : SCOLS_DATA_NONE;

--- a/libsmartcols/src/filter-param.c
+++ b/libsmartcols/src/filter-param.c
@@ -126,9 +126,11 @@ int filter_compile_param(struct libscols_filter *fltr, struct filter_param *n)
 {
 	int rc;
 
+	if (filter_node_get_type((struct filter_node *) n) != F_NODE_PARAM)
+		return -EINVAL;
 	if (n->re)
 		return 0;
-	if (!n->val.str)
+	if (n->type != SCOLS_DATA_STRING || !n->val.str)
 		return -EINVAL;
 
 	n->re = calloc(1, sizeof(regex_t));

--- a/libsmartcols/src/filter-param.c
+++ b/libsmartcols/src/filter-param.c
@@ -96,11 +96,20 @@ struct filter_node *filter_new_param(
 		enum filter_holder holder,
 		void *data)
 {
-	struct filter_param *n = (struct filter_param *) __filter_new_node(
+	struct filter_param *n;
+
+	if (fltr && fltr->parsing && fltr->parse_nodes >= SCOLS_FILTER_MAX_NODES) {
+		errno = ERANGE;
+		return NULL;
+	}
+
+	n = (struct filter_param *) __filter_new_node(
 					F_NODE_PARAM,
 					sizeof(struct filter_param));
 	if (!n)
 		return NULL;
+	if (fltr && fltr->parsing)
+		fltr->parse_nodes++;
 
 	n->type = type;
 	n->holder = holder;

--- a/libsmartcols/src/filter-param.c
+++ b/libsmartcols/src/filter-param.c
@@ -131,6 +131,32 @@ struct filter_node *filter_new_param(
 	return (struct filter_node *) n;
 }
 
+/* Consecutive ERE quantifiers (a++, a**) and nested group repetitions
+ * ((a+)+, (a*)*) cause glibc regcomp() to allocate gigabytes for the NFA. */
+static int is_unsafe_regex(const char *pattern)
+{
+	size_t i, len = strlen(pattern);
+
+	for (i = 0; i + 1 < len; i++) {
+		if ((pattern[i] == '+' || pattern[i] == '*')
+		    && (pattern[i + 1] == '+' || pattern[i + 1] == '*'))
+			return 1;
+
+		if (pattern[i] == ')'
+		    && (pattern[i + 1] == '+' || pattern[i + 1] == '*')) {
+			int j;
+
+			for (j = (int) i - 1; j >= 0; j--) {
+				if (pattern[j] == '(')
+					break;
+				if (pattern[j] == '+' || pattern[j] == '*')
+					return 1;
+			}
+		}
+	}
+	return 0;
+}
+
 int filter_compile_param(struct libscols_filter *fltr, struct filter_param *n)
 {
 	int rc;
@@ -140,6 +166,10 @@ int filter_compile_param(struct libscols_filter *fltr, struct filter_param *n)
 	if (n->re)
 		return 0;
 	if (n->type != SCOLS_DATA_STRING || !n->val.str)
+		return -EINVAL;
+	if (strlen(n->val.str) > SCOLS_FILTER_MAX_REGSZ)
+		return -EINVAL;
+	if (is_unsafe_regex(n->val.str))
 		return -EINVAL;
 
 	n->re = calloc(1, sizeof(regex_t));

--- a/libsmartcols/src/filter-parser.y
+++ b/libsmartcols/src/filter-parser.y
@@ -17,6 +17,8 @@
 
 void yyerror(yyscan_t *locp, struct libscols_filter *fltr, char const *fmt, ...);
 
+#define YYMAXDEPTH 256
+
 %}
 
 %define api.pure full
@@ -79,41 +81,133 @@ filter:
 expr:
 	param			{ $$ = $1; }
 	| '(' expr ')'		{ $$ = $2; }
-	| expr T_AND expr	{ $$ = filter_new_expr(fltr, F_EXPR_AND, $1, $3); }
-	| expr T_OR expr	{ $$ = filter_new_expr(fltr, F_EXPR_OR, $1, $3); }
-	| T_NEG expr		{ $$ = filter_new_expr(fltr, F_EXPR_NEG, NULL, $2); }
-	| expr T_EQ expr	{ $$ = filter_new_expr(fltr, F_EXPR_EQ, $1, $3); }
-	| expr T_NE expr	{ $$ = filter_new_expr(fltr, F_EXPR_NE, $1, $3); }
-	| expr T_LE expr	{ $$ = filter_new_expr(fltr, F_EXPR_LE, $1, $3); }
-	| expr T_LT expr	{ $$ = filter_new_expr(fltr, F_EXPR_LT, $1, $3); }
-	| expr T_GE expr	{ $$ = filter_new_expr(fltr, F_EXPR_GE, $1, $3); }
-	| expr T_GT expr	{ $$ = filter_new_expr(fltr, F_EXPR_GT, $1, $3); }
+	| expr T_AND expr	{
+		$$ = filter_new_expr(fltr, F_EXPR_AND, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
+			YYERROR;
+		}
+	}
+	| expr T_OR expr	{
+		$$ = filter_new_expr(fltr, F_EXPR_OR, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
+			YYERROR;
+		}
+	}
+	| T_NEG expr		{
+		$$ = filter_new_expr(fltr, F_EXPR_NEG, NULL, $2);
+		if (!$$) {
+			filter_unref_node($2);
+			YYERROR;
+		}
+	}
+	| expr T_EQ expr	{
+		$$ = filter_new_expr(fltr, F_EXPR_EQ, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
+			YYERROR;
+		}
+	}
+	| expr T_NE expr	{
+		$$ = filter_new_expr(fltr, F_EXPR_NE, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
+			YYERROR;
+		}
+	}
+	| expr T_LE expr	{
+		$$ = filter_new_expr(fltr, F_EXPR_LE, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
+			YYERROR;
+		}
+	}
+	| expr T_LT expr	{
+		$$ = filter_new_expr(fltr, F_EXPR_LT, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
+			YYERROR;
+		}
+	}
+	| expr T_GE expr	{
+		$$ = filter_new_expr(fltr, F_EXPR_GE, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
+			YYERROR;
+		}
+	}
+	| expr T_GT expr	{
+		$$ = filter_new_expr(fltr, F_EXPR_GT, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
+			YYERROR;
+		}
+	}
 
 	| expr T_REG expr	{
-		if (filter_compile_param(fltr, (struct filter_param *) $3) != 0)
+		$$ = NULL;
+		if (filter_compile_param(fltr, (struct filter_param *) $3) == 0)
+			$$ = filter_new_expr(fltr, F_EXPR_REG, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
 			YYERROR;
-		$$ = filter_new_expr(fltr, F_EXPR_REG, $1, $3);
+		}
 	}
 
 	| expr T_NREG expr	{
-		if (filter_compile_param(fltr, (struct filter_param *) $3) != 0)
+		$$ = NULL;
+		if (filter_compile_param(fltr, (struct filter_param *) $3) == 0)
+			$$ = filter_new_expr(fltr, F_EXPR_NREG, $1, $3);
+		if (!$$) {
+			filter_unref_node($1);
+			filter_unref_node($3);
 			YYERROR;
-		$$ = filter_new_expr(fltr, F_EXPR_NREG, $1, $3);
+		}
 	}
 ;
 
 param:
-	T_NUMBER	{ $$ = filter_new_param(fltr, SCOLS_DATA_U64, 0, (void *) (&$1)); }
-	| T_FLOAT	{ $$ = filter_new_param(fltr, SCOLS_DATA_FLOAT, 0, (void *) (&$1)); }
-	| T_HOLDER	{ $$ = filter_new_param(fltr, SCOLS_DATA_NONE, F_HOLDER_COLUMN, (void *) $1); }
-	| T_STRING	{ $$ = filter_new_param(fltr, SCOLS_DATA_STRING, 0, (void *) $1); }
+	T_NUMBER	{
+		$$ = filter_new_param(fltr, SCOLS_DATA_U64, 0, (void *) (&$1));
+		if (!$$)
+			YYERROR;
+	}
+	| T_FLOAT	{
+		$$ = filter_new_param(fltr, SCOLS_DATA_FLOAT, 0, (void *) (&$1));
+		if (!$$)
+			YYERROR;
+	}
+	| T_HOLDER	{
+		$$ = filter_new_param(fltr, SCOLS_DATA_NONE, F_HOLDER_COLUMN, (void *) $1);
+		if (!$$)
+			YYERROR;
+	}
+	| T_STRING	{
+		$$ = filter_new_param(fltr, SCOLS_DATA_STRING, 0, (void *) $1);
+		if (!$$)
+			YYERROR;
+	}
 	| T_TRUE	{
 		bool x = true;
 		$$ = filter_new_param(fltr, SCOLS_DATA_BOOLEAN, 0, (void *) &x);
+		if (!$$)
+			YYERROR;
 	}
 	| T_FALSE	{
 		bool x = false;
 		$$ = filter_new_param(fltr, SCOLS_DATA_BOOLEAN, 0, (void *) &x);
+		if (!$$)
+			YYERROR;
 	}
 	| T_INVALID_NUMBER {		/* YYerror token is unsupported in old Bisons */
 		ignore_result( $$ );	/* suppress "unset value" warning */

--- a/libsmartcols/src/filter.c
+++ b/libsmartcols/src/filter.c
@@ -193,6 +193,9 @@ int scols_filter_parse_string(struct libscols_filter *fltr, const char *str)
 	if (!str || !*str)
 		return 0;	/* empty filter is not error */
 
+	if (strlen(str) > SCOLS_FILTER_MAX_EXPRSZ)
+		return -ERANGE;
+
 	fltr->src = fmemopen((void *) str, strlen(str), "r");
 	if (!fltr->src)
 		return -errno;
@@ -200,7 +203,11 @@ int scols_filter_parse_string(struct libscols_filter *fltr, const char *str)
 	yylex_init_extra(fltr, &sc);
 	yyset_in(fltr->src, sc);
 
+	fltr->parsing = 1;
 	rc = yyparse(sc, fltr);
+	fltr->parsing = 0;
+	fltr->parse_nodes = 0;
+
 	yylex_destroy(sc);
 
 	fclose(fltr->src);

--- a/libsmartcols/src/filter.c
+++ b/libsmartcols/src/filter.c
@@ -76,6 +76,8 @@ static void reset_filter(struct libscols_filter *fltr)
 	filter_unref_node(fltr->root);
 	fltr->root = NULL;
 
+	filter_free_params(fltr);
+
 	if (fltr->src)
 		fclose(fltr->src);
 	fltr->src = NULL;

--- a/libsmartcols/src/fuzz.c
+++ b/libsmartcols/src/fuzz.c
@@ -18,7 +18,14 @@ static void process_string(const char *str)
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    char *str = malloc(size + 1);
+    char *str;
+
+    /* Larger than the library's 1024-byte limit to exercise the
+     * rejection path, small enough to avoid OOM in sanitizer builds */
+    if (size > 4096)
+        return 0;
+
+    str = malloc(size + 1);
     if (!str)
         return 0;
 

--- a/libsmartcols/src/fuzz.c
+++ b/libsmartcols/src/fuzz.c
@@ -1,0 +1,65 @@
+#include "fuzz.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libsmartcols.h"
+
+static void process_string(const char *str)
+{
+    /* Parse the input as a libsmartcols filter expression. This drives the
+       flex scanner, the bison grammar, parameter/holder construction and the
+       regcomp() done for the =~ operator. */
+    struct libscols_filter *fltr = scols_new_filter(str);
+
+    scols_unref_filter(fltr);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    char *str = malloc(size + 1);
+    if (!str)
+        return 0;
+
+    memcpy(str, data, size);
+    str[size] = '\0';
+
+    process_string(str);
+
+    free(str);
+    return 0;
+}
+
+#ifndef FUZZ_TARGET
+int main(int argc, char **argv)
+{
+    for (int i = 1; i < argc; i++) {
+        FILE *f = fopen(argv[i], "r");
+        char *buf;
+        long len;
+        size_t n;
+
+        if (!f)
+            continue;
+        fseek(f, 0, SEEK_END);
+        len = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        if (len < 0) {
+            fclose(f);
+            continue;
+        }
+        buf = malloc(len + 1);
+        if (!buf) {
+            fclose(f);
+            continue;
+        }
+        n = fread(buf, 1, len, f);
+        fclose(f);
+        buf[n] = '\0';
+        process_string(buf);
+        free(buf);
+    }
+    return 0;
+}
+#endif

--- a/libsmartcols/src/fuzz.c
+++ b/libsmartcols/src/fuzz.c
@@ -8,65 +8,60 @@
 
 static void process_string(const char *str)
 {
-    /* Parse the input as a libsmartcols filter expression. This drives the
-       flex scanner, the bison grammar, parameter/holder construction and the
-       regcomp() done for the =~ operator. */
-    struct libscols_filter *fltr = scols_new_filter(str);
+	struct libscols_filter *fltr = scols_new_filter(str);
 
-    scols_unref_filter(fltr);
+	scols_unref_filter(fltr);
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    char *str;
+	char *str;
 
-    /* Larger than the library's 1024-byte limit to exercise the
-     * rejection path, small enough to avoid OOM in sanitizer builds */
-    if (size > 4096)
-        return 0;
+	if (size > 4096)
+		return 0;
 
-    str = malloc(size + 1);
-    if (!str)
-        return 0;
+	str = malloc(size + 1);
+	if (!str)
+		return 0;
 
-    memcpy(str, data, size);
-    str[size] = '\0';
+	memcpy(str, data, size);
+	str[size] = '\0';
 
-    process_string(str);
+	process_string(str);
 
-    free(str);
-    return 0;
+	free(str);
+	return 0;
 }
 
 #ifndef FUZZ_TARGET
 int main(int argc, char **argv)
 {
-    for (int i = 1; i < argc; i++) {
-        FILE *f = fopen(argv[i], "r");
-        char *buf;
-        long len;
-        size_t n;
+	for (int i = 1; i < argc; i++) {
+		FILE *f = fopen(argv[i], "r");
+		char *buf;
+		long len;
+		size_t n;
 
-        if (!f)
-            continue;
-        fseek(f, 0, SEEK_END);
-        len = ftell(f);
-        fseek(f, 0, SEEK_SET);
-        if (len < 0) {
-            fclose(f);
-            continue;
-        }
-        buf = malloc(len + 1);
-        if (!buf) {
-            fclose(f);
-            continue;
-        }
-        n = fread(buf, 1, len, f);
-        fclose(f);
-        buf[n] = '\0';
-        process_string(buf);
-        free(buf);
-    }
-    return 0;
+		if (!f)
+			continue;
+		fseek(f, 0, SEEK_END);
+		len = ftell(f);
+		fseek(f, 0, SEEK_SET);
+		if (len < 0) {
+			fclose(f);
+			continue;
+		}
+		buf = malloc(len + 1);
+		if (!buf) {
+			fclose(f);
+			continue;
+		}
+		n = fread(buf, 1, len, f);
+		fclose(f);
+		buf[n] = '\0';
+		process_string(buf);
+		free(buf);
+	}
+	return 0;
 }
 #endif

--- a/libsmartcols/src/smartcolsP.h
+++ b/libsmartcols/src/smartcolsP.h
@@ -559,7 +559,13 @@ struct libscols_filter {
 
 	struct list_head params;
 	struct list_head counters;
+
+	size_t parse_nodes;
+	unsigned int parsing : 1;
 };
+
+#define SCOLS_FILTER_MAX_EXPRSZ	1024
+#define SCOLS_FILTER_MAX_NODES	256
 
 struct filter_node *__filter_new_node(enum filter_ntype type, size_t sz);
 void filter_ref_node(struct filter_node *n);

--- a/libsmartcols/src/smartcolsP.h
+++ b/libsmartcols/src/smartcolsP.h
@@ -574,6 +574,7 @@ void filter_dump_param(struct ul_jsonwrt *json, struct filter_param *n);
 int filter_eval_param(struct libscols_filter *fltr, struct libscols_line *ln,
 			struct filter_param *n, int *status);
 void filter_free_param(struct filter_param *n);
+void filter_free_params(struct libscols_filter *fltr);
 int filter_param_reset_holder(struct filter_param *n);
 int filter_param_get_datatype(struct filter_param *n);
 

--- a/libsmartcols/src/smartcolsP.h
+++ b/libsmartcols/src/smartcolsP.h
@@ -566,6 +566,7 @@ struct libscols_filter {
 
 #define SCOLS_FILTER_MAX_EXPRSZ	1024
 #define SCOLS_FILTER_MAX_NODES	256
+#define SCOLS_FILTER_MAX_REGSZ	256
 
 struct filter_node *__filter_new_node(enum filter_ntype type, size_t sz);
 void filter_ref_node(struct filter_node *n);

--- a/tools/oss-fuzz.sh
+++ b/tools/oss-fuzz.sh
@@ -24,7 +24,7 @@ if [[ "$SANITIZER" == undefined ]]; then
     CXXFLAGS+=" $UBSAN_FLAGS"
 fi
 
-CONFIGURE_ARGS="--disable-all-programs --enable-libuuid --enable-libfdisk --enable-last --enable-fuzzing-engine --enable-libmount --enable-libblkid"
+CONFIGURE_ARGS="--disable-all-programs --enable-libuuid --enable-libfdisk --enable-last --enable-fuzzing-engine --enable-libmount --enable-libblkid --enable-libsmartcols"
 
 LIBC_VERSION="$(dpkg -s libc6 | grep Version | cut -d' ' -f2)"
 


### PR DESCRIPTION
The `val` union in `filter_param` can hold different types (str, num, fnum,
boolean). When a non-string param (e.g. a number) is used as a regex
operand, the numeric value gets reinterpreted as a pointer through
`val.str`. A small number like 2 becomes pointer `0x2`, which passes the
existing NULL check but crashes in `regcomp()`.

Add a type check to reject non-string params before accessing `val.str`.

Depends on #4430 (merges the new libsmartcols fuzzer that found this).