### PR TITLE
mbsalign: check remaining buffer space before writing hex escapes

### DIFF
--- a/lib/mbsalign.c
+++ b/lib/mbsalign.c
@@ -201,8 +201,9 @@ char *mbs_safe_encode_to_buffer(const char *s, size_t *width, char *buf, size_t 
 
 		if ((*p == '\\' && *(p + 1) == 'x')
 		    || iscntrl((unsigned char) *p)) {
-			if (snprintf(r, rsz, "\\x%02x", (unsigned char) *p) < 4)
+			if (rsz < 5)
 				break;
+			snprintf(r, rsz, "\\x%02x", (unsigned char) *p);
 			r += 4;
 			rsz -= 4;
 			*width += 4;
@@ -223,8 +224,9 @@ char *mbs_safe_encode_to_buffer(const char *s, size_t *width, char *buf, size_t 
 				 * printable char according to the current locales.
 				 */
 				if (!isprint((unsigned char) *p)) {
-					if (snprintf(r, rsz, "\\x%02x", (unsigned char) *p) < 4)
+					if (rsz < 5)
 						break;
+					snprintf(r, rsz, "\\x%02x", (unsigned char) *p);
 					r += 4;
 					rsz -= 4;
 					*width += 4;
@@ -238,8 +240,9 @@ char *mbs_safe_encode_to_buffer(const char *s, size_t *width, char *buf, size_t 
 			} else if (!iswprint(wc)) {
 				size_t i;
 				for (i = 0; i < len; i++) {
-					if (snprintf(r, rsz, "\\x%02x", (unsigned char) p[i]) < 4)
+					if (rsz < 5)
 						break;
+					snprintf(r, rsz, "\\x%02x", (unsigned char) p[i]);
 					r += 4;
 					rsz -= 4;
 					*width += 4;
@@ -258,8 +261,9 @@ char *mbs_safe_encode_to_buffer(const char *s, size_t *width, char *buf, size_t 
 		}
 #else
 		else if (!isprint((unsigned char) *p)) {
-			if (snprintf(r, rsz, "\\x%02x", (unsigned char) *p) < 4)
+			if (rsz < 5)
 				break;
+			snprintf(r, rsz, "\\x%02x", (unsigned char) *p);
 			p++;
 			r += 4;
 			rsz -= 4;
@@ -321,8 +325,9 @@ char *mbs_invalid_encode_to_buffer(const char *s, size_t *width, char *buf, size
 			 * printable char according to the current locales.
 			 */
 			if (!isprint((unsigned char) *p)) {
-				if (snprintf(r, rsz, "\\x%02x", (unsigned char) *p) < 4)
+				if (rsz < 5)
 					break;
+				snprintf(r, rsz, "\\x%02x", (unsigned char) *p);
 				r += 4;
 				rsz -= 4;
 				*width += 4;
@@ -334,8 +339,9 @@ char *mbs_invalid_encode_to_buffer(const char *s, size_t *width, char *buf, size
 				rsz--;
 			}
 		} else if (*p == '\\' && *(p + 1) == 'x') {
-			if (snprintf(r, rsz, "\\x%02x", (unsigned char) *p) < 4)
+			if (rsz < 5)
 				break;
+			snprintf(r, rsz, "\\x%02x", (unsigned char) *p);
 			r += 4;
 			rsz -= 4;
 			*width += 4;


### PR DESCRIPTION
ASan, calling mbs_safe_encode_to_buffer() with a destination smaller than the encoded result:

    ==ERROR: AddressSanitizer: heap-buffer-overflow
    WRITE of size 2 ... 4 bytes after an 8-byte region
        in mbs_safe_encode_to_buffer (mbsalign.c)

The control-character branches gate the 4-byte escape write on snprintf()'s return value:

    if (snprintf(r, rsz, "\\x%02x", (unsigned char) *p) < 4)
        break;

snprintf() returns the length it would have written (always 4 for "\xNN"), not the amount that fit in rsz, so a short buffer is never noticed. r and rsz advance by 4 regardless; once rsz goes negative it reaches the next snprintf() as a huge size_t and the write runs off the end.

The other branches in the same function already check the space directly (rsz < 2, rsz < len + 1); the escape paths just did not. Replaced the snprintf-return test with rsz < 5 (four escape bytes plus the terminator) at every escape site, and the same in mbs_invalid_encode_to_buffer().

In-tree callers size the buffer with mbs_safe_encode_size(), so they are not affected; the helpers take a bufsiz and now honour it the same way in all branches.
