### PR TITLE
fdisk: clean up dead unref calls in resize_partition cleanup path

### DIFF
--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -679,7 +679,7 @@ static int strtosize_sectors(const char *str, unsigned long sector_size,
 
 void resize_partition(struct fdisk_context *cxt)
 {
-	struct fdisk_partition *pa = NULL, *npa = NULL, *next = NULL;
+	struct fdisk_partition  *npa = NULL;
 	char *query = NULL, *response = NULL, *default_size;
 	struct fdisk_table *tb = NULL;
 	uint64_t max_size, secs;
@@ -732,8 +732,6 @@ void resize_partition(struct fdisk_context *cxt)
 out:
 	free(query);
 	free(response);
-	fdisk_unref_partition(next);
-	fdisk_unref_partition(pa);
 	fdisk_unref_partition(npa);
 	fdisk_unref_table(tb);
 	return;


### PR DESCRIPTION
The pointers 'pa' and 'next' in resize_partition() are initialized to 
NULL and never reassigned. Calling fdisk_unref_partition() on them in 
the cleanup label is dead code.