### PR TITLE
cryptsetup: always use dlopen

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -218,15 +218,8 @@ edit_cmd += -e 's|@LIBSELINUX[@]||g'
 endif
 
 if HAVE_CRYPTSETUP
-if CRYPTSETUP_VIA_DLOPEN
-edit_cmd += -e 's|@LIBCRYPTSETUP[@]||g'
 edit_cmd += -e 's|@LIBDL[@]|-ldl|g'
 else
-edit_cmd += -e 's|@LIBCRYPTSETUP[@]|libcryptsetup|g'
-edit_cmd += -e 's|@LIBDL[@]||g'
-endif
-else
-edit_cmd += -e 's|@LIBCRYPTSETUP[@]||g'
 edit_cmd += -e 's|@LIBDL[@]||g'
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -3069,7 +3069,6 @@ AC_ARG_WITH([cryptsetup],
 
 AS_IF([test "x$with_cryptsetup" = xno], [
   AM_CONDITIONAL([HAVE_CRYPTSETUP], [false])
-  AM_CONDITIONAL([CRYPTSETUP_VIA_DLOPEN], [false])
 ], [
   PKG_CHECK_MODULES([CRYPTSETUP], [libcryptsetup],
 	[AC_DEFINE([HAVE_CRYPTSETUP], [1], [Define if cryptsetup is available])
@@ -3082,21 +3081,13 @@ AS_IF([test "x$with_cryptsetup" = xno], [
 	 AC_CHECK_LIB([cryptsetup], [crypt_activate_by_signed_key], [
 	  AC_DEFINE([HAVE_CRYPT_ACTIVATE_BY_SIGNED_KEY], [1], [Define if crypt_activate_by_signed_key exist in -lcryptsetup])
 	 ])
-	 AS_IF([test "x$with_cryptsetup" = xdlopen], [
-	  LIBS="-ldl $LIBS"
-	  AC_CHECK_LIB([dl], [dlsym], [
-	    AC_DEFINE([CRYPTSETUP_VIA_DLOPEN], [1], [Define if cryptsetup is to be loaded via dlopen])
-	    AM_CONDITIONAL([CRYPTSETUP_VIA_DLOPEN], [true])
-	   ], [AC_MSG_ERROR([libdl required to build with cryptsetup support])])
-	 ], [
-	  AM_CONDITIONAL([CRYPTSETUP_VIA_DLOPEN], [false])
-	 ])
+	 LIBS="-ldl $LIBS"
+	 AC_CHECK_LIB([dl], [dlsym], [], [AC_MSG_ERROR([libdl required to build with cryptsetup support])])
 	 CFLAGS="$SAVE_CFLAGS"
 	 LIBS="$SAVE_LIBS"
 	 have_cryptsetup=yes],
 	[have_cryptsetup=no
    AM_CONDITIONAL([HAVE_CRYPTSETUP], [false])
-   AM_CONDITIONAL([CRYPTSETUP_VIA_DLOPEN], [false])
   ])
 
   AS_CASE([$with_cryptsetup:$have_cryptsetup],

--- a/libmount/meson.build
+++ b/libmount/meson.build
@@ -95,7 +95,7 @@ mount_static_dep = declare_dependency(link_with: lib_mount_static, include_direc
 
 lib__mount_deps = [
   lib_selinux,
-  cryptsetup_dlopen ? lib_dl : lib_cryptsetup,
+  lib_dl,
   realtime_libs
 ]
 

--- a/libmount/mount.pc.in
+++ b/libmount/mount.pc.in
@@ -17,7 +17,7 @@ includedir=@includedir@
 Name: mount
 Description: mount library
 Version: @LIBMOUNT_VERSION@
-Requires.private: blkid @LIBSELINUX@ @LIBCRYPTSETUP@
+Requires.private: blkid @LIBSELINUX@
 Cflags: -I${includedir}/libmount
 Libs: -L${libdir} -lmount
 Libs.private: @LIBDL@

--- a/libmount/src/Makemodule.am
+++ b/libmount/src/Makemodule.am
@@ -62,11 +62,7 @@ libmount_la_LIBADD = \
 	$(REALTIME_LIBS)
 
 if HAVE_CRYPTSETUP
-if CRYPTSETUP_VIA_DLOPEN
 libmount_la_LIBADD += -ldl
-else
-libmount_la_LIBADD += $(CRYPTSETUP_LIBS)
-endif
 endif
 
 if USE_LIBMOUNT_UDEV_SUPPORT
@@ -120,11 +116,7 @@ libmount_tests_ldadd += $(SELINUX_LIBS)
 endif
 
 if HAVE_CRYPTSETUP
-if CRYPTSETUP_VIA_DLOPEN
 libmount_tests_ldadd += -ldl
-else
-libmount_tests_ldadd += $(CRYPTSETUP_LIBS)
-endif
 endif
 
 test_mount_cache_SOURCES = libmount/src/cache.c

--- a/libmount/src/hook_veritydev.c
+++ b/libmount/src/hook_veritydev.c
@@ -18,13 +18,12 @@
 #ifdef HAVE_CRYPTSETUP
 
 #include <libcryptsetup.h>
+#include <dlfcn.h>
 #include "path.h"
 #include "strutils.h"
 #include "fileutils.h"
 #include "pathnames.h"
 
-#ifdef CRYPTSETUP_VIA_DLOPEN
-# include <dlfcn.h>
 
 /* Pointers to libcryptsetup functions (initialized by dlsym()) */
 struct verity_opers {
@@ -76,24 +75,17 @@ static const struct verity_sym verity_symbols[] =
 
 	DEF_VERITY_SYM( crypt_deactivate_by_name ),
 };
-#endif /* CRYPTSETUP_VIA_DLOPEN */
 
 
 /* Data used by all verity hooks */
 struct hookset_data {
 	char *devname;			/* the device */
-#ifdef CRYPTSETUP_VIA_DLOPEN
 	void *dl;			/* dlopen() */
 	struct verity_opers dl_funcs;	/* dlsym() */
-#endif
 };
 
 /* libcryptsetup call -- dlopen version requires 'struct hookset_data *hsd' */
-#ifdef CRYPTSETUP_VIA_DLOPEN
-# define verity_call(_func)	(hsd->dl_funcs._func)
-#else
-# define verity_call(_func)	(_func)
-#endif
+#define verity_call(_func)	(hsd->dl_funcs._func)
 
 
 static void delete_veritydev(struct libmnt_context *cxt,
@@ -101,7 +93,6 @@ static void delete_veritydev(struct libmnt_context *cxt,
                         struct hookset_data *hsd);
 
 
-#ifdef CRYPTSETUP_VIA_DLOPEN
 static int load_libcryptsetup_symbols(struct libmnt_context *cxt,
 				      struct hookset_data *hsd)
 {
@@ -157,7 +148,6 @@ failed:
 		errno = ENOTSUP;
 	return -errno;
 }
-#endif
 
 /* libcryptsetup callback */
 static void libcryptsetup_log(int level __attribute__((__unused__)),
@@ -177,10 +167,8 @@ static void free_hookset_data(	struct libmnt_context *cxt,
 		return;
 	if (hsd->devname)
 		delete_veritydev(cxt, hs, hsd);
-#ifdef CRYPTSETUP_VIA_DLOPEN
 	if (hsd->dl)
 		dlclose(hsd->dl);
-#endif
 	free(hsd);
 	mnt_context_set_hookset_data(cxt, hs, NULL);
 }
@@ -199,10 +187,8 @@ static struct hookset_data *new_hookset_data(
 	if (mnt_context_set_hookset_data(cxt, hs, hsd) != 0)
 		goto failed;
 
-#ifdef CRYPTSETUP_VIA_DLOPEN
 	if (load_libcryptsetup_symbols(cxt, hsd) != 0)
 		goto failed;
-#endif
 	if (mnt_context_is_verbose(cxt))
 		verity_call( crypt_set_debug_level(CRYPT_DEBUG_ALL) );
 

--- a/meson.build
+++ b/meson.build
@@ -459,20 +459,14 @@ lib_cryptsetup = dependency(
   required : get_option('cryptsetup'))
 conf.set('HAVE_CRYPTSETUP', lib_cryptsetup.found() ? 1 : false)
 
-cryptsetup_dlopen = get_option('cryptsetup').allowed() and get_option('cryptsetup-dlopen').enabled()
-if cryptsetup_dlopen
+if get_option('cryptsetup').allowed()
   if meson.version().version_compare('>= 0.62.0')
     lib_dl = dependency('dl')
   else
     lib_dl = cc.find_library('dl')
   endif
-  conf.set('CRYPTSETUP_VIA_DLOPEN', 1)
   summary('cryptsetup support (dlopen)',
           'enabled',
-          section : 'components')
-else
-  summary('cryptsetup support',
-          lib_cryptsetup.found()  ? 'enabled' : 'disabled',
           section : 'components')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,7 +6,8 @@ option('ncurses',     type : 'feature')
 option('slang',       type : 'feature', value : 'disabled',
        description : 'compile cfdisk with slang rather than ncurses')
 option('cryptsetup',  type : 'feature')
-option('cryptsetup-dlopen',  type : 'feature')
+option('cryptsetup-dlopen',  type : 'feature', deprecated : true,
+       description : 'deprecated, only dlopen is now supported')
 option('zlib',        type : 'feature')
 option('readline',    type : 'feature')
 option('nls',         type : 'feature')


### PR DESCRIPTION
There are no drawbacks to using dlopen for optional dependencies nowadays, so remove support for linking to libcryptsetup and always dlopen it.