### PR TITLE
fdisk: fix return value for expert commands in sgi_menu_cb

### DIFF
--- a/disk-utils/fdisk-menu.c
+++ b/disk-utils/fdisk-menu.c
@@ -960,7 +960,7 @@ static int sgi_menu_cb(struct fdisk_context **cxt0,
 		       const struct menu_entry *ent)
 {
 	struct fdisk_context *cxt = *cxt0;
-	int rc = -EINVAL;
+	int rc = 0;
 	size_t n = 0;
 
 	DBG(MENU, ul_debug("enter SGI menu"));


### PR DESCRIPTION
Initialize rc to 0 instead of -EINVAL. This prevents expert mode 
commands from incorrectly returning an error when they should be 
passed to the upper layer.