### PR TITLE
meson: add compile test for scandirat()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -732,6 +732,17 @@ foreach func: funcs
   conf.set('HAVE_' + func.to_upper(), have ? 1 : false)
 endforeach
 
+# scandirat() may exist in the SDK but be gated behind availability
+# annotations (e.g. macOS); verify it is actually usable at compile time.
+if conf.get('HAVE_SCANDIRAT') in [1]
+  if not cc.links('''
+      #include <dirent.h>
+      int main(void) { return scandirat(0, ".", (void*)0, (void*)0, (void*)0); }
+    ''', args : ['-D_GNU_SOURCE', '-Werror'], name : 'scandirat (compile test)')
+    conf.set('HAVE_SCANDIRAT', false)
+  endif
+endif
+
 have_mempcpy = cc.has_function('mempcpy', prefix: '#include <string.h>', args: '-D_GNU_SOURCE')
 conf.set('HAVE_MEMPCPY', have_mempcpy ? 1 : false)
 


### PR DESCRIPTION
## Summary
- Add a compile+link verification for `scandirat()` after the bulk `has_function()` check
- On macOS with newer Xcode (clang 21+), `scandirat()` exists in the SDK but is gated behind availability annotations (macOS 26.4+), causing `-Wunguarded-availability-new` errors with `-Werror`
- The link-only check passes but compilation fails; the new test catches this and disables `HAVE_SCANDIRAT`