### PR TITLE
hwclock, rtcwake: fix RTC error reporting

### DIFF
--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -157,7 +157,7 @@ static int do_rtc_read_ioctl(int rtc_fd, struct tm *tm)
 	rc = ioctl(rtc_fd, RTC_RD_TIME, &rtc_tm);
 
 	if (rc == -1) {
-		warn(_("ioctl(RTC_RD_NAME) to %s to read the time failed"),
+		warn(_("ioctl(RTC_RD_TIME) to %s to read the time failed"),
 			rtc_dev_name);
 		return -1;
 	}

--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -157,8 +157,11 @@ static int do_rtc_read_ioctl(int rtc_fd, struct tm *tm)
 	rc = ioctl(rtc_fd, RTC_RD_TIME, &rtc_tm);
 
 	if (rc == -1) {
+		int errsv = errno;
 		warn(_("ioctl(RTC_RD_TIME) to %s to read the time failed"),
 			rtc_dev_name);
+		if (errsv == EINVAL)
+			warnx(_("RTC may not be initialized"));
 		return -1;
 	}
 

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -174,7 +174,10 @@ static int get_basetimes(struct rtcwake_control *ctl, int fd)
 	 * precisely (+/- a second) as we can read them.
 	 */
 	if (ioctl(fd, RTC_RD_TIME, &rtc) < 0) {
+		int errsv = errno;
 		warn(_("read rtc time failed"));
+		if (errsv == EINVAL)
+			warnx(_("RTC may not be initialized"));
 		return -1;
 	}
 


### PR DESCRIPTION
## Summary
- Fix typo in hwclock error message: `RTC_RD_NAME` → `RTC_RD_TIME`
- Add EINVAL-specific hint ("RTC may not be initialized") to hwclock and rtcwake — some RTC drivers return EINVAL when the hardware time counter was never initialized

Addresses: https://github.com/util-linux/util-linux/pull/4376