### PR TITLE
libmount: populate unique mount ID and merge utab for listmount

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -22,7 +22,7 @@
 
 #if !(defined(HAVE_BYTESWAP_H) && defined(HAVE_ENDIAN_H))
 /*
- * When both byteswap.h and endian.h are preseent, the proper macros are defined
+ * When both byteswap.h and endian.h are present, the proper macros are defined
  * as those files are glibc compatible.  Otherwise, compensate for the slightly
  * different interfaces between the different BSDs.
  */
@@ -37,18 +37,20 @@
 # define bswap_64(x) bswap64(x)
 #elif defined(__APPLE__)
 # include <libkern/OSByteOrder.h>
-# define htobe16(x) OSSwapHostToBigInt16(x)
-# define htole16(x) OSSwapHostToLittleInt16(x)
-# define be16toh(x) OSSwapBigToHostInt16(x)
-# define le16toh(x) OSSwapLittleToHostInt16(x)
-# define htobe32(x) OSSwapHostToBigInt32(x)
-# define htole32(x) OSSwapHostToLittleInt32(x)
-# define be32toh(x) OSSwapBigToHostInt32(x)
-# define le32toh(x) OSSwapLittleToHostInt32(x)
-# define htobe64(x) OSSwapHostToBigInt64(x)
-# define htole64(x) OSSwapHostToLittleInt64(x)
-# define be64toh(x) OSSwapBigToHostInt64(x)
-# define le64toh(x) OSSwapLittleToHostInt64(x)
+# ifndef HAVE_SYS_ENDIAN_H
+#  define htobe16(x) OSSwapHostToBigInt16(x)
+#  define htole16(x) OSSwapHostToLittleInt16(x)
+#  define be16toh(x) OSSwapBigToHostInt16(x)
+#  define le16toh(x) OSSwapLittleToHostInt16(x)
+#  define htobe32(x) OSSwapHostToBigInt32(x)
+#  define htole32(x) OSSwapHostToLittleInt32(x)
+#  define be32toh(x) OSSwapBigToHostInt32(x)
+#  define le32toh(x) OSSwapLittleToHostInt32(x)
+#  define htobe64(x) OSSwapHostToBigInt64(x)
+#  define htole64(x) OSSwapHostToLittleInt64(x)
+#  define be64toh(x) OSSwapBigToHostInt64(x)
+#  define le64toh(x) OSSwapLittleToHostInt64(x)
+# endif
 # define bswap_16(x) OSSwapInt16(x)
 # define bswap_32(x) OSSwapInt32(x)
 # define bswap_64(x) OSSwapInt64(x)

--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -413,6 +413,7 @@ mnt_table_next_fs
 mnt_table_over_fs
 mnt_table_parse_dir
 mnt_table_parse_file
+mnt_table_disable_useropts
 mnt_table_parse_fstab
 mnt_table_parse_mtab
 mnt_table_parse_stream

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -420,23 +420,33 @@ int mnt_context_reopen_target_fd(struct libmnt_context *cxt)
 		return -errno;
 
 	/* verify the mount landed on the expected target;
-	 * cxt->fs->id is set from fd_tree in hook_create_mount() */
-	if (cxt->fs && cxt->fs->id > 0) {
-		int id = 0;
+	 * IDs are set from fd_tree in hook_create_mount() */
+	if (cxt->fs && (cxt->fs->uniq_id || cxt->fs->id > 0)) {
+		int mismatch = 0;
 
-		if (mnt_id_from_fd(cxt->fd_target, NULL, &id) == 0
-		    && id != cxt->fs->id) {
+		if (cxt->fs->uniq_id) {
+			uint64_t uniq_id = 0;
+
+			if (mnt_id_from_fd(cxt->fd_target, &uniq_id, NULL) == 0
+			    && uniq_id != cxt->fs->uniq_id)
+				mismatch = 1;
+		} else {
+			int id = 0;
+
+			if (mnt_id_from_fd(cxt->fd_target, NULL, &id) == 0
+			    && id != cxt->fs->id)
+				mismatch = 1;
+		}
+		if (mismatch) {
 			const char *tgt = mnt_fs_get_target(cxt->fs);
 
-			DBG_OBJ(CXT, cxt, ul_debug(
-				"target mount ID mismatch (expected %d, got %d), umounting",
-				cxt->fs->id, id));
+			DBG_OBJ(CXT, cxt, ul_debug("target mount ID mismatch, umounting"));
 			if (tgt)
 				umount2(tgt, MNT_DETACH);
 			mnt_context_close_target_fd(cxt);
 			return -EPERM;
 		}
-		DBG_OBJ(CXT, cxt, ul_debug("target mount ID verified (%d)", id));
+		DBG_OBJ(CXT, cxt, ul_debug("target mount ID verified"));
 	}
 
 	return 0;

--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -276,6 +276,7 @@ struct libmnt_fs *mnt_copy_fs(struct libmnt_fs *dest,
 	dest->parent     = src->parent;
 	dest->devno      = src->devno;
 	dest->tid        = src->tid;
+	dest->uniq_id    = src->uniq_id;
 
 	if (cpy_str_at_offset(dest, src, offsetof(struct libmnt_fs, source)))
 		goto err;

--- a/libmount/src/fs.c
+++ b/libmount/src/fs.c
@@ -1533,6 +1533,45 @@ int mnt_fs_set_uniq_id(struct libmnt_fs *fs, uint64_t id)
 	return 0;
 }
 
+/*
+ * Fetch mount IDs from kernel via statx(). Prefers unique ID, falls back
+ * to old ID on old kernels. Uses @fd (AT_EMPTY_PATH) if >= 0, otherwise
+ * uses fs->target path.
+ *
+ * Returns: 0 on success, <0 on error.
+ */
+int mnt_fs_fetch_ids(struct libmnt_fs *fs, int fd)
+{
+	uint64_t uniq_id = 0;
+	int id = 0, rc;
+
+	if (!fs)
+		return -EINVAL;
+	if (fd < 0 && !mnt_fs_get_target(fs))
+		return -EINVAL;
+
+	if (fd >= 0)
+		rc = mnt_id_from_fd(fd, &uniq_id, NULL);
+	else
+		rc = mnt_id_from_path(mnt_fs_get_target(fs), &uniq_id, NULL);
+
+	if (rc == 0 && uniq_id > 0) {
+		fs->uniq_id = uniq_id;
+		return 0;
+	}
+
+	/* fallback to old mount ID */
+	if (fd >= 0)
+		rc = mnt_id_from_fd(fd, NULL, &id);
+	else
+		rc = mnt_id_from_path(mnt_fs_get_target(fs), NULL, &id);
+
+	if (rc == 0)
+		fs->id = id;
+
+	return rc;
+}
+
 /**
  * mnt_fs_get_parent_id:
  * @fs: /proc/self/mountinfo entry

--- a/libmount/src/hook_mount.c
+++ b/libmount/src/hook_mount.c
@@ -323,24 +323,22 @@ static int hook_create_mount(struct libmnt_context *cxt,
 		/* cleanup after fail (libmount may only try the FS type) */
 		close_sysapi_fds(api);
 
-#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(HAVE_STRUCT_STATX_STX_MNT_ID)
 	if (!rc && cxt->fs) {
-		struct statx st;
+		mnt_fs_fetch_ids(cxt->fs, api->fd_tree);
 
-		rc = statx(api->fd_tree, "", AT_EMPTY_PATH, STATX_MNT_ID, &st);
-		if (rc == 0) {
-			cxt->fs->id = (int) st.stx_mnt_id;
-			if (cxt->update) {
-				struct libmnt_fs *fs = mnt_update_get_fs(cxt->update);
-				if (fs)
-					fs->id = cxt->fs->id;
+		if ((cxt->fs->id || cxt->fs->uniq_id) && cxt->update) {
+			struct libmnt_fs *fs = mnt_update_get_fs(cxt->update);
+			if (fs) {
+				fs->id = cxt->fs->id;
+				fs->uniq_id = cxt->fs->uniq_id;
 			}
 		}
 	}
-#endif
 
 done:
-	DBG_OBJ(HOOK, hs, ul_debug("create FS done [rc=%d, id=%d]", rc, cxt->fs ? cxt->fs->id : -1));
+	DBG_OBJ(HOOK, hs, ul_debug("create FS done [rc=%d, id=%d, uniq=%" PRIu64 "]",
+				rc, cxt->fs ? cxt->fs->id : -1,
+				cxt->fs ? cxt->fs->uniq_id : (uint64_t) 0));
 	return rc;
 }
 

--- a/libmount/src/hook_mount_legacy.c
+++ b/libmount/src/hook_mount_legacy.c
@@ -251,10 +251,25 @@ static int hook_mount(struct libmnt_context *cxt,
 	else
 		mnt_fs_mark_attached(cxt->fs);
 
+	cxt->syscall_status = 0;
+
 	/* re-open to point to the mounted filesystem root */
 	rc = mnt_context_reopen_target_fd(cxt);
 
-	cxt->syscall_status = 0;
+	/* Fetch mount IDs for utab. Note that IDs are not 100% robust
+	 * with mount(2) -- another process could overmount the target
+	 * between mount(2) and our statx() call. */
+	if (rc == 0 && cxt->fs && cxt->update && mnt_update_is_ready(cxt->update)) {
+		mnt_fs_fetch_ids(cxt->fs, cxt->fd_target);
+		if (cxt->fs->id || cxt->fs->uniq_id) {
+			struct libmnt_fs *fs = mnt_update_get_fs(cxt->update);
+			if (fs) {
+				fs->id = cxt->fs->id;
+				fs->uniq_id = cxt->fs->uniq_id;
+			}
+		}
+	}
+
 	return rc;
 }
 

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -608,6 +608,7 @@ extern int mnt_table_parse_dir(struct libmnt_table *tb, const char *dirname);
 extern int mnt_table_parse_fstab(struct libmnt_table *tb, const char *filename);
 extern int mnt_table_parse_swaps(struct libmnt_table *tb, const char *filename);
 extern int mnt_table_parse_mtab(struct libmnt_table *tb, const char *filename);
+extern int mnt_table_disable_useropts(struct libmnt_table *tb, int disable);
 extern int mnt_table_set_parser_errcb(struct libmnt_table *tb,
                 int (*cb)(struct libmnt_table *tb, const char *filename, int line));
 

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -421,3 +421,7 @@ MOUNT_2_42 {
 	mnt_fs_is_attached;
 	mnt_fs_is_detached;
 } MOUNT_2_41;
+
+MOUNT_2_43 {
+	mnt_table_disable_useropts;
+} MOUNT_2_42;

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -140,6 +140,7 @@ extern int mnt_tmptgt_unshare(int *old_ns_fd);
 extern int mnt_tmptgt_cleanup(int old_ns_fd);
 
 extern int mnt_id_from_fd(int fd, uint64_t *uniq_id, int *id);
+extern int mnt_fs_fetch_ids(struct libmnt_fs *fs, int fd);
 
 /* tab.c */
 extern int is_mountinfo(struct libmnt_table *tb);

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -151,6 +151,8 @@ extern int mnt_table_set_parser_fltrcb(	struct libmnt_table *tb,
 extern int __mnt_table_parse_mountinfo(struct libmnt_table *tb,
 					const char *filename,
 					struct libmnt_table *u_tb);
+extern int mnt_table_merge_utab(struct libmnt_table *tb,
+				struct libmnt_table *u_tb);
 
 extern struct libmnt_fs *mnt_table_get_fs_root(struct libmnt_table *tb,
 					struct libmnt_fs *fs,
@@ -336,6 +338,7 @@ struct libmnt_table {
 	struct libmnt_statmnt	*stmnt; /* statmount() stuff */
 
 	int		noautofs;	/* ignore autofs mounts */
+	int		nouseropts;	/* do not merge utab */
 
 	struct list_head	ents;	/* list of entries (libmnt_fs) */
 	void		*userdata;

--- a/libmount/src/tab_listmount.c
+++ b/libmount/src/tab_listmount.c
@@ -408,6 +408,10 @@ int mnt_table_fetch_listmount(struct libmnt_table *tb)
 	 * have all the necessary data (or on error) */
 	tb->lsmnt->done = 1;
 
+	/* merge userspace mount options from utab */
+	if (rc == 0)
+		rc = mnt_table_merge_utab(tb, NULL);
+
 	/* restore */
 	if (tb->stmnt)
 		mnt_statmnt_disable_fetching(tb->stmnt, stmnt_status);

--- a/libmount/src/tab_parse.c
+++ b/libmount/src/tab_parse.c
@@ -1109,6 +1109,27 @@ int mnt_table_is_noautofs(struct libmnt_table *tb)
 }
 
 /**
+ * mnt_table_disable_useropts:
+ * @tb: table
+ * @disable: 1 to disable, 0 to enable
+ *
+ * Disable or enable merging of userspace mount options from utab when
+ * populating the mount table. This applies to both mountinfo and
+ * listmount-based table sources.
+ *
+ * Returns: 0 on success, <0 on error.
+ *
+ * Since: 2.43
+ */
+int mnt_table_disable_useropts(struct libmnt_table *tb, int disable)
+{
+	if (!tb)
+		return -EINVAL;
+	tb->nouseropts = disable ? 1 : 0;
+	return 0;
+}
+
+/**
  * mnt_table_parse_swaps:
  * @tb: table
  * @filename: overwrites default (/proc/swaps or $LIBMOUNT_SWAPS) or NULL
@@ -1231,7 +1252,9 @@ static struct libmnt_fs *mnt_table_merge_user_fs(struct libmnt_table *tb, struct
 
 	if (fs) {
 		DBG_OBJ(TAB, tb, ul_debug(" found"));
-		mnt_fs_append_options(fs, optstr);
+		mnt_optstr_append_option(&fs->user_optstr, optstr, NULL);
+		free(fs->optstr);
+		fs->optstr = NULL;
 		mnt_fs_append_attributes(fs, attrs);
 		mnt_fs_set_bindsrc(fs, mnt_fs_get_bindsrc(uf));
 		fs->flags |= MNT_FS_MERGED;
@@ -1241,12 +1264,62 @@ static struct libmnt_fs *mnt_table_merge_user_fs(struct libmnt_table *tb, struct
 	return fs;
 }
 
+/*
+ * Read utab and merge userspace options into the mount table @tb.
+ * If @u_tb is provided, use it as utab; otherwise read from
+ * /run/mount/utab.
+ */
+int mnt_table_merge_utab(struct libmnt_table *tb, struct libmnt_table *u_tb)
+{
+	int rc = 0, priv_utab = 0;
+
+	assert(tb);
+
+	if (tb->nouseropts)
+		return 0;
+	if (mnt_table_get_nents(tb) == 0)
+		return 0;
+
+	if (!u_tb) {
+		const char *utab = mnt_get_utab_path();
+
+		if (!utab || is_file_empty(utab))
+			return 0;
+
+		u_tb = mnt_new_table();
+		if (!u_tb)
+			return -ENOMEM;
+
+		u_tb->fmt = MNT_FMT_UTAB;
+		mnt_table_set_parser_fltrcb(u_tb, tb->fltrcb, tb->fltrcb_data);
+
+		rc = mnt_table_parse_file(u_tb, utab);
+		priv_utab = 1;
+	}
+
+	DBG_OBJ(TAB, tb, ul_debug("merging utab"));
+
+	if (rc == 0) {
+		struct libmnt_fs *u_fs;
+		struct libmnt_iter itr;
+
+		mnt_reset_iter(&itr, MNT_ITER_BACKWARD);
+
+		while (mnt_table_next_fs(u_tb, &itr, &u_fs) == 0)
+			mnt_table_merge_user_fs(tb, u_fs);
+	}
+
+	if (priv_utab)
+		mnt_unref_table(u_tb);
+	return 0;
+}
+
 /* default filename is /proc/self/mountinfo
  */
 int __mnt_table_parse_mountinfo(struct libmnt_table *tb, const char *filename,
 			   struct libmnt_table *u_tb)
 {
-	int rc = 0, priv_utab = 0;
+	int rc = 0;
 	int explicit_file = filename ? 1 : 0;
 
 	assert(tb);
@@ -1273,48 +1346,11 @@ int __mnt_table_parse_mountinfo(struct libmnt_table *tb, const char *filename,
 
 	if (!is_mountinfo(tb))
 		return 0;
-	DBG_OBJ(TAB, tb, ul_debug("mountinfo parse: #2 read utab"));
 
-	if (mnt_table_get_nents(tb) == 0)
-		return 0;			/* empty, ignore utab */
-	/*
-	 * try to read the user specific information from /run/mount/utabs
-	 */
-	if (!u_tb) {
-		const char *utab = mnt_get_utab_path();
-
-		if (!utab || is_file_empty(utab))
-			return 0;
-
-		u_tb = mnt_new_table();
-		if (!u_tb)
-			return -ENOMEM;
-
-		u_tb->fmt = MNT_FMT_UTAB;
-		mnt_table_set_parser_fltrcb(u_tb, tb->fltrcb, tb->fltrcb_data);
-
-		rc = mnt_table_parse_file(u_tb, utab);
-		priv_utab = 1;
-	}
-
-	DBG_OBJ(TAB, tb, ul_debug("mountinfo parse: #3 merge utab"));
-
-	if (rc == 0) {
-		struct libmnt_fs *u_fs;
-		struct libmnt_iter itr;
-
-		mnt_reset_iter(&itr, MNT_ITER_BACKWARD);
-
-		/*  merge user options into mountinfo from the kernel */
-		while(mnt_table_next_fs(u_tb, &itr, &u_fs) == 0)
-			mnt_table_merge_user_fs(tb, u_fs);
-	}
-
-
-	if (priv_utab)
-		mnt_unref_table(u_tb);
-	return 0;
+	DBG_OBJ(TAB, tb, ul_debug("mountinfo parse: #2 merge utab"));
+	return mnt_table_merge_utab(tb, u_tb);
 }
+
 /**
  * mnt_table_parse_mtab:
  * @tb: table

--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -449,7 +449,7 @@ static int fprintf_utab_fs(FILE *f, struct libmnt_fs *fs)
 	if (mnt_fs_get_id(fs) > 0)
 		rc = fprintf(f, "ID=%d ", mnt_fs_get_id(fs));
 	if (mnt_fs_get_uniq_id(fs) > 0)
-		rc = fprintf(f, "UNIQID=%" PRIu64, mnt_fs_get_uniq_id(fs));
+		rc = fprintf(f, "UNIQID=%" PRIu64 " ", mnt_fs_get_uniq_id(fs));
 
 	if (rc >= 0) {
 		p = mangle(mnt_fs_get_source(fs));

--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1108,6 +1108,7 @@ static struct libmnt_table *fetch_listmount(struct findmnt *findmnt)
 	mnt_table_set_userdata(tb, findmnt);
 
 	mnt_table_refer_statmnt(tb, sm);
+	mnt_table_disable_useropts(tb, 1);
 
 	if (mnt_table_fetch_listmount(tb) != 0) {
 		warn(_("failed to fetch mount nodes"));

--- a/tests/ts/mount/special
+++ b/tests/ts/mount/special
@@ -82,6 +82,7 @@ EOF
 		cat "$LIBMOUNT_UTAB" \
 			| grep "$mountpoint" \
 			| sed -e "s|$mountpoint|/mountpoint|g" \
+			      -e 's/UNIQID=[[:digit:]]* //g' \
 			      -e 's/ID=[[:digit:]]* //g' \
 			&> "$TS_OUTPUT"
 		$TS_CMD_UMOUNT "$mountpoint"


### PR DESCRIPTION
Ensure utab entries contain UNIQID= and merge userspace mount options
into listmount-based tables, so that systemd (and other callers using
listmount/statmount) can access x-systemd.*, user=, and other
userspace mount options.

**Bug fixes:**
- `mnt_copy_fs()`: copy `uniq_id` field (was missing, causing loss
  of unique mount ID when fs entries are duplicated for utab)
- `fprintf_utab_fs()`: add missing space separator after `UNIQID=`
  field

**Unique mount ID population:**
- Add `mnt_fs_fetch_ids()` internal helper -- fetches mount IDs via
  statx(), prefers `STATX_MNT_ID_UNIQUE`, falls back to old
  `STATX_MNT_ID`, accepts optional fd with path-based fallback
- `hook_create_mount()` (new mount API): use `mnt_fs_fetch_ids()`
  with `fd_tree` for robust fd-based ID
- `hook_mount()` (legacy mount(2)): fetch IDs after
  `reopen_target_fd()` only when utab update is needed
- `mnt_context_reopen_target_fd()`: prefer `uniq_id` for mount
  target verification, fall back to old ID

**Utab merge for listmount:**
- Extract utab merge logic from `__mnt_table_parse_mountinfo()` into
  shared `mnt_table_merge_utab()`, call it from
  `mnt_table_fetch_listmount()`
- Merge sets `user_optstr` directly (not combined `optstr`) to avoid
  conflicts with lazy statmount() which populates kernel options on
  demand
- Add `mnt_table_disable_useropts()` public API to skip utab merging
- Use it in findmnt `--kernel=listmount` for backward compatibility
  (kernel-only data); users who want userspace options can use `--mtab`