### PR TITLE
bitops: avoid macro redefinition on macOS

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -22,7 +22,7 @@
 
 #if !(defined(HAVE_BYTESWAP_H) && defined(HAVE_ENDIAN_H))
 /*
- * When both byteswap.h and endian.h are preseent, the proper macros are defined
+ * When both byteswap.h and endian.h are present, the proper macros are defined
  * as those files are glibc compatible.  Otherwise, compensate for the slightly
  * different interfaces between the different BSDs.
  */
@@ -37,18 +37,20 @@
 # define bswap_64(x) bswap64(x)
 #elif defined(__APPLE__)
 # include <libkern/OSByteOrder.h>
-# define htobe16(x) OSSwapHostToBigInt16(x)
-# define htole16(x) OSSwapHostToLittleInt16(x)
-# define be16toh(x) OSSwapBigToHostInt16(x)
-# define le16toh(x) OSSwapLittleToHostInt16(x)
-# define htobe32(x) OSSwapHostToBigInt32(x)
-# define htole32(x) OSSwapHostToLittleInt32(x)
-# define be32toh(x) OSSwapBigToHostInt32(x)
-# define le32toh(x) OSSwapLittleToHostInt32(x)
-# define htobe64(x) OSSwapHostToBigInt64(x)
-# define htole64(x) OSSwapHostToLittleInt64(x)
-# define be64toh(x) OSSwapBigToHostInt64(x)
-# define le64toh(x) OSSwapLittleToHostInt64(x)
+# ifndef HAVE_SYS_ENDIAN_H
+#  define htobe16(x) OSSwapHostToBigInt16(x)
+#  define htole16(x) OSSwapHostToLittleInt16(x)
+#  define be16toh(x) OSSwapBigToHostInt16(x)
+#  define le16toh(x) OSSwapLittleToHostInt16(x)
+#  define htobe32(x) OSSwapHostToBigInt32(x)
+#  define htole32(x) OSSwapHostToLittleInt32(x)
+#  define be32toh(x) OSSwapBigToHostInt32(x)
+#  define le32toh(x) OSSwapLittleToHostInt32(x)
+#  define htobe64(x) OSSwapHostToBigInt64(x)
+#  define htole64(x) OSSwapHostToLittleInt64(x)
+#  define be64toh(x) OSSwapBigToHostInt64(x)
+#  define le64toh(x) OSSwapLittleToHostInt64(x)
+# endif
 # define bswap_16(x) OSSwapInt16(x)
 # define bswap_32(x) OSSwapInt32(x)
 # define bswap_64(x) OSSwapInt64(x)


### PR DESCRIPTION
Newer macOS SDKs provide htobe16/htole16/be16toh/etc. via
<sys/endian.h>. When HAVE_SYS_ENDIAN_H is defined, skip our
OSSwap-based definitions to avoid -Wmacro-redefined errors.