### PR TITLE
findmnt: skip shadowed entries when matching by --target

### DIFF
--- a/misc-utils/findmnt.c
+++ b/misc-utils/findmnt.c
@@ -1763,6 +1763,7 @@ int main(int argc, char *argv[])
 	char *outarg = NULL;
 	size_t i;
 	int force_tree = 0, istree = 0;
+	int force_target = 0;
 
 	struct libscols_table *table = NULL;
 
@@ -2001,7 +2002,7 @@ int main(int argc, char *argv[])
 			FALLTHROUGH;
 		case 'T':
 			set_match(COL_TARGET, optarg);
-			findmnt.flags |= FL_NOSWAPMATCH;
+			force_target = 1;
 			break;
 		case 'U':
 			findmnt.flags |= FL_UNIQ;
@@ -2141,6 +2142,11 @@ int main(int argc, char *argv[])
 		if (!strncmp(x, "LABEL=", 6) || !strncmp(x, "UUID=", 5) ||
 		    !strncmp(x, "PARTLABEL=", 10) || !strncmp(x, "PARTUUID=", 9))
 			findmnt.flags |= FL_NOSWAPMATCH;
+	}
+
+	if (force_target) {
+		direction = MNT_ITER_BACKWARD;
+		findmnt.flags |= FL_NOSWAPMATCH | FL_FIRSTONLY;
 	}
 
 	/*


### PR DESCRIPTION
When a bind mount overlays the same mountpoint (e.g. mount -B /boot /boot), findmnt --target <path> produces duplicate results because both the original and bind entries match via mnt_fs_match_target().

Filter out over-mounted entries using mnt_table_over_fs() when the target match is active. This ensures --target returns only the visible (topmost) filesystem for the given path.

[misc-utils/findmnt.c: match_func()]

Fixes https://github.com/util-linux/util-linux/issues/4424