### PR TITLE
tests: (chrt) skip SCHED_EXT subtest when kernel lacks support

### DIFF
--- a/tests/ts/chrt/chrt
+++ b/tests/ts/chrt/chrt
@@ -35,6 +35,15 @@ function skip_policy {
 		ts_finalize_subtest
 		return 1
 	fi
+
+	if [ -n "$2" ]; then
+		$TS_CMD_CHRT $2 0 true >/dev/null 2>&1
+		if [ $? != 0 ]; then
+			ts_skip "unsupported by kernel"
+			ts_finalize_subtest
+			return 1
+		fi
+	fi
 	return 0
 }
 
@@ -132,7 +141,7 @@ if skip_policy SCHED_DEADLINE; then
 fi
 
 ts_init_subtest "ext"
-if skip_policy SCHED_EXT; then
+if skip_policy SCHED_EXT --ext; then
 	do_chrt --ext 0
 	do_chrt -e 0
 	cleanup_output


### PR DESCRIPTION
sched_get_priority_max/min() returns 0 for SCHED_EXT even when the kernel was built without CONFIG_SCHED_CLASS_EXT, so the existing skip_policy() check (grepping chrt --max output) cannot detect the missing support.  The test then fails at runtime with EINVAL rather than skipping gracefully.

Add an optional second argument to skip_policy(): when set, the function performs a runtime probe by actually trying to set the policy.  Pass '--ext' for the ext subtest so unsupported kernels correctly skip the test.

Addresses: https://github.com/util-linux/util-linux/issues/4429