### PR TITLE
unshare: Fix --map-auto regression

### DIFF
--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -535,15 +535,14 @@ static void add_single_map_range(struct map_range **chain, unsigned int outer,
 				 *next = map->next;
 		unsigned int inner_offset, outer_offset;
 
-		/* Start inner IDs from zero for an auto mapping */
+		/*
+		 * Start inner IDs from zero for an auto mapping; otherwise,
+		 * if the single mapping exists and overlaps the range,
+		 * remove an ID
+		 */
 		if (map->inner + 1 == 0)
 			map->inner = 0;
-
-		/*
-		 * If the single mapping exists and overlaps the range, remove
-		 * an ID
-		 */
-		if (inner + 1 != 0 &&
+		else if (inner + 1 != 0 &&
 		    ((outer >= map->outer && outer <= map->outer + map->count) ||
 		     (inner >= map->inner && inner <= map->inner + map->count)))
 			map->count--;


### PR DESCRIPTION
Commit 07935158 fixed an `unshare --user` bug which wasted a UID/GID when `--map-auto` was used with `--map-root-user`. This bug meant that, for example, a user with a single extra UID and GID delegated to them in `/etc/subuid` and `/etc/subgid` would not get that user or group mapped at all if they attempted `unshare -r --map-auto`.

Two years later, commit b64b769b added `unshare --map-subids` to identity-map subuids and subgids into a user namespace, but incorrectly removed a load-bearing `else if` in passing, and reintroduced the original bug.

Ironically, `map->inner != -1` for an identity mapping, so the `if` vs `else if` change has no effect on the `--map-subids` option; it only breaks `--map-auto`.

Fix the `unshare -r --map-auto` behaviour again.