### PR TITLE
libblkid: add pluggable VFS I/O operations

### DIFF
--- a/agetty-cmd/agetty.c
+++ b/agetty-cmd/agetty.c
@@ -513,7 +513,7 @@ int main(int argc, char **argv)
 	if (options.flags & F_INITSTRING &&
 	    options.initstring && *options.initstring != '\0') {
 		debug("writing init string\n");
-		write_all(STDOUT_FILENO, options.initstring,
+		ul_write_all(STDOUT_FILENO, options.initstring,
 			   strlen(options.initstring));
 	}
 
@@ -601,7 +601,7 @@ int main(int argc, char **argv)
 		agetty_reset_vc(&options, &termios, 1);
 
 	/* Now the newline character should be properly written. */
-	write_all(STDOUT_FILENO, "\r\n", 2);
+	ul_write_all(STDOUT_FILENO, "\r\n", 2);
 
 	sigaction(SIGQUIT, &sa_quit, NULL);
 	sigaction(SIGINT, &sa_int, NULL);
@@ -745,8 +745,8 @@ again:
 					cn = res->ai_canonname;
 			}
 
-			write_all(STDOUT_FILENO, cn, strlen(cn));
-			write_all(STDOUT_FILENO, " ", 1);
+			ul_write_all(STDOUT_FILENO, cn, strlen(cn));
+			ul_write_all(STDOUT_FILENO, " ", 1);
 
 			if (res)
 				freeaddrinfo(res);
@@ -755,7 +755,7 @@ again:
 	}
 	if (!op->autolog) {
 		/* Always show login prompt. */
-		write_all(STDOUT_FILENO, LOGIN_PROMPT,
+		ul_write_all(STDOUT_FILENO, LOGIN_PROMPT,
 				sizeof(LOGIN_PROMPT) - 1);
 	}
 }
@@ -924,7 +924,7 @@ static char *get_logname(struct agetty_issue *ie, struct agetty_options *op, str
 						/* Ideally it should be "\xe2\x90\x9b"
 						 * if (op->flags & (F_UTF8)),
 						 * but only some fonts contain it */
-						write_all(1, "^[", 2);
+						ul_write_all(1, "^[", 2);
 						*visual_bp = 2;		/* ESC shows as ^[ (2 chars) */
 					} else if (ascval == '\t') {
 						/* Tab expands to spaces */
@@ -932,10 +932,10 @@ static char *get_logname(struct agetty_issue *ie, struct agetty_options *op, str
 						int spaces = 8 - (pos % 8);
 						int i;
 						for (i = 0; i < spaces; i++)
-							write_all(1, " ", 1);
+							ul_write_all(1, " ", 1);
 						*visual_bp = spaces;
 					} else {
-						write_all(1, &c, 1);	/* echo the character */
+						ul_write_all(1, &c, 1);	/* echo the character */
 						*visual_bp = 1;		/* normal char shows as 1 */
 					}
 				} else {

--- a/agetty-cmd/issuefile.c
+++ b/agetty-cmd/issuefile.c
@@ -69,7 +69,7 @@ static char *read_os_release(struct agetty_options *op, const char *varname)
 		op->osrelease = malloc(st.st_size + 1);
 		if (!op->osrelease)
 			agetty_log_err(_("failed to allocate memory: %m"));
-		if (read_all(fd, op->osrelease, st.st_size) != (ssize_t) st.st_size) {
+		if (ul_read_all(fd, op->osrelease, st.st_size) != (ssize_t) st.st_size) {
 			free(op->osrelease);
 			op->osrelease = NULL;
 			goto done;
@@ -210,7 +210,7 @@ void agetty_print_issue_file(struct agetty_issue *ie __attribute__((__unused__))
 {
 	if ((op->flags & F_NONL) == 0) {
 		/* Issue not in use, start with a new line. */
-		write_all(STDOUT_FILENO, "\r\n", 2);
+		ul_write_all(STDOUT_FILENO, "\r\n", 2);
 	}
 }
 
@@ -292,7 +292,7 @@ void agetty_print_issue_file(struct agetty_issue *ie,
 
 	if ((op->flags & F_NONL) == 0) {
 		/* Issue not in use, start with a new line. */
-		write_all(STDOUT_FILENO, "\r\n", 2);
+		ul_write_all(STDOUT_FILENO, "\r\n", 2);
 	}
 
 	if (ie->do_tcsetattr) {
@@ -304,7 +304,7 @@ void agetty_print_issue_file(struct agetty_issue *ie,
 	}
 
 	if (ie->mem_sz && ie->mem)
-		write_all(STDOUT_FILENO, ie->mem, ie->mem_sz);
+		ul_write_all(STDOUT_FILENO, ie->mem, ie->mem_sz);
 
 	if (ie->do_tcrestore) {
 		/* Restore settings. */
@@ -446,7 +446,7 @@ void agetty_show_issue(struct agetty_options *op)
 	agetty_eval_issue_file(&ie, op, &tp);
 
 	if (ie.mem_sz)
-		write_all(STDOUT_FILENO, ie.mem, ie.mem_sz);
+		ul_write_all(STDOUT_FILENO, ie.mem, ie.mem_sz);
 	if (ie.output)
 		fclose(ie.output);
 	free(ie.mem);

--- a/agetty-cmd/tty.c
+++ b/agetty-cmd/tty.c
@@ -168,7 +168,7 @@ void agetty_termio_clear(int fd)
 	 * erase everything below the cursor (ESC [ J), and set the
 	 * scrolling region to the full window (ESC [ r)
 	 */
-	write_all(fd, "\033[r\033[H\033[J", 9);
+	ul_write_all(fd, "\033[r\033[H\033[J", 9);
 }
 
 void agetty_reset_vc(const struct agetty_options *op, struct termios *tp, int canon)
@@ -685,5 +685,5 @@ void agetty_erase_char(int visual_count, struct chardata *cp)
 	};
 	int i;
 	for (i = 0; i < visual_count; i++)
-		write_all(1, erase[cp->parity], 3);
+		ul_write_all(1, erase[cp->parity], 3);
 }

--- a/disk-utils/fdisk-list.c
+++ b/disk-utils/fdisk-list.c
@@ -416,7 +416,7 @@ char *next_proc_partition(FILE **f)
 		if (devno <= 0)
 			continue;
 
-		if (sysfs_devno_is_dm_private(devno, NULL) ||
+		if (sysfs_devno_is_dm_private(devno, NULL, NULL) ||
 		    sysfs_devno_is_wholedisk(devno) <= 0)
 			continue;
 

--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -1006,7 +1006,7 @@ static void dump_blkdev(struct fdisk_context *cxt, const char *name,
 	else {
 		unsigned char *buf = xmalloc(size);
 
-		if (read_all(fd, (char *) buf, size) != (ssize_t) size)
+		if (ul_read_all(fd, (char *) buf, size) != (ssize_t) size)
 			fdisk_warn(cxt, _("cannot read"));
 		else
 			dump_buffer(offset, buf, size);

--- a/disk-utils/fsck.minix.c
+++ b/disk-utils/fsck.minix.c
@@ -526,13 +526,13 @@ write_tables(void) {
 
 	write_super_block();
 
-	if (write_all(device_fd, inode_map, imaps * MINIX_BLOCK_SIZE))
+	if (ul_write_all(device_fd, inode_map, imaps * MINIX_BLOCK_SIZE))
 		die(_("Unable to write inode map"));
 
-	if (write_all(device_fd, zone_map, zmaps * MINIX_BLOCK_SIZE))
+	if (ul_write_all(device_fd, zone_map, zmaps * MINIX_BLOCK_SIZE))
 		die(_("Unable to write zone map"));
 
-	if (write_all(device_fd, inode_buffer, buffsz))
+	if (ul_write_all(device_fd, inode_buffer, buffsz))
 		die(_("Unable to write inodes"));
 }
 

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -196,21 +196,21 @@ static void write_tables(const struct fs_control *ctl)
 	if (lseek(ctl->device_fd, 0, SEEK_SET))
 		err(MKFS_EX_ERROR, _("%s: seek to boot block failed "
 				   "in write_tables"), ctl->device_name);
-	if (write_all(ctl->device_fd, boot_block_buffer, 512))
+	if (ul_write_all(ctl->device_fd, boot_block_buffer, 512))
 		err(MKFS_EX_ERROR, _("%s: unable to clear boot sector"), ctl->device_name);
 	if (MINIX_BLOCK_SIZE != lseek(ctl->device_fd, MINIX_BLOCK_SIZE, SEEK_SET))
 		err(MKFS_EX_ERROR, _("%s: seek failed in write_tables"), ctl->device_name);
 
-	if (write_all(ctl->device_fd, super_block_buffer, MINIX_BLOCK_SIZE))
+	if (ul_write_all(ctl->device_fd, super_block_buffer, MINIX_BLOCK_SIZE))
 		err(MKFS_EX_ERROR, _("%s: unable to write super-block"), ctl->device_name);
 
-	if (write_all(ctl->device_fd, inode_map, imaps * MINIX_BLOCK_SIZE))
+	if (ul_write_all(ctl->device_fd, inode_map, imaps * MINIX_BLOCK_SIZE))
 		err(MKFS_EX_ERROR, _("%s: unable to write inode map"), ctl->device_name);
 
-	if (write_all(ctl->device_fd, zone_map, zmaps * MINIX_BLOCK_SIZE))
+	if (ul_write_all(ctl->device_fd, zone_map, zmaps * MINIX_BLOCK_SIZE))
 		err(MKFS_EX_ERROR, _("%s: unable to write zone map"), ctl->device_name);
 
-	if (write_all(ctl->device_fd, inode_buffer, buffsz))
+	if (ul_write_all(ctl->device_fd, inode_buffer, buffsz))
 		err(MKFS_EX_ERROR, _("%s: unable to write inodes"), ctl->device_name);
 }
 
@@ -219,7 +219,7 @@ static void write_block(const struct fs_control *ctl, int blk, char * buffer)
 	if (blk * MINIX_BLOCK_SIZE != lseek(ctl->device_fd, blk * MINIX_BLOCK_SIZE, SEEK_SET))
 		errx(MKFS_EX_ERROR, _("%s: seek failed in write_block"), ctl->device_name);
 
-	if (write_all(ctl->device_fd, buffer, MINIX_BLOCK_SIZE))
+	if (ul_write_all(ctl->device_fd, buffer, MINIX_BLOCK_SIZE))
 		errx(MKFS_EX_ERROR, _("%s: write failed in write_block"), ctl->device_name);
 }
 

--- a/disk-utils/mkswap.c
+++ b/disk-utils/mkswap.c
@@ -492,7 +492,7 @@ static void wipe_device(struct mkswap_control *ctl)
 		if (lseek(ctl->fd, 0, SEEK_SET) != 0)
 			errx(EXIT_FAILURE, _("unable to rewind swap-device"));
 
-		if (write_all(ctl->fd, buf, sizeof(buf)))
+		if (ul_write_all(ctl->fd, buf, sizeof(buf)))
 			errx(EXIT_FAILURE, _("unable to erase bootbits sectors"));
 #ifdef HAVE_LIBBLKID
 		/*
@@ -544,7 +544,7 @@ static void write_header_to_device(struct mkswap_control *ctl)
 	if (lseek(ctl->fd, offset, SEEK_SET) != offset)
 		errx(EXIT_FAILURE, _("unable to rewind swap-device"));
 
-	if (write_all(ctl->fd, (char *) ctl->signature_page + SIGNATURE_OFFSET,
+	if (ul_write_all(ctl->fd, (char *) ctl->signature_page + SIGNATURE_OFFSET,
 		      ctl->pagesize - SIGNATURE_OFFSET) == -1)
 		err(EXIT_FAILURE,
 			_("%s: unable to write signature page"),

--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -305,12 +305,12 @@ static void backup_sectors(struct sfdisk *sf,
 	} else {
 		unsigned char *buf = xmalloc(size);
 
-		if (read_all(devfd, (char *) buf, size) != (ssize_t) size) {
+		if (ul_read_all(devfd, (char *) buf, size) != (ssize_t) size) {
 			fdisk_warn(sf->cxt, _("cannot read %s"), devname);
 			free(buf);
 			goto fail;
 		}
-		if (write_all(fd, buf, size) != 0) {
+		if (ul_write_all(fd, buf, size) != 0) {
 			fdisk_warn(sf->cxt, _("cannot write %s"), fname);
 			free(buf);
 			goto fail;
@@ -548,7 +548,7 @@ static int move_partition_data(struct sfdisk *sf, size_t partno, struct fdisk_pa
 		if (!sf->noact) {
 			/* read source */
 			if (lseek(fd, src, SEEK_SET) == (off_t) -1 ||
-			    read_all(fd, buf, step_bytes) != (ssize_t) step_bytes) {
+			    ul_read_all(fd, buf, step_bytes) != (ssize_t) step_bytes) {
 				if (f)
 					fprintf(f, "%05zu: read error %12ju %12ju\n", cc, src, dst);
 				fdisk_warn(sf->cxt,
@@ -559,7 +559,7 @@ static int move_partition_data(struct sfdisk *sf, size_t partno, struct fdisk_pa
 
 			/* write target */
 			if (lseek(fd, dst, SEEK_SET) == (off_t) -1 ||
-			    write_all(fd, buf, step_bytes) != 0) {
+			    ul_write_all(fd, buf, step_bytes) != 0) {
 				if (f)
 					fprintf(f, "%05zu: write error %12ju %12ju\n", cc, src, dst);
 				fdisk_warn(sf->cxt,

--- a/disk-utils/swaplabel.c
+++ b/disk-utils/swaplabel.c
@@ -79,7 +79,7 @@ static int change_info(const char *devname, const char *label,
 				warn(_("%s: failed to seek to swap UUID"), devname);
 				goto err;
 
-			} else if (write_all(fd, newuuid, sizeof(newuuid))) {
+			} else if (ul_write_all(fd, newuuid, sizeof(newuuid))) {
 				warn(_("%s: failed to write UUID"), devname);
 				goto err;
 			}
@@ -100,7 +100,7 @@ static int change_info(const char *devname, const char *label,
 		if (strlen(label) > strlen(newlabel))
 			warnx(_("label is too long. Truncating it to '%s'"),
 					newlabel);
-		if (write_all(fd, newlabel, sizeof(newlabel))) {
+		if (ul_write_all(fd, newlabel, sizeof(newlabel))) {
 			warn(_("%s: failed to write label"), devname);
 			goto err;
 		}

--- a/include/Makemodule.am
+++ b/include/Makemodule.am
@@ -84,6 +84,7 @@ dist_noinst_HEADERS += \
 	include/timer.h \
 	include/timeutils.h \
 	include/ttyutils.h \
+	include/vfs.h \
 	include/widechar.h \
 	include/xalloc.h \
 	include/xxhash.h \

--- a/include/all-io.h
+++ b/include/all-io.h
@@ -19,7 +19,7 @@
 
 #include "c.h"
 
-static inline int write_all(int fd, const void *buf, size_t count)
+static inline int ul_write_all(int fd, const void *buf, size_t count)
 {
 	while (count) {
 		ssize_t tmp;
@@ -38,7 +38,7 @@ static inline int write_all(int fd, const void *buf, size_t count)
 	return 0;
 }
 
-static inline int fwrite_all(const void *ptr, size_t size,
+static inline int ul_fwrite_all(const void *ptr, size_t size,
 			     size_t nmemb, FILE *stream)
 {
 	while (nmemb) {
@@ -58,7 +58,7 @@ static inline int fwrite_all(const void *ptr, size_t size,
 	return 0;
 }
 
-static inline ssize_t read_all(int fd, char *buf, size_t count)
+static inline ssize_t ul_read_all(int fd, char *buf, size_t count)
 {
 	ssize_t ret;
 	ssize_t c = 0;
@@ -84,7 +84,7 @@ static inline ssize_t read_all(int fd, char *buf, size_t count)
 	return c;
 }
 
-static inline ssize_t read_all_alloc(int fd, char **buf)
+static inline ssize_t ul_read_all_alloc(int fd, char **buf)
 {
 	size_t size = 1024, c = 0;
 	ssize_t ret;
@@ -94,7 +94,7 @@ static inline ssize_t read_all_alloc(int fd, char **buf)
 		return -1;
 
 	while (1) {
-		ret = read_all(fd, *buf + c, size - c);
+		ret = ul_read_all(fd, *buf + c, size - c);
 		if (ret < 0) {
 			free(*buf);
 			*buf = NULL;
@@ -114,7 +114,7 @@ static inline ssize_t read_all_alloc(int fd, char **buf)
 	}
 }
 
-static inline ssize_t sendfile_all(int out __attribute__((__unused__)),
+static inline ssize_t ul_sendfile_all(int out __attribute__((__unused__)),
 				   int in __attribute__((__unused__)),
 				   off_t *off __attribute__((__unused__)),
 				   size_t count __attribute__((__unused__)))

--- a/include/all-io.h
+++ b/include/all-io.h
@@ -18,14 +18,16 @@
 #endif
 
 #include "c.h"
+#include "vfs.h"
 
-static inline int ul_write_all(int fd, const void *buf, size_t count)
+static inline int __write_all(const struct ul_vfs_ops *vfs, int fd,
+			      const void *buf, size_t count)
 {
 	while (count) {
 		ssize_t tmp;
 
 		errno = 0;
-		tmp = write(fd, buf, count);
+		tmp = ul_vfs_write(vfs, fd, buf, count);
 		if (tmp > 0) {
 			count -= tmp;
 			if (count)
@@ -37,6 +39,9 @@ static inline int ul_write_all(int fd, const void *buf, size_t count)
 	}
 	return 0;
 }
+
+#define ul_write_all(fd, buf, count)		__write_all(NULL, (fd), (buf), (count))
+#define ul_vfs_write_all(vfs, fd, buf, count)	__write_all((vfs), (fd), (buf), (count))
 
 static inline int ul_fwrite_all(const void *ptr, size_t size,
 			     size_t nmemb, FILE *stream)
@@ -58,7 +63,8 @@ static inline int ul_fwrite_all(const void *ptr, size_t size,
 	return 0;
 }
 
-static inline ssize_t ul_read_all(int fd, char *buf, size_t count)
+static inline ssize_t __read_all(const struct ul_vfs_ops *vfs, int fd,
+				 char *buf, size_t count)
 {
 	ssize_t ret;
 	ssize_t c = 0;
@@ -66,7 +72,7 @@ static inline ssize_t ul_read_all(int fd, char *buf, size_t count)
 
 	memset(buf, 0, count);
 	while (count > 0) {
-		ret = read(fd, buf, count);
+		ret = ul_vfs_read(vfs, fd, buf, count);
 		if (ret < 0) {
 			if ((errno == EAGAIN || errno == EINTR) && (tries++ < 5)) {
 				xusleep(250000);
@@ -83,6 +89,9 @@ static inline ssize_t ul_read_all(int fd, char *buf, size_t count)
 	}
 	return c;
 }
+
+#define ul_read_all(fd, buf, count)		__read_all(NULL, (fd), (buf), (count))
+#define ul_vfs_read_all(vfs, fd, buf, count)	__read_all((vfs), (fd), (buf), (count))
 
 static inline ssize_t ul_read_all_alloc(int fd, char **buf)
 {

--- a/include/path.h
+++ b/include/path.h
@@ -25,6 +25,8 @@ struct path_cxt {
 	void	*dialect;
 	void	(*free_dialect)(struct path_cxt *);
 	int	(*redirect_on_enoent)(struct path_cxt *, const char *, int *);
+
+	const struct ul_vfs_ops *vfs;
 };
 
 struct path_cxt *ul_new_path(const char *dir, ...)
@@ -44,6 +46,9 @@ int ul_path_set_dialect(struct path_cxt *pc, void *data, void free_data(struct p
 void *ul_path_get_dialect(struct path_cxt *pc);
 
 int ul_path_set_enoent_redirect(struct path_cxt *pc, int (*func)(struct path_cxt *, const char *, int *));
+
+struct ul_vfs_ops;
+void ul_path_refer_vfs(struct path_cxt *pc, const struct ul_vfs_ops *vfs);
 int ul_path_get_dirfd(struct path_cxt *pc);
 void ul_path_close_dirfd(struct path_cxt *pc);
 int ul_path_isopen_dirfd(struct path_cxt *pc);

--- a/include/sysfs.h
+++ b/include/sysfs.h
@@ -93,10 +93,14 @@ int sysfs_blkdev_get_wholedisk( struct path_cxt *pc,
                                 size_t len,
                                 dev_t *diskdevno);
 
+struct ul_vfs_ops;
+
 int sysfs_devno_to_wholedisk(dev_t dev, char *diskname,
                              size_t len, dev_t *diskdevno);
-int sysfs_devno_is_dm_hidden(dev_t devno, char **uuid);
-int sysfs_devno_is_dm_private(dev_t devno, char **uuid);
+int sysfs_devno_is_dm_hidden(dev_t devno, char **uuid,
+                             const struct ul_vfs_ops *vfs);
+int sysfs_devno_is_dm_private(dev_t devno, char **uuid,
+                              const struct ul_vfs_ops *vfs);
 int sysfs_devno_is_wholedisk(dev_t devno);
 
 dev_t sysfs_devname_to_devno(const char *name);

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -1,0 +1,86 @@
+/*
+ * No copyright is claimed.  This code is in the public domain; do with
+ * it what you wish.
+ */
+#ifndef UTIL_LINUX_VFS_H
+#define UTIL_LINUX_VFS_H
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <string.h>
+
+#ifndef UL_VFS_OPS_DEFINED
+#define UL_VFS_OPS_DEFINED
+
+struct ul_vfs_ops {
+	size_t size;
+
+	ssize_t (*vfs_read)(int fd, void *buf, size_t count);
+	ssize_t (*vfs_write)(int fd, const void *buf, size_t count);
+	int     (*vfs_open)(const char *pathname, int flags, mode_t mode);
+	int     (*vfs_close)(int fd);
+	off_t   (*vfs_lseek)(int fd, off_t offset, int whence);
+	int     (*vfs_fsync)(int fd);
+};
+
+#endif /* UL_VFS_OPS_DEFINED */
+
+static inline void ul_vfs_init(struct ul_vfs_ops *dst,
+			       const struct ul_vfs_ops *src)
+{
+	memset(dst, 0, sizeof(*dst));
+	if (src && src->size > 0) {
+		size_t sz = src->size < sizeof(*dst) ? src->size : sizeof(*dst);
+		memcpy(dst, src, sz);
+	}
+	dst->size = sizeof(*dst);
+}
+
+static inline ssize_t ul_vfs_read(const struct ul_vfs_ops *vfs,
+				  int fd, void *buf, size_t count)
+{
+	if (vfs && vfs->vfs_read)
+		return vfs->vfs_read(fd, buf, count);
+	return read(fd, buf, count);
+}
+
+static inline ssize_t ul_vfs_write(const struct ul_vfs_ops *vfs,
+				   int fd, const void *buf, size_t count)
+{
+	if (vfs && vfs->vfs_write)
+		return vfs->vfs_write(fd, buf, count);
+	return write(fd, buf, count);
+}
+
+static inline int ul_vfs_open(const struct ul_vfs_ops *vfs,
+			      const char *pathname, int flags, mode_t mode)
+{
+	if (vfs && vfs->vfs_open)
+		return vfs->vfs_open(pathname, flags, mode);
+	return open(pathname, flags, mode);
+}
+
+static inline int ul_vfs_close(const struct ul_vfs_ops *vfs, int fd)
+{
+	if (vfs && vfs->vfs_close)
+		return vfs->vfs_close(fd);
+	return close(fd);
+}
+
+static inline off_t ul_vfs_lseek(const struct ul_vfs_ops *vfs,
+				 int fd, off_t offset, int whence)
+{
+	if (vfs && vfs->vfs_lseek)
+		return vfs->vfs_lseek(fd, offset, whence);
+	return lseek(fd, offset, whence);
+}
+
+static inline int ul_vfs_fsync(const struct ul_vfs_ops *vfs, int fd)
+{
+	if (vfs && vfs->vfs_fsync)
+		return vfs->vfs_fsync(fd);
+	return fsync(fd);
+}
+
+#endif /* UTIL_LINUX_VFS_H */

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -5,6 +5,7 @@
 #ifndef UTIL_LINUX_VFS_H
 #define UTIL_LINUX_VFS_H
 
+#include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -35,6 +36,19 @@ static inline void ul_vfs_init(struct ul_vfs_ops *dst,
 		memcpy(dst, src, sz);
 	}
 	dst->size = sizeof(*dst);
+}
+
+static inline struct ul_vfs_ops *ul_vfs_copy(const struct ul_vfs_ops *src)
+{
+	struct ul_vfs_ops *dst;
+
+	if (!src)
+		return NULL;
+	dst = malloc(sizeof(*dst));
+	if (!dst)
+		return NULL;
+	memcpy(dst, src, sizeof(*dst));
+	return dst;
 }
 
 static inline ssize_t ul_vfs_read(const struct ul_vfs_ops *vfs,

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -5,6 +5,7 @@
 #ifndef UTIL_LINUX_VFS_H
 #define UTIL_LINUX_VFS_H
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -23,6 +24,8 @@ struct ul_vfs_ops {
 	int     (*vfs_close)(int fd);
 	off_t   (*vfs_lseek)(int fd, off_t offset, int whence);
 	int     (*vfs_fsync)(int fd);
+
+	FILE   *(*vfs_fopen)(const char *pathname, const char *mode);
 };
 
 #endif /* UL_VFS_OPS_DEFINED */
@@ -124,6 +127,97 @@ static inline int ul_mode_to_flags(const char *mode)
 	}
 
 	return flags;
+}
+
+#ifdef __GLIBC__
+
+struct ul_vfs_cookie {
+	const struct ul_vfs_ops *vfs;
+	int fd;
+};
+
+static inline ssize_t ul_vfs_cookie_read(void *cookie, char *buf, size_t count)
+{
+	struct ul_vfs_cookie *ck = (struct ul_vfs_cookie *) cookie;
+	return ul_vfs_read(ck->vfs, ck->fd, buf, count);
+}
+
+static inline ssize_t ul_vfs_cookie_write(void *cookie, const char *buf, size_t count)
+{
+	struct ul_vfs_cookie *ck = (struct ul_vfs_cookie *) cookie;
+	return ul_vfs_write(ck->vfs, ck->fd, buf, count);
+}
+
+static inline int ul_vfs_cookie_seek(void *cookie, off64_t *pos, int whence)
+{
+	struct ul_vfs_cookie *ck = (struct ul_vfs_cookie *) cookie;
+	off_t rc = ul_vfs_lseek(ck->vfs, ck->fd, (off_t) *pos, whence);
+
+	if (rc == (off_t) -1)
+		return -1;
+	*pos = (off64_t) rc;
+	return 0;
+}
+
+static inline int ul_vfs_cookie_close(void *cookie)
+{
+	struct ul_vfs_cookie *ck = (struct ul_vfs_cookie *) cookie;
+	int rc = ul_vfs_close(ck->vfs, ck->fd);
+
+	free(ck);
+	return rc;
+}
+
+static inline FILE *ul_vfs_fdopen(const struct ul_vfs_ops *vfs,
+				  int fd, const char *mode)
+{
+	struct ul_vfs_cookie *ck;
+	cookie_io_functions_t io_funcs = {
+		.read  = ul_vfs_cookie_read,
+		.write = ul_vfs_cookie_write,
+		.seek  = ul_vfs_cookie_seek,
+		.close = ul_vfs_cookie_close,
+	};
+
+	if (!vfs)
+		return fdopen(fd, mode);
+
+	ck = malloc(sizeof(*ck));
+	if (!ck)
+		return NULL;
+	ck->vfs = vfs;
+	ck->fd = fd;
+
+	return fopencookie(ck, mode, io_funcs);
+}
+
+#else /* !__GLIBC__ */
+
+static inline FILE *ul_vfs_fdopen(
+		const struct ul_vfs_ops *vfs __attribute__((__unused__)),
+		int fd, const char *mode)
+{
+	return fdopen(fd, mode);
+}
+
+#endif /* __GLIBC__ */
+
+static inline FILE *ul_vfs_fopen(const struct ul_vfs_ops *vfs,
+				 const char *path, const char *mode)
+{
+	if (vfs && vfs->vfs_fopen)
+		return vfs->vfs_fopen(path, mode);
+#ifdef __GLIBC__
+	if (vfs && vfs->vfs_open) {
+		int flags = ul_mode_to_flags(mode);
+		int fd = ul_vfs_open(vfs, path, flags, 0);
+
+		if (fd < 0)
+			return NULL;
+		return ul_vfs_fdopen(vfs, fd, mode);
+	}
+#endif
+	return fopen(path, mode);
 }
 
 #endif /* UTIL_LINUX_VFS_H */

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -97,4 +97,33 @@ static inline int ul_vfs_fsync(const struct ul_vfs_ops *vfs, int fd)
 	return fsync(fd);
 }
 
+static inline int ul_mode_to_flags(const char *mode)
+{
+	int flags = 0;
+	const char *p;
+
+	for (p = mode; p && *p; p++) {
+		if (*p == 'r' && *(p + 1) == '+')
+			flags |= O_RDWR;
+		else if (*p == 'r')
+			flags |= O_RDONLY;
+
+		else if (*p == 'w' && *(p + 1) == '+')
+			flags |= O_RDWR | O_TRUNC;
+		else if (*p == 'w')
+			flags |= O_WRONLY | O_TRUNC;
+
+		else if (*p == 'a' && *(p + 1) == '+')
+			flags |= O_RDWR | O_APPEND;
+		else if (*p == 'a')
+			flags |= O_WRONLY | O_APPEND;
+#ifdef O_CLOEXEC
+		else if (*p == 'e')
+			flags |= O_CLOEXEC;
+#endif
+	}
+
+	return flags;
+}
+
 #endif /* UTIL_LINUX_VFS_H */

--- a/lib/blkdev.c
+++ b/lib/blkdev.c
@@ -46,7 +46,7 @@ blkdev_valid_offset (int fd, off_t offset) {
 
 	if (lseek (fd, offset, 0) < 0)
 		return 0;
-	if (read_all (fd, &ch, 1) < 1)
+	if (ul_read_all (fd, &ch, 1) < 1)
 		return 0;
 	return 1;
 }

--- a/lib/env.c
+++ b/lib/env.c
@@ -173,7 +173,7 @@ struct ul_env_list *env_list_from_fd(int fd)
 	struct ul_env_list *ls = NULL;
 
 	errno = 0;
-	if ((rc = read_all_alloc(fd, &buf)) < 1)
+	if ((rc = ul_read_all_alloc(fd, &buf)) < 1)
 		return NULL;
 	buf[rc] = '\0';
 	p = buf;

--- a/lib/fileeq.c
+++ b/lib/fileeq.c
@@ -394,7 +394,7 @@ static ssize_t read_block(struct ul_fileeq *eq, struct ul_fileeq_data *data,
 	if (!*block)
 		return -ENOMEM;
 
-	rsz = read_all(data->fd, (char *) *block, eq->readsiz);
+	rsz = ul_read_all(data->fd, (char *) *block, eq->readsiz);
 	if (rsz < 0) {
 		DBG_OBJ(DATA, data, ul_debug("  read failed"));
 		return rsz;
@@ -462,7 +462,7 @@ static ssize_t get_digest(struct ul_fileeq *eq, struct ul_fileeq_data *data,
 
 	/* get block digest (note 1st block is data->intro) */
 	*block = data->blocks + (n * eq->method->digsiz);
-	rsz = read_all(eq->fd_cip, (char *) *block, sz);
+	rsz = ul_read_all(eq->fd_cip, (char *) *block, sz);
 
 	if (rsz > 0)
 		data->nblocks++;
@@ -484,7 +484,7 @@ static ssize_t get_intro(struct ul_fileeq *eq, struct ul_fileeq_data *data,
 
 		if (fd < 0)
 			return -1;
-		rsz = read_all(fd, (char *) data->intro, sizeof(data->intro));
+		rsz = ul_read_all(fd, (char *) data->intro, sizeof(data->intro));
 		DBG_OBJ(DATA, data, ul_debug(" read %zd bytes [%zu wanted] intro", rsz, sizeof(data->intro)));
 		if (rsz < 0)
 			return -1;

--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -221,9 +221,9 @@ char *ul_restricted_path_oper(const char *path,
 		          errno ? -errno : -EINVAL;
 
 		/* send length or errno */
-		write_all(pipes[1], (char *) &len, sizeof(len));
+		ul_write_all(pipes[1], (char *) &len, sizeof(len));
 		if (result)
-			write_all(pipes[1], result, len);
+			ul_write_all(pipes[1], result, len);
 		_exit(0);
 	default:
 		break;
@@ -233,7 +233,7 @@ char *ul_restricted_path_oper(const char *path,
 	pipes[1] = -1;
 
 	/* read size or -errno */
-	if (read_all(pipes[0], (char *) &len, sizeof(len)) != sizeof(len))
+	if (ul_read_all(pipes[0], (char *) &len, sizeof(len)) != sizeof(len))
 		goto done;
 	if (len < 0) {
 		errsv = -len;
@@ -246,7 +246,7 @@ char *ul_restricted_path_oper(const char *path,
 		goto done;
 	}
 	/* read path */
-	if (read_all(pipes[0], result, len) != len) {
+	if (ul_read_all(pipes[0], result, len) != len) {
 		errsv = errno;
 		goto done;
 	}
@@ -355,8 +355,8 @@ static int copy_file_simple(int from, int to)
 	ssize_t nr;
 	char buf[BUFSIZ];
 
-	while ((nr = read_all(from, buf, sizeof(buf))) > 0)
-		if (write_all(to, buf, nr) == -1)
+	while ((nr = ul_read_all(from, buf, sizeof(buf))) > 0)
+		if (ul_write_all(to, buf, nr) == -1)
 			return UL_COPY_WRITE_ERROR;
 	if (nr < 0)
 		return UL_COPY_READ_ERROR;
@@ -377,10 +377,10 @@ int ul_copy_file(int from, int to)
 		return UL_COPY_READ_ERROR;
 	if (!S_ISREG(st.st_mode))
 		return copy_file_simple(from, to);
-	if (sendfile_all(to, from, NULL, st.st_size) < 0)
+	if (ul_sendfile_all(to, from, NULL, st.st_size) < 0)
 		return copy_file_simple(from, to);
 	/* ensure we either get an EOF or an error */
-	while ((nw = sendfile_all(to, from, NULL, 16*1024*1024)) != 0)
+	while ((nw = ul_sendfile_all(to, from, NULL, 16*1024*1024)) != 0)
 		if (nw < 0)
 			return copy_file_simple(from, to);
 	return 0;

--- a/lib/path.c
+++ b/lib/path.c
@@ -102,6 +102,12 @@ void ul_unref_path(struct path_cxt *pc)
 	}
 }
 
+void ul_path_refer_vfs(struct path_cxt *pc, const struct ul_vfs_ops *vfs)
+{
+	if (pc)
+		pc->vfs = vfs;
+}
+
 int ul_path_set_prefix(struct path_cxt *pc, const char *prefix)
 {
 	char *p = NULL;
@@ -511,7 +517,7 @@ FILE *ul_path_fopen(struct path_cxt *pc, const char *mode, const char *path)
 	if (fd < 0)
 		return NULL;
 
-	return fdopen(fd, mode);
+	return ul_vfs_fdopen(pc ? pc->vfs : NULL, fd, mode);
 }
 
 
@@ -649,10 +655,10 @@ int ul_path_read(struct path_cxt *pc, char *buf, size_t len, const char *path)
 		return -errno;
 
 	DBG(CXT, ul_debug(" reading '%s'", path));
-	rc = ul_read_all(fd, buf, len);
+	rc = ul_vfs_read_all(pc ? pc->vfs : NULL, fd, buf, len);
 
 	errsv = errno;
-	close(fd);
+	ul_vfs_close(pc ? pc->vfs : NULL, fd);
 	errno = errsv;
 	return rc;
 }
@@ -926,10 +932,10 @@ int ul_path_write_string(struct path_cxt *pc, const char *str, const char *path)
 	if (fd < 0)
 		return -errno;
 
-	rc = ul_write_all(fd, str, strlen(str));
+	rc = ul_vfs_write_all(pc ? pc->vfs : NULL, fd, str, strlen(str));
 
 	errsv = errno;
-	close(fd);
+	ul_vfs_close(pc ? pc->vfs : NULL, fd);
 	errno = errsv;
 	return rc;
 }
@@ -960,10 +966,10 @@ int ul_path_write_s64(struct path_cxt *pc, int64_t num, const char *path)
 	if (len < 0 || (size_t) len >= sizeof(buf))
 		rc = len < 0 ? -errno : -E2BIG;
 	else
-		rc = ul_write_all(fd, buf, len);
+		rc = ul_vfs_write_all(pc ? pc->vfs : NULL, fd, buf, len);
 
 	errsv = errno;
-	close(fd);
+	ul_vfs_close(pc ? pc->vfs : NULL, fd);
 	errno = errsv;
 	return rc;
 }
@@ -982,10 +988,10 @@ int ul_path_write_u64(struct path_cxt *pc, uint64_t num, const char *path)
 	if (len < 0 || (size_t) len >= sizeof(buf))
 		rc = len < 0 ? -errno : -E2BIG;
 	else
-		rc = ul_write_all(fd, buf, len);
+		rc = ul_vfs_write_all(pc ? pc->vfs : NULL, fd, buf, len);
 
 	errsv = errno;
-	close(fd);
+	ul_vfs_close(pc ? pc->vfs : NULL, fd);
 	errno = errsv;
 	return rc;
 }

--- a/lib/path.c
+++ b/lib/path.c
@@ -24,6 +24,7 @@
 #include "c.h"
 #include "fileutils.h"
 #include "all-io.h"
+#include "vfs.h"
 #include "path.h"
 #include "debug.h"
 #include "strutils.h"
@@ -502,38 +503,9 @@ int ul_path_openf(struct path_cxt *pc, int flags, const char *path, ...)
 /*
  * Maybe stupid, but good enough ;-)
  */
-static int mode2flags(const char *mode)
-{
-	int flags = 0;
-	const char *p;
-
-	for (p = mode; p && *p; p++) {
-		if (*p == 'r' && *(p + 1) == '+')
-			flags |= O_RDWR;
-		else if (*p == 'r')
-			flags |= O_RDONLY;
-
-		else if (*p == 'w' && *(p + 1) == '+')
-			flags |= O_RDWR | O_TRUNC;
-		else if (*p == 'w')
-			flags |= O_WRONLY | O_TRUNC;
-
-		else if (*p == 'a' && *(p + 1) == '+')
-			flags |= O_RDWR | O_APPEND;
-		else if (*p == 'a')
-			flags |= O_WRONLY | O_APPEND;
-#ifdef O_CLOEXEC
-		else if (*p == *UL_CLOEXECSTR)
-			flags |= O_CLOEXEC;
-#endif
-	}
-
-	return flags;
-}
-
 FILE *ul_path_fopen(struct path_cxt *pc, const char *mode, const char *path)
 {
-	int flags = mode2flags(mode);
+	int flags = ul_mode_to_flags(mode);
 	int fd = ul_path_open(pc, flags, path);
 
 	if (fd < 0)

--- a/lib/path.c
+++ b/lib/path.c
@@ -677,7 +677,7 @@ int ul_path_read(struct path_cxt *pc, char *buf, size_t len, const char *path)
 		return -errno;
 
 	DBG(CXT, ul_debug(" reading '%s'", path));
-	rc = read_all(fd, buf, len);
+	rc = ul_read_all(fd, buf, len);
 
 	errsv = errno;
 	close(fd);
@@ -954,7 +954,7 @@ int ul_path_write_string(struct path_cxt *pc, const char *str, const char *path)
 	if (fd < 0)
 		return -errno;
 
-	rc = write_all(fd, str, strlen(str));
+	rc = ul_write_all(fd, str, strlen(str));
 
 	errsv = errno;
 	close(fd);
@@ -988,7 +988,7 @@ int ul_path_write_s64(struct path_cxt *pc, int64_t num, const char *path)
 	if (len < 0 || (size_t) len >= sizeof(buf))
 		rc = len < 0 ? -errno : -E2BIG;
 	else
-		rc = write_all(fd, buf, len);
+		rc = ul_write_all(fd, buf, len);
 
 	errsv = errno;
 	close(fd);
@@ -1010,7 +1010,7 @@ int ul_path_write_u64(struct path_cxt *pc, uint64_t num, const char *path)
 	if (len < 0 || (size_t) len >= sizeof(buf))
 		rc = len < 0 ? -errno : -E2BIG;
 	else
-		rc = write_all(fd, buf, len);
+		rc = ul_write_all(fd, buf, len);
 
 	errsv = errno;
 	close(fd);

--- a/lib/plymouth-ctrl.c
+++ b/lib/plymouth-ctrl.c
@@ -112,14 +112,14 @@ int plymouth_command(int cmd, ...)
 		fdsock = open_un_socket_and_connect();
 		if (fdsock >= 0) {
 			command[0] = cmd;
-			write_all(fdsock, command, sizeof(command));
+			ul_write_all(fdsock, command, sizeof(command));
 		}
 		break;
 	case MAGIC_QUIT:
 		fdsock = open_un_socket_and_connect();
 		if (fdsock >= 0) {
 			command[0] = cmd;
-			write_all(fdsock, command, sizeof(command));
+			ul_write_all(fdsock, command, sizeof(command));
 		}
 		break;
 	default:
@@ -131,7 +131,7 @@ int plymouth_command(int cmd, ...)
 	answer[0] = '\0';
 	if (fdsock >= 0) {
 		if (can_read(fdsock, 1000))
-			read_all(fdsock, (char *) &answer[0], sizeof(answer));
+			ul_read_all(fdsock, (char *) &answer[0], sizeof(answer));
 		close(fdsock);
 	}
 	sigaction(SIGPIPE, &op, NULL);

--- a/lib/procfs.c
+++ b/lib/procfs.c
@@ -127,7 +127,7 @@ static ssize_t read_procfs_file(int fd, char *buf, size_t bufsz)
 	if (fd < 0)
 		return -EINVAL;
 
-	sz = read_all(fd, buf, bufsz);
+	sz = ul_read_all(fd, buf, bufsz);
 	if (sz <= 0)
 		return sz;
 

--- a/lib/procfs.c
+++ b/lib/procfs.c
@@ -17,6 +17,7 @@
 #include "procfs.h"
 #include "fileutils.h"
 #include "all-io.h"
+#include "vfs.h"
 #include "debug.h"
 #include "strutils.h"
 #include "statfs_magic.h"
@@ -119,7 +120,8 @@ static void procfs_process_deinit_path(struct path_cxt *pc)
 	ul_path_set_dialect(pc, NULL, NULL);
 }
 
-static ssize_t read_procfs_file(int fd, char *buf, size_t bufsz)
+static ssize_t read_procfs_file(const struct ul_vfs_ops *vfs, int fd,
+			       char *buf, size_t bufsz)
 {
 	ssize_t sz = 0;
 	size_t i;
@@ -127,7 +129,7 @@ static ssize_t read_procfs_file(int fd, char *buf, size_t bufsz)
 	if (fd < 0)
 		return -EINVAL;
 
-	sz = ul_read_all(fd, buf, bufsz);
+	sz = ul_vfs_read_all(vfs, fd, buf, bufsz);
 	if (sz <= 0)
 		return sz;
 
@@ -145,8 +147,8 @@ static ssize_t procfs_process_get_data_for(struct path_cxt *pc, char *buf, size_
 	int fd = ul_path_open(pc, O_RDONLY|O_CLOEXEC, fname);
 
 	if (fd >= 0) {
-		ssize_t sz = read_procfs_file(fd, buf, bufsz);
-		close(fd);
+		ssize_t sz = read_procfs_file(pc ? pc->vfs : NULL, fd, buf, bufsz);
+		ul_vfs_close(pc ? pc->vfs : NULL, fd);
 		return sz;
 	}
 	return -errno;
@@ -430,7 +432,7 @@ static char *strdup_procfs_file(pid_t pid, const char *name)
 	if (fd < 0)
 		return NULL;
 
-	if (read_procfs_file(fd, buf, sizeof(buf)) > 0)
+	if (read_procfs_file(NULL, fd, buf, sizeof(buf)) > 0)
 		re = strdup(buf);
 	close(fd);
 	return re;

--- a/lib/pty-session.c
+++ b/lib/pty-session.c
@@ -312,7 +312,7 @@ static int write_output(char *obuf, ssize_t bytes)
 {
 	DBG(IO, ul_debug(" writing output"));
 
-	if (write_all(STDOUT_FILENO, obuf, bytes)) {
+	if (ul_write_all(STDOUT_FILENO, obuf, bytes)) {
 		DBG(IO, ul_debug("  writing output *failed*"));
 		return -errno;
 	}

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -664,7 +664,8 @@ int sysfs_devno_to_wholedisk(dev_t devno, char *diskname,
  *
  * The @uuid (if not NULL) returns DM device UUID, use free() to deallocate.
  */
-int sysfs_devno_is_dm_hidden(dev_t devno, char **uuid)
+int sysfs_devno_is_dm_hidden(dev_t devno, char **uuid,
+			     const struct ul_vfs_ops *vfs)
 {
 	struct path_cxt *pc = NULL;
 	char *id = NULL;
@@ -673,6 +674,7 @@ int sysfs_devno_is_dm_hidden(dev_t devno, char **uuid)
 	pc = ul_new_sysfs_path(devno, NULL, NULL);
 	if (!pc)
 		goto done;
+	ul_path_refer_vfs(pc, vfs);
 	if (ul_path_read_string(pc, &id, "dm/uuid") <= 0 || !id)
 		goto done;
 
@@ -698,7 +700,8 @@ done:
  * Returns 1 if the device is private device mapper device. The @uuid
  * (if not NULL) returns DM device UUID, use free() to deallocate.
  */
-int sysfs_devno_is_dm_private(dev_t devno, char **uuid)
+int sysfs_devno_is_dm_private(dev_t devno, char **uuid,
+			      const struct ul_vfs_ops *vfs)
 {
 	struct path_cxt *pc = NULL;
 	char *id = NULL;
@@ -707,6 +710,7 @@ int sysfs_devno_is_dm_private(dev_t devno, char **uuid)
 	pc = ul_new_sysfs_path(devno, NULL, NULL);
 	if (!pc)
 		goto done;
+	ul_path_refer_vfs(pc, vfs);
 	if (ul_path_read_string(pc, &id, "dm/uuid") <= 0 || !id)
 		goto done;
 

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -474,7 +474,7 @@ static int sysfs_devchain_is_removable(char *chain)
 		/* try to read it */
 		fd = open(chain, O_RDONLY);
 		if (fd != -1) {
-			rc = read_all(fd, buf, sizeof(buf));
+			rc = ul_read_all(fd, buf, sizeof(buf));
 			close(fd);
 
 			if (rc > 0) {

--- a/libblkid/docs/libblkid-sections.txt
+++ b/libblkid/docs/libblkid-sections.txt
@@ -61,6 +61,7 @@ blkid_probe_reset_buffers
 blkid_probe_reset_hints
 blkid_probe_set_device
 blkid_probe_set_hint
+blkid_probe_open_device
 blkid_probe_set_sectorsize
 blkid_probe_set_vfs
 blkid_probe_step_back

--- a/libblkid/docs/libblkid-sections.txt
+++ b/libblkid/docs/libblkid-sections.txt
@@ -62,6 +62,7 @@ blkid_probe_reset_hints
 blkid_probe_set_device
 blkid_probe_set_hint
 blkid_probe_set_sectorsize
+blkid_probe_set_vfs
 blkid_probe_step_back
 blkid_reset_probe
 BLKID_PROBE_OK

--- a/libblkid/src/blkid.h.in
+++ b/libblkid/src/blkid.h.in
@@ -22,6 +22,7 @@
 #ifndef _BLKID_BLKID_H
 #define _BLKID_BLKID_H
 
+#include <stdio.h>
 #include <stdint.h>
 #include <sys/types.h>
 

--- a/libblkid/src/blkid.h.in
+++ b/libblkid/src/blkid.h.in
@@ -243,6 +243,25 @@ extern int blkid_probe_set_device(blkid_probe pr, int fd,
 	                blkid_loff_t off, blkid_loff_t size)
 			__ul_attribute__((nonnull));
 
+#ifndef UL_VFS_OPS_DEFINED
+#define UL_VFS_OPS_DEFINED
+
+struct ul_vfs_ops {
+	size_t size;
+
+	ssize_t (*vfs_read)(int fd, void *buf, size_t count);
+	ssize_t (*vfs_write)(int fd, const void *buf, size_t count);
+	int     (*vfs_open)(const char *pathname, int flags, mode_t mode);
+	int     (*vfs_close)(int fd);
+	off_t   (*vfs_lseek)(int fd, off_t offset, int whence);
+	int     (*vfs_fsync)(int fd);
+};
+
+#endif /* UL_VFS_OPS_DEFINED */
+
+extern int blkid_probe_set_vfs(blkid_probe pr, const struct ul_vfs_ops *ops)
+			__ul_attribute__((nonnull(1)));
+
 extern dev_t blkid_probe_get_devno(blkid_probe pr)
 			__ul_attribute__((nonnull));
 

--- a/libblkid/src/blkid.h.in
+++ b/libblkid/src/blkid.h.in
@@ -255,6 +255,8 @@ struct ul_vfs_ops {
 	int     (*vfs_close)(int fd);
 	off_t   (*vfs_lseek)(int fd, off_t offset, int whence);
 	int     (*vfs_fsync)(int fd);
+
+	FILE   *(*vfs_fopen)(const char *pathname, const char *mode);
 };
 
 #endif /* UL_VFS_OPS_DEFINED */

--- a/libblkid/src/blkid.h.in
+++ b/libblkid/src/blkid.h.in
@@ -262,6 +262,10 @@ struct ul_vfs_ops {
 extern int blkid_probe_set_vfs(blkid_probe pr, const struct ul_vfs_ops *ops)
 			__ul_attribute__((nonnull(1)));
 
+extern int blkid_probe_open_device(blkid_probe pr, const char *filename,
+			int flags)
+			__ul_attribute__((nonnull));
+
 extern dev_t blkid_probe_get_devno(blkid_probe pr)
 			__ul_attribute__((nonnull));
 

--- a/libblkid/src/blkidP.h
+++ b/libblkid/src/blkidP.h
@@ -32,6 +32,7 @@
 #include "blkdev.h"
 
 #include "debug.h"
+#include "vfs.h"
 #include "blkid.h"
 #include "list.h"
 #include "encode.h"
@@ -232,6 +233,8 @@ struct blkid_struct_probe
 
 	struct blkid_struct_probe *parent;	/* for clones */
 	struct blkid_struct_probe *disk_probe;	/* whole-disk probing */
+
+	struct ul_vfs_ops	*vfs;		/* pluggable I/O ops (owned, or NULL) */
 };
 
 /* private flags library flags */

--- a/libblkid/src/evaluate.c
+++ b/libblkid/src/evaluate.c
@@ -54,7 +54,7 @@
 static int verify_tag(const char *devname, const char *name, const char *value)
 {
 	blkid_probe pr;
-	int fd = -1, rc = -1;
+	int rc = -1;
 	size_t len;
 	const char *data;
 	int errsv = 0;
@@ -73,13 +73,10 @@ static int verify_tag(const char *devname, const char *name, const char *value)
 	blkid_probe_enable_partitions(pr, TRUE);
 	blkid_probe_set_partitions_flags(pr, BLKID_PARTS_ENTRY_DETAILS);
 
-	fd = open(devname, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
-	if (fd < 0) {
+	if (blkid_probe_open_device(pr, devname, 0)) {
 		errsv = errno;
 		goto done;
 	}
-	if (blkid_probe_set_device(pr, fd, 0, 0))
-		goto done;
 	rc = blkid_do_safeprobe(pr);
 	if (rc)
 		goto done;
@@ -89,8 +86,6 @@ static int verify_tag(const char *devname, const char *name, const char *value)
 done:
 	DBG(EVALUATE, ul_debug("%s: %s verification %s",
 			devname, name, rc == 0 ? "PASS" : "FAILED"));
-	if (fd >= 0)
-		close(fd);
 	blkid_free_probe(pr);
 
 	/* for non-root users we use unverified udev links */

--- a/libblkid/src/libblkid.sym
+++ b/libblkid/src/libblkid.sym
@@ -194,4 +194,5 @@ BLKID_2_40 {
 
 BLKID_2_43 {
     blkid_evaluate_tag2;
+    blkid_probe_set_vfs;
 } BLKID_2_40;

--- a/libblkid/src/libblkid.sym
+++ b/libblkid/src/libblkid.sym
@@ -194,5 +194,6 @@ BLKID_2_40 {
 
 BLKID_2_43 {
     blkid_evaluate_tag2;
+    blkid_probe_open_device;
     blkid_probe_set_vfs;
 } BLKID_2_40;

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -194,6 +194,14 @@ blkid_probe blkid_clone_probe(blkid_probe parent)
 
 	pr->flags &= ~BLKID_FL_PRIVATE_FD;
 
+	if (parent->vfs) {
+		pr->vfs = ul_vfs_copy(parent->vfs);
+		if (!pr->vfs) {
+			blkid_free_probe(pr);
+			return NULL;
+		}
+	}
+
 	return pr;
 }
 
@@ -277,13 +285,14 @@ void blkid_free_probe(blkid_probe pr)
 	}
 
 	if ((pr->flags & BLKID_FL_PRIVATE_FD) && pr->fd >= 0)
-		close(pr->fd);
+		ul_vfs_close(pr->vfs, pr->fd);
 	blkid_probe_reset_buffers(pr);
 	blkid_probe_reset_values(pr);
 	blkid_probe_reset_hints(pr);
 	blkid_free_probe(pr->disk_probe);
 
 	DBG(LOWPROBE, ul_debug("free probe"));
+	free(pr->vfs);
 	free(pr);
 }
 
@@ -578,7 +587,7 @@ static struct blkid_bufinfo *read_buffer(blkid_probe pr, uint64_t real_off, uint
 	ssize_t ret;
 	struct blkid_bufinfo *bf = NULL;
 
-	if (lseek(pr->fd, real_off, SEEK_SET) == (off_t) -1) {
+	if (ul_vfs_lseek(pr->vfs, pr->fd, real_off, SEEK_SET) == (off_t) -1) {
 		errno = 0;
 		return NULL;
 	}
@@ -611,7 +620,7 @@ static struct blkid_bufinfo *read_buffer(blkid_probe pr, uint64_t real_off, uint
 	DBG(LOWPROBE, ul_debug("\tread: off=%"PRIu64" len=%"PRIu64"",
 	                       real_off, len));
 
-	ret = read(pr->fd, bf->data, len);
+	ret = ul_vfs_read(pr->vfs, pr->fd, bf->data, len);
 	if (ret != (ssize_t) len) {
 		DBG(LOWPROBE, ul_debug("\tread failed: %m"));
 		remove_buffer(bf);
@@ -967,15 +976,15 @@ int blkdid_probe_is_opal_locked(blkid_probe pr)
 
 #ifdef CDROM_GET_CAPABILITY
 
-static int is_sector_readable(int fd, uint64_t sector)
+static int is_sector_readable(blkid_probe pr, uint64_t sector)
 {
 	char buf[512];
 	ssize_t sz;
 
-	if (lseek(fd, sector * 512, SEEK_SET) == (off_t) -1)
+	if (ul_vfs_lseek(pr->vfs, pr->fd, sector * 512, SEEK_SET) == (off_t) -1)
 		goto failed;
 
-	sz = read(fd, buf, sizeof(buf));
+	sz = ul_vfs_read(pr->vfs, pr->fd, buf, sizeof(buf));
 	if (sz != (ssize_t) sizeof(buf))
 		goto failed;
 
@@ -1002,7 +1011,7 @@ static void cdrom_size_correction(blkid_probe pr, uint64_t last_written)
 		nsectors = (last_written+1) << 2;
 
 	for (n = nsectors - 12; n < nsectors; n++) {
-		if (!is_sector_readable(pr->fd, n))
+		if (!is_sector_readable(pr, n))
 			goto failed;
 	}
 
@@ -1073,7 +1082,7 @@ int blkid_probe_set_device(blkid_probe pr, int fd,
 	blkid_probe_reset_buffers(pr);
 
 	if ((pr->flags & BLKID_FL_PRIVATE_FD) && pr->fd >= 0)
-		close(pr->fd);
+		ul_vfs_close(pr->vfs, pr->fd);
 
 	if (pr->disk_probe) {
 		blkid_free_probe(pr->disk_probe);
@@ -1614,7 +1623,7 @@ int blkid_do_wipe(blkid_probe pr, int dryrun)
 	    "do_wipe [offset=0x%"PRIx64" (%"PRIu64"), len=%zu, chain=%s, idx=%d, dryrun=%s]\n",
 	    offset, offset, len, chn->driver->name, chn->idx, dryrun ? "yes" : "not"));
 
-	if (lseek(fd, offset, SEEK_SET) == (off_t) -1)
+	if (ul_vfs_lseek(pr->vfs, fd, offset, SEEK_SET) == (off_t) -1)
 		return BLKID_PROBE_ERROR;
 
 	if (!dryrun && len) {
@@ -1622,9 +1631,9 @@ int blkid_do_wipe(blkid_probe pr, int dryrun)
 			memset(buf, 0, len);
 
 			/* wipen on device */
-			if (ul_write_all(fd, buf, len))
+			if (ul_vfs_write_all(pr->vfs, fd, buf, len))
 				return BLKID_PROBE_ERROR;
-			if (fsync(fd) != 0)
+			if (ul_vfs_fsync(pr->vfs, fd) != 0)
 				return BLKID_PROBE_ERROR;
 		} else {
 #ifdef HAVE_LINUX_BLKZONED_H

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -1622,7 +1622,7 @@ int blkid_do_wipe(blkid_probe pr, int dryrun)
 			memset(buf, 0, len);
 
 			/* wipen on device */
-			if (write_all(fd, buf, len))
+			if (ul_write_all(fd, buf, len))
 				return BLKID_PROBE_ERROR;
 			if (fsync(fd) != 0)
 				return BLKID_PROBE_ERROR;

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -232,7 +232,7 @@ int blkid_probe_open_device(blkid_probe pr, const char *filename, int flags)
 	struct stat sb;
 
 	if (stat(filename, &sb) == 0 && S_ISBLK(sb.st_mode) &&
-	    sysfs_devno_is_dm_hidden(sb.st_rdev, NULL)) {
+	    sysfs_devno_is_dm_hidden(sb.st_rdev, NULL, pr->vfs)) {
 		DBG(LOWPROBE, ul_debug("ignore hidden device mapper device"));
 		errno = EINVAL;
 		return -EINVAL;
@@ -1213,7 +1213,7 @@ int blkid_probe_set_device(blkid_probe pr, int fd,
 #endif
 	if (S_ISBLK(sb.st_mode) &&
 	    !is_floppy &&
-	    sysfs_devno_is_dm_private(sb.st_rdev, &dm_uuid)) {
+	    sysfs_devno_is_dm_private(sb.st_rdev, &dm_uuid, pr->vfs)) {
 		DBG(LOWPROBE, ul_debug("ignore private device mapper device"));
 		pr->flags |= BLKID_FL_NOSCAN_DEV;
 	}

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -2245,6 +2245,45 @@ int blkid_probe_set_sectorsize(blkid_probe pr, unsigned int sz)
 }
 
 /**
+ * blkid_probe_set_vfs:
+ * @pr: probe
+ * @ops: VFS operations or NULL to reset to defaults
+ *
+ * Sets custom I/O operations for the probe. This allows replacing
+ * standard read/write/lseek/etc. with custom implementations
+ * (e.g., fiber-aware I/O).
+ *
+ * The @ops struct is copied into a private allocation owned by the
+ * probe. The caller sets ops->size to sizeof(struct ul_vfs_ops) to
+ * enable forward/backward compatibility. NULL function pointers fall
+ * back to standard syscalls. Passing @ops as NULL frees the private
+ * copy and resets the probe to default (direct syscall) I/O.
+ *
+ * Note: blkid_new_probe_from_filename() opens the device before VFS
+ * can be set. VFS users should use blkid_new_probe(), then
+ * blkid_probe_set_vfs(), then blkid_probe_open_device().
+ *
+ * Since: 2.43
+ *
+ * Returns: 0 on success, or <0 in case of error.
+ */
+int blkid_probe_set_vfs(blkid_probe pr, const struct ul_vfs_ops *ops)
+{
+	if (!ops) {
+		free(pr->vfs);
+		pr->vfs = NULL;
+		return 0;
+	}
+	if (!pr->vfs) {
+		pr->vfs = calloc(1, sizeof(*pr->vfs));
+		if (!pr->vfs)
+			return -ENOMEM;
+	}
+	ul_vfs_init(pr->vfs, ops);
+	return 0;
+}
+
+/**
  * blkid_probe_get_sectors:
  * @pr: probe
  *

--- a/libblkid/src/probe.c
+++ b/libblkid/src/probe.c
@@ -205,7 +205,54 @@ blkid_probe blkid_clone_probe(blkid_probe parent)
 	return pr;
 }
 
+/**
+ * blkid_probe_open_device:
+ * @pr: probe
+ * @filename: device or regular file
+ * @flags: open(2) flags or 0 for default (O_RDONLY|O_CLOEXEC|O_NONBLOCK)
+ *
+ * Opens the @filename and assigns it to the probe. This is equivalent to
+ * calling open() and blkid_probe_set_device(), but uses VFS operations
+ * if previously set by blkid_probe_set_vfs().
+ *
+ * This allows probe setup before the device is opened:
+ *
+ *   blkid_new_probe() → blkid_probe_set_vfs() → blkid_probe_open_device()
+ *
+ * The @filename is closed by blkid_free_probe() or by the
+ * blkid_probe_set_device() call.
+ *
+ * Since: 2.43
+ *
+ * Returns: 0 on success, or <0 in case of error.
+ */
+int blkid_probe_open_device(blkid_probe pr, const char *filename, int flags)
+{
+	int fd;
+	struct stat sb;
 
+	if (stat(filename, &sb) == 0 && S_ISBLK(sb.st_mode) &&
+	    sysfs_devno_is_dm_hidden(sb.st_rdev, NULL)) {
+		DBG(LOWPROBE, ul_debug("ignore hidden device mapper device"));
+		errno = EINVAL;
+		return -EINVAL;
+	}
+
+	if (!flags)
+		flags = O_RDONLY | O_CLOEXEC | O_NONBLOCK;
+
+	fd = ul_vfs_open(pr->vfs, filename, flags, 0);
+	if (fd < 0)
+		return -errno;
+
+	if (blkid_probe_set_device(pr, fd, 0, 0)) {
+		ul_vfs_close(pr->vfs, fd);
+		return -errno ? -errno : -EINVAL;
+	}
+
+	pr->flags |= BLKID_FL_PRIVATE_FD;
+	return 0;
+}
 
 /**
  * blkid_new_probe_from_filename:
@@ -222,43 +269,18 @@ blkid_probe blkid_clone_probe(blkid_probe parent)
  */
 blkid_probe blkid_new_probe_from_filename(const char *filename)
 {
-	int fd;
-	blkid_probe pr = NULL;
-	struct stat sb;
-
-	/*
-	 * Check for hidden device-mapper devices (LVM internals, etc.)
-	 * before open() to avoid bumping the kernel open count.  A racing
-	 * DM_DEVICE_REMOVE would otherwise see EBUSY.
-	 *
-	 * Use sysfs_devno_is_dm_hidden() rather than _dm_private() so that
-	 * Stratis devices remain accessible to tools like mkfs.xfs that
-	 * need to probe device geometry.
-	 */
-	if (stat(filename, &sb) == 0 && S_ISBLK(sb.st_mode) &&
-	    sysfs_devno_is_dm_hidden(sb.st_rdev, NULL)) {
-		DBG(LOWPROBE, ul_debug("ignore hidden device mapper device"));
-		errno = EINVAL;
-		return NULL;
-	}
-
-	fd = open(filename, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
-	if (fd < 0)
-		return NULL;
+	blkid_probe pr;
 
 	pr = blkid_new_probe();
 	if (!pr)
-		goto err;
+		return NULL;
 
-	if (blkid_probe_set_device(pr, fd, 0, 0))
-		goto err;
+	if (blkid_probe_open_device(pr, filename, 0)) {
+		blkid_free_probe(pr);
+		return NULL;
+	}
 
-	pr->flags |= BLKID_FL_PRIVATE_FD;
 	return pr;
-err:
-	close(fd);
-	blkid_free_probe(pr);
-	return NULL;
 }
 
 /**

--- a/libblkid/src/topology/md.c
+++ b/libblkid/src/topology/md.c
@@ -97,7 +97,7 @@ static int probe_md_tp(blkid_probe pr,
 		if (!diskpath)
 			goto nothing;
 
-		fd = open(diskpath, O_RDONLY|O_CLOEXEC);
+		fd = ul_vfs_open(pr->vfs, diskpath, O_RDONLY|O_CLOEXEC, 0);
 		free(diskpath);
 
                 if (fd == -1)
@@ -110,7 +110,7 @@ static int probe_md_tp(blkid_probe pr,
 		goto nothing;
 
 	if (fd >= 0 && fd != pr->fd) {
-		close(fd);
+		ul_vfs_close(pr->vfs, fd);
 		fd = -1;
 	}
 

--- a/libblkid/src/topology/sysfs.c
+++ b/libblkid/src/topology/sysfs.c
@@ -56,6 +56,7 @@ static int probe_sysfs_tp(blkid_probe pr,
 	pc = ul_new_sysfs_path(dev, NULL, NULL);
 	if (!pc)
 		return 1;
+	ul_path_refer_vfs(pc, pr->vfs);
 
 	rc = 1;		/* nothing (default) */
 

--- a/libblkid/src/verify.c
+++ b/libblkid/src/verify.c
@@ -105,7 +105,7 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 		   (long long)diff));
 #endif
 
-	if (sysfs_devno_is_dm_private(st.st_rdev, NULL))
+	if (sysfs_devno_is_dm_private(st.st_rdev, NULL, NULL))
 		goto dev_free;
 	if (!cache->probe) {
 		cache->probe = blkid_new_probe();

--- a/libblkid/src/verify.c
+++ b/libblkid/src/verify.c
@@ -64,7 +64,6 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 	const char *type, *value;
 	struct stat st;
 	time_t diff, now;
-	int fd;
 
 	if (!dev || !cache)
 		return NULL;
@@ -76,15 +75,7 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 		DBG(PROBE, ul_debug("blkid_verify: error %m (%d) while "
 			   "trying to stat %s", errno,
 			   dev->bid_name));
-	open_err:
-		if ((errno == EPERM) || (errno == EACCES) || (errno == ENOENT)) {
-			/* We don't have read permission, just return cache data. */
-			DBG(PROBE, ul_debug("returning unverified data for %s",
-						dev->bid_name));
-			return dev;
-		}
-		blkid_free_dev(dev);
-		return NULL;
+		goto dev_err;
 	}
 
 	if (now >= dev->bid_time &&
@@ -114,31 +105,19 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 		   (long long)diff));
 #endif
 
-	if (sysfs_devno_is_dm_private(st.st_rdev, NULL)) {
-		blkid_free_dev(dev);
-		return NULL;
-	}
+	if (sysfs_devno_is_dm_private(st.st_rdev, NULL))
+		goto dev_free;
 	if (!cache->probe) {
 		cache->probe = blkid_new_probe();
-		if (!cache->probe) {
-			blkid_free_dev(dev);
-			return NULL;
-		}
+		if (!cache->probe)
+			goto dev_free;
 	}
 
-	fd = open(dev->bid_name, O_RDONLY|O_CLOEXEC|O_NONBLOCK);
-	if (fd < 0) {
+	if (blkid_probe_open_device(cache->probe, dev->bid_name, 0)) {
 		DBG(PROBE, ul_debug("blkid_verify: error %m (%d) while "
 					"opening %s", errno,
 					dev->bid_name));
-		goto open_err;
-	}
-
-	if (blkid_probe_set_device(cache->probe, fd, 0, 0)) {
-		/* failed to read the device */
-		close(fd);
-		blkid_free_dev(dev);
-		return NULL;
+		goto dev_err;
 	}
 
 	/* remove old cache info */
@@ -187,9 +166,18 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 	/* reset prober */
 	blkid_probe_reset_superblocks_filter(cache->probe);
 	blkid_probe_set_device(cache->probe, -1, 0, 0);
-	close(fd);
 
 	return dev;
+
+dev_err:
+	if ((errno == EPERM) || (errno == EACCES) || (errno == ENOENT)) {
+		DBG(PROBE, ul_debug("returning unverified data for %s",
+					dev->bid_name));
+		return dev;
+	}
+dev_free:
+	blkid_free_dev(dev);
+	return NULL;
 }
 
 #ifdef TEST_PROGRAM

--- a/libfdisk/src/bsd.c
+++ b/libfdisk/src/bsd.c
@@ -643,7 +643,7 @@ static int bsd_get_bootstrap(struct fdisk_context *cxt,
 		return -errno;
 	}
 
-	if (read_all(fd, ptr, size) != size) {
+	if (ul_read_all(fd, ptr, size) != size) {
 		fdisk_warn(cxt, _("cannot read %s"), path);
 		close(fd);
 		return -errno;
@@ -720,7 +720,7 @@ int fdisk_bsd_write_bootstrap(struct fdisk_context *cxt)
 		rc = -errno;
 		goto done;
 	}
-	if (write_all(cxt->dev_fd, l->bsdbuffer, BSD_BBSIZE)) {
+	if (ul_write_all(cxt->dev_fd, l->bsdbuffer, BSD_BBSIZE)) {
 		fdisk_warn(cxt, _("cannot write %s"), cxt->dev_path);
 		rc = -errno;
 		goto done;
@@ -839,7 +839,7 @@ static int bsd_readlabel(struct fdisk_context *cxt)
 
 	if (lseek(cxt->dev_fd, offset, SEEK_SET) == -1)
 		return -1;
-	if (read_all(cxt->dev_fd, l->bsdbuffer, sizeof(l->bsdbuffer)) < 0)
+	if (ul_read_all(cxt->dev_fd, l->bsdbuffer, sizeof(l->bsdbuffer)) < 0)
 		return errno ? -errno : -1;
 
 	/* The offset to begin of the disk label. Note that BSD uses
@@ -903,7 +903,7 @@ static int bsd_write_disklabel(struct fdisk_context *cxt)
 		fdisk_warn(cxt, _("seek on %s failed"), cxt->dev_path);
 		return -errno;
 	}
-	if (write_all(cxt->dev_fd, l->bsdbuffer, sizeof(l->bsdbuffer))) {
+	if (ul_write_all(cxt->dev_fd, l->bsdbuffer, sizeof(l->bsdbuffer))) {
 		fdisk_warn(cxt, _("cannot write %s"), cxt->dev_path);
 		return -errno;
 	}

--- a/libfdisk/src/gpt.c
+++ b/libfdisk/src/gpt.c
@@ -2067,7 +2067,7 @@ static int gpt_read(struct fdisk_context *cxt, off_t offset, void *buf, size_t c
 	if (offset != lseek(cxt->dev_fd, offset, SEEK_SET))
 		return -errno;
 
-	if (read_all(cxt->dev_fd, buf, count))
+	if (ul_read_all(cxt->dev_fd, buf, count))
 		return -errno;
 
 	DBG(GPT, ul_debug("  read OK [offset=%zu, size=%zu]",
@@ -2080,7 +2080,7 @@ static int gpt_write(struct fdisk_context *cxt, off_t offset, void *buf, size_t 
 	if (offset != lseek(cxt->dev_fd, offset, SEEK_SET))
 		return -errno;
 
-	if (write_all(cxt->dev_fd, buf, count))
+	if (ul_write_all(cxt->dev_fd, buf, count))
 		return -errno;
 
 	if (fsync(cxt->dev_fd) != 0)

--- a/libfdisk/src/script.c
+++ b/libfdisk/src/script.c
@@ -1712,7 +1712,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	fd = mkstemp_cloexec(name);
 	if (fd < 0)
 		err(EXIT_FAILURE, "mkstemp() failed");
-	if (write_all(fd, data, size) != 0)
+	if (ul_write_all(fd, data, size) != 0)
 		err(EXIT_FAILURE, "write() failed");
 	f = fopen(name, "r");
 	if (!f)

--- a/libfdisk/src/sgi.c
+++ b/libfdisk/src/sgi.c
@@ -484,7 +484,7 @@ static int sgi_write_disklabel(struct fdisk_context *cxt)
 
 	if (lseek(cxt->dev_fd, 0, SEEK_SET) < 0)
 		goto err;
-	if (write_all(cxt->dev_fd, sgilabel, DEFAULT_SECTOR_SIZE))
+	if (ul_write_all(cxt->dev_fd, sgilabel, DEFAULT_SECTOR_SIZE))
 		goto err;
 	if (!strncmp((char *) sgilabel->volume[0].name, "sgilabel", 8)) {
 		/*
@@ -500,7 +500,7 @@ static int sgi_write_disklabel(struct fdisk_context *cxt)
 		info = sgi_new_info();
 		if (!info)
 			goto err;
-		if (write_all(cxt->dev_fd, info, sizeof(*info)))
+		if (ul_write_all(cxt->dev_fd, info, sizeof(*info)))
 			goto err;
 	}
 

--- a/libfdisk/src/sun.c
+++ b/libfdisk/src/sun.c
@@ -1026,7 +1026,7 @@ static int sun_write_disklabel(struct fdisk_context *cxt)
 
 	if (lseek(cxt->dev_fd, 0, SEEK_SET) < 0)
 		return -errno;
-	if (write_all(cxt->dev_fd, sunlabel, sz) != 0)
+	if (ul_write_all(cxt->dev_fd, sunlabel, sz) != 0)
 		return -errno;
 
 	return 0;

--- a/libmount/src/hook_idmap.c
+++ b/libmount/src/hook_idmap.c
@@ -100,7 +100,7 @@ static int write_id_mapping(idmap_type_t map_type, pid_t pid, const char *buf,
 			goto err;
 
 		if (setgroups_fd >= 0) {
-			rc = write_all(setgroups_fd, "deny\n", strlen("deny\n"));
+			rc = ul_write_all(setgroups_fd, "deny\n", strlen("deny\n"));
 			if (rc)
 				goto err;
 		}
@@ -113,7 +113,7 @@ static int write_id_mapping(idmap_type_t map_type, pid_t pid, const char *buf,
 	if (fd < 0)
 		goto err;
 
-	rc = write_all(fd, buf, buf_size);
+	rc = ul_write_all(fd, buf, buf_size);
 
 err:
 	if (fd >= 0)
@@ -213,12 +213,12 @@ static int get_userns_fd_from_idmap(struct list_head *idmap)
 			_exit(EXIT_FAILURE);
 
 		/* Let parent know we're ready to have the idmapping written. */
-		rc = write_all(sock_fds[0], &c, 1);
+		rc = ul_write_all(sock_fds[0], &c, 1);
 		if (rc)
 			_exit(EXIT_FAILURE);
 
 		/* Hang around until the parent has persisted our namespace. */
-		rc = read_all(sock_fds[0], &c, 1);
+		rc = ul_read_all(sock_fds[0], &c, 1);
 		if (rc != 1)
 			_exit(EXIT_FAILURE);
 
@@ -230,7 +230,7 @@ static int get_userns_fd_from_idmap(struct list_head *idmap)
 	sock_fds[0] = -1;
 
 	/* Wait for child to set up a new namespace. */
-	rc = read_all(sock_fds[1], &c, 1);
+	rc = ul_read_all(sock_fds[1], &c, 1);
 	if (rc != 1) {
 		kill(pid, SIGKILL);
 		goto err_wait;
@@ -246,7 +246,7 @@ static int get_userns_fd_from_idmap(struct list_head *idmap)
 	fd_userns = open(path, O_RDONLY | O_CLOEXEC | O_NOCTTY);
 
 	/* Let child know we've persisted its namespace. */
-	(void)write_all(sock_fds[1], &c, 1);
+	(void)ul_write_all(sock_fds[1], &c, 1);
 
 err_wait:
 	rc = wait_for_pid(pid);

--- a/libuuid/src/gen_uuid.c
+++ b/libuuid/src/gen_uuid.c
@@ -509,14 +509,14 @@ static int get_uuid_via_daemon(int op, uuid_t out, int *num)
 	if (ret < 1)
 		goto fail;
 
-	ret = read_all(s, (char *) &reply_len, sizeof(reply_len));
+	ret = ul_read_all(s, (char *) &reply_len, sizeof(reply_len));
 	if (ret < 0)
 		goto fail;
 
 	if (reply_len != expected)
 		goto fail;
 
-	ret = read_all(s, op_buf, reply_len);
+	ret = ul_read_all(s, op_buf, reply_len);
 
 	if (op == UUIDD_OP_BULK_TIME_UUID)
 		memcpy(op_buf+16, num, sizeof(int));

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -964,7 +964,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	fd = mkstemp_cloexec(name);
 	if (fd < 0)
 		err(EXIT_FAILURE, "mkstemp() failed");
-	if (write_all(fd, data, size) != 0)
+	if (ul_write_all(fd, data, size) != 0)
 		err(EXIT_FAILURE, "write() failed");
 
 	process_wtmp_file(&ctl, name);

--- a/misc-utils/enosys.c
+++ b/misc-utils/enosys.c
@@ -282,7 +282,7 @@ int main(int argc, char **argv)
 	INSTR(BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW));
 
 	if (dump) {
-		if (fwrite_all(filter, (f - filter) * sizeof(filter[0]), 1, dump))
+		if (ul_fwrite_all(filter, (f - filter) * sizeof(filter[0]), 1, dump))
 			err(EXIT_FAILURE, _("Could not dump seccomp filter"));
 		return EXIT_SUCCESS;
 	}

--- a/misc-utils/lsclocks.c
+++ b/misc-utils/lsclocks.c
@@ -283,7 +283,7 @@ static int64_t get_namespace_offset(const char *name)
 	if (fd == -1)
 		err(EXIT_FAILURE, _("Could not open %s"), _PATH_PROC_TIMENS_OFF);
 
-	read_all_alloc(fd, &buf);
+	ul_read_all_alloc(fd, &buf);
 
 	for (tokstr = buf; ; tokstr = NULL) {
 		line = strtok_r(tokstr, "\n", &saveptr);

--- a/misc-utils/mcookie.c
+++ b/misc-utils/mcookie.c
@@ -69,7 +69,7 @@ static uint64_t hash_file(struct mcookie_control *ctl, int fd)
 		if (wanted - count < rdsz)
 			rdsz = wanted - count;
 
-		r = read_all(fd, (char *) buf, rdsz);
+		r = ul_read_all(fd, (char *) buf, rdsz);
 		if (r <= 0)
 			break;
 		ul_MD5Update(&ctl->ctx, buf, r);

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -178,7 +178,7 @@ static int call_daemon(const char *socket_path, uuidd_prot_op_t op, char *buf,
 		op_len += sizeof(*num);
 	}
 
-	ret = write_all(s, op_buf, op_len);
+	ret = ul_write_all(s, op_buf, op_len);
 	if (ret < 0) {
 		if (err_context)
 			*err_context = _("write");
@@ -186,7 +186,7 @@ static int call_daemon(const char *socket_path, uuidd_prot_op_t op, char *buf,
 		return -1;
 	}
 
-	ret = read_all(s, (char *) &reply_len, sizeof(reply_len));
+	ret = ul_read_all(s, (char *) &reply_len, sizeof(reply_len));
 	if (ret < 0) {
 		if (err_context)
 			*err_context = _("read count");
@@ -199,7 +199,7 @@ static int call_daemon(const char *socket_path, uuidd_prot_op_t op, char *buf,
 		close(s);
 		return -1;
 	}
-	ret = read_all(s, (char *) buf, reply_len);
+	ret = ul_read_all(s, (char *) buf, reply_len);
 
 	if ((ret > 0) && (op == UUIDD_OP_BULK_TIME_UUID)) {
 		if ((sizeof(uuid_t) + sizeof(*num)) <= (size_t) reply_len)
@@ -402,7 +402,7 @@ static void server_loop(const char *socket_path, const char *pidfile_path,
 			snprintf(reply_buf, sizeof(reply_buf), "%8d\n", getpid());
 			if (ftruncate(fd_pidfile, 0))
 				err(EXIT_FAILURE, _("could not truncate file: %s"), pidfile_path);
-			write_all(fd_pidfile, reply_buf, strlen(reply_buf));
+			ul_write_all(fd_pidfile, reply_buf, strlen(reply_buf));
 			if (fd_pidfile > 1 && close_fd(fd_pidfile) != 0)
 				err(EXIT_FAILURE, _("write failed: %s"), pidfile_path);
 		}
@@ -479,7 +479,7 @@ static void server_loop(const char *socket_path, const char *pidfile_path,
 		}
 		if ((op == UUIDD_OP_BULK_TIME_UUID) ||
 		    (op == UUIDD_OP_BULK_RANDOM_UUID)) {
-			if (read_all(ns, (char *) &num, sizeof(num)) != sizeof(num))
+			if (ul_read_all(ns, (char *) &num, sizeof(num)) != sizeof(num))
 				goto shutdown_socket;
 			if (uuidd_cxt->debug)
 				fprintf(stderr, _("operation %d, incoming num = %d\n"),
@@ -560,8 +560,8 @@ static void server_loop(const char *socket_path, const char *pidfile_path,
 				fprintf(stderr, _("Invalid operation %d\n"), op);
 			goto shutdown_socket;
 		}
-		write_all(ns, (char *) &reply_len, sizeof(num));
-		write_all(ns, reply_buf, reply_len);
+		ul_write_all(ns, (char *) &reply_len, sizeof(num));
+		ul_write_all(ns, reply_buf, reply_len);
 	shutdown_socket:
 		close(ns);
 	}

--- a/misc-utils/wipefs.c
+++ b/misc-utils/wipefs.c
@@ -367,20 +367,10 @@ new_probe(const char *devname, int mode)
 	if (!devname)
 		return NULL;
 
-	if (mode) {
-		int fd = open(devname, mode | O_NONBLOCK);
-		if (fd < 0)
-			goto error;
-
-		pr = blkid_new_probe();
-		if (!pr || blkid_probe_set_device(pr, fd, 0, 0) != 0) {
-			close(fd);
-			goto error;
-		}
-	} else
-		pr = blkid_new_probe_from_filename(devname);
-
+	pr = blkid_new_probe();
 	if (!pr)
+		goto error;
+	if (blkid_probe_open_device(pr, devname, mode ? mode | O_NONBLOCK : 0))
 		goto error;
 
 	blkid_probe_enable_superblocks(pr, 1);

--- a/misc-utils/wipefs.c
+++ b/misc-utils/wipefs.c
@@ -478,7 +478,7 @@ static void do_backup(struct wipe_desc *wp, const char *base)
 	fd = open(fname, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
 	if (fd < 0)
 		goto err;
-	if (write_all(fd, wp->magic, wp->len) != 0)
+	if (ul_write_all(fd, wp->magic, wp->len) != 0)
 		goto err;
 	close(fd);
 	free(fname);

--- a/sys-utils/ldattach.c
+++ b/sys-utils/ldattach.c
@@ -463,7 +463,7 @@ int main(int argc, char **argv)
 	if (introparm && *introparm)
 	{
 		dbg("intro command is '%s'", introparm);
-		if (write_all(tty_fd, introparm, strlen(introparm)) != 0)
+		if (ul_write_all(tty_fd, introparm, strlen(introparm)) != 0)
 			err(EXIT_FAILURE,
 			    _("cannot write intro command to %s"), dev);
 

--- a/sys-utils/lscpu-virt.c
+++ b/sys-utils/lscpu-virt.c
@@ -75,7 +75,7 @@ void *get_mem_chunk(size_t base, size_t len, const char *devmem)
 		goto nothing;
 	if (lseek(fd, base, SEEK_SET) == -1)
 		goto nothing;
-	if (read_all(fd, p, len) == -1)
+	if (ul_read_all(fd, p, len) == -1)
 		goto nothing;
 
 	close(fd);

--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -475,7 +475,7 @@ static void open_cgroup_procs(void)
 
 	open_target_fd(&cgroup_fd, "cgroup", optarg);
 
-	if (read_all_alloc(cgroup_fd, &buf) < 1)
+	if (ul_read_all_alloc(cgroup_fd, &buf) < 1)
 		err(EXIT_FAILURE, _("failed to get cgroup path"));
 
 	p = strtok(buf, "\n");
@@ -512,7 +512,7 @@ static void join_into_cgroup(void)
 
 	pid = getpid();
 	len = snprintf(buf, sizeof(buf), "%zu", (size_t) pid);
-	if (write_all(cgroup_procs_fd, buf, len))
+	if (ul_write_all(cgroup_procs_fd, buf, len))
 		err(EXIT_FAILURE, _("write cgroup.procs failed"));
 }
 

--- a/sys-utils/rfkill.c
+++ b/sys-utils/rfkill.c
@@ -562,7 +562,7 @@ static int __rfkill_block(int fd, struct rfkill_id *id, uint8_t block, const cha
 		abort();
 	}
 
-	if (write_all(fd, &event, sizeof(event)) != 0)
+	if (ul_write_all(fd, &event, sizeof(event)) != 0)
 		warn(_("write failed: %s"), _PATH_DEV_RFKILL);
 	else {
 		openlog("rfkill", 0, LOG_USER);

--- a/sys-utils/setpriv.c
+++ b/sys-utils/setpriv.c
@@ -742,7 +742,7 @@ static void do_seccomp_filter(const char *file)
 		err(SETPRIV_EXIT_PRIVERR,
 		    _("cannot open %s"), file);
 
-	s = read_all_alloc(fd, &filter);
+	s = ul_read_all_alloc(fd, &filter);
 	if (s < 0)
 		err(SETPRIV_EXIT_PRIVERR,
 		    _("cannot read %s"), file);

--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -122,7 +122,7 @@ static void setgroups_control(int action)
 		err(EXIT_FAILURE, _("cannot open %s"), file);
 	}
 
-	if (write_all(fd, cmd, strlen(cmd)))
+	if (ul_write_all(fd, cmd, strlen(cmd)))
 		err(EXIT_FAILURE, _("write failed %s"), file);
 	close(fd);
 }
@@ -137,7 +137,7 @@ static void map_id(const char *file, uint32_t from, uint32_t to)
 		 err(EXIT_FAILURE, _("cannot open %s"), file);
 
 	xasprintf(&buf, "%u %u 1", from, to);
-	if (write_all(fd, buf, strlen(buf)))
+	if (ul_write_all(fd, buf, strlen(buf)))
 		err(EXIT_FAILURE, _("write failed %s"), file);
 	free(buf);
 	close(fd);
@@ -273,7 +273,7 @@ static void sync_with_child(pid_t pid, int fd)
 {
 	uint64_t ch = PIPE_SYNC_BYTE;
 
-	write_all(fd, &ch, sizeof(ch));
+	ul_write_all(fd, &ch, sizeof(ch));
 	close(fd);
 
 	waitchild(pid);
@@ -307,7 +307,7 @@ static pid_t fork_and_wait(int *fd)
 
 	if (!pid) {
 		/* wait for the our parent to tell us to continue */
-		if (read_all(*fd, (char *)&ch, sizeof(ch)) != sizeof(ch) ||
+		if (ul_read_all(*fd, (char *)&ch, sizeof(ch)) != sizeof(ch) ||
 		    ch != PIPE_SYNC_BYTE)
 			err(EXIT_FAILURE, _("failed to read eventfd"));
 		close(*fd);
@@ -660,7 +660,7 @@ static void map_ids_internal(const char *type, int ppid, struct map_range *chain
 	fd = open(path, O_WRONLY | O_CLOEXEC | O_NOCTTY);
 	if (fd < 0)
 		err(EXIT_FAILURE, _("failed to open %s"), path);
-	if (write_all(fd, buffer, length) < 0)
+	if (ul_write_all(fd, buffer, length) < 0)
 		err(EXIT_FAILURE, _("failed to write %s"), path);
 	close(fd);
 	free(path);
@@ -733,7 +733,7 @@ static void load_interp(const char *binfmt_mnt, const char *interp)
 	if (fd < 0)
 		err(EXIT_FAILURE, _("cannot open %s/register"), binfmt_mnt);
 
-	if (write_all(fd, interp, strlen(interp)))
+	if (ul_write_all(fd, interp, strlen(interp)))
 		err(EXIT_FAILURE, _("write failed %s/register"), binfmt_mnt);
 
 	close(fd);

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -499,7 +499,7 @@ static ssize_t log_write(struct script_control *ctl,
 	switch (log->format) {
 	case SCRIPT_FMT_RAW:
 		DBG(IO, ul_debug("  log raw data"));
-		rc = fwrite_all(obuf, 1, bytes, log->fp);
+		rc = ul_fwrite_all(obuf, 1, bytes, log->fp);
 		if (rc) {
 			warn(_("cannot write %s"), log->filename);
 			return rc;

--- a/term-utils/setterm.c
+++ b/term-utils/setterm.c
@@ -896,7 +896,7 @@ static int resizetty(void)
 		errx(EXIT_FAILURE, _("stdin does not refer to a terminal"));
 
 	tty_raw(&saved_attributes, &saved_fl);
-	if (write_all(STDIN_FILENO, getpos, strlen(getpos)) < 0) {
+	if (ul_write_all(STDIN_FILENO, getpos, strlen(getpos)) < 0) {
 		warn(_("write failed"));
 		tty_restore(&saved_attributes, &saved_fl);
 		return 1;

--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -296,7 +296,7 @@ static size_t xmbstowcs(wchar_t * pwcs, const char *s, size_t nwcs)
 static int outcap(int i)
 {
 	char c = i;
-	return write_all(STDOUT_FILENO, &c, 1) == 0 ? 1 : -1;
+	return ul_write_all(STDOUT_FILENO, &c, 1) == 0 ? 1 : -1;
 }
 
 /* Write messages to terminal. */
@@ -306,7 +306,7 @@ static void mesg(const char *message)
 		return;
 	if (*message != '\n' && sflag)
 		vidputs(A_STANDOUT, outcap);
-	write_all(STDOUT_FILENO, message, strlen(message));
+	ul_write_all(STDOUT_FILENO, message, strlen(message));
 	if (*message != '\n' && sflag)
 		vidputs(A_NORMAL, outcap);
 }
@@ -518,7 +518,7 @@ static void cline(void)
 	memset(buf, ' ', ttycols + 2);
 	buf[0] = '\r';
 	buf[ttycols + 1] = '\r';
-	write_all(STDOUT_FILENO, buf, ttycols + 2);
+	ul_write_all(STDOUT_FILENO, buf, ttycols + 2);
 	free(buf);
 }
 
@@ -646,7 +646,7 @@ static void prompt(long long pageno)
 		}
 		if (key == tio.c_cc[VERASE]) {
 			if (cmd.cmdlen) {
-				write_all(STDOUT_FILENO, "\b \b", 3);
+				ul_write_all(STDOUT_FILENO, "\b \b", 3);
 				cmd.cmdline[--cmd.cmdlen] = '\0';
 				switch (state) {
 				case ADDON_FIN:
@@ -748,7 +748,7 @@ static void prompt(long long pageno)
 				cmd.key = key;
 			}
 		}
-		write_all(STDOUT_FILENO, &key, 1);
+		ul_write_all(STDOUT_FILENO, &key, 1);
 
 		if (cmd.cmdlen + 1 >= sizeof(cmd.cmdline))
 			goto endprompt;
@@ -935,7 +935,7 @@ static void pgfile(FILE *f, const char *name)
 	if (ontty == 0) {
 		/* Just copy stdin to stdout. */
 		while ((sz = fread(b, sizeof *b, READBUF, f)) != 0)
-			write_all(STDOUT_FILENO, b, sz);
+			ul_write_all(STDOUT_FILENO, b, sz);
 		if (ferror(f)) {
 			warn("%s", name);
 			exitstatus++;
@@ -1012,7 +1012,7 @@ static void pgfile(FILE *f, const char *name)
 
 				if (!nobuf)
 					fputs(b, fbuf);
-				fwrite_all(&pos, sizeof pos, 1, find);
+				ul_fwrite_all(&pos, sizeof pos, 1, find);
 				if (!fflag) {
 					oldpos = pos;
 					p = b;
@@ -1020,7 +1020,7 @@ static void pgfile(FILE *f, const char *name)
 							     p))
 					       != '\0') {
 						pos = oldpos + (p - b);
-						fwrite_all(&pos,
+						ul_fwrite_all(&pos,
 							   sizeof pos,
 							   1, find);
 						fline++;
@@ -1090,7 +1090,7 @@ static void pgfile(FILE *f, const char *name)
 				sz = p - b;
 				makeprint(b, sz);
 				canjump = 1;
-				write_all(STDOUT_FILENO, b, sz);
+				ul_write_all(STDOUT_FILENO, b, sz);
 				canjump = 0;
 			}
 		}
@@ -1234,7 +1234,7 @@ static void pgfile(FILE *f, const char *name)
 					}
 					if (!nobuf)
 						fputs(b, fbuf);
-					fwrite_all(&pos, sizeof pos, 1, find);
+					ul_fwrite_all(&pos, sizeof pos, 1, find);
 					if (!fflag) {
 						oldpos = pos;
 						p = b;
@@ -1242,7 +1242,7 @@ static void pgfile(FILE *f, const char *name)
 								     p))
 						       != '\0') {
 							pos = oldpos + (p - b);
-							fwrite_all(&pos,
+							ul_fwrite_all(&pos,
 								   sizeof pos,
 								   1, find);
 							fline++;
@@ -1256,7 +1256,7 @@ static void pgfile(FILE *f, const char *name)
 				while ((sz = fread(b, sizeof *b, READBUF,
 						   fbuf)) != 0) {
 					/* No error check for compat. */
-					fwrite_all(b, sizeof *b, sz, save);
+					ul_fwrite_all(b, sizeof *b, sz, save);
 				}
 				if (close_stream(save) != 0) {
 					cmd.count = errno;
@@ -1362,9 +1362,9 @@ static void pgfile(FILE *f, const char *name)
 				} else {
 					pid_t cpid;
 
-					write_all(STDOUT_FILENO, cmd.cmdline,
+					ul_write_all(STDOUT_FILENO, cmd.cmdline,
 						  strlen(cmd.cmdline));
-					write_all(STDOUT_FILENO, "\n", 1);
+					ul_write_all(STDOUT_FILENO, "\n", 1);
 					my_sigset(SIGINT, SIG_IGN);
 					my_sigset(SIGQUIT, SIG_IGN);
 					switch (cpid = fork()) {
@@ -1406,9 +1406,9 @@ static void pgfile(FILE *f, const char *name)
 				{
 					/* Help! */
 					const char *help = _(helpscreen);
-					write_all(STDOUT_FILENO, copyright,
+					ul_write_all(STDOUT_FILENO, copyright,
 						  strlen(copyright));
-					write_all(STDOUT_FILENO, help,
+					ul_write_all(STDOUT_FILENO, help,
 						  strlen(help));
 					goto newcmd;
 				}
@@ -1528,9 +1528,9 @@ static int parse_arguments(int arg, int argc, char **argv)
 		}
 		if (ontty == 0 && argc > 2) {
 			/* Use the prefix as specified by SUSv2. */
-			write_all(STDOUT_FILENO, "::::::::::::::\n", 15);
-			write_all(STDOUT_FILENO, argv[arg], strlen(argv[arg]));
-			write_all(STDOUT_FILENO, "\n::::::::::::::\n", 16);
+			ul_write_all(STDOUT_FILENO, "::::::::::::::\n", 15);
+			ul_write_all(STDOUT_FILENO, argv[arg], strlen(argv[arg]));
+			ul_write_all(STDOUT_FILENO, "\n::::::::::::::\n", 16);
 		}
 		pgfile(input, argv[arg]);
 		if (input != stdin)


### PR DESCRIPTION
## Summary

Add pluggable VFS I/O abstraction layer for libblkid, allowing callers
to replace standard read/write/lseek/open/close/fsync with custom
implementations (e.g., systemd fiber-aware I/O).

Addresses: https://github.com/util-linux/util-linux/issues/4308

## API

New public functions:

    int blkid_probe_set_vfs(blkid_probe pr, const struct ul_vfs_ops *ops);
    int blkid_probe_open_device(blkid_probe pr, const char *filename, int flags);

Function pointer signatures match POSIX prototypes exactly, so callers
can assign directly (e.g., `ops.vfs_read = sd_fiber_read`). Any NULL
function pointer falls back to the real syscall.

The ops struct is copied into a private allocation owned by the probe.
Passing NULL resets to default (direct syscall) I/O. Cloned probes get
their own independent copy.

## Usage example

    struct ul_vfs_ops ops = {
        .size      = sizeof(struct ul_vfs_ops),
        .vfs_open  = my_fiber_open,
        .vfs_close = my_fiber_close,
        .vfs_read  = my_fiber_read,
        .vfs_write = my_fiber_write,
        .vfs_lseek = my_fiber_lseek,
        .vfs_fsync = my_fiber_fsync,
    };

    pr = blkid_new_probe();
    blkid_probe_set_vfs(pr, &ops);
    blkid_probe_open_device(pr, devname, 0);

    blkid_do_safeprobe(pr);
    /* ... use results ... */

    blkid_free_probe(pr);

`blkid_probe_open_device()` accepts open(2) flags (e.g., O_RDWR) or
0 for the default (O_RDONLY|O_CLOEXEC|O_NONBLOCK). It replaces the
pattern of open() + blkid_probe_set_device() and is VFS-aware.

## Forward/backward compatibility

The `size` field as the first struct member enables safe struct evolution:
- Caller sets `ops.size = sizeof(struct ul_vfs_ops)` at compile time
- Library copies `min(ops.size, sizeof(internal))` bytes
- New fields added at end — old callers have smaller size, new fields
  stay zero (NULL) and fall back to real syscalls
- Same pattern as io_uring_params, Vulkan create info structs

## FILE* stream support (fopencookie)

The VFS layer also supports `FILE*` streams via an optional `vfs_fopen`
callback. If the caller provides it, it is used directly. If not, but
fd-level callbacks are set, the library wraps them into a `FILE*` using
glibc's `fopencookie()` — stdio buffering (fgets, fprintf, etc.) works
transparently on top.

`ul_vfs_fdopen()` wraps an existing fd into a VFS-aware `FILE*`,
used internally by lib/path.c to make sysfs/procfs reads fiber-aware.