### PR TITLE
libmount: add mnt_table_parse_utab()

### DIFF
--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -418,6 +418,7 @@ mnt_table_parse_fstab
 mnt_table_parse_mtab
 mnt_table_parse_stream
 mnt_table_parse_swaps
+mnt_table_parse_utab
 mnt_table_remove_fs
 mnt_table_set_cache
 mnt_table_set_intro_comment

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -608,6 +608,7 @@ extern int mnt_table_parse_dir(struct libmnt_table *tb, const char *dirname);
 extern int mnt_table_parse_fstab(struct libmnt_table *tb, const char *filename);
 extern int mnt_table_parse_swaps(struct libmnt_table *tb, const char *filename);
 extern int mnt_table_parse_mtab(struct libmnt_table *tb, const char *filename);
+extern int mnt_table_parse_utab(struct libmnt_table *tb, const char *filename);
 extern int mnt_table_disable_useropts(struct libmnt_table *tb, int disable);
 extern int mnt_table_set_parser_errcb(struct libmnt_table *tb,
                 int (*cb)(struct libmnt_table *tb, const char *filename, int line));

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -424,4 +424,5 @@ MOUNT_2_42 {
 
 MOUNT_2_43 {
 	mnt_table_disable_useropts;
+	mnt_table_parse_utab;
 } MOUNT_2_42;

--- a/libmount/src/tab_parse.c
+++ b/libmount/src/tab_parse.c
@@ -1156,6 +1156,32 @@ int mnt_table_parse_swaps(struct libmnt_table *tb, const char *filename)
 }
 
 /**
+ * mnt_table_parse_utab:
+ * @tb: table
+ * @filename: overwrites default or NULL (recommended)
+ *
+ * This function parses the utab file and appends new lines to the @tb. The utab
+ * is a private libmount file that stores userspace mount options. The file
+ * location and format are library implementation details and subject to change;
+ * use NULL as @filename to let the library determine the correct path.
+ *
+ * Returns: 0 on success or negative number in case of error.
+ */
+int mnt_table_parse_utab(struct libmnt_table *tb, const char *filename)
+{
+	if (!tb)
+		return -EINVAL;
+	if (!filename)
+		filename = mnt_get_utab_path();
+	if (!filename || is_file_empty(filename))
+		return 0;
+
+	tb->fmt = MNT_FMT_UTAB;
+
+	return mnt_table_parse_file(tb, filename);
+}
+
+/**
  * mnt_table_parse_fstab:
  * @tb: table
  * @filename: overwrites default (/etc/fstab or $LIBMOUNT_FSTAB) or NULL


### PR DESCRIPTION
## Summary
- Add `mnt_table_parse_utab()` — public API to parse the utab file into a table, hiding the private file location and format from callers

This is needed by systemd for incremental fanotify-based mount monitoring, where utab needs to be parsed independently of the full mountinfo/listmount rescan path.