### PR TITLE
col: fix cur_col underflow on backspace over a wide char

### DIFF
--- a/text-utils/col.c
+++ b/text-utils/col.c
@@ -397,7 +397,7 @@ static int handle_not_graphic(struct col_ctl *ctl, struct col_lines *lns)
 		if (lns->cur_col == 0)
 			return 1;	/* can't go back further */
 		if (lns->c) {
-			if ((size_t) lns->c->c_width <= lns->cur_col)
+			if (lns->c->c_width >= 0 && (size_t) lns->c->c_width <= lns->cur_col)
 				lns->cur_col -= lns->c->c_width;
 			else
 				lns->cur_col = 0;

--- a/text-utils/col.c
+++ b/text-utils/col.c
@@ -396,9 +396,12 @@ static int handle_not_graphic(struct col_ctl *ctl, struct col_lines *lns)
 	case BS:
 		if (lns->cur_col == 0)
 			return 1;	/* can't go back further */
-		if (lns->c)
-			lns->cur_col -= lns->c->c_width;
-		else
+		if (lns->c) {
+			if ((size_t) lns->c->c_width <= lns->cur_col)
+				lns->cur_col -= lns->c->c_width;
+			else
+				lns->cur_col = 0;
+		} else
 			lns->cur_col -= 1;
 		return 1;
 	case CR:


### PR DESCRIPTION
AddressSanitizer, feeding col a small crafted stream under a UTF-8 locale:

    ==ERROR: AddressSanitizer: negative-size-param: (size=-7)
        #2 flush_line col.c:249
        #3 flush_lines col.c:383
        #4 main col.c:700

Tracked it back to the BS branch in handle_not_graphic(). cur_col is a
size_t and the only guard there is cur_col == 0. Give it a double-width
glyph, then CR, one space, then BS: the last stored character still has
c_width 2 while cur_col has dropped to 1, so cur_col -= 2 wraps to
SIZE_MAX. That value then lands in l_max_col and the stored c_column, and
flush_line() sizes count[] as l_max_col + 1 (which wraps to 0) before it
memsets and indexes the array, so the write runs off the end.

Reproducer under a UTF-8 locale:

    printf '\xef\xbc\xa1\r \bXY\n' | col

Clamp the subtraction to the column origin, matching the intent of the
existing cur_col == 0 check.
