### PR TITLE
libblkid: (iso9660) fix out-of-bounds read of root dir record

### DIFF
--- a/libblkid/src/superblocks/iso9660.c
+++ b/libblkid/src/superblocks/iso9660.c
@@ -301,7 +301,13 @@ static int probe_iso9660(blkid_probe pr, const struct blkid_idmag *mag)
 		uint64_t root_off = (uint64_t) root_lba * logical_block_size;
 		const unsigned char *rootdata;
 
-		if (root_len == 0)
+		/*
+		 * A valid root directory holds at least the 34-byte "."
+		 * record inspected below (offsets up to 33). A shorter extent
+		 * cannot be valid and would under-map the buffer, so the fixed
+		 * offset reads must not run before this check.
+		 */
+		if (root_len < 34)
 			return 1;
 
 		rootdata = blkid_probe_get_buffer(pr, root_off,


### PR DESCRIPTION
noticed the new root-dir validation only rejects root_len == 0, yet it later reads rootdata[32]/[33] on a buffer mapped for min(root_len, 2048) bytes; blkid_probe_get_buffer() skips the io_size round-up when the extent sits in the final partial block, so a crafted image with 1 <= root_len < 34 and rootdata[0] >= 34 makes the validation read past the mapping (ASan: heap-buffer-overflow read at offset 32 of a root_len-byte buffer), fixed by requiring the 34-byte minimum the record already assumes before the read.