### PR TITLE
Fix Coverity scan issues

### DIFF
--- a/agetty-cmd/tty.c
+++ b/agetty-cmd/tty.c
@@ -193,8 +193,9 @@ void agetty_reset_vc(const struct agetty_options *op, struct termios *tp, int ca
 		agetty_log_warn(_("setting terminal attributes failed: %m"));
 
 	/* Go to blocking input even in local mode. */
-	fcntl(STDIN_FILENO, F_SETFL,
-	      fcntl(STDIN_FILENO, F_GETFL, 0) & ~O_NONBLOCK);
+	fl = fcntl(STDIN_FILENO, F_GETFL, 0);
+	if (fl >= 0)
+		fcntl(STDIN_FILENO, F_SETFL, fl & ~O_NONBLOCK);
 }
 
 void agetty_open_tty(const char *tty, struct termios *tp, struct agetty_options *op)

--- a/agetty-cmd/tty.c
+++ b/agetty-cmd/tty.c
@@ -387,7 +387,8 @@ void agetty_termio_init(struct agetty_options *op, struct termios *tp)
 		sleep(1);
 	}
 	memset(&lock, 0, sizeof(struct termios));
-	ioctl(STDIN_FILENO, TIOCSLCKTRMIOS, &lock);
+	if (ioctl(STDIN_FILENO, TIOCSLCKTRMIOS, &lock))
+		debug("unlock termios failed\n");
 #endif
 
 	if (op->flags & F_VCONSOLE) {

--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -1626,6 +1626,7 @@ static int loopcxt_get_device_nr(struct loopdev_cxt *lc, int *nr)
 	errno = 0;
 	if (!lc || !nr)
 		return rc;
+	*nr = -1;
 
 	dev = loopcxt_get_device(lc);
 	if (!dev)

--- a/libblkid/src/partitions/dos.c
+++ b/libblkid/src/partitions/dos.c
@@ -138,8 +138,8 @@ static int parse_dos_extended(blkid_probe pr, blkid_parttable tab,
 		 * is junk.
 		 */
 		for (p = p0, i = 0; i < 4; i++, p++) {
-			start = dos_partition_get_start(p) * ssf;
-			size = dos_partition_get_size(p) * ssf;
+			start = (uint64_t) dos_partition_get_start(p) * ssf;
+			size = (uint64_t) dos_partition_get_size(p) * ssf;
 
 			if (size && is_extended(p)) {
 				if (start == 0)

--- a/sys-utils/chcpu.c
+++ b/sys-utils/chcpu.c
@@ -103,8 +103,9 @@ static int cpu_enable(struct chcpu_context *ctx, int enable)
 			continue;
 		}
 
-		if (ul_path_accessf(ctx->sys, F_OK, "cpu%d/configure", cpu) == 0)
-			ul_path_readf_s32(ctx->sys, &configured, "cpu%d/configure", cpu);
+		if (ul_path_accessf(ctx->sys, F_OK, "cpu%d/configure", cpu) != 0
+		    || ul_path_readf_s32(ctx->sys, &configured, "cpu%d/configure", cpu) != 0)
+			configured = -1;
 		if (enable) {
 			rc = ul_path_writef_string(ctx->sys, "1", "cpu%d/online", cpu);
 			if (rc != 0 && configured == 0) {

--- a/sys-utils/chmem.c
+++ b/sys-utils/chmem.c
@@ -226,7 +226,8 @@ static int chmem_configured(struct chmem_desc *desc, char *name)
 {
 	int mblock_configured = 0;
 
-	ul_path_readf_s32(desc->sysmemconfig, &mblock_configured, "%s/config", name);
+	if (ul_path_readf_s32(desc->sysmemconfig, &mblock_configured, "%s/config", name) != 0)
+		return 0;
 	return mblock_configured;
 }
 

--- a/sys-utils/lscpu-riscv.c
+++ b/sys-utils/lscpu-riscv.c
@@ -19,6 +19,9 @@ bool is_riscv(struct lscpu_cputype *ct)
 	const char *base_isa[] = {"rv32", "rv64", "rv128"};
 	size_t i;
 
+	if (!ct->isa)
+		return false;
+
 	for (i = 0; i < ARRAY_SIZE(base_isa); i++) {
 		if (!c_strncasecmp(ct->isa, base_isa[i], strlen(base_isa[i])))
 			return true;
@@ -34,6 +37,9 @@ void lscpu_format_isa_riscv(struct lscpu_cputype *ct)
 {
 	char **split;
 	size_t i;
+
+	if (!ct->isa)
+		return;
 
 	split = ul_strv_split(ct->isa, "_");
 

--- a/sys-utils/lscpu-topology.c
+++ b/sys-utils/lscpu-topology.c
@@ -584,8 +584,8 @@ static int read_address(struct lscpu_cxt *cxt, struct lscpu_cpu *cpu)
 
 	DBG_OBJ(CPU, cpu, ul_debug("#%d reading address", num));
 
-	ul_path_readf_s32(sys, &cpu->address, "cpu%d/address", num);
-	if (cpu->type)
+	if (ul_path_readf_s32(sys, &cpu->address, "cpu%d/address", num) == 0
+	    && cpu->type)
 		cpu->type->has_addresses = 1;
 	return 0;
 }

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -975,13 +975,12 @@ print_summary_cputype(struct lscpu_cxt *cxt,
 	if (ct->flags)
 		add_summary_s(tb, sec, _("Flags:"), ct->flags);
 
-	if (ct->isa && is_riscv(ct)) {
+	if (is_riscv(ct)) {
 		lscpu_format_isa_riscv(ct);
 		add_summary_s(tb, sec, _("ISA:"), ct->isa);
+		if (ct->mmu)
+			add_summary_s(tb, sec, _("MMU:"), ct->mmu);
 	}
-
-	if (ct->mmu && is_riscv(ct))
-		add_summary_s(tb, sec, _("MMU:"), ct->mmu);
 }
 
 /*


### PR DESCRIPTION
## Summary
- agetty: check fcntl() and ioctl() return values (CID 503788, 503786)
- lscpu: add NULL guards for RISC-V ISA functions, check ul_path_readf_s32() return (CID 503785, 504058)
- chcpu: check ul_path_readf_s32() return value (CID 504056)
- chmem: check ul_path_readf_s32() return value (CID 504055)
- libblkid: fix 32-bit overflow in DOS partition start/size (CID 503517, 503518)
- loopdev: initialize nr to avoid uninitialized use in debug (CID 490831)