### PR TITLE
libmount: add pluggable VFS I/O support

### DIFF
--- a/libmount/docs/libmount-sections.txt
+++ b/libmount/docs/libmount-sections.txt
@@ -9,6 +9,7 @@ mnt_cache_device_has_tag
 mnt_cache_find_tag_value
 mnt_cache_read_tags
 mnt_cache_set_targets
+mnt_cache_refer_vfs
 mnt_cache_set_sbprobe
 mnt_get_fstype
 mnt_pretty_path
@@ -94,6 +95,7 @@ mnt_context_is_swapmatch
 mnt_context_is_verbose
 mnt_context_reset_status
 mnt_context_set_cache
+mnt_context_set_vfs
 mnt_context_set_fs
 mnt_context_set_fstab
 mnt_context_set_fstype
@@ -420,6 +422,7 @@ mnt_table_parse_stream
 mnt_table_parse_swaps
 mnt_table_parse_utab
 mnt_table_remove_fs
+mnt_table_refer_vfs
 mnt_table_set_cache
 mnt_table_set_intro_comment
 mnt_table_set_iter

--- a/libmount/src/cache.c
+++ b/libmount/src/cache.c
@@ -65,6 +65,8 @@ struct libmnt_cache {
 	int			probe_sb_extra;	/* extra BLKID_SUBLKS_* flags */
 	bool			noprobe;	/* disable libblkid device probing */
 
+	const struct ul_vfs_ops	*vfs;		/* borrowed VFS ops (not owned) */
+
 	/* blkid_evaluate_tag() works in two ways:
 	 *
 	 * 1/ all tags are evaluated by udev /dev/disk/by-* symlinks,
@@ -219,6 +221,27 @@ void mnt_cache_enable_noprobe(struct libmnt_cache *cache, int enable)
 {
 	if (cache)
 		cache->noprobe = !!enable;
+}
+
+/**
+ * mnt_cache_refer_vfs:
+ * @cache: cache pointer
+ * @vfs: VFS operations or NULL
+ *
+ * Set reference to VFS I/O operations. The cache does not own the @vfs
+ * pointer -- the caller is responsible for its lifetime (e.g. the mount
+ * context owns it).
+ *
+ * The VFS is used for blkid device probing (see mnt_cache_read_tags()).
+ *
+ * Returns: 0 on success, negative number in case of error.
+ */
+int mnt_cache_refer_vfs(struct libmnt_cache *cache, const struct ul_vfs_ops *vfs)
+{
+	if (!cache)
+		return -EINVAL;
+	cache->vfs = vfs;
+	return 0;
 }
 
 /* note that the @key could be the same pointer as @value */
@@ -393,9 +416,16 @@ static int read_from_blkid(struct libmnt_cache *cache, const char *devname)
 
 	DBG_OBJ(CACHE, cache, ul_debug("%s: reading from blkid", devname));
 
-	pr =  blkid_new_probe_from_filename(devname);
+	pr = blkid_new_probe();
 	if (!pr)
 		return -EINVAL;
+
+	if (cache->vfs)
+		blkid_probe_set_vfs(pr, cache->vfs);
+	if (blkid_probe_open_device(pr, devname, 0)) {
+		blkid_free_probe(pr);
+		return -errno;
+	}
 
 	blkid_probe_enable_superblocks(pr, 1);
 	blkid_probe_set_superblocks_flags(pr,
@@ -583,16 +613,23 @@ static char *fstype_from_cache(const char *devname, struct libmnt_cache *cache)
 	return val;
 }
 
-static char *fstype_from_blkid(const char *devname, int *ambi)
+static char *fstype_from_blkid(const char *devname, int *ambi,
+			       const struct ul_vfs_ops *vfs)
 {
 	blkid_probe pr;
 	const char *data;
 	char *type = NULL;
 	int rc;
 
-	pr =  blkid_new_probe_from_filename(devname);
+	pr = blkid_new_probe();
 	if (!pr)
 		return NULL;
+	if (vfs)
+		blkid_probe_set_vfs(pr, vfs);
+	if (blkid_probe_open_device(pr, devname, 0)) {
+		blkid_free_probe(pr);
+		return NULL;
+	}
 
 	blkid_probe_enable_superblocks(pr, 1);
 	blkid_probe_set_superblocks_flags(pr, BLKID_SUBLKS_TYPE);
@@ -627,7 +664,7 @@ char *mnt_get_fstype(const char *devname, int *ambi, struct libmnt_cache *cache)
 	if (cache)
 		return fstype_from_cache(devname, cache);
 
-	return fstype_from_blkid(devname, ambi);
+	return fstype_from_blkid(devname, ambi, NULL);
 }
 
 static char *canonicalize_path_and_cache(const char *path,

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -3602,6 +3602,8 @@ struct libmnt_ns *mnt_context_switch_target_ns(struct libmnt_context *cxt)
 
 #ifdef TEST_PROGRAM
 
+#include <blkid.h>
+
 static int test_search_helper(struct libmnt_test *ts __attribute__((unused)),
 			      int argc, char *argv[])
 {
@@ -3630,6 +3632,70 @@ static int test_search_helper(struct libmnt_test *ts __attribute__((unused)),
 
 
 static struct libmnt_lock *lock;
+
+static unsigned int test_vfs_opens;
+static unsigned int test_vfs_closes;
+static unsigned int test_vfs_reads;
+static unsigned int test_vfs_writes;
+static unsigned int test_vfs_lseeks;
+
+static ssize_t test_vfs_read(int fd, void *buf, size_t count)
+{
+	test_vfs_reads++;
+	return read(fd, buf, count);
+}
+
+static ssize_t test_vfs_write(int fd, const void *buf, size_t count)
+{
+	test_vfs_writes++;
+	return write(fd, buf, count);
+}
+
+static int test_vfs_open(const char *pathname, int flags, mode_t mode)
+{
+	test_vfs_opens++;
+	return open(pathname, flags, mode);
+}
+
+static int test_vfs_close(int fd)
+{
+	test_vfs_closes++;
+	return close(fd);
+}
+
+static off_t test_vfs_lseek(int fd, off_t offset, int whence)
+{
+	test_vfs_lseeks++;
+	return lseek(fd, offset, whence);
+}
+
+static FILE *test_vfs_fopen(const char *pathname, const char *mode)
+{
+	fprintf(stderr, "VFS: fopen(\"%s\", \"%s\")\n", pathname, mode);
+	return fopen(pathname, mode);
+}
+
+static void test_vfs_dump_stats(void)
+{
+	fprintf(stderr, "VFS calls: open=%u close=%u read=%u write=%u lseek=%u\n",
+			test_vfs_opens, test_vfs_closes,
+			test_vfs_reads, test_vfs_writes, test_vfs_lseeks);
+}
+
+static int test_set_vfs(struct libmnt_context *cxt)
+{
+	struct ul_vfs_ops ops = {
+		.size      = sizeof(ops),
+		.vfs_read  = test_vfs_read,
+		.vfs_write = test_vfs_write,
+		.vfs_open  = test_vfs_open,
+		.vfs_close = test_vfs_close,
+		.vfs_lseek = test_vfs_lseek,
+		.vfs_fopen = test_vfs_fopen,
+	};
+
+	return mnt_context_set_vfs(cxt, &ops);
+}
 
 static void lock_fallback(void)
 {
@@ -3876,6 +3942,101 @@ static int test_mountall(struct libmnt_test *ts __attribute__((unused)),
 
 
 
+static int test_vfs(struct libmnt_test *ts __attribute__((unused)),
+		    int argc, char *argv[])
+{
+	int idx = 1, rc = 0;
+	struct libmnt_context *cxt;
+	struct libmnt_table *tb = NULL;
+
+	cxt = mnt_new_context();
+	if (!cxt)
+		return -ENOMEM;
+
+	test_set_vfs(cxt);
+
+	if (idx < argc && !strcmp(argv[idx], "--table")) {
+		idx++;
+		if (idx >= argc) {
+			rc = -EINVAL;
+			goto done;
+		}
+		rc = mnt_context_get_table(cxt, argv[idx++], &tb);
+		if (rc) {
+			warn("failed to parse table");
+			goto done;
+		}
+		printf("table: parsed %d entries\n",
+				mnt_table_get_nents(tb));
+		mnt_unref_table(tb);
+	}
+
+	if (idx < argc && !strcmp(argv[idx], "--cache")) {
+		struct libmnt_cache *cache;
+		char *type;
+
+		idx++;
+		if (idx >= argc) {
+			rc = -EINVAL;
+			goto done;
+		}
+		cache = mnt_context_get_cache(cxt);
+		if (!cache) {
+			warnx("no cache");
+			rc = -ENOMEM;
+			goto done;
+		}
+		rc = mnt_cache_read_tags(cache, argv[idx]);
+		if (rc < 0) {
+			warn("failed to read tags for %s", argv[idx]);
+			goto done;
+		}
+		type = mnt_get_fstype(argv[idx], NULL, cache);
+		printf("cache: %s type=%s\n", argv[idx], type ? type : "unknown");
+		idx++;
+	}
+
+	if (idx < argc && !strcmp(argv[idx], "--blkid")) {
+		blkid_probe pr;
+		const char *data;
+
+		idx++;
+		if (idx >= argc) {
+			rc = -EINVAL;
+			goto done;
+		}
+		pr = blkid_new_probe();
+		if (!pr) {
+			rc = -ENOMEM;
+			goto done;
+		}
+		blkid_probe_set_vfs(pr, cxt->vfs);
+		if (blkid_probe_open_device(pr, argv[idx], 0)) {
+			warn("failed to open %s", argv[idx]);
+			blkid_free_probe(pr);
+			rc = -errno;
+			goto done;
+		}
+		blkid_probe_enable_superblocks(pr, 1);
+		blkid_probe_set_superblocks_flags(pr, BLKID_SUBLKS_TYPE);
+
+		rc = blkid_do_safeprobe(pr);
+		if (!rc && !blkid_probe_lookup_value(pr, "TYPE", &data, NULL))
+			printf("blkid: %s type=%s\n", argv[idx], data);
+		else
+			printf("blkid: %s type=unknown\n", argv[idx]);
+
+		blkid_free_probe(pr);
+		idx++;
+		rc = 0;
+	}
+
+done:
+	test_vfs_dump_stats();
+	mnt_free_context(cxt);
+	return rc;
+}
+
 int main(int argc, char *argv[])
 {
 	struct libmnt_test tss[] = {
@@ -3885,6 +4046,7 @@ int main(int argc, char *argv[])
 	{ "--flags", test_flags,   "[-o <opts>] <spec>" },
 	{ "--cxtsync", test_cxtsync, "<fsopts> <cxtopts> <fsopts>" },
 	{ "--search-helper", test_search_helper, "<fstype>" },
+	{ "--vfs", test_vfs, "[--table <file>] [--cache <dev>] [--blkid <dev>]" },
 	{ NULL }};
 
 	umask(S_IWGRP|S_IWOTH);	/* to be compatible with mount(8) */

--- a/libmount/src/context.c
+++ b/libmount/src/context.c
@@ -104,6 +104,12 @@ void mnt_free_context(struct libmnt_context *cxt)
 	free(cxt->optstr_pattern);
 	free(cxt->tgt_prefix);
 
+	if (cxt->vfs) {
+		mnt_table_refer_vfs(cxt->fstab, NULL);
+		mnt_table_refer_vfs(cxt->mountinfo, NULL);
+		mnt_cache_refer_vfs(cxt->cache, NULL);
+		free(cxt->vfs);
+	}
 	mnt_unref_table(cxt->fstab);
 	mnt_unref_cache(cxt->cache);
 	mnt_unref_fs(cxt->fs);
@@ -1472,6 +1478,8 @@ int mnt_context_get_fstab(struct libmnt_context *cxt, struct libmnt_table **tb)
 			return -MNT_ERR_NAMESPACE;
 
 		mnt_table_set_cache(cxt->fstab, mnt_context_get_cache(cxt));
+		if (cxt->vfs)
+			mnt_table_refer_vfs(cxt->fstab, cxt->vfs);
 		rc = mnt_table_parse_fstab(cxt->fstab, NULL);
 
 		if (!mnt_context_switch_ns(cxt, ns_old))
@@ -1516,6 +1524,8 @@ int mnt_context_get_mountinfo(struct libmnt_context *cxt, struct libmnt_table **
 					cxt->table_fltrcb_data);
 
 		mnt_table_set_cache(cxt->mountinfo, mnt_context_get_cache(cxt));
+		if (cxt->vfs)
+			mnt_table_refer_vfs(cxt->mountinfo, cxt->vfs);
 	}
 
 	/* Read the table; it's empty, because this first mnt_context_get_mountinfo()
@@ -1678,6 +1688,8 @@ int mnt_context_get_table(struct libmnt_context *cxt,
 
 	if (cxt->table_errcb)
 		mnt_table_set_parser_errcb(*tb, cxt->table_errcb);
+	if (cxt->vfs)
+		mnt_table_refer_vfs(*tb, cxt->vfs);
 
 	ns_old = mnt_context_switch_target_ns(cxt);
 	if (!ns_old)
@@ -1729,6 +1741,45 @@ int mnt_context_set_tables_errcb(struct libmnt_context *cxt,
 }
 
 /**
+ * mnt_context_set_vfs:
+ * @cxt: mount context
+ * @ops: VFS operations or NULL
+ *
+ * Set pluggable VFS I/O operations. The library stores a private copy of @ops.
+ * If @ops is NULL, the VFS is reset to defaults (standard libc I/O).
+ *
+ * The VFS is automatically propagated to the cache (see mnt_cache_refer_vfs())
+ * and to the tables (see mnt_table_refer_vfs()) when they are created or set.
+ *
+ * Returns: 0 on success, negative number in case of error.
+ */
+int mnt_context_set_vfs(struct libmnt_context *cxt, const struct ul_vfs_ops *ops)
+{
+	if (!cxt)
+		return -EINVAL;
+
+	if (!ops) {
+		free(cxt->vfs);
+		cxt->vfs = NULL;
+		return 0;
+	}
+	if (!cxt->vfs) {
+		cxt->vfs = calloc(1, sizeof(*cxt->vfs));
+		if (!cxt->vfs)
+			return -ENOMEM;
+	}
+	ul_vfs_init(cxt->vfs, ops);
+
+	if (cxt->cache)
+		mnt_cache_refer_vfs(cxt->cache, cxt->vfs);
+	if (cxt->fstab)
+		mnt_table_refer_vfs(cxt->fstab, cxt->vfs);
+	if (cxt->mountinfo)
+		mnt_table_refer_vfs(cxt->mountinfo, cxt->vfs);
+	return 0;
+}
+
+/**
  * mnt_context_set_cache:
  * @cxt: mount context
  * @cache: cache instance or NULL
@@ -1758,6 +1809,8 @@ int mnt_context_set_cache(struct libmnt_context *cxt, struct libmnt_cache *cache
 
 	cxt->cache = cache;
 
+	if (cache && cxt->vfs)
+		mnt_cache_refer_vfs(cache, cxt->vfs);
 	if (cxt->mountinfo)
 		mnt_table_set_cache(cxt->mountinfo, cache);
 	if (cxt->fstab)

--- a/libmount/src/libmount.h.in
+++ b/libmount/src/libmount.h.in
@@ -147,6 +147,24 @@ struct libmnt_ns;
  */
 struct libmnt_statmnt;
 
+#ifndef UL_VFS_OPS_DEFINED
+#define UL_VFS_OPS_DEFINED
+
+struct ul_vfs_ops {
+	size_t size;
+
+	ssize_t (*vfs_read)(int fd, void *buf, size_t count);
+	ssize_t (*vfs_write)(int fd, const void *buf, size_t count);
+	int     (*vfs_open)(const char *pathname, int flags, mode_t mode);
+	int     (*vfs_close)(int fd);
+	off_t   (*vfs_lseek)(int fd, off_t offset, int whence);
+	int     (*vfs_fsync)(int fd);
+
+	FILE   *(*vfs_fopen)(const char *pathname, const char *mode);
+};
+
+#endif /* UL_VFS_OPS_DEFINED */
+
 /*
  * Actions
  */
@@ -388,6 +406,7 @@ extern void mnt_unref_cache(struct libmnt_cache *cache);
 extern int mnt_cache_set_targets(struct libmnt_cache *cache,
 				struct libmnt_table *mountinfo);
 extern int mnt_cache_set_sbprobe(struct libmnt_cache *cache, int flags);
+extern int mnt_cache_refer_vfs(struct libmnt_cache *cache, const struct ul_vfs_ops *vfs);
 extern int mnt_cache_read_tags(struct libmnt_cache *cache, const char *devname);
 
 extern int mnt_cache_device_has_tag(struct libmnt_cache *cache,
@@ -640,6 +659,7 @@ extern const char *mnt_table_get_trailing_comment(struct libmnt_table *tb);
 extern int mnt_table_append_trailing_comment(struct libmnt_table *tb, const char *comm);
 
 extern int mnt_table_set_cache(struct libmnt_table *tb, struct libmnt_cache *mpc);
+extern int mnt_table_refer_vfs(struct libmnt_table *tb, const struct ul_vfs_ops *vfs);
 extern struct libmnt_cache *mnt_table_get_cache(struct libmnt_table *tb);
 extern int mnt_table_add_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
 extern int mnt_table_find_fs(struct libmnt_table *tb, struct libmnt_fs *fs);
@@ -923,6 +943,8 @@ extern int mnt_context_get_mtab(struct libmnt_context *cxt,
 extern int mnt_context_get_table(struct libmnt_context *cxt,
 				const char *filename,
 				struct libmnt_table **tb);
+extern int mnt_context_set_vfs(struct libmnt_context *cxt,
+				const struct ul_vfs_ops *ops);
 extern int mnt_context_set_cache(struct libmnt_context *cxt,
 				 struct libmnt_cache *cache);
 extern struct libmnt_cache *mnt_context_get_cache(struct libmnt_context *cxt);

--- a/libmount/src/libmount.sym
+++ b/libmount/src/libmount.sym
@@ -426,3 +426,9 @@ MOUNT_2_43 {
 	mnt_table_disable_useropts;
 	mnt_table_parse_utab;
 } MOUNT_2_42;
+
+MOUNT_2_44 {
+	mnt_cache_refer_vfs;
+	mnt_context_set_vfs;
+	mnt_table_refer_vfs;
+} MOUNT_2_43;

--- a/libmount/src/mountP.h
+++ b/libmount/src/mountP.h
@@ -31,6 +31,7 @@
 #include "list.h"
 #include "debug.h"
 #include "buffer.h"
+#include "vfs.h"
 #include "libmount.h"
 
 #include "mountutils.h"
@@ -327,6 +328,7 @@ struct libmnt_table {
 	char		*comm_tail;	/* Last comment in file */
 
 	struct libmnt_cache *cache;		/* canonicalized paths/tags cache */
+	const struct ul_vfs_ops *vfs;		/* borrowed VFS ops (not owned) */
 
         int		(*errcb)(struct libmnt_table *tb,
 				 const char *filename, int line);
@@ -477,6 +479,7 @@ struct libmnt_context
 	const void	*mountdata;	/* final mount(2) data, string or binary data */
 
 	struct libmnt_cache	*cache;		/* paths cache */
+	struct ul_vfs_ops	*vfs;		/* pluggable I/O ops (owned, or NULL) */
 	struct libmnt_lock	*lock;		/* utab lock */
 	struct libmnt_update	*update;	/* utab update */
 

--- a/libmount/src/tab.c
+++ b/libmount/src/tab.c
@@ -394,6 +394,26 @@ int mnt_table_set_cache(struct libmnt_table *tb, struct libmnt_cache *mpc)
 }
 
 /**
+ * mnt_table_refer_vfs:
+ * @tb: pointer to tab
+ * @vfs: VFS operations or NULL
+ *
+ * Set reference to VFS I/O operations. The table does not own the @vfs
+ * pointer -- the caller is responsible for its lifetime.
+ *
+ * The VFS is used for table parsing (see mnt_table_parse_file()).
+ *
+ * Returns: 0 on success or negative number in case of error.
+ */
+int mnt_table_refer_vfs(struct libmnt_table *tb, const struct ul_vfs_ops *vfs)
+{
+	if (!tb)
+		return -EINVAL;
+	tb->vfs = vfs;
+	return 0;
+}
+
+/**
  * mnt_table_get_cache:
  * @tb: pointer to tab
  *

--- a/libmount/src/tab_parse.c
+++ b/libmount/src/tab_parse.c
@@ -844,7 +844,7 @@ int mnt_table_parse_file(struct libmnt_table *tb, const char *filename)
 	if (!filename || !tb)
 		return -EINVAL;
 
-	f = fopen(filename, "r" UL_CLOEXECSTR);
+	f = ul_vfs_fopen(tb->vfs, filename, "r" UL_CLOEXECSTR);
 	if (f) {
 		rc = mnt_table_parse_stream(tb, f, filename);
 		fclose(f);

--- a/tests/expected/libmount/vfs-blkid
+++ b/tests/expected/libmount/vfs-blkid
@@ -1,0 +1,2 @@
+VFS calls: open=1 close=1 read=N write=0 lseek=N
+blkid: DEVICE type=ext2

--- a/tests/expected/libmount/vfs-table-fstab
+++ b/tests/expected/libmount/vfs-table-fstab
@@ -1,0 +1,3 @@
+VFS: fopen("files/fstab", "re")
+VFS calls: open=0 close=0 read=0 write=0 lseek=0
+table: parsed 11 entries

--- a/tests/expected/libmount/vfs-table-mountinfo
+++ b/tests/expected/libmount/vfs-table-mountinfo
@@ -1,0 +1,3 @@
+VFS: fopen("files/mountinfo", "re")
+VFS calls: open=0 close=0 read=0 write=0 lseek=0
+table: parsed 33 entries

--- a/tests/ts/libmount/vfs
+++ b/tests/ts/libmount/vfs
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2025 Karel Zak <kzak@redhat.com>
+
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="VFS"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_skip_nonroot
+ts_check_prog "mkfs.ext2"
+
+TESTPROG="$TS_HELPER_LIBMOUNT_CONTEXT"
+
+[ -x $TESTPROG ] || ts_skip "test not compiled"
+
+ts_scsi_debug_init dev_size_mb=10
+mkfs.ext2 -F "$TS_DEVICE" &> /dev/null || ts_skip "mkfs.ext2 failed"
+udevadm settle
+
+ts_init_subtest "table-fstab"
+ts_run $TESTPROG --vfs --table "$TS_SELF/files/fstab" &> "$TS_OUTPUT"
+sed -i -e 's,VFS: fopen(".*/files/,VFS: fopen("files/,g' "$TS_OUTPUT"
+ts_finalize_subtest
+
+ts_init_subtest "table-mountinfo"
+ts_run $TESTPROG --vfs --table "$TS_SELF/files/mountinfo" &> "$TS_OUTPUT"
+sed -i -e 's,VFS: fopen(".*/files/,VFS: fopen("files/,g' "$TS_OUTPUT"
+ts_finalize_subtest
+
+ts_init_subtest "blkid"
+ts_run $TESTPROG --vfs --blkid "$TS_DEVICE" &> "$TS_OUTPUT"
+sed -i -e "s,$TS_DEVICE,DEVICE,g" \
+       -e 's,read=[0-9]*,read=N,g' \
+       -e 's,lseek=[0-9]*,lseek=N,g' "$TS_OUTPUT"
+ts_finalize_subtest
+
+ts_finalize


### PR DESCRIPTION
## Summary

Add pluggable VFS I/O operations to libmount, following the libblkid VFS support (PR #4460).

Three new public APIs:
- `mnt_context_set_vfs(cxt, ops)` — set VFS on mount context (owned copy)
- `mnt_cache_refer_vfs(cache, vfs)` — set VFS reference on cache (borrowed)
- `mnt_table_refer_vfs(tb, vfs)` — set VFS reference on table (borrowed)

The VFS is automatically propagated from context to cache and tables.
Blkid probe calls in `cache.c` are converted from `blkid_new_probe_from_filename()`
to `blkid_new_probe()` + `blkid_probe_set_vfs()` + `blkid_probe_open_device()`,
and `mnt_table_parse_file()` uses `ul_vfs_fopen()`.

Addresses: https://github.com/util-linux/util-linux/issues/4308