### PR TITLE
libfdisk: recommend GPT on interactive terminals on EFI systems for an empty device

### DIFF
--- a/disk-utils/fdisk.8.adoc
+++ b/disk-utils/fdisk.8.adoc
@@ -163,6 +163,9 @@ An IRIX/SGI disklabel can describe 16 partitions, the eleventh of which should b
 +
 A *sync*(2) and an ioctl(BLKRRPART) (rereading the partition table from disk) are performed before exiting when the partition table has been updated.
 
+*Default label on empty devices*::
+When *fdisk* is given a device with no recognized partition table, it creates one automatically (unless --noauto-pt is used). Since v2.43, on an interactive terminal and on an EFI system, the chosen disklabel is GPT; otherwise, it defaults to DOS/MBR, or BSD/SUN on SPARC.
+
 == DOS mode and DOS 6.x WARNING
 
 *Note that all this is deprecated. You don't have to care about things like* *geometry and cylinders on modern operating systems. If you really want* *DOS-compatible partitioning then you have to enable DOS mode and cylinder* *units by using the '-c=dos -u=cylinders' fdisk command-line options.*

--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -1404,7 +1404,11 @@ int main(int argc, char **argv)
 		if (!fdisk_has_label(cxt)) {
 			fdisk_info(cxt, _("Device does not contain a recognized partition table."));
 			if (!noauto_pt) {
-				rc = fdisk_create_disklabel(cxt, wanted_label);
+				if (is_interactive && !wanted_label)
+					rc = fdisk_create_disklabel(cxt, fdisk_get_recommended_labelname());
+				else
+					rc = fdisk_create_disklabel(cxt, wanted_label);
+
 				if (rc)
 					fdisk_warn(cxt, _("Failed to create a disklabel."));
 			}

--- a/disk-utils/sfdisk.8.adoc
+++ b/disk-utils/sfdisk.8.adoc
@@ -458,6 +458,8 @@ Since version 2.26 *sfdisk* no longer provides the *-R* or *--re-read* option to
 
 Since version 2.26 *sfdisk* does not provide the *--DOS*, *--IBM*, *--DOS-extended*, *--unhide*, *--show-extended*, *--cylinders*, *--heads*, *--sectors*, *--inside-outer*, *--not-inside-outer* options.
 
+Since version 2.43, on an interactive terminal and on an EFI system, the chosen disklabel is GPT; otherwise, *sfdisk* defaults to DOS/MBR, or BSD/SUN on SPARC.
+
 == EXAMPLES
 
 *sfdisk --list --label-nested=mbr /dev/sda*::

--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -1952,6 +1952,8 @@ static int command_fdisk(struct sfdisk *sf, int argc, char **argv)
 		label = sf->label;
 	else if (fdisk_has_label(sf->cxt))
 		label = fdisk_label_get_name(fdisk_get_label(sf->cxt, NULL));
+	else if (sf->interactive)
+		label = fdisk_get_recommended_labelname();
 	else
 		label = "dos";	/* just for backward compatibility */
 

--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -121,6 +121,7 @@
 #define _PATH_SYS_SCSI		"/sys/bus/scsi"
 #define _PATH_SYS_CPU_BYTEORDER	"/sys/kernel/cpu_byteorder"
 #define _PATH_SYS_ADDRESS_BITS	"/sys/kernel/address_bits"
+#define _PATH_SYS_EFI		"/sys/firmware/efi"
 
 #define _PATH_SYS_SELINUX	"/sys/fs/selinux"
 #define _PATH_SYS_APPARMOR	"/sys/kernel/security/apparmor"

--- a/libfdisk/docs/libfdisk-sections.txt
+++ b/libfdisk/docs/libfdisk-sections.txt
@@ -77,6 +77,7 @@ fdisk_save_user_sector_size
 
 <SECTION>
 <FILE>label</FILE>
+fdisk_get_recommended_labelname
 fdisk_create_disklabel
 fdisk_list_disklabel
 fdisk_locate_disklabel

--- a/libfdisk/src/label.c
+++ b/libfdisk/src/label.c
@@ -2,6 +2,7 @@
 
 #include "fdiskP.h"
 #include "cctype.h"
+#include "pathnames.h"
 
 
 /**
@@ -330,6 +331,27 @@ int fdisk_list_disklabel(struct fdisk_context *cxt)
 	} while (rc == 0 || rc == 1);
 
 	return rc < 0 ? rc : 0;
+}
+
+/**
+ * fdisk_get_recommended_labelname:
+ *
+ * Suggests a disklabel type based on the current system: "sun" on SPARC,
+ * "gpt" when booted via EFI, otherwise "dos".
+ *
+ * Returns: label name string
+ * Since: 2.43
+ */
+const char *fdisk_get_recommended_labelname(void)
+{
+#ifdef __sparc__
+	return "sun";
+#else
+	if (access(_PATH_SYS_EFI, F_OK) == 0)
+		return "gpt";
+
+	return "dos";
+#endif
 }
 
 /**

--- a/libfdisk/src/libfdisk.h.in
+++ b/libfdisk/src/libfdisk.h.in
@@ -397,6 +397,7 @@ int fdisk_label_require_geometry(const struct fdisk_label *lb);
 
 extern int fdisk_write_disklabel(struct fdisk_context *cxt);
 extern int fdisk_verify_disklabel(struct fdisk_context *cxt);
+extern const char *fdisk_get_recommended_labelname(void);
 extern int fdisk_create_disklabel(struct fdisk_context *cxt, const char *name);
 extern int fdisk_list_disklabel(struct fdisk_context *cxt);
 extern int fdisk_locate_disklabel(struct fdisk_context *cxt, int n,

--- a/libfdisk/src/libfdisk.sym
+++ b/libfdisk/src/libfdisk.sym
@@ -336,4 +336,5 @@ FDISK_2_42 {
 FDISK_2_43 {
 	fdisk_script_disable_devnames;
 	fdisk_script_has_devnames;
+	fdisk_get_recommended_labelname;
 } FDISK_2_42;


### PR DESCRIPTION
# Summary

When running fdisk or sfdisk on a device without any partition label, on a terminal (stdin) and on an EFI system, the function ```fdisk_get_recommended_labelname()``` suggests to them the GPT disklabel, otherwise it returns DOS or SUN on SPARC.

## Example

fdisk:
```
$ sudo ./fdisk /dev/sda

Welcome to fdisk (util-linux 2.43.devel-1026-0f119-dirty).
Changes will remain in memory only, until you decide to write them.
Be careful before using the write command.

Device does not contain a recognized partition table.
Created a new GPT disklabel (GUID: 5B4DA203-8C43-4C13-B609-2B4442D557A9).

Command (m for help):
```
sfdisk:
```
$ sudo ./sfdisk /dev/sda    

Welcome to sfdisk (util-linux 2.43-devel).
Changes will remain in memory only, until you decide to write them.
Be careful before using the write command.

Checking that no-one is using this disk right now ... OK

Disk /dev/sda: 3.76 GiB, 4037017600 bytes, 7884800 sectors
Disk model: Flash Disk      
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes

sfdisk is going to create a new 'gpt' disk label.
Use 'label: <name>' before you define a first partition
to override the default.

Type 'help' to get more information.

>>>
```

Addresses: https://github.com/util-linux/util-linux/issues/4478
