### PR TITLE
Update lsfd.c

### DIFF
--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -1969,7 +1969,7 @@ static void mark_poll_fds_as_multiplexed(char *buf,
 		struct file *file = list_entry(f, struct file, files);
 		if (is_opened_file(file) && !file->multiplexed) {
 			int fd = file->association;
-			if (bsearch((&(struct pollfd){.fd = fd,}), local.iov_base,
+			if (bsearch((&(struct pollfd){.fd = fd}), local.iov_base,
 				    nfds, sizeof(struct pollfd), pollfdcmp))
 				file->multiplexed = 1;
 		}


### PR DESCRIPTION
Unable to compile. I would like to take the comma after fd, so that it is getting 5 arguments not 6.