### PR TITLE
fdisk: fix -t/--type when auto-creating a label on empty devices

### DIFF
--- a/disk-utils/fdisk.8.adoc
+++ b/disk-utils/fdisk.8.adoc
@@ -85,7 +85,7 @@ Print SIZE in bytes rather than in human readable format.
 Print the size in 512-byte sectors of each given block device. This option is DEPRECATED in favour of *blockdev*(8).
 
 *-t*, *--type* _type_::
-Enable support only for disklabels of the specified _type_, and disable support for all other types.
+Enable support only for disklabels of the specified _type_, and disable support for all other types. This also determines the disklabel type used when *fdisk* automatically creates a new disklabel on an empty device.
 
 *-u*, *--units*[**=**_unit_]::
 When listing partition tables, show sizes in 'sectors' or in 'cylinders'. The default is to show sizes in sectors. For backward compatibility, it is possible to use the option without the _unit_ argument -- then the default is used. Note that the optional _unit_ argument cannot be separated from the *-u* option by a space; the correct form is *-u=cylinders*, for example.

--- a/disk-utils/fdisk.c
+++ b/disk-utils/fdisk.c
@@ -1149,6 +1149,7 @@ int main(int argc, char **argv)
 	struct fdisk_context *cxt;
 	char *outarg = NULL;
 	const char *devname, *lockmode = NULL;
+	const char *wanted_label = NULL;
 	enum {
 		OPT_BYTES	= CHAR_MAX + 1,
 		OPT_LOCK
@@ -1274,6 +1275,7 @@ int main(int argc, char **argv)
 			if (!lb)
 				errx(EXIT_FAILURE, _("unsupported disklabel: %s"), optarg);
 			fdisk_label_set_disabled(lb, 0);
+			wanted_label = fdisk_label_get_name(lb);
 			break;
 		}
 		case 'u':
@@ -1401,8 +1403,11 @@ int main(int argc, char **argv)
 
 		if (!fdisk_has_label(cxt)) {
 			fdisk_info(cxt, _("Device does not contain a recognized partition table."));
-			if (!noauto_pt)
-				fdisk_create_disklabel(cxt, NULL);
+			if (!noauto_pt) {
+				rc = fdisk_create_disklabel(cxt, wanted_label);
+				if (rc)
+					fdisk_warn(cxt, _("Failed to create a disklabel."));
+			}
 
 		} else if (fdisk_is_label(cxt, GPT) && fdisk_gpt_is_hybrid(cxt))
 			fdisk_warnx(cxt, _(


### PR DESCRIPTION
# Summary

fdisk_create_disklabel(cxt, NULL) always resolves to "dos" or "sun", regardless of any restriction set via -t/--type. If -t disabled "dos" (like in -t gpt) auto-creation on an empty device fails with -EINVAL. As the return code was never checked, the failure was silent, thus no label got created and no error was shown.

The requested label via -t is now passed to the auto-create call, which warns if creation still fails.

There is no behavior change when -t is not used in the program.

## Example:

Version without the fix on an empty device:

```
$ sudo ./fdisk -t gpt /dev/sda 

Welcome to fdisk (util-linux 2.43-devel).
Changes will remain in memory only, until you decide to write them.
Be careful before using the write command.

Device does not contain a recognized partition table.

Command (m for help): q

$ sudo ./fdisk -t dos /dev/sda 

Welcome to fdisk (util-linux 2.43-devel).
Changes will remain in memory only, until you decide to write them.
Be careful before using the write command.

Device does not contain a recognized partition table.
Created a new DOS (MBR) disklabel with disk identifier 0x69e2ffee.

Command (m for help): q
```
Fixed version with the same conditions:

```
$ sudo ./fdisk -t gpt /dev/sda 

Welcome to fdisk (util-linux 2.43-devel).
Changes will remain in memory only, until you decide to write them.
Be careful before using the write command.

Device does not contain a recognized partition table.
Created a new GPT disklabel (GUID: BE745236-0527-4A93-B06E-26F28CC1AFDD).

Command (m for help): q

$ sudo ./fdisk -t dos /dev/sda 

Welcome to fdisk (util-linux 2.43-devel).
Changes will remain in memory only, until you decide to write them.
Be careful before using the write command.

Device does not contain a recognized partition table.
Created a new DOS (MBR) disklabel with disk identifier 0xbaace9ec.

Command (m for help): q
```