### PR TITLE
Switch libsystemd and libeconf to dlopen

### DIFF
--- a/agetty-cmd/Makemodule.am
+++ b/agetty-cmd/Makemodule.am
@@ -25,6 +25,11 @@ agetty_LDADD += -lutil
 endif
 
 if HAVE_SYSTEMD
+agetty_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-systemd.c \
+	include/dl-systemd.h
 agetty_LDADD += $(SYSTEMD_LIBS)
 agetty_CFLAGS = $(SYSTEMD_CFLAGS)
 endif

--- a/agetty-cmd/issuefile.c
+++ b/agetty-cmd/issuefile.c
@@ -38,8 +38,7 @@
 #endif
 
 #ifdef USE_SYSTEMD
-# include <systemd/sd-daemon.h>
-# include <systemd/sd-login.h>
+# include "dl-systemd.h"
 #endif
 
 #ifdef USE_NETLINK
@@ -791,8 +790,8 @@ static void output_special_char(struct agetty_issue *ie,
 	{
 		int users = 0;
 #ifdef USE_SYSTEMD
-		if (sd_booted() > 0) {
-			users = sd_get_sessions(NULL);
+		if (ul_dlopen_libsystemd() == 0 && systemd_call(sd_booted)() > 0) {
+			users = systemd_call(sd_get_sessions)(NULL);
 			if (users < 0)
 				users = 0;
 		} else

--- a/configure.ac
+++ b/configure.ac
@@ -2789,6 +2789,12 @@ AS_IF([test "x$with_systemd" != xno], [
        AC_CHECK_DECLS([sd_device_new_from_syspath], [], [], [#include <systemd/sd-device.h>])
        AC_CHECK_DECLS([sd_device_open], [], [], [#include <systemd/sd-device.h>])
        AC_SUBST([SYSTEMD_USER_LOCK])
+       # libsystemd is loaded with dlopen() at runtime rather than linked
+       # against, so the tools need libdl instead of libsystemd (the
+       # SYSTEMD_CFLAGS headers are still used at build time).
+       SYSTEMD_LIBS="-ldl"
+       SYSTEMD_DAEMON_LIBS=
+       SYSTEMD_JOURNAL_LIBS=
   )
 ])
 AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$have_systemd" = xyes])

--- a/configure.ac
+++ b/configure.ac
@@ -1006,6 +1006,21 @@ AS_IF([test "x$build_widechar" = xyes ], [
   AC_DEFINE([HAVE_WIDECHAR], [1], [Do we have wide character support?])
 ])
 
+# The "R" (SHF_GNU_RETAIN) section flag is only understood by binutils >= 2.36.
+AC_MSG_CHECKING([whether the assembler supports the R (SHF_GNU_RETAIN) section flag])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+	__asm__(".pushsection .note.test, \"aR\", %note\n.popsection\n");
+]])], [
+	AC_MSG_RESULT([yes])
+	ul_dlopen_section_flags="aGR"
+], [
+	AC_MSG_RESULT([no])
+	ul_dlopen_section_flags="aG"
+])
+AC_DEFINE_UNQUOTED([_UL_ELF_NOTE_DLOPEN_SECTION_FLAGS],
+	["$ul_dlopen_section_flags"],
+	[ELF section flags for the .note.dlopen ELF note])
+
 
 AC_CHECK_TYPES([cpu_set_t], [have_cpu_set_t=yes], [], [[
 #include <sched.h>

--- a/configure.ac
+++ b/configure.ac
@@ -2893,8 +2893,13 @@ AS_IF([test "x$with_econf" != xno], [
   AS_CASE([$with_econf:$have_econf],
     [yes:no],
       [AC_MSG_ERROR([libeconf expected but libeconf not found])],
-    [*:yes],
+    [*:yes], [
        AC_DEFINE([HAVE_LIBECONF], [1], [Define if libeconf is available])
+       # libeconf is loaded with dlopen() at runtime rather than linked
+       # against, so the tools need libdl instead of libeconf (the ECONF_CFLAGS
+       # headers are still used at build time).
+       ECONF_LIBS="-ldl"
+    ]
   )
 ])
 AM_CONDITIONAL([HAVE_ECONF], [test "x$have_econf" = xyes])

--- a/include/Makemodule.am
+++ b/include/Makemodule.am
@@ -24,6 +24,7 @@ dist_noinst_HEADERS += \
 	include/default_shell.h \
 	include/dl-cryptsetup.h \
 	include/dl-selinux.h \
+	include/dl-systemd.h \
 	include/dl-utils.h \
 	include/encode.h \
 	include/env.h \

--- a/include/Makemodule.am
+++ b/include/Makemodule.am
@@ -23,6 +23,7 @@ dist_noinst_HEADERS += \
 	include/debug.h \
 	include/default_shell.h \
 	include/dl-cryptsetup.h \
+	include/dl-econf.h \
 	include/dl-selinux.h \
 	include/dl-systemd.h \
 	include/dl-utils.h \

--- a/include/dl-econf.h
+++ b/include/dl-econf.h
@@ -1,0 +1,51 @@
+/*
+ * No copyright is claimed.  This code is in the public domain; do with
+ * it what you wish.
+ */
+#ifndef UTIL_LINUX_DL_ECONF_H
+#define UTIL_LINUX_DL_ECONF_H
+
+#ifdef HAVE_LIBECONF
+
+#include <libeconf.h>
+
+#include "dl-utils.h"
+
+/* Pointers to libeconf functions (initialized by dlsym()) */
+struct ul_econf_opers {
+	econf_err (*econf_readFile)(econf_file **, const char *,
+			const char *, const char *);
+	econf_err (*econf_mergeFiles)(econf_file **, econf_file *, econf_file *);
+#ifdef HAVE_ECONF_READCONFIG
+	econf_err (*econf_readConfig)(econf_file **, const char *,
+			const char *, const char *, const char *,
+			const char *, const char *);
+#endif
+	econf_err (*econf_readDirs)(econf_file **, const char *,
+			const char *, const char *, const char *,
+			const char *, const char *);
+	econf_err (*econf_getKeys)(econf_file *, const char *,
+			size_t *, char ***);
+	econf_err (*econf_getStringValue)(econf_file *, const char *,
+			const char *, char **);
+	econf_err (*econf_getBoolValue)(econf_file *, const char *,
+			const char *, bool *);
+	econf_err (*econf_getUInt64Value)(econf_file *, const char *,
+			const char *, uint64_t *);
+	const char *(*econf_errString)(const econf_err);
+
+	/* the econf_free() macro dispatches to these depending on the type */
+	econf_file *(*econf_freeFile)(econf_file *);
+	char **(*econf_freeArray)(char **);
+};
+
+typedef struct ul_econf_opers ul_econf_opers;
+
+extern struct ul_econf_opers ul_econf;
+
+extern int ul_dlopen_libeconf(void);
+
+#define econf_call(_func)	(ul_econf._func)
+
+#endif /* HAVE_LIBECONF */
+#endif /* UTIL_LINUX_DL_ECONF_H */

--- a/include/dl-systemd.h
+++ b/include/dl-systemd.h
@@ -1,0 +1,96 @@
+/*
+ * No copyright is claimed.  This code is in the public domain; do with
+ * it what you wish.
+ */
+#ifndef UTIL_LINUX_DL_SYSTEMD_H
+#define UTIL_LINUX_DL_SYSTEMD_H
+
+#ifdef HAVE_LIBSYSTEMD
+
+#include <sys/uio.h>
+
+#include <systemd/sd-daemon.h>
+#include <systemd/sd-login.h>
+/* keep sd_journal_sendv as a plain symbol (not the _with_location macro) */
+#ifndef SD_JOURNAL_SUPPRESS_LOCATION
+# define SD_JOURNAL_SUPPRESS_LOCATION
+#endif
+#include <systemd/sd-journal.h>
+#if HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH
+# include <systemd/sd-device.h>
+# include <systemd/sd-event.h>
+#endif
+
+#include "dl-utils.h"
+
+/* Pointers to libsystemd functions (initialized by dlsym()) */
+struct ul_systemd_opers {
+	/* sd-daemon */
+	int (*sd_booted)(void);
+	int (*sd_listen_fds)(int);
+
+	/* sd-login */
+	int (*sd_get_sessions)(char ***);
+#if HAVE_DECL_SD_SESSION_GET_USERNAME
+	int (*sd_session_get_username)(const char *, char **);
+	int (*sd_session_get_tty)(const char *, char **);
+#endif
+
+	/* sd-journal */
+	int (*sd_journal_open)(sd_journal **, int);
+	int (*sd_journal_open_directory)(sd_journal **, const char *, int);
+	void (*sd_journal_close)(sd_journal *);
+	int (*sd_journal_next)(sd_journal *);
+	int (*sd_journal_previous_skip)(sd_journal *, uint64_t);
+	int (*sd_journal_get_realtime_usec)(sd_journal *, uint64_t *);
+	int (*sd_journal_get_data)(sd_journal *, const char *,
+			const void **, size_t *);
+	int (*sd_journal_add_match)(sd_journal *, const void *, size_t);
+	void (*sd_journal_flush_matches)(sd_journal *);
+	int (*sd_journal_seek_tail)(sd_journal *);
+	int (*sd_journal_sendv)(const struct iovec *, int);
+
+#if HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH
+	/* sd-device */
+	int (*sd_device_new_from_syspath)(sd_device **, const char *);
+	int (*sd_device_get_property_value)(sd_device *, const char *,
+			const char **);
+	sd_device *(*sd_device_ref)(sd_device *);
+	sd_device *(*sd_device_unref)(sd_device *);
+	int (*sd_device_get_action)(sd_device *, sd_device_action_t *);
+	int (*sd_device_get_devname)(sd_device *, const char **);
+	int (*sd_device_get_is_initialized)(sd_device *);
+
+	/* sd-device monitor */
+	int (*sd_device_monitor_new)(sd_device_monitor **);
+	sd_device_monitor *(*sd_device_monitor_unref)(sd_device_monitor *);
+	sd_event *(*sd_device_monitor_get_event)(sd_device_monitor *);
+	int (*sd_device_monitor_start)(sd_device_monitor *,
+			sd_device_monitor_handler_t, void *);
+	int (*sd_device_monitor_filter_add_match_subsystem_devtype)(
+			sd_device_monitor *, const char *, const char *);
+
+	/* sd-event */
+	int (*sd_event_add_time_relative)(sd_event *, sd_event_source **,
+			clockid_t, uint64_t, uint64_t,
+			sd_event_time_handler_t, void *);
+	int (*sd_event_loop)(sd_event *);
+	int (*sd_event_exit)(sd_event *, int);
+#endif
+#if HAVE_DECL_SD_DEVICE_OPEN
+	/* sd_device_open() and sd_device_new_from_devname() are both since systemd-251 */
+	int (*sd_device_open)(sd_device *, int);
+	int (*sd_device_new_from_devname)(sd_device **, const char *);
+#endif
+};
+
+typedef struct ul_systemd_opers ul_systemd_opers;
+
+extern struct ul_systemd_opers ul_systemd;
+
+extern int ul_dlopen_libsystemd(void);
+
+#define systemd_call(_func)	(ul_systemd._func)
+
+#endif /* HAVE_LIBSYSTEMD */
+#endif /* UTIL_LINUX_DL_SYSTEMD_H */

--- a/include/dl-utils.h
+++ b/include/dl-utils.h
@@ -55,10 +55,16 @@ extern int ul_dlopen_symbols(const char *libname, int flags,
 # define _UL_ELF_NOTE_DLOPEN_SECTION_FLAGS "aGR"
 #endif
 
+#if defined(__hppa__) || defined(__hppa64__)
+# define _UL_ELF_NOTE_DLOPEN_GUARD ".set"
+#else
+# define _UL_ELF_NOTE_DLOPEN_GUARD ".equ"
+#endif
+
 #define _UL_ELF_NOTE_DLOPEN(json)                                                                                            \
         __asm__ (                                                                                                             \
                 ".ifndef \"ul_dlopen:" json "\"\n"                                                                            \
-                ".set \"ul_dlopen:" json "\", 1\n"                                                                            \
+                _UL_ELF_NOTE_DLOPEN_GUARD " \"ul_dlopen:" json "\", 1\n"                                                      \
                 ".pushsection .note.dlopen, \"" _UL_ELF_NOTE_DLOPEN_SECTION_FLAGS "\", %note, \"ul_dlopen:" json "\", comdat\n" \
                 ".balign 4\n"                                                                                                 \
                 ".long 884f - 883f\n"                                                                                         \

--- a/include/shells.h
+++ b/include/shells.h
@@ -7,7 +7,7 @@
 #include <stdio.h>
 
 #if defined (HAVE_LIBECONF) && defined (USE_VENDORDIR)
-# include <libeconf.h>
+# include "dl-econf.h"
 econf_file *open_etc_shells(void);
 #endif
 

--- a/lib/Makemodule.am
+++ b/lib/Makemodule.am
@@ -74,6 +74,12 @@ libcommon_logindefs_la_CFLAGS = $(AM_CFLAGS)
 libcommon_logindefs_la_SOURCES = \
 	lib/logindefs.c
 if HAVE_ECONF
+libcommon_logindefs_la_CFLAGS += $(ECONF_CFLAGS)
+libcommon_logindefs_la_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-econf.c \
+	include/dl-econf.h
 libcommon_logindefs_la_LIBADD = $(ECONF_LIBS)
 endif
 
@@ -83,6 +89,12 @@ libcommon_shells_la_SOURCES = \
 	lib/shells.c
 if HAVE_ECONF
 if USE_VENDORDIR
+libcommon_shells_la_CFLAGS += $(ECONF_CFLAGS)
+libcommon_shells_la_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-econf.c \
+	include/dl-econf.h
 libcommon_shells_la_LIBADD = $(ECONF_LIBS)
 endif
 endif
@@ -270,5 +282,11 @@ test_logindefs_SOURCES = lib/logindefs.c
 test_logindefs_CPPFLAGS = -DTEST_PROGRAM $(AM_CPPFLAGS)
 test_logindefs_LDADD = $(LDADD) libcommon.la
 if HAVE_ECONF
+test_logindefs_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-econf.c \
+	include/dl-econf.h
+test_logindefs_CPPFLAGS += $(ECONF_CFLAGS)
 test_logindefs_LDADD += $(ECONF_LIBS)
 endif

--- a/lib/dl-econf.c
+++ b/lib/dl-econf.c
@@ -1,0 +1,58 @@
+/*
+ * No copyright is claimed.  This code is in the public domain; do with
+ * it what you wish.
+ */
+#include <dlfcn.h>
+
+#include "c.h"
+#include "dl-econf.h"
+
+#ifdef HAVE_LIBECONF
+
+UL_ELF_NOTE_DLOPEN("econf",
+		    "Support for libeconf",
+		    UL_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+		    "libeconf.so.0");
+
+struct ul_econf_opers ul_econf;
+
+static const struct ul_dlsym ul_econf_symbols[] =
+{
+	UL_DLSYM( ul_econf_opers, econf_readFile ),
+	UL_DLSYM( ul_econf_opers, econf_mergeFiles ),
+#ifdef HAVE_ECONF_READCONFIG
+	UL_DLSYM( ul_econf_opers, econf_readConfig ),
+#endif
+	UL_DLSYM( ul_econf_opers, econf_readDirs ),
+	UL_DLSYM( ul_econf_opers, econf_getKeys ),
+	UL_DLSYM( ul_econf_opers, econf_getStringValue ),
+	UL_DLSYM( ul_econf_opers, econf_getBoolValue ),
+	UL_DLSYM( ul_econf_opers, econf_getUInt64Value ),
+	UL_DLSYM( ul_econf_opers, econf_errString ),
+
+	UL_DLSYM( ul_econf_opers, econf_freeFile ),
+	UL_DLSYM( ul_econf_opers, econf_freeArray ),
+};
+
+int ul_dlopen_libeconf(void)
+{
+	/* 0 = not tried, 1 = loaded, -1 = failed */
+	static int status = 0;
+	static void *dl = NULL;
+	int flags = RTLD_LAZY | RTLD_LOCAL;
+
+	if (status)
+		return status > 0 ? 0 : -ENOSYS;
+
+#ifdef RTLD_NODELETE
+	flags |= RTLD_NODELETE;
+#endif
+	status = ul_dlopen_symbols("libeconf.so.0", flags,
+				   ul_econf_symbols,
+				   ARRAY_SIZE(ul_econf_symbols),
+				   &ul_econf, &dl) == 0 ? 1 : -1;
+
+	return status > 0 ? 0 : -ENOSYS;
+}
+
+#endif /* HAVE_LIBECONF */

--- a/lib/dl-systemd.c
+++ b/lib/dl-systemd.c
@@ -1,0 +1,88 @@
+/*
+ * No copyright is claimed.  This code is in the public domain; do with
+ * it what you wish.
+ */
+#include <dlfcn.h>
+
+#include "c.h"
+#include "dl-systemd.h"
+
+#ifdef HAVE_LIBSYSTEMD
+
+UL_ELF_NOTE_DLOPEN("systemd",
+		    "Support for systemd",
+		    UL_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+		    "libsystemd.so.0");
+
+struct ul_systemd_opers ul_systemd;
+
+static const struct ul_dlsym ul_systemd_symbols[] =
+{
+	UL_DLSYM( ul_systemd_opers, sd_booted ),
+	UL_DLSYM( ul_systemd_opers, sd_listen_fds ),
+
+	UL_DLSYM( ul_systemd_opers, sd_get_sessions ),
+#if HAVE_DECL_SD_SESSION_GET_USERNAME
+	UL_DLSYM( ul_systemd_opers, sd_session_get_username ),
+	UL_DLSYM( ul_systemd_opers, sd_session_get_tty ),
+#endif
+
+	UL_DLSYM( ul_systemd_opers, sd_journal_open ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_open_directory ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_close ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_next ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_previous_skip ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_get_realtime_usec ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_get_data ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_add_match ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_flush_matches ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_seek_tail ),
+	UL_DLSYM( ul_systemd_opers, sd_journal_sendv ),
+
+#if HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH
+	UL_DLSYM( ul_systemd_opers, sd_device_new_from_syspath ),
+	UL_DLSYM( ul_systemd_opers, sd_device_get_property_value ),
+	UL_DLSYM( ul_systemd_opers, sd_device_ref ),
+	UL_DLSYM( ul_systemd_opers, sd_device_unref ),
+	UL_DLSYM( ul_systemd_opers, sd_device_get_action ),
+	UL_DLSYM( ul_systemd_opers, sd_device_get_devname ),
+	UL_DLSYM( ul_systemd_opers, sd_device_get_is_initialized ),
+
+	UL_DLSYM( ul_systemd_opers, sd_device_monitor_new ),
+	UL_DLSYM( ul_systemd_opers, sd_device_monitor_unref ),
+	UL_DLSYM( ul_systemd_opers, sd_device_monitor_get_event ),
+	UL_DLSYM( ul_systemd_opers, sd_device_monitor_start ),
+	UL_DLSYM( ul_systemd_opers, sd_device_monitor_filter_add_match_subsystem_devtype ),
+
+	UL_DLSYM( ul_systemd_opers, sd_event_add_time_relative ),
+	UL_DLSYM( ul_systemd_opers, sd_event_loop ),
+	UL_DLSYM( ul_systemd_opers, sd_event_exit ),
+#endif
+#if HAVE_DECL_SD_DEVICE_OPEN
+	UL_DLSYM( ul_systemd_opers, sd_device_open ),
+	UL_DLSYM( ul_systemd_opers, sd_device_new_from_devname ),
+#endif
+};
+
+int ul_dlopen_libsystemd(void)
+{
+	/* 0 = not tried, 1 = loaded, -1 = failed */
+	static int status = 0;
+	static void *dl = NULL;
+	int flags = RTLD_LAZY | RTLD_LOCAL;
+
+	if (status)
+		return status > 0 ? 0 : -ENOSYS;
+
+#ifdef RTLD_NODELETE
+	flags |= RTLD_NODELETE;
+#endif
+	status = ul_dlopen_symbols("libsystemd.so.0", flags,
+				   ul_systemd_symbols,
+				   ARRAY_SIZE(ul_systemd_symbols),
+				   &ul_systemd, &dl) == 0 ? 1 : -1;
+
+	return status > 0 ? 0 : -ENOSYS;
+}
+
+#endif /* HAVE_LIBSYSTEMD */

--- a/lib/logindefs.c
+++ b/lib/logindefs.c
@@ -238,13 +238,14 @@ const char *getlogindefs_str(const char *name, const char *dflt)
 
 #else /* !HAVE_LIBECONF */
 
-#include <libeconf.h>
+#include "dl-econf.h"
 
 static econf_file *file = NULL;
 
 void free_getlogindefs_data(void)
 {
-	econf_free (file);
+	if (file)
+		econf_call(econf_freeFile)(file);
 	file = NULL;
 }
 
@@ -255,16 +256,18 @@ static void load_defaults(void)
 	if (file != NULL)
 		free_getlogindefs_data();
 
+	if (ul_dlopen_libeconf() == 0) {
 #ifdef HAVE_ECONF_READCONFIG
-	error = econf_readConfig(&file, NULL,
-			UL_VENDORDIR_PATH, "login", "defs", "= \t", "#");
+		error = econf_call(econf_readConfig)(&file, NULL,
+				UL_VENDORDIR_PATH, "login", "defs", "= \t", "#");
 #else
-	error = econf_readDirs(&file,
-			UL_VENDORDIR_PATH, "/etc", "login", "defs", "= \t", "#");
+		error = econf_call(econf_readDirs)(&file,
+				UL_VENDORDIR_PATH, "/etc", "login", "defs", "= \t", "#");
 #endif
-	if (error)
-	  syslog(LOG_NOTICE, _("Error reading login.defs: %s"),
-		 econf_errString(error));
+		if (error)
+			syslog(LOG_NOTICE, _("Error reading login.defs: %s"),
+			       econf_call(econf_errString)(error));
+	}
 
 	if (logindefs_loader)
 		logindefs_loader(logindefs_loader_data);
@@ -278,16 +281,19 @@ void logindefs_load_file(const char *filename)
 
 	logindefs_loader = NULL; /* No recursion */
 
+	if (ul_dlopen_libeconf() != 0)
+		return;
+
 #if USE_VENDORDIR
 	xasprintf(&path, _PATH_VENDORDIR"/%s", filename);
 
-	if (!econf_readFile(&file_l, path, "= \t", "#")) {
+	if (!econf_call(econf_readFile)(&file_l, path, "= \t", "#")) {
 		if (file == NULL)
 			file = file_l;
-		else if (!econf_mergeFiles(&file_m, file, file_l)) {
-			econf_free(file);
+		else if (!econf_call(econf_mergeFiles)(&file_m, file, file_l)) {
+			econf_call(econf_freeFile)(file);
 			file = file_m;
-			econf_free(file_l);
+			econf_call(econf_freeFile)(file_l);
 		}
 	}
 	free (path);
@@ -295,23 +301,23 @@ void logindefs_load_file(const char *filename)
 
 	xasprintf(&path, "/etc/%s", filename);
 
-	if (!econf_readFile(&file_l, path, "= \t", "#")) {
+	if (!econf_call(econf_readFile)(&file_l, path, "= \t", "#")) {
 		if (file == NULL)
 			file = file_l;
-		else if (!econf_mergeFiles(&file_m, file, file_l)) {
-			econf_free(file);
+		else if (!econf_call(econf_mergeFiles)(&file_m, file, file_l)) {
+			econf_call(econf_freeFile)(file);
 			file = file_m;
-			econf_free(file_l);
+			econf_call(econf_freeFile)(file_l);
 		}
 
 	/* Try original filename, could be relative */
-	} else if (!econf_readFile(&file_l, filename, "= \t", "#")) {
+	} else if (!econf_call(econf_readFile)(&file_l, filename, "= \t", "#")) {
 		if (file == NULL)
 			file = file_l;
-		else if (!econf_mergeFiles(&file_m, file, file_l)) {
-			econf_free(file);
+		else if (!econf_call(econf_mergeFiles)(&file_m, file, file_l)) {
+			econf_call(econf_freeFile)(file);
 			file = file_m;
-			econf_free(file_l);
+			econf_call(econf_freeFile)(file_l);
 		}
 	}
 	free (path);
@@ -328,10 +334,10 @@ int getlogindefs_bool(const char *name, int dflt)
 	if (!file)
 		return dflt;
 
-	if ((error = econf_getBoolValue(file, NULL, name, &value))) {
+	if ((error = econf_call(econf_getBoolValue)(file, NULL, name, &value))) {
 		if (error != ECONF_NOKEY)
 			syslog(LOG_NOTICE, _("couldn't fetch %s: %s"), name,
-			       econf_errString(error));
+			       econf_call(econf_errString)(error));
 		return dflt;
 	}
 	return value;
@@ -348,10 +354,10 @@ unsigned long getlogindefs_num(const char *name, unsigned long dflt)
 	if (!file)
 		return dflt;
 
-	if ((error = econf_getUInt64Value(file, NULL, name, &value))) {
+	if ((error = econf_call(econf_getUInt64Value)(file, NULL, name, &value))) {
 		if (error != ECONF_NOKEY)
 			syslog(LOG_NOTICE, _("couldn't fetch %s: %s"), name,
-			       econf_errString(error));
+			       econf_call(econf_errString)(error));
 		return dflt;
 	}
 	return value;
@@ -374,10 +380,10 @@ const char *getlogindefs_str(const char *name, const char *dflt)
 	if (!file)
 		return dflt;
 
-	if ((error = econf_getStringValue(file, NULL, name, &value))) {
+	if ((error = econf_call(econf_getStringValue)(file, NULL, name, &value))) {
 		if (error != ECONF_NOKEY)
 			syslog(LOG_NOTICE, _("couldn't fetch %s: %s"), name,
-			       econf_errString(error));
+			       econf_call(econf_errString)(error));
 		return dflt;
 	}
 	if (value)
@@ -590,14 +596,15 @@ int main(int argc, char *argv[])
 				"BOOLEAN", "NUMBER", "STRING", "HELLO_WORLD",
 				NULL};
 
-		for (i = 0; keys[i] != NULL; i++) {
+		for (i = 0; file && keys[i] != NULL; i++) {
 			char *value = NULL;
 
-			econf_getStringValue(file, NULL, keys[i], &value);
+			econf_call(econf_getStringValue)(file, NULL, keys[i], &value);
 			printf ("%s: $%s: '%s'\n", argv[1], keys[i], value);
 		}
 
-		econf_free (file);
+		if (file)
+			econf_call(econf_freeFile)(file);
 
 #else
 		struct item *ptr;

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -51,22 +51,24 @@ pty_session_c = files('pty-session.c')
 ismounted_c = files('ismounted.c')
 exec_shell_c = files('exec_shell.c')
 fileeq_c = files('fileeq.c')
-lib_common_logindefs = static_library('common_logindefs',
-  sources : ['logindefs.c'],
-  include_directories : dir_include,
-  dependencies : lib_econf,
-)
-
-lib_common_shells = static_library('common_shells',
-  sources : ['shells.c'],
-  include_directories : dir_include,
-  dependencies : lib_econf,
-)
 
 dl_utils_c = files('dl-utils.c')
 dl_cryptsetup_c = files('dl-cryptsetup.c')
 dl_selinux_c = files('dl-selinux.c')
 dl_systemd_c = files('dl-systemd.c')
+dl_econf_c = files('dl-econf.c')
+
+lib_common_logindefs = static_library('common_logindefs',
+  sources : ['logindefs.c', dl_utils_c, dl_econf_c],
+  include_directories : dir_include,
+  dependencies : lib_econf_dlopen_deps,
+)
+
+lib_common_shells = static_library('common_shells',
+  sources : ['shells.c', dl_utils_c, dl_econf_c],
+  include_directories : dir_include,
+  dependencies : lib_econf_dlopen_deps,
+)
 
 selinux_utils_c = files('selinux-utils.c')
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -66,6 +66,7 @@ lib_common_shells = static_library('common_shells',
 dl_utils_c = files('dl-utils.c')
 dl_cryptsetup_c = files('dl-cryptsetup.c')
 dl_selinux_c = files('dl-selinux.c')
+dl_systemd_c = files('dl-systemd.c')
 
 selinux_utils_c = files('selinux-utils.c')
 

--- a/lib/shells.c
+++ b/lib/shells.c
@@ -8,7 +8,7 @@
 #include <unistd.h>
 #include <sys/syslog.h>
 #if defined (HAVE_LIBECONF) && defined (USE_VENDORDIR)
-#include <libeconf.h>
+#include "dl-econf.h"
 #endif
 
 #include "closestream.h"
@@ -20,7 +20,10 @@ econf_file *open_etc_shells(void)
 	econf_err error;
 	econf_file *key_file = NULL;
 
-	error = econf_readDirs(&key_file,
+	if (ul_dlopen_libeconf() != 0)
+		return NULL;
+
+	error = econf_call(econf_readDirs)(&key_file,
 			       _PATH_VENDORDIR,
 			       "/etc",
 			       "shells",
@@ -30,7 +33,7 @@ econf_file *open_etc_shells(void)
 	if (error) {
 		syslog(LOG_ALERT,
 		       _("Cannot parse shells files: %s"),
-		       econf_errString(error));
+		       econf_call(econf_errString)(error));
 		return NULL;
 	}
 
@@ -52,19 +55,19 @@ extern void print_shells(FILE *out, const char *format)
 	if (!key_file)
 	  return;
 
-	error = econf_getKeys(key_file, NULL, &size, &keys);
+	error = econf_call(econf_getKeys)(key_file, NULL, &size, &keys);
 	if (error) {
-		econf_free(key_file);
+		econf_call(econf_freeFile)(key_file);
 		errx(EXIT_FAILURE,
 		  _("Cannot evaluate entries in shells files: %s"),
-		  econf_errString(error));
+		  econf_call(econf_errString)(error));
 	}
 
 	for (size_t i = 0; i < size; i++) {
 		fprintf(out, format, keys[i]);
 	}
-	econf_free(keys);
-	econf_free(key_file);
+	econf_call(econf_freeArray)(keys);
+	econf_call(econf_freeFile)(key_file);
 #else
 	char *s;
 
@@ -96,17 +99,17 @@ extern int is_known_shell(const char *shell_name)
 	if (!key_file)
 		return 0;
 
-	error = econf_getStringValue (key_file, NULL, shell_name, &val);
+	error = econf_call(econf_getStringValue) (key_file, NULL, shell_name, &val);
 	if (error) {
 		if (error != ECONF_NOKEY)
 			syslog(LOG_ALERT,
 			       _("Cannot evaluate entries in shells files: %s"),
-			       econf_errString(error));
+			       econf_call(econf_errString)(error));
 	} else
 		ret = 1;
 
 	free(val);
-	econf_free(key_file);
+	econf_call(econf_freeFile)(key_file);
 #else
 	char *s;
 

--- a/libblkid/meson.build
+++ b/libblkid/meson.build
@@ -155,12 +155,14 @@ lib_blkid = both_libraries(
   'blkid',
   list_h,
   lib_blkid_sources,
+  dl_utils_c,
+  dl_econf_c,
   include_directories : [dir_include, dir_libblkid],
   link_depends : libblkid_link_depends,
   version : libblkid_version,
   link_args : libblkid_link_args,
   link_with : lib_common,
-  dependencies : build_libblkid ? [lib_econf] : disabler(),
+  dependencies : build_libblkid ? lib_econf_dlopen_deps : disabler(),
   install : build_libblkid)
 blkid_dep = declare_dependency(link_with: lib_blkid, include_directories: '.')
 

--- a/libblkid/src/Makemodule.am
+++ b/libblkid/src/Makemodule.am
@@ -121,6 +121,11 @@ endif
 
 libblkid_la_LIBADD = libcommon.la
 if HAVE_ECONF
+libblkid_la_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-econf.c \
+	include/dl-econf.h
 libblkid_la_LIBADD += $(ECONF_LIBS)
 endif
 
@@ -130,6 +135,7 @@ EXTRA_libblkid_la_DEPENDENCIES = \
 libblkid_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(SOLIB_CFLAGS) \
+	$(ECONF_CFLAGS) \
 	-I$(ul_libblkid_incdir) \
 	-I$(top_srcdir)/libblkid/src
 

--- a/libblkid/src/config.c
+++ b/libblkid/src/config.c
@@ -23,7 +23,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 #if defined (HAVE_LIBECONF)
-# include <libeconf.h>
+# include "dl-econf.h"
 # include "pathnames.h"
 #endif
 
@@ -159,15 +159,18 @@ struct blkid_config *blkid_read_config(const char *filename)
 	bool uevent = false;
 	econf_err error;
 
+	if (ul_dlopen_libeconf() != 0)
+		goto dflt;
+
 	if (filename) {
 		DBG(CONFIG, ul_debug("reading config file: %s.", filename));
-		error = econf_readFile(&file, filename, "= \t", "#");
+		error = econf_call(econf_readFile)(&file, filename, "= \t", "#");
 	} else {
 #ifdef HAVE_ECONF_READCONFIG
-		error = econf_readConfig(&file, NULL,
+		error = econf_call(econf_readConfig)(&file, NULL,
 			UL_VENDORDIR_PATH, "blkid", "conf", "= \t", "#");
 #else
-		error = econf_readDirs(&file,
+		error = econf_call(econf_readDirs)(&file,
 			UL_VENDORDIR_PATH, "/etc", "blkid", "conf", "= \t", "#");
 #endif
 	}
@@ -183,17 +186,17 @@ struct blkid_config *blkid_read_config(const char *filename)
 			goto dflt;
 		} else {
 			if (filename)
-				DBG(CONFIG, ul_debug("%s: parse error:%s", filename, econf_errString(error)));
+				DBG(CONFIG, ul_debug("%s: parse error:%s", filename, econf_call(econf_errString)(error)));
 			else
-				DBG(CONFIG, ul_debug("parse error:%s", econf_errString(error)));
+				DBG(CONFIG, ul_debug("parse error:%s", econf_call(econf_errString)(error)));
 
 			goto err;
 		}
 	}
 
-	if ((error = econf_getBoolValue(file, NULL, "SEND_UEVENT", &uevent))) {
+	if ((error = econf_call(econf_getBoolValue)(file, NULL, "SEND_UEVENT", &uevent))) {
 		if (error != ECONF_NOKEY) {
-			DBG(CONFIG, ul_debug("couldn't fetch SEND_UEVENT currently: %s", econf_errString(error)));
+			DBG(CONFIG, ul_debug("couldn't fetch SEND_UEVENT currently: %s", econf_call(econf_errString)(error)));
 			goto err;
 		} else {
 			DBG(CONFIG, ul_debug("key SEND_UEVENT not found, using built-in default "));
@@ -202,20 +205,20 @@ struct blkid_config *blkid_read_config(const char *filename)
 		conf->uevent = uevent ? TRUE : FALSE;
 	}
 
-	if ((error = econf_getStringValue(file, NULL, "CACHE_FILE", &(conf->cachefile)))) {
+	if ((error = econf_call(econf_getStringValue)(file, NULL, "CACHE_FILE", &(conf->cachefile)))) {
 		conf->cachefile = NULL;
 		if (error != ECONF_NOKEY) {
-			DBG(CONFIG, ul_debug("couldn't fetch CACHE_FILE correctly: %s", econf_errString(error)));
+			DBG(CONFIG, ul_debug("couldn't fetch CACHE_FILE correctly: %s", econf_call(econf_errString)(error)));
 			goto err;
 		} else {
 			DBG(CONFIG, ul_debug("key CACHE_FILE not found, using built-in default "));
 		}
 	}
 
-	if ((error = econf_getStringValue(file, NULL, "EVALUATE", &line))) {
+	if ((error = econf_call(econf_getStringValue)(file, NULL, "EVALUATE", &line))) {
 		conf->nevals = 0;
 		if (error != ECONF_NOKEY) {
-			DBG(CONFIG, ul_debug("couldn't fetch EVALUATE correctly: %s", econf_errString(error)));
+			DBG(CONFIG, ul_debug("couldn't fetch EVALUATE correctly: %s", econf_call(econf_errString)(error)));
 			goto err;
 		} else {
 			DBG(CONFIG, ul_debug("key CACHE_FILE not found, using built-in default "));
@@ -240,7 +243,8 @@ dflt:
 	if (f)
 		fclose(f);
 #else
-	econf_free(file);
+	if (file)
+		econf_call(econf_freeFile)(file);
 	free(line);
 #endif
 	return conf;
@@ -250,7 +254,8 @@ err:
 #ifndef HAVE_LIBECONF
 	fclose(f);
 #else
-	econf_free(file);
+	if (file)
+		econf_call(econf_freeFile)(file);
 	free(line);
 #endif
 	return NULL;

--- a/libmount/meson.build
+++ b/libmount/meson.build
@@ -82,6 +82,13 @@ if lib_cryptsetup.found()
   lib_mount_sources += dl_cryptsetup_c
 endif
 
+if conf.get('USE_LIBMOUNT_UDEV_SUPPORT').to_string() == '1'
+  if not (lib_selinux.found() or lib_cryptsetup.found())
+    lib_mount_sources += dl_utils_c
+  endif
+  lib_mount_sources += dl_systemd_c
+endif
+
 libmount_sym = 'src/libmount.sym'
 libmount_sym_path = '@0@/@1@'.format(meson.current_source_dir(), libmount_sym)
 
@@ -95,6 +102,9 @@ if lib_selinux.found()
 endif
 if lib_cryptsetup.found()
   lib__mount_compile_deps += lib_cryptsetup.partial_dependency(compile_args : true, includes : true)
+endif
+if conf.get('USE_LIBMOUNT_UDEV_SUPPORT').to_string() == '1'
+  lib__mount_compile_deps += lib_systemd.partial_dependency(compile_args : true, includes : true)
 endif
 
 lib__mount = static_library(
@@ -116,10 +126,6 @@ lib__mount_deps = [
   lib_dl,
   realtime_libs
 ]
-
-if conf.get('USE_LIBMOUNT_UDEV_SUPPORT').to_string() == '1'
-  lib__mount_deps += [lib_systemd]
-endif
 
 libmount_link_depends = []
 libmount_link_args = []

--- a/libmount/src/Makemodule.am
+++ b/libmount/src/Makemodule.am
@@ -84,6 +84,16 @@ libmount_la_LIBADD += -ldl
 endif
 
 if USE_LIBMOUNT_UDEV_SUPPORT
+libmount_la_SOURCES += \
+	lib/dl-systemd.c \
+	include/dl-systemd.h
+if !HAVE_SELINUX
+if !HAVE_CRYPTSETUP
+libmount_la_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h
+endif
+endif
 libmount_la_LIBADD += $(SYSTEMD_LIBS)
 endif
 
@@ -94,7 +104,8 @@ libmount_la_CFLAGS = \
 	-I$(top_srcdir)/libmount/src \
 	$(SOLIB_CFLAGS) \
 	$(CRYPTSETUP_CFLAGS) \
-	$(SELINUX_CFLAGS)
+	$(SELINUX_CFLAGS) \
+	$(SYSTEMD_CFLAGS)
 
 EXTRA_libmount_la_DEPENDENCIES = \
 	libmount/src/libmount.sym

--- a/libmount/src/cache.c
+++ b/libmount/src/cache.c
@@ -32,7 +32,7 @@
 
 /* sd-device is a replacement for libudev */
 #ifdef USE_LIBMOUNT_UDEV_SUPPORT
-# include <systemd/sd-device.h>
+# include "dl-systemd.h"
 #endif
 
 #include "canonicalize.h"
@@ -480,7 +480,10 @@ static int read_from_udev(struct libmnt_cache *cache, const char *devname)
 	assert(cache);
 	assert(devname);
 
-	rc = sd_device_new_from_devname(&sd, devname);
+	if (ul_dlopen_libsystemd() != 0)
+		return -ENOSYS;
+
+	rc = systemd_call(sd_device_new_from_devname)(&sd, devname);
 	if (rc < 0)
 		return rc;
 
@@ -491,7 +494,7 @@ static int read_from_udev(struct libmnt_cache *cache, const char *devname)
 
 		if (cache_find_tag_value(cache, devname, t->mnt_name))
 			continue;
-		if (sd_device_get_property_value(sd, t->udev_name, &data) < 0)
+		if (systemd_call(sd_device_get_property_value)(sd, t->udev_name, &data) < 0)
 			continue;
 
 		tagval = strdup(data); /* temporary for unhexmangle() */
@@ -511,7 +514,7 @@ static int read_from_udev(struct libmnt_cache *cache, const char *devname)
 	}
 
 	DBG_OBJ(CACHE, cache, ul_debug("\tread %zu tags [rc=%d]", ntags, rc));
-	sd_device_unref(sd);
+	systemd_call(sd_device_unref)(sd);
 	free(cacheval);
 	free(tagval);
 

--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -236,6 +236,14 @@ lslogins_LDADD += -ldl
 lslogins_CFLAGS += $(SELINUX_CFLAGS)
 endif
 if HAVE_SYSTEMD
+lslogins_SOURCES += \
+	lib/dl-systemd.c \
+	include/dl-systemd.h
+if !HAVE_SELINUX
+lslogins_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h
+endif
 lslogins_LDADD += $(SYSTEMD_LIBS) $(SYSTEMD_JOURNAL_LIBS)
 lslogins_CFLAGS += $(SYSTEMD_CFLAGS) $(SYSTEMD_JOURNAL_CFLAGS)
 endif

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -1528,20 +1528,20 @@ static void login_shell_fallback(char **child_argv)
 	if (!key_file)
 		return;
 
-	error = econf_getKeys(key_file, NULL, &size, &keys);
+	error = econf_call(econf_getKeys)(key_file, NULL, &size, &keys);
 	if (error) {
-		econf_free(key_file);
+		econf_call(econf_freeFile)(key_file);
 		errx(EXIT_FAILURE,
 			_("Cannot evaluate entries in shells files: %s"),
-			econf_errString(error));
+			econf_call(econf_errString)(error));
 	}
 
 	for (size_t i = 0; i < size; i++) {
 		build_shell_argv(keys[i], child_argv);
 		execvp(child_argv[0], child_argv + 1);
 	}
-	econf_free(keys);
-	econf_free(key_file);
+	econf_call(econf_freeArray)(keys);
+	econf_call(econf_freeFile)(key_file);
 #else
 	char *s;
 	setusershell();

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -43,7 +43,7 @@
 #endif
 
 #ifdef HAVE_LIBSYSTEMD
-# include <systemd/sd-journal.h>
+# include "dl-systemd.h"
 #endif
 
 #ifdef HAVE_LIBLASTLOG2
@@ -1385,7 +1385,7 @@ static char *get_journal_data(sd_journal *j, const char *name)
 	const char *data = NULL, *p;
 	size_t len = 0;
 
-	if (sd_journal_get_data(j, name, (const void **) &data, &len) < 0
+	if (systemd_call(sd_journal_get_data)(j, name, (const void **) &data, &len) < 0
 	    || !data || !len)
 		return NULL;
 
@@ -1403,23 +1403,26 @@ static void print_journal_tail(const char *journal_path, uid_t uid, size_t len, 
 	sd_journal *j;
 	char *match;
 
+	if (ul_dlopen_libsystemd() != 0)
+		return;
+
 	if (journal_path)
-		sd_journal_open_directory(&j, journal_path, 0);
+		systemd_call(sd_journal_open_directory)(&j, journal_path, 0);
 	else
-		sd_journal_open(&j, SD_JOURNAL_LOCAL_ONLY);
+		systemd_call(sd_journal_open)(&j, SD_JOURNAL_LOCAL_ONLY);
 
 	xasprintf(&match, "_UID=%u", uid);
 
-	sd_journal_add_match(j, match, 0);
-	sd_journal_seek_tail(j);
-	sd_journal_previous_skip(j, len);
+	systemd_call(sd_journal_add_match)(j, match, 0);
+	systemd_call(sd_journal_seek_tail)(j);
+	systemd_call(sd_journal_previous_skip)(j, len);
 
 	do {
 		char *id, *pid, *msg, *ts;
 		uint64_t x;
 		time_t t;
 
-		sd_journal_get_realtime_usec(j, &x);
+		systemd_call(sd_journal_get_realtime_usec)(j, &x);
 		t = x / 1000000;
 		ts = make_time(time_mode, t);
 
@@ -1434,11 +1437,11 @@ static void print_journal_tail(const char *journal_path, uid_t uid, size_t len, 
 		free(id);
 		free(pid);
 		free(msg);
-	} while (sd_journal_next(j));
+	} while (systemd_call(sd_journal_next)(j));
 
 	free(match);
-	sd_journal_flush_matches(j);
-	sd_journal_close(j);
+	systemd_call(sd_journal_flush_matches)(j);
+	systemd_call(sd_journal_close)(j);
 }
 #endif
 

--- a/meson.build
+++ b/meson.build
@@ -391,6 +391,12 @@ lib_utempter = cc.find_library(
   required : get_option('libutempter'))
 conf.set('HAVE_LIBUTEMPTER', lib_utempter.found() ? 1 : false)
 
+if meson.version().version_compare('>= 0.62.0')
+  lib_dl = dependency('dl')
+else
+  lib_dl = cc.find_library('dl')
+endif
+
 systemd = dependency(
   'systemd',
   required : get_option('systemd'))
@@ -405,7 +411,18 @@ lib_systemd = dependency(
   required : get_option('systemd'))
 conf.set('HAVE_LIBSYSTEMD', lib_systemd.found() ? 1 : false)
 conf.set('USE_SYSTEMD', lib_systemd.found() ? 1 : false)
-summary('libsystemd', lib_systemd.found() ? 'enabled' : 'disabled', section : 'components')
+summary('libsystemd', lib_systemd.found() ? 'enabled (dlopen)' : 'disabled', section : 'components')
+
+# libsystemd is loaded with dlopen() at runtime (through lib/dl-systemd.c)
+# instead of being linked, so the tools only need the headers at build time
+# plus libdl. lib_systemd_dlopen_deps bundles both and is used by all
+# libsystemd-using targets.
+lib_systemd_compile_deps = []
+lib_systemd_dlopen_deps = []
+if lib_systemd.found()
+  lib_systemd_compile_deps = [lib_systemd.partial_dependency(compile_args : true, includes : true)]
+  lib_systemd_dlopen_deps = lib_systemd_compile_deps + [lib_dl]
+endif
 
 # Since systemd-240, which provides basic functions in sd-device.
 have = cc.has_function(
@@ -467,12 +484,6 @@ lib_cryptsetup = dependency(
   'libcryptsetup',
   required : get_option('cryptsetup'))
 conf.set('HAVE_CRYPTSETUP', lib_cryptsetup.found() ? 1 : false)
-
-if meson.version().version_compare('>= 0.62.0')
-  lib_dl = dependency('dl')
-else
-  lib_dl = cc.find_library('dl')
-endif
 
 summary('cryptsetup support (dlopen)',
         lib_cryptsetup.found() ? 'enabled' : 'disabled',
@@ -1239,13 +1250,13 @@ opt = get_option('build-lslogins') \
 exe = executable(
   'lslogins',
   'login-utils/lslogins.c',
-  dl_utils_c, dl_selinux_c,
+  dl_utils_c, dl_selinux_c, dl_systemd_c,
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols,
                lib_common_logindefs] +
                (build_liblastlog2 ? [lib_lastlog2] : []),
-  dependencies : [lib_systemd] + lib_selinux_dlopen_deps,
+  dependencies : lib_systemd_dlopen_deps + lib_selinux_dlopen_deps,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -1930,11 +1941,11 @@ opt = get_option('build-zramctl').allowed()
 exe = executable(
   'zramctl',
   zramctl_sources,
+  dl_utils_c, dl_systemd_c,
   include_directories : includes,
   link_with : [lib_common,
                lib_smartcols],
-  # requires systemd v240 or newer
-  dependencies : [conf.get('HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH').to_string() == '1' ? lib_systemd : [] ],
+  dependencies : lib_systemd_dlopen_deps,
   install_dir : sbindir,
   install : opt,
   build_by_default : opt)
@@ -2806,9 +2817,10 @@ opt = get_option('build-agetty') \
 exe = executable(
   'agetty',
   agetty_sources,
+  dl_utils_c, dl_systemd_c,
   include_directories : includes,
   link_with : [lib_common, lib_common_logindefs],
-  dependencies : [BSD ? lib_util : [], lib_systemd],
+  dependencies : [BSD ? lib_util : []] + lib_systemd_dlopen_deps,
   install_dir : sbindir,
   install : opt,
   build_by_default : opt)
@@ -2861,9 +2873,10 @@ opt = get_option('build-wall').allowed()
 exe = executable(
   'wall',
   wall_sources,
+  dl_utils_c, dl_systemd_c,
   include_directories : includes,
   link_with : [lib_common],
-  dependencies : [lib_systemd],
+  dependencies : lib_systemd_dlopen_deps,
   install_dir : usrbin_exec_dir,
   install_mode : tty_install_mode,
   install : opt,
@@ -2883,9 +2896,10 @@ opt = get_option('build-write') \
 exe = executable(
   'write',
   write_sources,
+  dl_utils_c, dl_systemd_c,
   include_directories : includes,
   link_with : [lib_common],
-  dependencies : [lib_systemd],
+  dependencies : lib_systemd_dlopen_deps,
   install_dir : usrbin_exec_dir,
   install_mode : tty_install_mode,
   install : opt,
@@ -2953,9 +2967,10 @@ opt = get_option('build-logger').allowed()
 exe = executable(
   'logger',
   logger_sources,
+  dl_utils_c, dl_systemd_c,
   include_directories : includes,
   link_with : [lib_common],
-  dependencies : [lib_systemd],
+  dependencies : lib_systemd_dlopen_deps,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -2968,10 +2983,11 @@ endif
 exe = executable(
   'test_logger',
   logger_sources,
+  dl_utils_c, dl_systemd_c,
   include_directories : includes,
   c_args : '-DTEST_LOGGER',
   link_with : [lib_common],
-  dependencies : [lib_systemd],
+  dependencies : lib_systemd_dlopen_deps,
   build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe
@@ -3144,11 +3160,11 @@ opt = build_uuidd
 exe = executable(
   'uuidd',
   uuidd_sources,
+  dl_utils_c, dl_systemd_c,
   include_directories : includes,
   link_with : [lib_common,
                lib_uuid],
-  dependencies : [realtime_libs,
-                  lib_systemd],
+  dependencies : [realtime_libs] + lib_systemd_dlopen_deps,
   install_dir : usrsbin_exec_dir,
   install : opt,
   build_by_default : opt)

--- a/meson.build
+++ b/meson.build
@@ -295,6 +295,15 @@ if get_option('ncurses').enabled() and get_option('widechar').enabled()
 endif
 conf.set('HAVE_WIDECHAR', have ? 1 : false)
 
+# The "R" (SHF_GNU_RETAIN) section flag is only understood by binutils >= 2.36.
+if cc.compiles(
+        '__asm__(".pushsection .note.test, \\"aR\\", %note\\n.popsection\\n");',
+        name : 'assembler supports the "R" (SHF_GNU_RETAIN) section flag')
+        conf.set_quoted('_UL_ELF_NOTE_DLOPEN_SECTION_FLAGS', 'aGR')
+else
+        conf.set_quoted('_UL_ELF_NOTE_DLOPEN_SECTION_FLAGS', 'aG')
+endif
+
 lib_m = cc.find_library('m')
 
 lib_tinfo = dependency(

--- a/meson.build
+++ b/meson.build
@@ -525,11 +525,21 @@ lib_econf = dependency(
   'libeconf',
   required : get_option('econf'))
 conf.set('HAVE_LIBECONF', lib_econf.found() ? 1 : false)
+summary('libeconf', lib_econf.found() ? 'enabled (dlopen)' : 'disabled', section : 'components')
 
 have = cc.has_function(
   'econf_readConfig',
   dependencies : lib_econf)
 conf.set('HAVE_ECONF_READCONFIG', have ? 1 : false)
+
+# libeconf is loaded with dlopen() at runtime (through lib/dl-econf.c) instead
+# of being linked, so the tools only need the headers at build time plus libdl.
+lib_econf_compile_deps = []
+lib_econf_dlopen_deps = []
+if lib_econf.found()
+  lib_econf_compile_deps = [lib_econf.partial_dependency(compile_args : true, includes : true)]
+  lib_econf_dlopen_deps = lib_econf_compile_deps + [lib_dl]
+endif
 
 lib_audit = dependency(
   'audit',
@@ -3828,9 +3838,12 @@ endif
 exe = executable(
   'test_logindefs',
   'lib/logindefs.c',
+  dl_utils_c,
+  dl_econf_c,
   c_args : ['-DTEST_PROGRAM'],
   include_directories : dir_include,
-  link_with : [lib_common, lib_common_logindefs],
+  link_with : lib_common,
+  dependencies : lib_econf_dlopen_deps,
   build_by_default: program_tests)
 if not is_disabler(exe)
   exes += exe

--- a/misc-utils/Makemodule.am
+++ b/misc-utils/Makemodule.am
@@ -38,6 +38,11 @@ logger_SOURCES = misc-utils/logger.c lib/strutils.c lib/strv.c
 logger_LDADD = $(LDADD) libcommon.la
 logger_CFLAGS = $(AM_CFLAGS)
 if HAVE_SYSTEMD
+logger_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-systemd.c \
+	include/dl-systemd.h
 logger_LDADD += $(SYSTEMD_LIBS) $(SYSTEMD_DAEMON_LIBS) $(SYSTEMD_JOURNAL_LIBS)
 logger_CFLAGS += $(SYSTEMD_CFLAGS) $(SYSTEMD_DAEMON_CFLAGS) $(SYSTEMD_JOURNAL_CFLAGS)
 endif
@@ -139,6 +144,11 @@ uuidd_CFLAGS = $(DAEMON_CFLAGS) $(AM_CFLAGS) -I$(ul_libuuid_incdir)
 uuidd_LDFLAGS = $(DAEMON_LDFLAGS) $(AM_LDFLAGS)
 uuidd_SOURCES = misc-utils/uuidd.c lib/monotonic.c lib/timer.c
 if HAVE_SYSTEMD
+uuidd_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-systemd.c \
+	include/dl-systemd.h
 uuidd_LDADD += $(SYSTEMD_LIBS) $(SYSTEMD_DAEMON_LIBS)
 uuidd_CFLAGS += $(SYSTEMD_CFLAGS) $(SYSTEMD_DAEMON_CFLAGS)
 tmpfiles_DATA += misc-utils/uuidd-tmpfiles.conf

--- a/misc-utils/logger.c
+++ b/misc-utils/logger.c
@@ -68,9 +68,7 @@
 #include <syslog.h>
 
 #ifdef HAVE_LIBSYSTEMD
-# define SD_JOURNAL_SUPPRESS_LOCATION
-# include <systemd/sd-daemon.h>
-# include <systemd/sd-journal.h>
+# include "dl-systemd.h"
 #endif
 
 #ifdef HAVE_SYS_TIMEX_H
@@ -391,8 +389,11 @@ static int journald_entry(struct logger_ctl *ctl, FILE *fp)
 		++lines;
 	}
 
-	if (!ctl->noact)
-		ret = sd_journal_sendv(iovec, lines);
+	if (!ctl->noact) {
+		if (ul_dlopen_libsystemd() != 0)
+			errx(EXIT_FAILURE, _("libsystemd is not available"));
+		ret = systemd_call(sd_journal_sendv)(iovec, lines);
+	}
 	if (ctl->stderr_printout) {
 		for (n = 0; n < lines; n++)
 			fprintf(stderr, "%s\n", (char *) iovec[n].iov_base);
@@ -1321,7 +1322,8 @@ int main(int argc, char **argv)
 	case AF_UNIX_ERRORS_AUTO:
 		ctl.unix_socket_errors = ctl.noact || ctl.stderr_printout;
 #ifdef HAVE_LIBSYSTEMD
-		ctl.unix_socket_errors |= !!sd_booted();
+		ctl.unix_socket_errors |= (ul_dlopen_libsystemd() == 0
+					   && systemd_call(sd_booted)() > 0);
 #endif
 		break;
 	default:

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -53,7 +53,7 @@
 #include "timer.h"
 
 #ifdef HAVE_LIBSYSTEMD
-# include <systemd/sd-daemon.h>
+# include "dl-systemd.h"
 #endif
 
 #include "nls.h"
@@ -411,7 +411,8 @@ static void server_loop(const char *socket_path, const char *pidfile_path,
 
 #ifdef HAVE_LIBSYSTEMD
 	if (uuidd_cxt->no_sock) {
-		const int r = sd_listen_fds(0);
+		const int r = ul_dlopen_libsystemd() == 0 ?
+				systemd_call(sd_listen_fds)(0) : -ENOSYS;
 
 		if (r < 0) {
 			errno = r * -1;

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -334,6 +334,11 @@ zramctl_SOURCES = sys-utils/zramctl.c \
 zramctl_LDADD = $(LDADD) libcommon.la libsmartcols.la
 zramctl_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
 if HAVE_SYSTEMD
+zramctl_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-systemd.c \
+	include/dl-systemd.h
 zramctl_LDADD += $(SYSTEMD_LIBS)
 zramctl_CFLAGS += $(SYSTEMD_CFLAGS)
 endif

--- a/sys-utils/zramctl.c
+++ b/sys-utils/zramctl.c
@@ -29,7 +29,7 @@
 #include <libsmartcols.h>
 
 #if HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH
-#include <systemd/sd-device.h>
+#include "dl-systemd.h"
 #endif
 
 #include "c.h"
@@ -163,6 +163,23 @@ static int column_name_to_id(const char *name, size_t namesz)
 }
 
 #if HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH
+/*
+ * Cleanup helpers for __attribute__((cleanup)) -- libsystemd's own
+ * sd_device_unrefp()/sd_device_monitor_unrefp() inlines reference the library
+ * symbols directly, which does not work when libsystemd is loaded via dlopen().
+ */
+static inline void ul_sd_device_unrefp(sd_device **p)
+{
+	if (*p)
+		systemd_call(sd_device_unref)(*p);
+}
+
+static inline void ul_sd_device_monitor_unrefp(sd_device_monitor **p)
+{
+	if (*p)
+		systemd_call(sd_device_monitor_unref)(*p);
+}
+
 static int monitor_callback(sd_device_monitor *m, sd_device *device, void *userdata)
 {
 	struct zram *z = userdata;
@@ -172,64 +189,67 @@ static int monitor_callback(sd_device_monitor *m, sd_device *device, void *userd
 	assert(z);
 	assert(device);
 
-	if (sd_device_get_action(device, &a) < 0)
+	if (systemd_call(sd_device_get_action)(device, &a) < 0)
 		return 0;
 
 	if (a == SD_DEVICE_REMOVE)
 		return 0;
 
-	if (sd_device_get_devname(device, &s) < 0)
+	if (systemd_call(sd_device_get_devname)(device, &s) < 0)
 		return 0;
 
 	if (strcmp(s, z->devname) != 0)
 		return 0;
 
-	if (sd_device_get_is_initialized(device) <= 0)
+	if (systemd_call(sd_device_get_is_initialized)(device) <= 0)
 		return 0;
 
 	assert(!z->device);
-	z->device = sd_device_ref(device);
+	z->device = systemd_call(sd_device_ref)(device);
 
-	return sd_event_exit(sd_device_monitor_get_event(m), 0);
+	return systemd_call(sd_event_exit)(systemd_call(sd_device_monitor_get_event)(m), 0);
 }
 #endif
 
 static int zram_wait_initialized(struct zram *z)
 {
 #if HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH
-	_cleanup_(sd_device_unrefp) sd_device *dev = NULL;
-	_cleanup_(sd_device_monitor_unrefp) sd_device_monitor *m = NULL;
+	_cleanup_(ul_sd_device_unrefp) sd_device *dev = NULL;
+	_cleanup_(ul_sd_device_monitor_unrefp) sd_device_monitor *m = NULL;
 	sd_event *event;
 	int r;
 
 	assert(z);
 
-	z->device = sd_device_unref(z->device);
+	if (ul_dlopen_libsystemd() != 0)
+		return 0;
+
+	z->device = systemd_call(sd_device_unref)(z->device);
 
 	/* prepare device monitor. */
-	r = sd_device_monitor_new(&m);
+	r = systemd_call(sd_device_monitor_new)(&m);
 	if (r < 0)
 		return r;
 
-	r = sd_device_monitor_filter_add_match_subsystem_devtype(m, "block", "disk");
+	r = systemd_call(sd_device_monitor_filter_add_match_subsystem_devtype)(m, "block", "disk");
 	if (r < 0)
 		return r;
 
-	r = sd_device_monitor_start(m, monitor_callback, z);
+	r = systemd_call(sd_device_monitor_start)(m, monitor_callback, z);
 	if (r < 0)
 		return r;
 
-	event = sd_device_monitor_get_event(m);
+	event = systemd_call(sd_device_monitor_get_event)(m);
 
 	/* Wait up to 3 seconds. */
-	r = sd_event_add_time_relative(event, NULL, CLOCK_BOOTTIME, 3 * 1000 * 1000, 0, NULL, (void*) (intptr_t) (-ETIMEDOUT));
+	r = systemd_call(sd_event_add_time_relative)(event, NULL, CLOCK_BOOTTIME, 3 * 1000 * 1000, 0, NULL, (void*) (intptr_t) (-ETIMEDOUT));
 	if (r < 0)
 		return r;
 
 	/* Check if the device is already initialized. */
 #if HAVE_DECL_SD_DEVICE_OPEN
 	/* sd_device_new_from_devname() and sd_device_open() are both since systemd-251 */
-	r = sd_device_new_from_devname(&dev, z->devname);
+	r = systemd_call(sd_device_new_from_devname)(&dev, z->devname);
 #else
 	{
 		char syspath[PATH_MAX];
@@ -240,13 +260,13 @@ static int zram_wait_initialized(struct zram *z)
 			return -EINVAL;
 		snprintf(syspath, sizeof(syspath), "/sys/class/block/%s", slash+1);
 
-		r = sd_device_new_from_syspath(&dev, syspath);
+		r = systemd_call(sd_device_new_from_syspath)(&dev, syspath);
 	}
 #endif
 	if (r < 0)
 		return r;
 
-	r = sd_device_get_is_initialized(dev);
+	r = systemd_call(sd_device_get_is_initialized)(dev);
 	if (r < 0)
 		return r;
 	if (r > 0) {
@@ -256,7 +276,7 @@ static int zram_wait_initialized(struct zram *z)
 		return 0;
 	}
 
-	return sd_event_loop(event);
+	return systemd_call(sd_event_loop)(event);
 #else
 	assert(z);
 	return 0;
@@ -276,7 +296,7 @@ static int zram_lock(struct zram *z, int operation)
 
 #if HAVE_DECL_SD_DEVICE_OPEN
 	if (z->device) {
-		fd = sd_device_open(z->device, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
+		fd = systemd_call(sd_device_open)(z->device, O_RDONLY|O_CLOEXEC|O_NONBLOCK|O_NOCTTY);
 		if (fd < 0)
 			return fd;
 	} else {
@@ -363,7 +383,8 @@ static void free_zram(struct zram *z)
 	zram_unlock(z);
 
 #if HAVE_DECL_SD_DEVICE_NEW_FROM_SYSPATH
-	sd_device_unref(z->device);
+	if (z->device)
+		systemd_call(sd_device_unref)(z->device);
 #endif
 
 	free(z);

--- a/term-utils/Makemodule.am
+++ b/term-utils/Makemodule.am
@@ -81,6 +81,11 @@ wall_CFLAGS = $(SUID_CFLAGS) $(AM_CFLAGS)
 wall_LDFLAGS = $(SUID_LDFLAGS) $(AM_LDFLAGS)
 wall_LDADD = $(LDADD) libcommon.la
 if HAVE_SYSTEMD
+wall_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-systemd.c \
+	include/dl-systemd.h
 wall_LDADD += $(SYSTEMD_LIBS)
 wall_CFLAGS += $(SYSTEMD_CFLAGS)
 endif
@@ -107,6 +112,11 @@ write_CFLAGS = $(SUID_CFLAGS) $(AM_CFLAGS)
 write_LDFLAGS = $(SUID_LDFLAGS) $(AM_LDFLAGS)
 write_LDADD = $(LDADD) libcommon.la
 if HAVE_SYSTEMD
+write_SOURCES += \
+	lib/dl-utils.c \
+	include/dl-utils.h \
+	lib/dl-systemd.c \
+	include/dl-systemd.h
 write_LDADD += $(SYSTEMD_LIBS)
 write_CFLAGS += $(SYSTEMD_CFLAGS)
 endif

--- a/term-utils/wall.c
+++ b/term-utils/wall.c
@@ -59,8 +59,7 @@
 #include <grp.h>
 
 #if defined(USE_SYSTEMD) && HAVE_DECL_SD_SESSION_GET_USERNAME == 1
-# include <systemd/sd-login.h>
-# include <systemd/sd-daemon.h>
+# include "dl-systemd.h"
 #endif
 
 #include "nls.h"
@@ -269,11 +268,11 @@ int main(int argc, char **argv)
 	iov.iov_len = mbufsize;
 
 #if defined(USE_SYSTEMD) && HAVE_DECL_SD_SESSION_GET_USERNAME == 1
-	if (sd_booted() > 0) {
+	if (ul_dlopen_libsystemd() == 0 && systemd_call(sd_booted)() > 0) {
 		char **sessions_list;
 		int sessions;
 
-		sessions = sd_get_sessions(&sessions_list);
+		sessions = systemd_call(sd_get_sessions)(&sessions_list);
 		if (sessions < 0) {
 			warnx(_("error getting sessions: %s"), strerror(-sessions));
 			goto utmp;
@@ -283,12 +282,12 @@ int main(int argc, char **argv)
 			char *name, *tty;
 			int r;
 
-			if ((r = sd_session_get_username(sessions_list[i], &name)) < 0) {
+			if ((r = systemd_call(sd_session_get_username)(sessions_list[i], &name)) < 0) {
 				warnx(_("get user name failed: %s"), strerror (-r));
 				goto utmp;
 			}
 			if (!(group_buf && !is_gr_member(name, group_buf))
-			    && sd_session_get_tty(sessions_list[i], &tty) >= 0
+			    && systemd_call(sd_session_get_tty)(sessions_list[i], &tty) >= 0
 			    && ul_strv_consume(&ttys, tty) < 0)
 				err(EXIT_FAILURE, _("failed to allocate lines list"));
 

--- a/term-utils/write.c
+++ b/term-utils/write.c
@@ -57,8 +57,7 @@
 #include <utmpx.h>
 
 #if defined(USE_SYSTEMD) && HAVE_DECL_SD_SESSION_GET_USERNAME == 1
-# include <systemd/sd-login.h>
-# include <systemd/sd-daemon.h>
+# include "dl-systemd.h"
 #endif
 
 #include "c.h"
@@ -139,9 +138,9 @@ static int check_utmp(const struct write_control *ctl)
 	struct utmpx *u;
 	int res = 1;
 #if defined(USE_SYSTEMD) && HAVE_DECL_SD_SESSION_GET_USERNAME == 1
-	if (sd_booted() > 0) {
+	if (ul_dlopen_libsystemd() == 0 && systemd_call(sd_booted)() > 0) {
 		char **sessions_list;
-		int sessions = sd_get_sessions(&sessions_list);
+		int sessions = systemd_call(sd_get_sessions)(&sessions_list);
 
 		if (sessions < 0)
 			goto utmp;
@@ -149,9 +148,9 @@ static int check_utmp(const struct write_control *ctl)
 		for (int i = 0; i < sessions; i++) {
 			char *name, *tty;
 
-			if (sd_session_get_username(sessions_list[i], &name) < 0)
+			if (systemd_call(sd_session_get_username)(sessions_list[i], &name) < 0)
 				continue;
-			if (sd_session_get_tty(sessions_list[i], &tty) < 0) {
+			if (systemd_call(sd_session_get_tty)(sessions_list[i], &tty) < 0) {
 				free(name);
 				continue;
 			}
@@ -214,10 +213,10 @@ static void search_utmp(struct write_control *ctl)
 	int num_ttys = 0, valid_ttys = 0, tty_writeable = 0, user_is_me = 0;
 
 #if defined(USE_SYSTEMD) && HAVE_DECL_SD_SESSION_GET_USERNAME == 1
-	if (sd_booted() > 0) {
+	if (ul_dlopen_libsystemd() == 0 && systemd_call(sd_booted)() > 0) {
 		char path[256];
 		char **sessions_list;
-		int sessions = sd_get_sessions(&sessions_list);
+		int sessions = systemd_call(sd_get_sessions)(&sessions_list);
 
 		if (sessions < 0)
 			goto utmp;
@@ -225,13 +224,13 @@ static void search_utmp(struct write_control *ctl)
 		for (int i = 0; i < sessions; i++) {
 			char *name, *tty;
 
-			if (sd_session_get_username(sessions_list[i], &name) < 0)
+			if (systemd_call(sd_session_get_username)(sessions_list[i], &name) < 0)
 				continue;
 			if (strcmp(ctl->dst_login, name) != 0) {
 				free(name);
 				continue;
 			}
-			if (sd_session_get_tty(sessions_list[i], &tty) < 0) {
+			if (systemd_call(sd_session_get_tty)(sessions_list[i], &tty) < 0) {
 				free(name);
 				continue;
 			}


### PR DESCRIPTION
Both of these provide functionality that is not strictly necessary in a very minimal host (e.g.: build container), so they are good candidates for being runtime optional via dlopen. Follows the same pattern as the other dlopened dependencies.