### PR TITLE
lsfd: optimize string building in loops using xstrnappend() and xstrnputc()

### DIFF
--- a/include/strutils.h
+++ b/include/strutils.h
@@ -464,6 +464,7 @@ extern char *ul_strfconcat(const char *s, const char *format, ...)
 		 __attribute__ ((__format__ (__printf__, 2, 3)));
 
 extern int ul_strappend(char **a, const char *b);
+extern int ul_strnappend(char **a, size_t *const al, const char *b, const size_t bl);
 extern int strfappend(char **a, const char *format, ...)
 		 __attribute__ ((__format__ (__printf__, 2, 3)));
 extern int ul_strvfappend(char **a, const char *format, va_list ap)

--- a/include/xalloc.h
+++ b/include/xalloc.h
@@ -150,10 +150,16 @@ static inline void xstrappend(char **a, const char *b)
 		err(XALLOC_EXIT_CODE, "cannot allocate string");
 }
 
-static inline void xstrputc(char **a, char c)
+static inline void xstrnputc(char **a, size_t *const al, char c)
 {
 	char b[] = {c, '\0'};
-	xstrappend(a, b);
+	xstrnappend(a, al, b, (c == '\0') ? 0 : 1);
+}
+
+static inline void xstrputc(char **a, char c)
+{
+	size_t al = (a && *a) ? strlen(*a) : 0;
+	xstrnputc(a, &al, c);
 }
 
 static inline

--- a/include/xalloc.h
+++ b/include/xalloc.h
@@ -11,6 +11,7 @@
 #ifndef UTIL_LINUX_XALLOC_H
 #define UTIL_LINUX_XALLOC_H
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -135,6 +136,12 @@ int xvasprintf(char **strp, const char *fmt, va_list ap)
 	if (ret < 0)
 		err(XALLOC_EXIT_CODE, "cannot allocate string");
 	return ret;
+}
+
+static inline void xstrnappend(char **a, size_t *const al, const char *b, const size_t bl)
+{
+	if (ul_strnappend(a, al, b, bl) < 0)
+		err(XALLOC_EXIT_CODE, "cannot allocate string");
 }
 
 static inline void xstrappend(char **a, const char *b)

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -1063,29 +1063,62 @@ char *ul_strfconcat(const char *s, const char *format, ...)
 	return res;
 }
 
-int ul_strappend(char **a, const char *b)
+/*
+ * Append b to *a using caller-supplied lengths. *al must be the current
+ * length of *a, and bl must be the exact length of b, not an upper bound
+ * as in strncat(). On success, *al is updated to the new length.
+ */
+int ul_strnappend(char **a, size_t *const al, const char *b, const size_t bl)
 {
-	size_t al, bl;
 	char *tmp;
 
 	if (!a)
 		return -EINVAL;
-	if (!b || !*b)
+	if (!al)
+		return -EINVAL;
+	if (!b)
+		return bl ? -EINVAL : 0;
+	if (!bl)
 		return 0;
+	if (!*b)
+		return -EINVAL;
 	if (!*a) {
-		*a = strdup(b);
-		return !*a ? -ENOMEM : 0;
+		assert(!*al);
+		if (*al)
+			return -EINVAL;
+
+		*a = malloc(bl + 1);
+		if (!*a)
+			return -ENOMEM;
+
+		memcpy(*a, b, bl);
+		*((*a) + bl) = '\0';
+		*al = bl;
+		return 0;
 	}
 
-	al = strlen(*a);
-	bl = strlen(b);
 
-	tmp = realloc(*a, al + bl + 1);
+	if (bl == SIZE_MAX)
+		return -ENOMEM;
+	if (SIZE_MAX  - *al < bl + 1)
+		return -ENOMEM;
+
+	tmp = realloc(*a, *al + bl + 1);
 	if (!tmp)
 		return -ENOMEM;
 	*a = tmp;
-	memcpy((*a) + al, b, bl + 1);
+	memcpy((*a) + *al, b, bl);
+	*((*a) + *al + bl) = '\0';
+	*al += bl;
 	return 0;
+}
+
+int ul_strappend(char **a, const char *b)
+{
+	size_t al = (a && *a) ? strlen(*a) : 0;
+	size_t bl = b ? strlen(b) : 0;
+
+	return ul_strnappend(a, &al, b, bl);
 }
 
 /* the hybrid version of strfconcat and strappend. */

--- a/lsfd-cmd/cdev.c
+++ b/lsfd-cmd/cdev.c
@@ -568,13 +568,13 @@ static char * cdev_tty_get_name(struct cdev *cdev)
 	return str;
 }
 
-static inline char *cdev_tty_xstrendpoint(struct file *file)
+static inline char *cdev_tty_xstrendpoint(struct file *file, size_t *len)
 {
 	char *str = NULL;
-	xasprintf(&str, "%d,%s,%d%c%c",
-		  file->proc->pid, file->proc->command, file->association,
-		  (file->mode & S_IRUSR)? 'r': '-',
-		  (file->mode & S_IWUSR)? 'w': '-');
+	*len = xasprintf(&str, "%d,%s,%d%c%c",
+			 file->proc->pid, file->proc->command, file->association,
+			 (file->mode & S_IRUSR)? 'r': '-',
+			 (file->mode & S_IWUSR)? 'w': '-');
 	return str;
 }
 
@@ -606,8 +606,10 @@ static bool cdev_tty_fill_column(struct proc *proc  __attribute__((__unused__)),
 		if (is_pty(data->drv)) {
 			struct ttydata *this = data;
 			struct list_head *e;
+			size_t strl = *str ? strlen(*str) : 0;
 			foreach_endpoint(e, data->endpoint) {
 				char *estr;
+				size_t estrl;
 				struct ttydata *other = list_entry(e, struct ttydata, endpoint.endpoints);
 				if (this == other)
 					continue;
@@ -617,9 +619,9 @@ static bool cdev_tty_fill_column(struct proc *proc  __attribute__((__unused__)),
 					continue;
 
 				if (*str)
-					xstrputc(str, '\n');
-				estr = cdev_tty_xstrendpoint(&other->cdev->file);
-				xstrappend(str, estr);
+					xstrnputc(str, &strl, '\n');
+				estr = cdev_tty_xstrendpoint(&other->cdev->file, &estrl);
+				xstrnappend(str, &strl, estr, estrl);
 				free(estr);
 			}
 			if (*str)

--- a/lsfd-cmd/fifo.c
+++ b/lsfd-cmd/fifo.c
@@ -31,13 +31,13 @@ struct fifo_ipc {
 	ino_t ino;
 };
 
-static inline char *fifo_xstrendpoint(struct file *file)
+static inline char *fifo_xstrendpoint(struct file *file, size_t *len)
 {
 	char *str = NULL;
-	xasprintf(&str, "%d,%s,%d%c%c",
-		  file->proc->pid, file->proc->command, file->association,
-		  (file->mode & S_IRUSR)? 'r': '-',
-		  (file->mode & S_IWUSR)? 'w': '-');
+	*len = xasprintf(&str, "%d,%s,%d%c%c",
+			 file->proc->pid, file->proc->command, file->association,
+			 (file->mode & S_IRUSR)? 'r': '-',
+			 (file->mode & S_IWUSR)? 'w': '-');
 	return str;
 }
 
@@ -62,17 +62,19 @@ static bool fifo_fill_column(struct proc *proc __attribute__((__unused__)),
 		}
 		return false;
 	case COL_ENDPOINTS: {
+		size_t strl = 0;
 		struct fifo *this = (struct fifo *)file;
 		struct list_head *e;
 		foreach_endpoint(e, this->endpoint) {
 			char *estr;
+			size_t estrl;
 			struct fifo *other = list_entry(e, struct fifo, endpoint.endpoints);
 			if (this == other)
 				continue;
 			if (str)
-				xstrputc(&str, '\n');
-			estr = fifo_xstrendpoint(&other->file);
-			xstrappend(&str, estr);
+				xstrnputc(&str, &strl, '\n');
+			estr = fifo_xstrendpoint(&other->file, &estrl);
+			xstrnappend(&str, &strl, estr, estrl);
 			free(estr);
 		}
 		if (!str)

--- a/lsfd-cmd/file.c
+++ b/lsfd-cmd/file.c
@@ -763,13 +763,13 @@ bool is_mqueue_dev(dev_t dev)
 	return false;
 }
 
-static inline char *mqueue_file_xstrendpoint(struct file *file)
+static inline char *mqueue_file_xstrendpoint(struct file *file, size_t *len)
 {
 	char *str = NULL;
-	xasprintf(&str, "%d,%s,%d%c%c",
-		  file->proc->pid, file->proc->command, file->association,
-		  (file->mode & S_IRUSR)? 'r': '-',
-		  (file->mode & S_IWUSR)? 'w': '-');
+	*len = xasprintf(&str, "%d,%s,%d%c%c",
+			 file->proc->pid, file->proc->command, file->association,
+			 (file->mode & S_IRUSR)? 'r': '-',
+			 (file->mode & S_IWUSR)? 'w': '-');
 	return str;
 }
 
@@ -786,18 +786,20 @@ static bool mqueue_file_fill_column(struct proc *proc __attribute__((__unused__)
 		return true;
 	case COL_ENDPOINTS: {
 		char *str = NULL;
+		size_t strl = 0;
 		struct mqueue_file *this = (struct mqueue_file *)file;
 		struct list_head *e;
 		foreach_endpoint(e, this->endpoint) {
 			char *estr;
+			size_t estrl;
 			struct mqueue_file *other = list_entry(e, struct mqueue_file,
 							       endpoint.endpoints);
 			if (this == other)
 				continue;
 			if (str)
-				xstrputc(&str, '\n');
-			estr = mqueue_file_xstrendpoint(&other->file);
-			xstrappend(&str, estr);
+				xstrnputc(&str, &strl, '\n');
+			estr = mqueue_file_xstrendpoint(&other->file, &estrl);
+			xstrnappend(&str, &strl, estr, estrl);
 			free(estr);
 		}
 		if (!str)

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -2095,17 +2095,23 @@ static void read_process(struct lsfd_control *ctl, struct path_cxt *pc,
 	if (procfs_process_get_stat(pc, buf, sizeof(buf)) > 0) {
 		char *p;
 		unsigned int flags;
-		char *pat = NULL;
+		char *pat, *q;
 
 		/* See proc(5) about the column in the line. */
-		xstrappend(&pat, "%*d (");
+		pat = xmalloc(sizeof("%*d (")
+			      + strlen(proc->command) * 2
+			      + sizeof(") %*c %*d %*d %*d %*d %*d %u %*[^\n]")
+			      + 1);
+		q = stpcpy(pat, "%*d (");
 		for (p = proc->command; *p != '\0'; p++) {
 			if (*p == '%')
-				xstrappend(&pat, "%%");
-			else
-				xstrputc(&pat, *p);
+				q = stpcpy(q, "%%");
+			else {
+				*q++ = *p;
+				*q = '\0';
+			}
 		}
-		xstrappend(&pat, ") %*c %*d %*d %*d %*d %*d %u %*[^\n]");
+		stpcpy(q, ") %*c %*d %*d %*d %*d %*d %u %*[^\n]");
 		if (sscanf(buf, pat, &flags) == 1)
 			proc->kthread = !!(flags & PF_KTHREAD);
 		free(pat);

--- a/lsfd-cmd/sock-xinfo.c
+++ b/lsfd-cmd/sock-xinfo.c
@@ -586,7 +586,7 @@ static bool unix_shutdown_chars(struct unix_xinfo *ux, char rw[2])
 	return false;
 }
 
-static inline char *unix_xstrendpoint(struct sock *sock)
+static inline char *unix_xstrendpoint(struct sock *sock, size_t *len)
 {
 	char *str = NULL;
 	char shutdown_chars[3] = { 0 };
@@ -595,9 +595,9 @@ static inline char *unix_xstrendpoint(struct sock *sock)
 		shutdown_chars[0] = '?';
 		shutdown_chars[1] = '?';
 	}
-	xasprintf(&str, "%d,%s,%d%c%c",
-		  sock->file.proc->pid, sock->file.proc->command, sock->file.association,
-		  shutdown_chars[0], shutdown_chars[1]);
+	*len = xasprintf(&str, "%d,%s,%d%c%c",
+			 sock->file.proc->pid, sock->file.proc->command, sock->file.association,
+			 shutdown_chars[0], shutdown_chars[1]);
 
 	return str;
 }
@@ -619,15 +619,17 @@ static struct ipc *unix_get_peer_ipc(struct unix_xinfo *ux,
 static void unix_fill_column_append_endpoints(struct ipc *peer_ipc, char **str)
 {
 	struct list_head *e;
+	size_t strl = *str ? strlen(*str) : 0;
 
 	list_for_each_backwardly(e, &peer_ipc->endpoints) {
 		struct sock *peer_sock = list_entry(e, struct sock, endpoint.endpoints);
 		char *estr;
+		size_t estrl;
 
 		if (*str)
-			xstrputc(str, '\n');
-		estr = unix_xstrendpoint(peer_sock);
-		xstrappend(str, estr);
+			xstrnputc(str, &strl, '\n');
+		estr = unix_xstrendpoint(peer_sock, &estrl);
+		xstrnappend(str, &strl, estr, estrl);
 		free(estr);
 	}
 }

--- a/lsfd-cmd/unkn.c
+++ b/lsfd-cmd/unkn.c
@@ -334,11 +334,11 @@ static int anon_eventfd_handle_fdinfo(struct unkn *unkn, const char *key, const 
 	return 0;
 }
 
-static inline char *anon_eventfd_data_xstrendpoint(struct file *file)
+static inline char *anon_eventfd_data_xstrendpoint(struct file *file, size_t *len)
 {
 	char *str = NULL;
-	xasprintf(&str, "%d,%s,%d",
-		  file->proc->pid, file->proc->command, file->association);
+	*len = xasprintf(&str, "%d,%s,%d",
+			 file->proc->pid, file->proc->command, file->association);
 	return str;
 }
 
@@ -358,6 +358,8 @@ static bool anon_eventfd_fill_column(struct proc *proc  __attribute__((__unused_
 	case COL_ENDPOINTS: {
 		struct list_head *e;
 		char *estr;
+		size_t strl = *str ? strlen(*str) : 0;
+		size_t estrl;
 		foreach_endpoint(e, data->endpoint) {
 			struct anon_eventfd_data *other = list_entry(e,
 								     struct anon_eventfd_data,
@@ -365,9 +367,9 @@ static bool anon_eventfd_fill_column(struct proc *proc  __attribute__((__unused_
 			if (data == other)
 				continue;
 			if (*str)
-				xstrputc(str, '\n');
-			estr = anon_eventfd_data_xstrendpoint(&other->backptr->file);
-			xstrappend(str, estr);
+				xstrnputc(str, &strl, '\n');
+			estr = anon_eventfd_data_xstrendpoint(&other->backptr->file, &estrl);
+			xstrnappend(str, &strl, estr, estrl);
 			free(estr);
 		}
 		if (!*str)
@@ -462,18 +464,24 @@ static char *anon_eventpoll_make_tfds_string(struct anon_eventpoll_data *data,
 					     const char *prefix,
 					     const char sep)
 {
-	char *str = prefix? xstrdup(prefix): NULL;
+	size_t strl = prefix ? strlen(prefix) : 0;
+	char *str = prefix ? xstrndup(prefix, strl) : NULL;
 
 	char buf[256];
 	for (size_t i = 0; i < data->count; i++) {
 		size_t offset = 0;
+		size_t bufl;
+		int n;
 
 		if (i > 0) {
 			buf[0] = sep;
 			offset = 1;
 		}
-		snprintf(buf + offset, sizeof(buf) - offset, "%d", data->tfds[i]);
-		xstrappend(&str, buf);
+
+		n = snprintf(buf + offset, sizeof(buf) - offset, "%d", data->tfds[i]);
+		bufl = offset + (n < 0 ? 0 : (size_t)n);
+		bufl = (bufl >= sizeof(buf)) ? sizeof(buf) - 1 : bufl;
+		xstrnappend(&str, &strl, buf, bufl);
 	}
 	return str;
 }
@@ -732,6 +740,8 @@ static int anon_signalfd_handle_fdinfo(struct unkn *unkn, const char *key, const
 static char *anon_signalfd_make_mask_string(const char* prefix, uint64_t sigmask)
 {
 	char *str = NULL;
+	size_t strl = 0;
+	size_t prefixl = prefix ? strlen(prefix) : 0;
 
 	for (size_t i = 0; i < sizeof(sigmask) * 8; i++) {
 		if ((((uint64_t)0x1) << i) & sigmask) {
@@ -739,16 +749,20 @@ static char *anon_signalfd_make_mask_string(const char* prefix, uint64_t sigmask
 			const char *signame = signum_to_signame(signum);
 
 			if (str)
-				xstrappend(&str, ",");
+				xstrnputc(&str, &strl, ',');
 			else if (prefix)
-				xstrappend(&str, prefix);
+				xstrnappend(&str, &strl, prefix, prefixl);
 
 			if (signame) {
-				xstrappend(&str, signame);
+				size_t signamel = strlen(signame);
+				xstrnappend(&str, &strl, signame, signamel);
 			} else {
 				char buf[BUFSIZ];
-				snprintf(buf, sizeof(buf), "%d", signum);
-				xstrappend(&str, buf);
+				size_t bufl;
+				int n = snprintf(buf, sizeof(buf), "%d", signum);
+				bufl = (n < 0 ? 0 : (size_t)n);
+				bufl = (bufl > sizeof(buf)) ? sizeof(buf) - 1 : bufl;
+				xstrnappend(&str, &strl, buf, bufl);
 			}
 		}
 	}
@@ -824,6 +838,7 @@ static char *anon_inotify_make_inodes_string(const char *prefix,
 					     struct anon_inotify_data *data)
 {
 	char *str = NULL;
+	size_t strl = 0;
 	char buf[BUFSIZ] = {'\0'};
 	bool first_element = true;
 
@@ -833,15 +848,19 @@ static char *anon_inotify_make_inodes_string(const char *prefix,
 		struct anon_inotify_inode *inode = list_entry(i,
 							      struct anon_inotify_inode,
 							      inodes);
+		size_t bufl;
+		int n;
 
 		decode_source(source, sizeof(source),
 			      ANON_INOTIFY_MAJOR(inode->sdev), ANON_INOTIFY_MINOR(inode->sdev),
 			      decode_level);
-		snprintf(buf, sizeof(buf), "%s%llu@%s", first_element? prefix: sep,
-			 (unsigned long long)inode->ino, source);
+		n = snprintf(buf, sizeof(buf), "%s%llu@%s", first_element? prefix: sep,
+			     (unsigned long long)inode->ino, source);
+		bufl = (n < 0) ? 0 : (size_t)n;
+		bufl = (bufl >= sizeof(buf)) ? sizeof(buf) - 1 : bufl;
 		first_element = false;
 
-		xstrappend(&str, buf);
+		xstrnappend(&str, &strl, buf, bufl);
 	}
 
 	return str;

--- a/lsfd-cmd/unkn.c
+++ b/lsfd-cmd/unkn.c
@@ -495,7 +495,7 @@ static bool anon_eventpoll_fill_column(struct proc *proc  __attribute__((__unuse
 
 	switch(column_id) {
 	case COL_EVENTPOLL_TFDS:
-		*str =anon_eventpoll_make_tfds_string(data, NULL, '\n');
+		*str = anon_eventpoll_make_tfds_string(data, NULL, '\n');
 		if (*str)
 			return true;
 		break;


### PR DESCRIPTION
Profiling lsfd revealed a large number of strlen() calls originating from ul_strappend(). At many call sites, the current length of the destination string and the length of the string to append are already known.

The first commit adds ul_strnappend(), which accepts these lengths from the caller and updates the destination length after appending. This allows callers to avoid redundant strlen() calls.

The last commit optimizes string-building in loops by using xstrnappend() and xstrnputc().