### PR TITLE
Setpriv landlock improvements

### DIFF
--- a/bash-completion/setpriv
+++ b/bash-completion/setpriv
@@ -1,9 +1,57 @@
+# See bash-completion's _comp_ltrim_colon_completions
+_setpriv_ltrim_colon_completions()
+{
+	local cur="$1"
+	local colon_word i
+	if [[ $cur == *:* && $COMP_WORDBREAKS == *:* ]]; then
+		colon_word=${cur%"${cur##*:}"}
+		for i in "${!COMPREPLY[@]}"; do
+			COMPREPLY[i]=${COMPREPLY[i]#"$colon_word"}
+		done
+	fi
+}
+
+_setpriv_landlock_rights()
+{
+	local cmd="$1" access="$2" prefix="$3" cur="$4"
+	local realcur RIGHTS RIGHTS_ALL WORD
+	RIGHTS_ALL=$("$cmd" --list-landlock-rights "$access" 2>/dev/null) || return 1
+	realcur="${cur##*,}"
+	prefix+="${cur%"$realcur"}"
+	for WORD in $RIGHTS_ALL; do
+		if ! [[ $prefix == *"$WORD"* ]]; then
+			RIGHTS="$WORD ${RIGHTS:-""}"
+		fi
+	done
+	COMPREPLY=( $(compgen -P "$prefix" -W "$RIGHTS" -- "$realcur") )
+	_setpriv_ltrim_colon_completions "$prefix$realcur"
+}
+
 _setpriv_module()
 {
 	local cur prev OPTS
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	# ':' is a field separator for landlock options, but it is also a default
+	# COMP_WORDBREAKS character. If it's still one here, COMP_WORDS may have
+	# been split on it, so glue any nonempty run of ":"s -- and the real word
+	# before it -- back onto $cur.
+	if [[ $COMP_WORDBREAKS == *:* ]]; then
+		local i=$COMP_CWORD
+		# $cur itself may be the lone ":" (e.g. a trailing "fs:"); absorb
+		# the word before it first so the loop below sees a real word in
+		# $cur to keep extending.
+		if (( i > 0 )) && [[ -n ${COMP_WORDS[i]} && -z ${COMP_WORDS[i]//:/} ]]; then
+			cur="${COMP_WORDS[i-1]}$cur"
+			((i--))
+		fi
+		while (( i > 1 )) && [[ -n ${COMP_WORDS[i-1]} && -z ${COMP_WORDS[i-1]//:/} ]]; do
+			cur="${COMP_WORDS[i-2]}${COMP_WORDS[i-1]}$cur"
+			(( i -= 2 ))
+		done
+		prev="${COMP_WORDS[i-1]}"
+	fi
 	case $prev in
 		'--ambient-caps'|'--inh-caps'|'--bounding-set')
 			local prefix realcur INHERIT_ALL INHERIT
@@ -94,13 +142,44 @@ _setpriv_module()
 			return 0
 			;;
 		'--landlock-access')
-			# FIXME: how to list landlock accesses?
-			COMPREPLY=( $(compgen -W "access" -- $cur) )
+			case $cur in
+				*:*)
+					_setpriv_landlock_rights "$1" "${cur%%:*}" "${cur%%:*}:" "${cur#*:}"
+					;;
+				*)
+					local WORD OPTS_ACCESS
+					for WORD in $($1 --list-landlock-access); do
+						OPTS_ACCESS="$OPTS_ACCESS $WORD $WORD:"
+					done
+					compopt -o nospace
+					COMPREPLY=( $(compgen -W "$OPTS_ACCESS" -- $cur) )
+					;;
+			esac
 			return 0
 			;;
 		'--landlock-rule')
-			# FIXME: how to list landlock rules?
-			COMPREPLY=( $(compgen -W "rule" -- $cur) )
+			case $cur in
+				path-beneath:*:*)
+					# path-beneath:<rights>:<path>
+					local rest="${cur#path-beneath:}" i
+					local prefix="path-beneath:${rest%%:*}:"
+					local path="${cur#"$prefix"}"
+					compopt -o filenames
+					mapfile -t COMPREPLY < <(compgen -f -- "$path")
+					for i in "${!COMPREPLY[@]}"; do
+						COMPREPLY[i]="$prefix${COMPREPLY[i]}"
+					done
+					_setpriv_ltrim_colon_completions "$cur"
+					;;
+				path-beneath:*)
+					compopt -o nospace
+					_setpriv_landlock_rights "$1" fs 'path-beneath:' "${cur#path-beneath:}"
+					;;
+				*)
+					compopt -o nospace
+					COMPREPLY=( $(compgen -W "path-beneath:" -- $cur) )
+					;;
+			esac
 			return 0
 			;;
 		'--seccomp-filter')
@@ -137,6 +216,7 @@ _setpriv_module()
 				--apparmor-profile
 				--landlock-access
 				--landlock-rule
+				--landlock-support
 				--seccomp-filter
 				--help
 				--version"

--- a/configure.ac
+++ b/configure.ac
@@ -343,7 +343,6 @@ AC_CHECK_HEADERS([ \
 	linux/falloc.h \
 	linux/fd.h \
 	linux/fiemap.h \
-	linux/landlock.h \
 	linux/kcmp.h \
 	linux/net_namespace.h \
 	linux/nsfs.h \
@@ -646,9 +645,6 @@ AC_CHECK_FUNCS([ \
 	getttynam \
 	inotify_init \
 	jrand48 \
-	landlock_create_ruleset \
-	landlock_add_rule \
-	landlock_restrict_self \
 	lchown \
 	lgetxattr \
 	llistxattr \
@@ -712,7 +708,6 @@ AC_CHECK_FUNCS([statx], [have_statx=yes], [have_statx=no])
 
 AM_CONDITIONAL([HAVE_OPENAT], [test "x$have_openat" = xyes])
 AM_CONDITIONAL([HAVE_SYS_PRCTL_H], [test "x$ac_cv_header_sys_prctl_h" = xyes])
-AM_CONDITIONAL([HAVE_LINUX_LANDLOCK_H], [test "x$ac_cv_header_linux_landlock_h" = xyes])
 
 have_setns_syscall="yes"
 UL_CHECK_SYSCALL([setns])
@@ -1716,6 +1711,17 @@ UL_REQUIRES_HAVE([setpriv], [linux_securebits_h], [linux/securebits.h header fil
 UL_REQUIRES_HAVE([setpriv], [linux_capability_h], [linux/capability.h header file])
 UL_REQUIRES_HAVE([setpriv], [cap_ng], [libcap-ng library])
 AM_CONDITIONAL([BUILD_SETPRIV], [test "x$build_setpriv" = xyes])
+
+UL_CHECK_SYSCALL([landlock_create_ruleset])
+UL_CHECK_SYSCALL([landlock_add_rule])
+UL_CHECK_SYSCALL([landlock_restrict_self])
+AS_IF([test "x$ul_cv_syscall_landlock_create_ruleset" != xno &&
+       test "x$ul_cv_syscall_landlock_add_rule" != xno &&
+       test "x$ul_cv_syscall_landlock_restrict_self" != xno],
+      [have_landlock=yes], [have_landlock=no])
+AM_CONDITIONAL([HAVE_LANDLOCK], [test "x$have_landlock" = xyes])
+AS_IF([test "x$have_landlock" = xyes],
+      [AC_DEFINE([HAVE_LANDLOCK], [1], [Define if Landlock syscalls are available])])
 
 AC_ARG_ENABLE([hardlink],
   AS_HELP_STRING([--disable-hardlink], [do not build hardlink]),

--- a/meson.build
+++ b/meson.build
@@ -118,7 +118,6 @@ headers = '''
         linux/fiemap.h
         linux/gsmmux.h
         linux/if_alg.h
-        linux/landlock.h
         linux/lp.h
         linux/kcmp.h
         linux/net_namespace.h
@@ -235,6 +234,11 @@ if have_listmount and not cc.has_header_symbol('bits/syscall.h', 'SYS_listmount'
 endif
 
 conf.set('HAVE_STATMOUNT_API', have_statmount and have_listmount ? 1 : false)
+
+have_landlock = cc.has_header_symbol('sys/syscall.h', '__NR_landlock_create_ruleset') \
+            and cc.has_header_symbol('sys/syscall.h', '__NR_landlock_add_rule') \
+            and cc.has_header_symbol('sys/syscall.h', '__NR_landlock_restrict_self')
+conf.set('HAVE_LANDLOCK', have_landlock ? 1 : false)
 
 
 have_sys_vfs_header = cc.has_header('sys/vfs.h')
@@ -654,9 +658,6 @@ funcs = '''
         getsgnam
         inotify_init
         jrand48
-        landlock_create_ruleset
-        landlock_add_rule
-        landlock_restrict_self
         lchown
         lgetxattr
         llistxattr

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -613,7 +613,7 @@ dist_noinst_DATA += sys-utils/setpriv.1.adoc
 setpriv_SOURCES = sys-utils/setpriv.c \
 		  lib/caputils.c
 dist_noinst_HEADERS += sys-utils/setpriv-landlock.h
-if HAVE_LINUX_LANDLOCK_H
+if HAVE_LANDLOCK
 setpriv_SOURCES += sys-utils/setpriv-landlock.c
 endif
 setpriv_LDADD = $(LDADD) $(CAP_NG_LIBS) libcommon.la libcommon_logindefs.la

--- a/sys-utils/meson.build
+++ b/sys-utils/meson.build
@@ -236,7 +236,7 @@ setpriv_sources = files(
   'setpriv.c',
 ) + \
     caputils_c
-if LINUX and conf.get('HAVE_LINUX_LANDLOCK_H').to_string() == '1'
+if LINUX and conf.get('HAVE_LANDLOCK').to_string() == '1'
   setpriv_sources += files('setpriv-landlock.c')
 endif
 setpriv_manadocs = files('setpriv.1.adoc')

--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -11,7 +11,6 @@
 
 #include <sys/prctl.h>
 #include <sys/syscall.h>
-#include <linux/landlock.h>
 
 #include "setpriv-landlock.h"
 
@@ -20,16 +19,44 @@
 #include "nls.h"
 #include "c.h"
 
-#ifndef HAVE_LANDLOCK_CREATE_RULESET
+enum landlock_rule_type {
+	LANDLOCK_RULE_PATH_BENEATH = 1,
+	LANDLOCK_RULE_NET_PORT = 2,
+};
+
+struct landlock_ruleset_attr {
+	uint64_t handled_access_fs;
+};
+
+struct landlock_path_beneath_attr {
+	uint64_t allowed_access;
+	int32_t parent_fd;
+} __attribute__((packed));
+
+#define LANDLOCK_ACCESS_FS_EXECUTE			(1ULL << 0)
+#define LANDLOCK_ACCESS_FS_WRITE_FILE			(1ULL << 1)
+#define LANDLOCK_ACCESS_FS_READ_FILE			(1ULL << 2)
+#define LANDLOCK_ACCESS_FS_READ_DIR			(1ULL << 3)
+#define LANDLOCK_ACCESS_FS_REMOVE_DIR			(1ULL << 4)
+#define LANDLOCK_ACCESS_FS_REMOVE_FILE			(1ULL << 5)
+#define LANDLOCK_ACCESS_FS_MAKE_CHAR			(1ULL << 6)
+#define LANDLOCK_ACCESS_FS_MAKE_DIR			(1ULL << 7)
+#define LANDLOCK_ACCESS_FS_MAKE_REG			(1ULL << 8)
+#define LANDLOCK_ACCESS_FS_MAKE_SOCK			(1ULL << 9)
+#define LANDLOCK_ACCESS_FS_MAKE_FIFO			(1ULL << 10)
+#define LANDLOCK_ACCESS_FS_MAKE_BLOCK			(1ULL << 11)
+#define LANDLOCK_ACCESS_FS_MAKE_SYM			(1ULL << 12)
+#define LANDLOCK_ACCESS_FS_REFER			(1ULL << 13)
+#define LANDLOCK_ACCESS_FS_TRUNCATE			(1ULL << 14)
+#define LANDLOCK_ACCESS_FS_IOCTL_DEV			(1ULL << 15)
+
 static inline int landlock_create_ruleset(
 		const struct landlock_ruleset_attr *attr,
 		size_t size, uint32_t flags)
 {
 	return syscall(__NR_landlock_create_ruleset, attr, size, flags);
 }
-#endif
 
-#ifndef HAVE_LANDLOCK_ADD_RULE
 static inline int landlock_add_rule(
 		int ruleset_fd, enum landlock_rule_type rule_type,
 		const void *rule_attr, uint32_t flags)
@@ -37,14 +64,11 @@ static inline int landlock_add_rule(
 	return syscall(__NR_landlock_add_rule, ruleset_fd, rule_type,
 		       rule_attr, flags);
 }
-#endif
 
-#ifndef HAVE_LANDLOCK_RESTRICT_SELF
 static inline int landlock_restrict_self(int ruleset_fd, uint32_t flags)
 {
 	return syscall(__NR_landlock_restrict_self, ruleset_fd, flags);
 }
-#endif
 
 #define SETPRIV_EXIT_PRIVERR 127	/* how we exit when we fail to set privs */
 
@@ -74,15 +98,9 @@ static const struct {
 	{ LANDLOCK_ACCESS_FS_MAKE_FIFO,   "make-fifo",   N_("create (or rename or link) a named pipe") },
 	{ LANDLOCK_ACCESS_FS_MAKE_BLOCK,  "make-block",  N_("create (or rename or link) a block device") },
 	{ LANDLOCK_ACCESS_FS_MAKE_SYM,    "make-sym",    N_("create (or rename or link) a symbolic link") },
-#ifdef LANDLOCK_ACCESS_FS_REFER
 	{ LANDLOCK_ACCESS_FS_REFER,       "refer",       N_("link or rename a file from or to a different directory") },
-#endif
-#ifdef LANDLOCK_ACCESS_FS_TRUNCATE
 	{ LANDLOCK_ACCESS_FS_TRUNCATE,    "truncate",    N_("truncate a file with truncate(2)") },
-#endif
-#ifdef LANDLOCK_ACCESS_FS_IOCTL_DEV
 	{ LANDLOCK_ACCESS_FS_IOCTL_DEV,   "ioctl-dev",   N_("invoke ioctl(2) on an opened character or block device") },
-#endif
 };
 
 static long landlock_access_to_mask(const char *str, size_t len)

--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -51,6 +51,7 @@ struct landlock_path_beneath_attr {
 #define LANDLOCK_ACCESS_FS_REFER			(1ULL << 13)
 #define LANDLOCK_ACCESS_FS_TRUNCATE			(1ULL << 14)
 #define LANDLOCK_ACCESS_FS_IOCTL_DEV			(1ULL << 15)
+#define LANDLOCK_ACCESS_FS_RESOLVE_UNIX			(1ULL << 16)
 
 static inline int landlock_create_ruleset(
 		const struct landlock_ruleset_attr *attr,
@@ -87,22 +88,23 @@ static const struct {
 	const char *type;
 	const char *help;
 } landlock_access_fs[] = {
-	{ LANDLOCK_ACCESS_FS_EXECUTE,     "execute",     N_("execute a file") },
-	{ LANDLOCK_ACCESS_FS_WRITE_FILE,  "write-file",  N_("open a file with write access") },
-	{ LANDLOCK_ACCESS_FS_READ_FILE,   "read-file",   N_("open a file with read access") },
-	{ LANDLOCK_ACCESS_FS_READ_DIR,    "read-dir",    N_("open a directory or list its content") },
-	{ LANDLOCK_ACCESS_FS_REMOVE_DIR,  "remove-dir",  N_("remove an empty directory or rename one")  },
-	{ LANDLOCK_ACCESS_FS_REMOVE_FILE, "remove-file", N_("unlink (or rename) a file") },
-	{ LANDLOCK_ACCESS_FS_MAKE_CHAR,   "make-char",   N_("create (or rename or link) a character device") },
-	{ LANDLOCK_ACCESS_FS_MAKE_DIR,    "make-dir",    N_("create (or rename) a directory") },
-	{ LANDLOCK_ACCESS_FS_MAKE_REG,    "make-reg",    N_("create (or rename or link) a regular file") },
-	{ LANDLOCK_ACCESS_FS_MAKE_SOCK,   "make-sock",   N_("create (or rename or link) a UNIX domain socket") },
-	{ LANDLOCK_ACCESS_FS_MAKE_FIFO,   "make-fifo",   N_("create (or rename or link) a named pipe") },
-	{ LANDLOCK_ACCESS_FS_MAKE_BLOCK,  "make-block",  N_("create (or rename or link) a block device") },
-	{ LANDLOCK_ACCESS_FS_MAKE_SYM,    "make-sym",    N_("create (or rename or link) a symbolic link") },
-	{ LANDLOCK_ACCESS_FS_REFER,       "refer",       N_("link or rename a file from or to a different directory") },
-	{ LANDLOCK_ACCESS_FS_TRUNCATE,    "truncate",    N_("truncate a file with truncate(2)") },
-	{ LANDLOCK_ACCESS_FS_IOCTL_DEV,   "ioctl-dev",   N_("invoke ioctl(2) on an opened character or block device") },
+	{ LANDLOCK_ACCESS_FS_EXECUTE,      "execute",      N_("execute a file") },
+	{ LANDLOCK_ACCESS_FS_WRITE_FILE,   "write-file",   N_("open a file with write access") },
+	{ LANDLOCK_ACCESS_FS_READ_FILE,    "read-file",    N_("open a file with read access") },
+	{ LANDLOCK_ACCESS_FS_READ_DIR,     "read-dir",     N_("open a directory or list its content") },
+	{ LANDLOCK_ACCESS_FS_REMOVE_DIR,   "remove-dir",   N_("remove an empty directory or rename one")  },
+	{ LANDLOCK_ACCESS_FS_REMOVE_FILE,  "remove-file",  N_("unlink (or rename) a file") },
+	{ LANDLOCK_ACCESS_FS_MAKE_CHAR,    "make-char",    N_("create (or rename or link) a character device") },
+	{ LANDLOCK_ACCESS_FS_MAKE_DIR,     "make-dir",     N_("create (or rename) a directory") },
+	{ LANDLOCK_ACCESS_FS_MAKE_REG,     "make-reg",     N_("create (or rename or link) a regular file") },
+	{ LANDLOCK_ACCESS_FS_MAKE_SOCK,    "make-sock",    N_("create (or rename or link) a UNIX domain socket") },
+	{ LANDLOCK_ACCESS_FS_MAKE_FIFO,    "make-fifo",    N_("create (or rename or link) a named pipe") },
+	{ LANDLOCK_ACCESS_FS_MAKE_BLOCK,   "make-block",   N_("create (or rename or link) a block device") },
+	{ LANDLOCK_ACCESS_FS_MAKE_SYM,     "make-sym",     N_("create (or rename or link) a symbolic link") },
+	{ LANDLOCK_ACCESS_FS_REFER,        "refer",        N_("link or rename a file from or to a different directory") },
+	{ LANDLOCK_ACCESS_FS_TRUNCATE,     "truncate",     N_("truncate a file with truncate(2)") },
+	{ LANDLOCK_ACCESS_FS_IOCTL_DEV,    "ioctl-dev",    N_("invoke ioctl(2) on an opened character or block device") },
+	{ LANDLOCK_ACCESS_FS_RESOLVE_UNIX, "resolve-unix", N_("connect(2) or bind(2) a pathname UNIX domain socket") },
 };
 
 /* cumulative access_fs rights supported by each landlock ABI version, indexed by (abi - 1) */
@@ -112,6 +114,10 @@ static const uint64_t landlock_access_fs_mask[] = {
 	/* ABI 3 */ (LANDLOCK_ACCESS_FS_TRUNCATE << 1) - 1,
 	/* ABI 4 */ (LANDLOCK_ACCESS_FS_TRUNCATE << 1) - 1,
 	/* ABI 5 */ (LANDLOCK_ACCESS_FS_IOCTL_DEV << 1) - 1,
+	/* ABI 6 */ (LANDLOCK_ACCESS_FS_IOCTL_DEV << 1) - 1,
+	/* ABI 7 */ (LANDLOCK_ACCESS_FS_IOCTL_DEV << 1) - 1,
+	/* ABI 8 */ (LANDLOCK_ACCESS_FS_IOCTL_DEV << 1) - 1,
+	/* ABI 9 */ (LANDLOCK_ACCESS_FS_RESOLVE_UNIX << 1) - 1,
 };
 
 static int supported_landlock_abi(void)

--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -33,6 +33,8 @@ struct landlock_path_beneath_attr {
 	int32_t parent_fd;
 } __attribute__((packed));
 
+#define LANDLOCK_CREATE_RULESET_VERSION			(1U << 0)
+
 #define LANDLOCK_ACCESS_FS_EXECUTE			(1ULL << 0)
 #define LANDLOCK_ACCESS_FS_WRITE_FILE			(1ULL << 1)
 #define LANDLOCK_ACCESS_FS_READ_FILE			(1ULL << 2)
@@ -103,6 +105,38 @@ static const struct {
 	{ LANDLOCK_ACCESS_FS_IOCTL_DEV,   "ioctl-dev",   N_("invoke ioctl(2) on an opened character or block device") },
 };
 
+/* cumulative access_fs rights supported by each landlock ABI version, indexed by (abi - 1) */
+static const uint64_t landlock_access_fs_mask[] = {
+	/* ABI 1 */ (LANDLOCK_ACCESS_FS_MAKE_SYM << 1) - 1,
+	/* ABI 2 */ (LANDLOCK_ACCESS_FS_REFER << 1) - 1,
+	/* ABI 3 */ (LANDLOCK_ACCESS_FS_TRUNCATE << 1) - 1,
+	/* ABI 4 */ (LANDLOCK_ACCESS_FS_TRUNCATE << 1) - 1,
+	/* ABI 5 */ (LANDLOCK_ACCESS_FS_IOCTL_DEV << 1) - 1,
+};
+
+static int supported_landlock_abi(void)
+{
+	static int abi = -1;
+
+	if (abi < 0) {
+		abi = landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION);
+		if (abi <= 0)
+			err(EXIT_FAILURE, _("landlock is not supported"));
+	}
+	return abi;
+}
+
+static uint64_t landlock_abi_fs_mask(void)
+{
+	int abi = supported_landlock_abi();
+	size_t n = ARRAY_SIZE(landlock_access_fs_mask);
+	size_t idx = (size_t) (abi - 1);
+
+	if (idx >= n)
+		idx = n - 1;
+	return landlock_access_fs_mask[idx];
+}
+
 static long landlock_access_to_mask(const char *str, size_t len)
 {
 	size_t i;
@@ -116,17 +150,14 @@ static long landlock_access_to_mask(const char *str, size_t len)
 static uint64_t parse_landlock_fs_access(const char *list)
 {
 	unsigned long r = 0;
-	size_t i;
 
-	/* without argument, match all */
-	if (list[0] == '\0') {
-		for (i = 0; i < ARRAY_SIZE(landlock_access_fs); i++)
-			r |= landlock_access_fs[i].value;
-	} else {
-		if (string_to_bitmask(list, &r, landlock_access_to_mask))
-			errx(EXIT_FAILURE,
-			     _("could not parse landlock fs access: %s"), list);
-	}
+	/* without argument, match all supported by the current kernel */
+	if (list[0] == '\0')
+		return landlock_abi_fs_mask();
+
+	if (string_to_bitmask(list, &r, landlock_access_to_mask))
+		errx(EXIT_FAILURE,
+		     _("could not parse landlock fs access: %s"), list);
 
 	return r;
 }
@@ -134,11 +165,10 @@ static uint64_t parse_landlock_fs_access(const char *list)
 void parse_landlock_access(struct setpriv_landlock_opts *opts, const char *str)
 {
 	const char *type;
-	size_t i;
 
+	/* without argument, match all supported by the current kernel */
 	if (strcmp(str, "fs") == 0) {
-		for (i = 0; i < ARRAY_SIZE(landlock_access_fs); i++)
-			opts->access_fs |= landlock_access_fs[i].value;
+		opts->access_fs |= landlock_abi_fs_mask();
 		return;
 	}
 

--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -34,6 +34,7 @@ struct landlock_path_beneath_attr {
 } __attribute__((packed));
 
 #define LANDLOCK_CREATE_RULESET_VERSION			(1U << 0)
+#define LANDLOCK_CREATE_RULESET_ERRATA			(1U << 1)
 
 #define LANDLOCK_ACCESS_FS_EXECUTE			(1ULL << 0)
 #define LANDLOCK_ACCESS_FS_WRITE_FILE			(1ULL << 1)
@@ -288,18 +289,33 @@ void usage_landlock(FILE *out)
 
 void list_landlock_support(void)
 {
-	size_t i;
+	int abi, errata;
+	unsigned i;
+	uint64_t mask;
 
-	printf("ABI: %d\n", supported_landlock_abi());
+	abi = supported_landlock_abi();
+	errata = landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_ERRATA);
+	if (errata < 0) errata = 0;
 
-	printf("access: fs\n");
-
-	printf("rights:");
-	for (i = 0; i < ARRAY_SIZE(landlock_access_fs); i++)
-		printf(" %s", landlock_access_fs[i].type);
+	printf(_("ABI version: %d\n"), abi);
+	printf(_("ABI errata:"));
+	for (i = 1; errata != 0; errata >>= 1, i++) {
+		if (errata & 1)
+			printf(" %u", i);
+	}
 	printf("\n");
 
-	printf("rules: path-beneath\n");
+	printf(_("access: %s\n"), "fs");
+
+	mask = landlock_abi_fs_mask();
+	printf(_("%s rights:"), "fs");
+	for (i = 0; i < ARRAY_SIZE(landlock_access_fs); i++)
+		if (landlock_access_fs[i].value & mask)
+			printf(" %s", landlock_access_fs[i].type);
+
+	printf("\n");
+
+	printf(_("%s rules: %s\n"), "fs", "path-beneath");
 }
 
 void list_landlock_access(void)

--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -285,3 +285,38 @@ void usage_landlock(FILE *out)
 					_(landlock_access_fs[i].help));
 	}
 }
+
+void list_landlock_support(void)
+{
+	size_t i;
+
+	printf("ABI: %d\n", supported_landlock_abi());
+
+	printf("access: fs\n");
+
+	printf("rights:");
+	for (i = 0; i < ARRAY_SIZE(landlock_access_fs); i++)
+		printf(" %s", landlock_access_fs[i].type);
+	printf("\n");
+
+	printf("rules: path-beneath\n");
+}
+
+void list_landlock_access(void)
+{
+	printf("fs\n");
+}
+
+void list_landlock_rights(const char *access)
+{
+	uint64_t mask;
+	size_t i;
+
+	if (strcmp(access, "fs") != 0)
+		errx(EXIT_FAILURE, _("unknown landlock access: %s"), access);
+
+	mask = landlock_abi_fs_mask();
+	for (i = 0; i < ARRAY_SIZE(landlock_access_fs); i++)
+		if (landlock_access_fs[i].value & mask)
+			printf("%s\n", landlock_access_fs[i].type);
+}

--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -224,6 +224,14 @@ void do_landlock(const struct setpriv_landlock_opts *opts)
 	struct list_head *entry;
 	int fd, ret;
 
+	list_for_each(entry, &opts->rules) {
+		rule = list_entry(entry, struct landlock_rule_entry, head);
+		if (rule->rule_type == LANDLOCK_RULE_PATH_BENEATH && !opts->access_fs) {
+			errx(EXIT_FAILURE,
+				_("landlock path-beneath rule requires a filesystem access restriction (--landlock-access fs)"));
+		}
+	}
+
 	if (!opts->access_fs)
 		return;
 

--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -157,10 +157,6 @@ static uint64_t parse_landlock_fs_access(const char *list)
 {
 	unsigned long r = 0;
 
-	/* without argument, match all supported by the current kernel */
-	if (list[0] == '\0')
-		return landlock_abi_fs_mask();
-
 	if (string_to_bitmask(list, &r, landlock_access_to_mask))
 		errx(EXIT_FAILURE,
 		     _("could not parse landlock fs access: %s"), list);
@@ -172,13 +168,14 @@ void parse_landlock_access(struct setpriv_landlock_opts *opts, const char *str)
 {
 	const char *type;
 
+	type = ul_startswith(str, "fs:");
+
 	/* without argument, match all supported by the current kernel */
-	if (strcmp(str, "fs") == 0) {
+	if (strcmp(str, "fs") == 0 || (type && type[0] == '\0')) {
 		opts->access_fs |= landlock_abi_fs_mask();
 		return;
 	}
 
-	type = ul_startswith(str, "fs:");
 	if (type)
 		opts->access_fs |= parse_landlock_fs_access(type);
 }
@@ -199,7 +196,10 @@ void parse_landlock_rule(struct setpriv_landlock_opts *opts, const char *str)
 	rule->rule_type = LANDLOCK_RULE_PATH_BENEATH;
 
 	accesses_part = xstrndup(accesses, path - accesses);
-	rule->path_beneath_attr.allowed_access = parse_landlock_fs_access(accesses_part);
+	if (accesses_part[0] != '\0')
+		rule->path_beneath_attr.allowed_access = parse_landlock_fs_access(accesses_part);
+	else
+		rule->path_beneath_attr.allowed_access = 0;
 	free(accesses_part);
 
 	path++;
@@ -223,6 +223,7 @@ void do_landlock(const struct setpriv_landlock_opts *opts)
 	struct landlock_rule_entry *rule;
 	struct list_head *entry;
 	int fd, ret;
+	struct landlock_path_beneath_attr path_beneath_attr;
 
 	list_for_each(entry, &opts->rules) {
 		rule = list_entry(entry, struct landlock_rule_entry, head);
@@ -248,7 +249,11 @@ void do_landlock(const struct setpriv_landlock_opts *opts)
 
 		assert(rule->rule_type == LANDLOCK_RULE_PATH_BENEATH);
 
-		ret = landlock_add_rule(fd, rule->rule_type, &rule->path_beneath_attr, 0);
+		path_beneath_attr = rule->path_beneath_attr;
+		if (!path_beneath_attr.allowed_access)
+			path_beneath_attr.allowed_access = opts->access_fs;
+
+		ret = landlock_add_rule(fd, rule->rule_type, &path_beneath_attr, 0);
 		if (ret == -1)
 			err(SETPRIV_EXIT_PRIVERR, _("adding landlock rule failed"));
 	}

--- a/sys-utils/setpriv-landlock.h
+++ b/sys-utils/setpriv-landlock.h
@@ -12,7 +12,7 @@
 #ifndef UTIL_LINUX_SETPRIV_LANDLOCK
 #define UTIL_LINUX_SETPRIV_LANDLOCK
 
-#ifdef HAVE_LINUX_LANDLOCK_H
+#ifdef HAVE_LANDLOCK
 
 #include <stdint.h>
 
@@ -47,6 +47,6 @@ static inline void parse_landlock_access(
 static inline void init_landlock_opts(void *opts __attribute__((unused))) {}
 static inline void usage_landlock(FILE *out __attribute__((unused))) {}
 
-#endif /* HAVE_LINUX_LANDLOCK_H */
+#endif /* HAVE_LANDLOCK */
 
 #endif

--- a/sys-utils/setpriv-landlock.h
+++ b/sys-utils/setpriv-landlock.h
@@ -28,6 +28,9 @@ void parse_landlock_access(struct setpriv_landlock_opts *opts, const char *str);
 void parse_landlock_rule(struct setpriv_landlock_opts *opts, const char *str);
 void init_landlock_opts(struct setpriv_landlock_opts *opts);
 void usage_landlock(FILE *out);
+void list_landlock_support(void);
+void list_landlock_access(void);
+void list_landlock_rights(const char *access);
 
 #else
 
@@ -46,6 +49,15 @@ static inline void parse_landlock_access(
 #define parse_landlock_rule parse_landlock_access
 static inline void init_landlock_opts(void *opts __attribute__((unused))) {}
 static inline void usage_landlock(FILE *out __attribute__((unused))) {}
+static inline void list_landlock_support(void)
+{
+	errx(EXIT_FAILURE, _("no support for landlock"));
+}
+#define list_landlock_access list_landlock_support
+static inline void list_landlock_rights(const char *access __attribute__((unused)))
+{
+	errx(EXIT_FAILURE, _("no support for landlock"));
+}
 
 #endif /* HAVE_LANDLOCK */
 

--- a/sys-utils/setpriv.1.adoc
+++ b/sys-utils/setpriv.1.adoc
@@ -130,6 +130,17 @@ For example grant file read access to everything under */boot*:
 +
 *--landlock-rule path-beneath:read-file:/boot*
 
+*--landlock-support*::
+List the landlock ABI version supported by the running kernel, together with the access
+categories, rights, and rule types that *setpriv* understands. Must be specified alone.
+
+*--list-landlock-access*::
+List the landlock access categories supported by *--landlock-access* and *--landlock-rule*.
+
+*--list-landlock-rights* _access_::
+List the rights of the given landlock access category that are supported by the running
+kernel.
+
 *--seccomp-filter* _file_::
 
 Load raw BPF seccomp filter code from a file.

--- a/sys-utils/setpriv.c
+++ b/sys-utils/setpriv.c
@@ -173,6 +173,10 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" --apparmor-profile <pr>     set AppArmor profile\n"), out);
 	fputs(_(" --landlock-access <access>  add Landlock access\n"), out);
 	fputs(_(" --landlock-rule <rule>      add Landlock rule\n"), out);
+	fputs(_(" --landlock-support          list supported Landlock ABI, access, rights, and rules\n"), out);
+	fputs(_(" --list-landlock-access      list Landlock access categories\n"), out);
+	fputs(_(" --list-landlock-rights <access>\n"
+		"                             list an access category's rights\n"), out);
 	fputs(_(" --seccomp-filter <file>     load seccomp filter from file\n"), out);
 	fputs(_(" --reset-env                 clear all environment and initialize\n"
 		"                               HOME, SHELL, USER, LOGNAME and PATH\n"), out);
@@ -874,6 +878,9 @@ int main(int argc, char **argv)
 		APPARMOR_PROFILE,
 		LANDLOCK_ACCESS,
 		LANDLOCK_RULE,
+		LANDLOCK_SUPPORT,
+		LIST_LANDLOCK_ACCESS,
+		LIST_LANDLOCK_RIGHTS,
 		SECCOMP_FILTER,
 		RESET_ENV
 	};
@@ -903,6 +910,9 @@ int main(int argc, char **argv)
 		{ "apparmor-profile", required_argument, NULL, APPARMOR_PROFILE },
 		{ "landlock-access",  required_argument, NULL, LANDLOCK_ACCESS  },
 		{ "landlock-rule",    required_argument, NULL, LANDLOCK_RULE    },
+		{ "landlock-support", no_argument,       NULL, LANDLOCK_SUPPORT },
+		{ "list-landlock-access", no_argument,       NULL, LIST_LANDLOCK_ACCESS },
+		{ "list-landlock-rights", required_argument, NULL, LIST_LANDLOCK_RIGHTS },
 		{ "seccomp-filter",   required_argument, NULL, SECCOMP_FILTER   },
 		{ "help",             no_argument,       NULL, 'h'              },
 		{ "reset-env",        no_argument,       NULL, RESET_ENV,       },
@@ -923,6 +933,9 @@ int main(int argc, char **argv)
 	int dumplevel = 0;
 	int total_opts = 0;
 	int list_caps = 0;
+	int landlock_support = 0;
+	int landlock_list_access = 0;
+	const char *landlock_list_rights_access = NULL;
 
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
@@ -1072,6 +1085,15 @@ int main(int argc, char **argv)
 		case LANDLOCK_RULE:
 			parse_landlock_rule(&opts.landlock, optarg);
 			break;
+		case LANDLOCK_SUPPORT:
+			landlock_support = 1;
+			break;
+		case LIST_LANDLOCK_ACCESS:
+			landlock_list_access = 1;
+			break;
+		case LIST_LANDLOCK_RIGHTS:
+			landlock_list_rights_access = optarg;
+			break;
 		case SECCOMP_FILTER:
 			if (opts.seccomp_filter)
 				errx(EXIT_FAILURE,
@@ -1104,6 +1126,30 @@ int main(int argc, char **argv)
 			errx(EXIT_FAILURE,
 			     _("--list-caps must be specified alone"));
 		list_known_caps();
+		return EXIT_SUCCESS;
+	}
+
+	if (landlock_support) {
+		if (total_opts != 1 || optind < argc)
+			errx(EXIT_FAILURE,
+			     _("--landlock-support must be specified alone"));
+		list_landlock_support();
+		return EXIT_SUCCESS;
+	}
+
+	if (landlock_list_access) {
+		if (total_opts != 1 || optind < argc)
+			errx(EXIT_FAILURE,
+			     _("--list-landlock-access must be specified alone"));
+		list_landlock_access();
+		return EXIT_SUCCESS;
+	}
+
+	if (landlock_list_rights_access) {
+		if (total_opts != 1 || optind < argc)
+			errx(EXIT_FAILURE,
+			     _("--list-landlock-rights must be specified alone"));
+		list_landlock_rights(landlock_list_rights_access);
 		return EXIT_SUCCESS;
 	}
 

--- a/tests/ts/setpriv/landlock
+++ b/tests/ts/setpriv/landlock
@@ -61,4 +61,18 @@ ts_init_subtest "wildcard-access"
 	&> "$TS_OUTPUT"
 ts_finalize_subtest
 
+ts_init_subtest "wildcard-partial-access"
+"$TS_CMD_SETPRIV" --landlock-access fs:execute \
+	--landlock-rule path-beneath::/ \
+	true \
+	&> "$TS_OUTPUT"
+ts_finalize_subtest
+
+ts_init_subtest "wildcard-partial-access-reversed"
+"$TS_CMD_SETPRIV" --landlock-rule path-beneath::/ \
+	--landlock-access fs:execute \
+	true \
+	&> "$TS_OUTPUT"
+ts_finalize_subtest
+
 ts_finalize


### PR DESCRIPTION
This PR implements an initial set of improvements to `setpriv`'s landlock functionality.

## Changes

The most relevant change is the removal of the compile-time checks for Landlock access macros, instead unconditionally defining the functions, structs, enum and macros in `setpriv-landlock.c`.
This is necessary for future landlock additions, as `setpriv` is not able to simply `#ifndef` to add extra fields to `landlock_ruleset_attr`, or to define additional enum values in `landlock_rule_type`.
Linux will return an error when an unsupported option is requested, so this does not cause any issues with compatibility.

This functionality only requires the `__NR_landlock_*` syscall definitions, so the configure scripts now check for the presence of those symbols instead of the `<linux/landlock.h>` header. The value was renamed from `HAVE_LANDLOCK_H` to `HAVE_LANDLOCK` to match.

The other changes are:

### Treat `--landlock-access fs` as "all access rules supported by the current kernel"

Because `setpriv-landlock.c` previously relied on `<linux/landlock.h>`, it would always use the same list of access restrictions when an empty list was provided. This meant that a `setpriv` binary compiled on a newer Linux kernel would produce an error when attempting to use `--landlock-access fs` on an older kernel.

This logic is now handled at runtime by querying the Landlock ABI, and if an explicit list of access rights is not provided then the set understood by the current kernel is used. Passing an explicit list of access rights is not checked this way, so a user that requests a specific unsupported filesystem restriction will still get an error.

### Implement bash completion for `--landlock-access` and `--landlock-rule`

This was complex, as `:` is usually a completion word separator. The completion script now includes some logic that re-assembles the list of words in order to handle this properly.

### Error out when `--landlock-rule` is given without `--landlock-access`

This would previously silently "succeed", without actually performing any kind of restriction.
Now this combination will produce an error message so that users are not accidentally not enabling the sandbox.

### Treat an empty `--landlock-rule` access list as "all enabled landlock-access restrictions"

`--landlock-access fs:read-file,execute` enables restrictions on what files can be read and executed.
If that option is combined with `--landlock-rule path-beneath::/usr`, that is currently treated as "allow read-file, execute, read-dir, make-fifo, ... underneath /usr", and will result in the cryptic error message `setpriv: adding landlock rule failed: Invalid argument`.

This PR changes the behavior of `--landlock-rule path-beneath::/usr` in this scenario to mean `--landlock-rule path-beneath:read-file,execute:/usr`, as the other restrictions were not enabled. If the `--landlock-rule` explicitly mentioned an access rule that was not enabled by `--landlock-access`, this will still result in an error (though the `Invalid argument` is then more clear).

## Future work

I have a branch with additional features [here](https://github.com/Skyb0rg007/util-linux/pull/1), which adds the new Landlock access and rule domains (net, scope, port-rule, *-quiet) as well as the landlock_restrict_self flags.
My commit set also includes a new `--landlock-abi <min>-<max>` option, which could use additional feedback on its design.

Because those changes are more substantial, I tried to extract the less controversial changes into this PR.