### PR TITLE
more: fix out-of-bounds write in get_line() on invalid multibyte input

### DIFF
--- a/text-utils/more.c
+++ b/text-utils/more.c
@@ -551,6 +551,8 @@ static int get_line(struct more_control *ctl, int *length)
 				break;
 
 			case (size_t)-1:	/* Invalid as a multibyte character. */
+				if (p >= &ctl->line_buf[ctl->line_sz - 1])
+					break;
 				*p++ = mbc[0];
 				state = state_bak;
 				column++;


### PR DESCRIPTION
Fixes the heap out-of-bounds write reported in #4494.

In `get_line()`, the `case (size_t)-1` (invalid multibyte) arm writes
`*p++ = mbc[0]` without the bounds check its sibling write paths use, and the
`goto process_mbc` back-edge lets it re-run within one loop iteration, bypassing
the loop-head guard. A line of zero-width combining characters (which advance `p`
but not `column`) followed by an invalid multibyte sequence steps `p` past the
`num_columns*4 + 2` byte `line_buf` allocation.

This guards the write the same way the sibling path does.

Verified against v2.42.2 built with AddressSanitizer: before the patch the
reproducer in #4494 triggers `heap-buffer-overflow WRITE` at `get_line`
(more.c:554); with the patch ASan is silent and `more` still displays the file.

Closes #4494
