### PR TITLE
pg: fix out-of-bounds access past wbuf on a trailing tab

### DIFF
--- a/text-utils/pg.c
+++ b/text-utils/pg.c
@@ -444,7 +444,7 @@ static char *endline_for_mb(unsigned col, char *s)
 				 * Assume the terminal will print the
 				 * entire character onto the next row. */
 				p--;
-			if (*++p == L'\n')
+			if (*p != L'\0' && *++p == L'\n')
 				p++;
 			end = p;
 			goto ended;
@@ -499,7 +499,7 @@ static char *endline(unsigned col, char *s)
 		if (pos > col) {
 			if (*s == '\t')
 				s++;
-			if (*++s == '\n')
+			if (*s != '\0' && *++s == '\n')
 				s++;
 			t = s;
 			goto cend;


### PR DESCRIPTION
Fixes the out-of-bounds access past `wbuf` reported in #4495.

`endline_for_mb()` and its single-byte twin `endline()` advance the scan pointer
twice when the last character of a buffer-filling line is a tab (the tab branch
`p++`, then the shared `*++p`) with no terminator re-check in between. A full line
ending in a tab makes `*++p` read `wbuf[READBUF]` and the following
`*end = L'\0'` write it, one element past the array.

This re-checks the terminator before the second advance, in both functions.

Verified against v2.42.2 built with AddressSanitizer: before the patch the
reproducer in #4495 triggers `global-buffer-overflow READ` at `endline_for_mb`
(pg.c:447); with the patch ASan is silent and `pg` still displays the file.

Closes #4495
