### PR TITLE
fsck: free compiled fs types list

### DIFF
--- a/disk-utils/fsck.c
+++ b/disk-utils/fsck.c
@@ -954,6 +954,19 @@ static struct fs_type_compile {
 #define FS_TYPE_OPT	1
 #define FS_TYPE_NEGOPT	2
 
+static void free_fs_type_compile(struct fs_type_compile *cmp)
+{
+    if (cmp->list) {
+        size_t i;
+        for (i = 0; cmp->list[i]; i++)
+	    free(cmp->list[i]);
+        free(cmp->list);
+    }
+    free(cmp->type);
+    cmp->list = NULL;
+    cmp->type = NULL;
+}
+
 static void compile_fs_type(char *fs_type, struct fs_type_compile *cmp)
 {
 	char	*cp, *list, *s;
@@ -1706,5 +1719,6 @@ int main(int argc, char *argv[])
 	mnt_unref_cache(mntcache);
 	mnt_unref_table(fstab);
 	mnt_unref_table(mtab);
+	free_fs_type_compile(&fs_type_compiled);
 	return status;
 }


### PR DESCRIPTION
The fs_type_compiled structure allocated by compile_fs_type() was not
freed before program exit, resulting in a minor memory leak. Add
free_fs_type_compile() to release the memory properly.