### PR TITLE
lsfd: improve bpf-map display when fdinfo is not available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -591,6 +591,11 @@ AC_CHECK_DECL([BPF_LINK_CREATE],
 	      [#include <linux/bpf.h>])
 AS_IF([test "x$have_bpf_link_create" = xyes],
 	      [AC_DEFINE([HAVE_BPF_LINK_CREATE], [1], [Define if BPF_LINK_CREATE is available])])
+AC_CHECK_DECL([BPF_F_MMAPABLE],
+	      [have_bpf_f_mmapable=yes], [have_bpf_f_mmapable=no],
+	      [#include <linux/bpf.h>])
+AS_IF([test "x$have_bpf_f_mmapable" = xyes],
+      [AC_DEFINE([HAVE_BPF_F_MMAPABLE], [1], [Define if BPF_F_MMAPABLE is available])])
 
 AC_CHECK_DECL([TIOCGLCKTRMIOS],
 	      [have_tiocglcktrmios=yes], [have_tiocglcktrmios=no],

--- a/lsfd-cmd/unkn.c
+++ b/lsfd-cmd/unkn.c
@@ -1179,6 +1179,7 @@ struct anon_bpf_map_data {
 	int type;
 	int id;
 	char name[BPF_OBJ_NAME_LEN + 1];
+	bool has_data;		/* true if fdinfo was parsed */
 };
 
 static bool anon_bpf_map_probe(const char *str)
@@ -1202,6 +1203,9 @@ static bool anon_bpf_map_fill_column(struct proc *proc  __attribute__((__unused_
 {
 	struct anon_bpf_map_data *data = (struct anon_bpf_map_data *)unkn->anon_data;
 	const char *t;
+
+	if (!data->has_data)
+		return false;
 
 	switch(column_id) {
 	case COL_BPF_MAP_ID:
@@ -1231,6 +1235,9 @@ static char *anon_bpf_map_get_name(struct unkn *unkn)
 	char *str = NULL;
 	struct anon_bpf_map_data *data = (struct anon_bpf_map_data *)unkn->anon_data;
 
+	if (!data->has_data)
+		return NULL;
+
 	t = anon_bpf_map_get_map_type_name(data->type);
 	if (t)
 		xasprintf(&str, "id=%d type=%s", data->id, t);
@@ -1249,6 +1256,7 @@ static void anon_bpf_map_init(struct unkn *unkn)
 	data->type = -1;
 	data->id = -1;
 	data->name[0] = '\0';
+	data->has_data = false;
 	unkn->anon_data = data;
 }
 
@@ -1292,6 +1300,7 @@ static int anon_bpf_map_handle_fdinfo(struct unkn *unkn, const char *key, const 
 		if (rc < 0)
 			return 0; /* ignore -- parse failed */
 		((struct anon_bpf_map_data *)unkn->anon_data)->id = (int)t;
+		((struct anon_bpf_map_data *)unkn->anon_data)->has_data = true;
 		anon_bpf_map_get_more_info((struct anon_bpf_map_data *)unkn->anon_data);
 		return 1;
 	}

--- a/meson.build
+++ b/meson.build
@@ -4065,6 +4065,9 @@ if LINUX and lib_rt.found()
   if cc.has_header_symbol('linux/bpf.h', 'BPF_LINK_CREATE')
     test_mkfds_c_args += ['-DHAVE_BPF_LINK_CREATE']
   endif
+  if cc.has_header_symbol('linux/bpf.h', 'BPF_F_MMAPABLE')
+    test_mkfds_c_args += ['-DHAVE_BPF_F_MMAPABLE']
+  endif
   exe = executable(
     'test_mkfds',
     'tests/helpers/test_mkfds.c',

--- a/tests/expected/lsfd/mkfds-mapped-bpf-map
+++ b/tests/expected/lsfd/mkfds-mapped-bpf-map
@@ -1,0 +1,4 @@
+bpf-map anon_inode:bpf-map
+TYPE,NAME: 0
+array 2 mkfds_map
+BPF-MAP.TYPE,BPF-MAP.TYPE.RAW,BPF.NAME: 0

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -3094,6 +3094,56 @@ static void free_bpf_link(const struct factory * factory _U_, void *data)
 	free(data);
 }
 #endif /* HAVE_BPF_LINK_CREATE */
+#ifdef HAVE_BPF_F_MMAPABLE
+static void *make_mmapped_bpf_map(const struct factory *factory, struct fdesc fdescs[],
+				  int argc, char ** argv)
+{
+	struct arg name = decode_arg("name", factory->params, argc, argv);
+	const char *sname = ARG_STRING(name);
+
+	int bfd;
+	union bpf_attr attr;
+	struct munmap_data *munmap_data;
+
+	memset(&attr, 0, sizeof(attr));
+	attr.map_type = BPF_MAP_TYPE_ARRAY;
+	attr.map_flags = BPF_F_MMAPABLE;
+	attr.value_size = 4;
+	attr.key_size = 4;
+	attr.max_entries = 10;
+
+	strncpy(attr.map_name, sname, sizeof(attr.map_name) - 1);
+
+	free_arg(&name);
+
+	bfd = syscall(SYS_bpf, BPF_MAP_CREATE, &attr, sizeof(attr));
+	if (bfd < 0)
+		err_nosys(EXIT_FAILURE, "failed in bpf(BPF_MAP_CREATE)");
+
+	if (bfd != fdescs[0].fd) {
+		if (dup2(bfd, fdescs[0].fd) < 0) {
+			err(EXIT_FAILURE, "failed to dup %d -> %d", bfd, fdescs[0].fd);
+		}
+		close(bfd);
+	}
+
+	munmap_data = xmalloc(sizeof(*munmap_data));
+	munmap_data->len = 4096;
+	munmap_data->ptr = mmap(NULL, munmap_data->len,
+				PROT_READ | PROT_WRITE,
+				MAP_SHARED, fdescs[0].fd, 0);
+	if (munmap_data->ptr == MAP_FAILED)
+		err(EXIT_FAILURE, "failed to mmap bpf-map");
+
+	fdescs[0] = (struct fdesc){
+		.fd    = fdescs[0].fd,
+		.close = close_fdesc_after_munmap,
+		.data  = munmap_data,
+	};
+
+	return NULL;
+}
+#endif	/* HAVE_BPF_F_MMAPABLE */
 
 static void *make_pty(const struct factory *factory _U_, struct fdesc fdescs[],
 		      int argc _U_, char ** argv _U_)
@@ -4423,6 +4473,25 @@ static const struct factory factories[] = {
 		},
 	},
 #endif
+#ifdef HAVE_BPF_F_MMAPABLE
+	{
+		.name = "mapped-bpf-map",
+		.desc = "mmap'ed bpf map",
+		.priv = true,
+		.N    = 1,
+		.EX_N = 0,
+		.make = make_mmapped_bpf_map,
+		.params = (struct parameter []) {
+			{
+				.name = "name",
+				.type = PTYPE_STRING,
+				.desc = "name assigned to the bpf map object",
+				.defv.string = "mkfds_bpf_map",
+			},
+			PARAM_END
+		}
+	},
+#endif	/* HAVE_BPF_F_MMAPABLE */
 	{
 		.name = "pty",
 		.desc = "make a pair of ptmx and pts",

--- a/tests/ts/lsfd/mkfds-mapped-bpf-map
+++ b/tests/ts/lsfd/mkfds-mapped-bpf-map
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 WanBingjiang <wanbingjiang@webray.com.cn>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="mmap'ed bpf map files"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+ts_skip_nonroot
+ts_skip_docker
+
+. "$TS_SELF/lsfd-functions.bash"
+ts_check_test_command "$TS_CMD_LSFD"
+ts_check_test_command "$TS_HELPER_MKFDS"
+lsfd_check_mkfds_factory mapped-bpf-map
+
+ts_cd "$TS_OUTDIR"
+
+PID=
+FD=3
+NAME=mkfds_map
+EXPR=
+
+{
+    coproc MKFDS { "$TS_HELPER_MKFDS" mapped-bpf-map "$FD" name="$NAME"; }
+    if read -r -u "${MKFDS[0]}" PID; then
+	EXPR='(ASSOC == "shm") and (TYPE == "bpf-map")'
+	"${TS_CMD_LSFD}" -p "${PID}" -n -o TYPE,NAME -Q "${EXPR}"
+	echo 'TYPE,NAME': $?
+
+	EXPR="(FD == $FD)"
+	"${TS_CMD_LSFD}" -r -n -o BPF-MAP.TYPE,BPF-MAP.TYPE.RAW,BPF.NAME -p "${PID}" -Q "${EXPR}"
+	echo 'BPF-MAP.TYPE,BPF-MAP.TYPE.RAW,BPF.NAME': $?
+
+	echo DONE >&"${MKFDS[1]}"
+    fi
+    wait "${MKFDS_PID}"
+    RC=$?
+} > "$TS_OUTPUT" 2>&1
+
+if [ "$RC" == "$TS_EXIT_NOTSUPP" ]; then
+    ts_skip "bpf(2) is not available"
+fi
+
+ts_finalize


### PR DESCRIPTION
The `bpf-map` obtained from `/proc/xxx/maps` no longer parses detailed information.

before:
```bash
# sudo ./lsfd -Q '(AINODECLASS == "bpf-map")'                                                    130 lsfd/fix-bpf-map!
COMMAND       PID USER ASSOC  XMODE    TYPE       SOURCE MNTID INODE NAME
systemd         1 root     9 rw---- bpf-map anon_inodefs    17    58 id=11 type=hash-of-maps name=cgroup_hash
test_mkfds 196868 root   shm rw---- bpf-map anon_inodefs    17    58 id=-1 type=UNKNOWN(-1)
test_mkfds 196868 root     3 rw---- bpf-map anon_inodefs    17    58 id=32 type=array name=mkfds_bpf_map
```
after:
```bash
# sudo ./lsfd -Q '(AINODECLASS == "bpf-map")'                                                      lsfd/fix-bpf-map!
COMMAND       PID USER ASSOC  XMODE    TYPE       SOURCE MNTID INODE NAME
systemd         1 root     9 rw---- bpf-map anon_inodefs    17    58 id=11 type=hash-of-maps name=cgroup_hash
test_mkfds 196868 root   shm rw---- bpf-map anon_inodefs    17    58 anon_inode:bpf-map
test_mkfds 196868 root     3 rw---- bpf-map anon_inodefs    17    58 id=32 type=array name=mkfds_bpf_map
```