### PR TITLE
agetty: show default issue file when built without issue.d support

### DIFF
--- a/agetty-cmd/issuefile.c
+++ b/agetty-cmd/issuefile.c
@@ -19,16 +19,22 @@
 #include "agetty.h"
 #include "c.h"
 #include "color-names.h"
+#include "configs.h"
 #include "nls.h"
 #include "fileutils.h"
 #include "pathnames.h"
 #include "widechar.h"
 
+/* The default issue file (e.g. /etc/issue) is read via ul_configs_file_list()
+ * whenever ISSUE_SUPPORT is enabled. The drop-in directory (issue.d) scanning
+ * performed by that function additionally requires ISSUEDIR_SUPPORT
+ * (i.e. scandirat()/openat()); when it is unavailable ul_configs_file_list()
+ * still returns the main issue file. */
+#define ISSUEDIR_EXT	"issue"
+#define ISSUEDIR_EXTSIZ	sizeof(ISSUEDIR_EXT)
+
 #ifdef ISSUEDIR_SUPPORT
-# include "configs.h"
 # include <dirent.h>
-# define ISSUEDIR_EXT	"issue"
-# define ISSUEDIR_EXTSIZ	sizeof(ISSUEDIR_EXT)
 #endif
 
 #ifdef USE_SYSTEMD
@@ -393,7 +399,6 @@ skip:
 		goto done;
 	}
 
-#ifdef ISSUEDIR_SUPPORT
 	struct list_head file_list;
 	struct list_head *current = NULL;
 	char *name = NULL;
@@ -403,6 +408,11 @@ skip:
 	 * https://github.com/uapi-group/specifications/blob/main/specs/configuration_files_specification.md
 	 *
 	 * Note that _PATH_RUNSTATEDIR (/run) is always read by ul_configs_file_list().
+	 *
+	 * ul_configs_file_list() returns the main issue file (e.g. /etc/issue)
+	 * even when drop-in directory support (ISSUEDIR_SUPPORT) is unavailable,
+	 * so the default issue file is still shown on builds without issue.d
+	 * support (see https://github.com/util-linux/util-linux/issues/4505).
 	 */
 	ul_configs_file_list(&file_list,
 			     NULL,
@@ -417,7 +427,6 @@ skip:
 	}
 
 	ul_configs_free_list(&file_list);
-#endif
 
 done:
 	if (ie->output) {


### PR DESCRIPTION
## Summary

Since commit d1cf7ef the default issue file (`/etc/issue`) is only read when issue.d support (`ISSUEDIR_SUPPORT`, i.e. `scandirat()`/`openat()`) is available. On builds without issue.d support (for example systems where `scandirat()` is unavailable, such as musl libc) `agetty --show-issue` and the login prompt print nothing unless `--issue-file` is given, regressing the long-standing behaviour of displaying `/etc/issue`.

The regression happened because the `ul_configs_file_list()` call that reads the default issue file was placed inside an `#ifdef ISSUEDIR_SUPPORT` block. `ul_configs_file_list()` already returns the main issue file even when drop-in directory support is unavailable — it simply skips the drop-in scan — so the call does not need to be gated on `ISSUEDIR_SUPPORT`.

## Changes
- `agetty-cmd/issuefile.c`: include `configs.h` and define `ISSUEDIR_EXT`/`ISSUEDIR_EXTSIZ` unconditionally, and drop the `#ifdef ISSUEDIR_SUPPORT` guard around the `ul_configs_file_list()` call. The drop-in directory scanning itself still requires `ISSUEDIR_SUPPORT` (handled inside `ul_configs_file_list()`), which is unchanged.

## Verification

Built agetty in two configurations (the relevant macros toggled via `config.h`):

**Without `ISSUEDIR_SUPPORT` (the broken case), `_PATH_SYSCONFDIR=/usr/local/etc`:**
```
$ ./agetty --show-issue        # original (unpatched)
<no output>

$ ./agetty --show-issue        # patched
Welcome ... (contents of /usr/local/etc/issue)
```
`--show-issue` was run under a pty (it needs a terminal on stdin).

**With `ISSUEDIR_SUPPORT` (default glibc build):** `--show-issue` still prints the issue file — no regression.

Fixes https://github.com/util-linux/util-linux/issues/4505
