### PR TITLE
pty-session: handle SIGALRM instead of aborting

### DIFF
--- a/lib/pty-session.c
+++ b/lib/pty-session.c
@@ -582,6 +582,8 @@ static int handle_signal(struct ul_pty *pty, int fd)
 							&info, (void *) &pty->win);
 		}
 		break;
+	case SIGALRM:
+		FALLTHROUGH;
 	case SIGHUP:
 		FALLTHROUGH;
 	case SIGTERM:
@@ -589,7 +591,7 @@ static int handle_signal(struct ul_pty *pty, int fd)
 	case SIGINT:
 		FALLTHROUGH;
 	case SIGQUIT:
-		DBG_OBJ(SIG, pty, ul_debug(" get signal SIG{TERM,INT,QUIT}"));
+		DBG_OBJ(SIG, pty, ul_debug(" get signal SIG{ALRM,HUP,TERM,INT,QUIT}"));
 		pty->delivered_signal = info.ssi_signo;
 		/* Child termination is going to generate SIGCHLD (see above) */
 		if (pty->child > 0)


### PR DESCRIPTION
## Summary

`ul_pty_signals_setup()` subscribes to `SIGALRM` through the signalfd set, but `handle_signal()` has no `case SIGALRM:`, so a `SIGALRM` delivered to the proxy (e.g. an `alarm(2)` timer armed before `execve()`, or an external `kill -ALRM`) falls through to `default: abort()`.

The `abort()` terminates `script`, `su --pty` and `runuser --pty` with `SIGABRT` before `ul_pty_cleanup()` runs, leaving the user's terminal in raw mode (no echo, no canonical mode, control characters read as bytes) until `stty sane`/`reset` is run.

## Changes
- `lib/pty-session.c`: treat `SIGALRM` like the other terminating signals (`SIGHUP`/`SIGTERM`/`SIGINT`/`SIGQUIT`): record it in `delivered_signal` and forward `SIGTERM` to the child so the proxy leaves its `poll()` loop through the normal path and `ul_pty_cleanup()` restores the saved terminal settings. The default disposition of `SIGALRM` is termination, so this preserves the previous outcome while adding the cleanup.

None of `script`, `su --pty` or `runuser --pty` arms `SIGALRM` internally on this code path.

## Verification

Reproducer from the issue (terminal A):
```
$ script -q -c 'printf "script PID: %s\n" "$PPID"; sleep 30' /dev/null
```
terminal B:
```
$ kill -ALRM <script-pid>
```

| build | result |
|---|---|
| unpatched | `script` dies with `SIGABRT` (exit 134); terminal left in raw mode |
| patched | `script` prints `Session terminated, killing shell... ...killed.` and exits 0; `ul_pty_cleanup()` restores termios |

The narrower window where a terminating signal arrives between `ul_pty_setup()` (raw mode on) and `ul_pty_signals_setup()` (signals blocked) is **not** addressed here — closing it requires reworking the signal-mask contract between those two calls and is left as a separate change.

Partially fixes https://github.com/util-linux/util-linux/issues/4499
