### PR TITLE
pty-session: defer raw mode until after signals are blocked

### DIFF
--- a/include/pty-session.h
+++ b/include/pty-session.h
@@ -108,6 +108,7 @@ struct ul_pty_callbacks *ul_pty_get_callbacks(struct ul_pty *pty);
 int ul_pty_is_running(struct ul_pty *pty);
 int ul_pty_setup(struct ul_pty *pty);
 int ul_pty_signals_setup(struct ul_pty *pty);
+int ul_pty_terminal_setup(struct ul_pty *pty);
 void ul_pty_cleanup(struct ul_pty *pty);
 int ul_pty_chownmod_slave(struct ul_pty *pty, uid_t uid, gid_t gid, mode_t mode);
 void ul_pty_init_slave(struct ul_pty *pty);

--- a/lib/pty-session.c
+++ b/lib/pty-session.c
@@ -186,9 +186,6 @@ int ul_pty_setup(struct ul_pty *pty)
 		if (rc)
 			goto done;
 
-		/* set the current terminal to raw mode; pty_cleanup() reverses this change on exit */
-		cfmakeraw(&attrs);
-		tcsetattr(STDIN_FILENO, TCSANOW, &attrs);
 	} else {
 		DBG_OBJ(SETUP, pty, ul_debug("create for non-terminal"));
 
@@ -215,6 +212,23 @@ done:
 	DBG_OBJ(SETUP, pty, ul_debug("pty setup done [master=%d, slave=%d, rc=%d]",
 				pty->master, pty->slave, rc));
 	return rc;
+}
+
+/* call me after ul_pty_signals_setup() and before fork() */
+int ul_pty_terminal_setup(struct ul_pty *pty)
+{
+	struct termios attrs;
+
+	if (!pty->isterm)
+		return 0;
+
+	attrs = pty->stdin_attrs;
+	cfmakeraw(&attrs);
+	if (tcsetattr(STDIN_FILENO, TCSANOW, &attrs))
+		return -errno;
+
+	DBG_OBJ(SETUP, pty, ul_debug("terminal raw mode setup done"));
+	return 0;
 }
 
 /* call me before fork() */
@@ -806,6 +820,8 @@ int main(int argc, char *argv[])
 		err(EXIT_FAILURE, "failed to create pseudo-terminal");
 	if (ul_pty_signals_setup(pty))
 		err(EXIT_FAILURE, "failed to initialize signals handler");
+	if (ul_pty_terminal_setup(pty))
+		err(EXIT_FAILURE, "failed to setup terminal");
 
 	fflush(stdout);			/* ??? */
 

--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -564,6 +564,10 @@ static void create_watching_parent(struct su_context *su)
 			supam_cleanup(su, PAM_ABORT);
 			err(EXIT_FAILURE, _("failed to initialize signals handler"));
 		}
+		if (ul_pty_terminal_setup(su->pty)) {
+			supam_cleanup(su, PAM_ABORT);
+			err(EXIT_FAILURE, _("failed to setup terminal"));
+		}
 	}
 #endif
 	fflush(stdout);			/* ??? */

--- a/term-utils/script.c
+++ b/term-utils/script.c
@@ -1027,6 +1027,8 @@ int main(int argc, char **argv)
 
 	if (ul_pty_signals_setup(ctl.pty))
 		err(EXIT_FAILURE, _("failed to initialize signals handler"));
+	if (ul_pty_terminal_setup(ctl.pty))
+		err(EXIT_FAILURE, _("failed to setup terminal"));
 	fflush(stdout);
 
 	/*

--- a/term-utils/scriptlive.c
+++ b/term-utils/scriptlive.c
@@ -305,6 +305,8 @@ main(int argc, char *argv[])
 		err(EXIT_FAILURE, _("failed to create pseudo-terminal"));
 	if (ul_pty_signals_setup(ss.pty))
 		err(EXIT_FAILURE, _("failed to initialize signals handler"));
+	if (ul_pty_terminal_setup(ss.pty))
+		err(EXIT_FAILURE, _("failed to setup terminal"));
 
 	fflush(stdout);			/* ??? */
 


### PR DESCRIPTION
## Summary

- Move the raw-mode `tcsetattr()` out of `ul_pty_setup()` into a new `ul_pty_terminal_setup()` function
- Callers invoke it after `ul_pty_signals_setup()`, so signals are already on `signalfd` when raw mode is activated
- Closes the race window where a terminating signal could leave the terminal in raw mode

The setup sequence becomes:
```
ul_pty_setup()          -- open pty, save terminal attrs
<app-specific work>     -- e.g. utempter (needs SIGCHLD unblocked)
ul_pty_signals_setup()  -- block signals, create signalfd
ul_pty_terminal_setup() -- set raw mode (signals already blocked)
fork()
```

Addresses the remaining setup-window race from https://github.com/util-linux/util-linux/issues/4499 (the SIGALRM fix was merged separately in 2d05ed224).