### PR TITLE
RFC: hwclock-rtc: add RTC_PARAM_BATTERY_LOW_DETECT support

### DIFF
--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -54,11 +54,16 @@ struct rtc_param {
 # define RTC_PARAM_BACKUP_SWITCH_MODE	2
 #endif /* RTC_PARAM_GET */
 
+#if defined(RTC_PARAM_GET) && !defined(RTC_PARAM_BATTERY_LOW_DETECT)
+# define RTC_PARAM_BATTERY_LOW_DETECT 3
+#endif
+
 static const struct hwclock_param hwclock_params[] =
 {
 	{ RTC_PARAM_FEATURES,  "features", N_("supported features") },
 	{ RTC_PARAM_CORRECTION, "correction", N_("time correction") },
 	{ RTC_PARAM_BACKUP_SWITCH_MODE, "bsm", N_("backup switch mode") },
+	{ RTC_PARAM_BATTERY_LOW_DETECT, "bld", N_("battery low detection") },
 	{ }
 };
 

--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -39,6 +39,7 @@ static const struct hwclock_param hwclock_params[] =
 	{ RTC_PARAM_FEATURES,  "features", N_("supported features") },
 	{ RTC_PARAM_CORRECTION, "correction", N_("time correction") },
 	{ RTC_PARAM_BACKUP_SWITCH_MODE, "bsm", N_("backup switch mode") },
+	{ RTC_PARAM_BATTERY_LOW_DETECT, "bld", N_("battery low detection") },
 	{ }
 };
 

--- a/sys-utils/hwclock.h
+++ b/sys-utils/hwclock.h
@@ -42,7 +42,12 @@ struct rtc_param {
 #  define RTC_PARAM_FEATURES		0
 #  define RTC_PARAM_CORRECTION		1
 #  define RTC_PARAM_BACKUP_SWITCH_MODE	2
+#  define RTC_PARAM_BATTERY_LOW_DETECT	3
 # endif /* RTC_PARAM_GET */
+
+#if defined(RTC_PARAM_GET) && !defined(RTC_PARAM_BATTERY_LOW_DETECT)
+# define RTC_PARAM_BATTERY_LOW_DETECT 3
+#endif
 
 # ifndef RTC_VL_READ
 #  define RTC_VL_READ	_IOR('p', 0x13, unsigned int)


### PR DESCRIPTION
**Draft PR - depends on pending linux patch series**

Some rtcs like the pcf2131 do not enable low battery detection by default. A new linux patch series[1] exposes a parameter to enable the detection, support is implemented in this commit.

[1]: https://lore.kernel.org/all/20260311200237.3531981-1-hugo@hugovil.com/