### PR TITLE
Guard non-portable <sys/syscall.h> and <err.h> includes

### DIFF
--- a/lib/configs.c
+++ b/lib/configs.c
@@ -1,7 +1,9 @@
 /*
  * configs_file.c instantiates functions defined and described in configs_file.h
  */
+#ifdef HAVE_ERR_H
 #include <err.h>
+#endif
 #include <errno.h>
 #include <sys/syslog.h>
 #include <sys/stat.h>

--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -11,7 +11,9 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#ifdef HAVE_SYS_SYSCALL_H
 #include <sys/syscall.h>
+#endif
 #include <string.h>
 #include <sys/wait.h>
 #include <fcntl.h>


### PR DESCRIPTION
Hi All,

Some platforms, such as AIX, do not provide the following headers:

- <sys/syscall.h>
- <err.h>

As a result, util-linux fails to build with errors such as:

```
lib/fileutils.c:14:10: fatal error: sys/syscall.h: No such file or directory
   14 | #include <sys/syscall.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.


lib/configs.c:4:10: fatal error: err.h: No such file or directory
    4 | #include <err.h>
      |          ^~~~~~~
compilation terminated.
```

**Proposed Fix**

Can we guard these includes with the corresponding HAVE_SYS_SYSCALL_H and HAVE_ERR_H checks before including them? This allows the project to build on platforms where these headers are unavailable, while preserving the existing behavior on platforms that provide them.

```
#ifdef HAVE_SYS_SYSCALL_H
#include <sys/syscall.h>
#endif
```

and

```
#ifdef HAVE_ERR_H
#include <err.h>
#endif
```

Please let me know if there is a preferred approach for handling these platform-specific headers.