### PR TITLE
Avoid Linux statx() implementation on AIX

### DIFF
--- a/lib/path.c
+++ b/lib/path.c
@@ -398,7 +398,7 @@ int ul_path_statf(struct path_cxt *pc, struct stat *sb, int flags, const char *p
 
 	return rc;
 }
-#ifdef HAVE_STATX
+#if defined(HAVE_STATX) && !defined(_AIX)
 /*
 * This function follows the semantics of statx(). To call statx() for the directory
 * itself addressed by @pc, use an empty string and the AT_EMPTY_PATH @flag.


### PR DESCRIPTION
Hi All,

While building util-linux on AIX, the build fails in lib/path.c with errors such as:

```
In file included from /usr/include/sys/lockf.h:45,
                 from /opt/freeware/lib/gcc/powerpc-ibm-aix7.1.0.0/10/include-fixed/unistd.h:866,
                 from lib/path.c:19:
/usr/include/sys/stat.h:497:19: note: expected 'struct stat *' but argument is of type 'const char *'
  497 | int statx(char *, struct stat *, int, int);
      |                   ^~~~~~~~~~~~~
lib/path.c:409:15: error: too many arguments to function 'statx'
  409 |   rc = path ? statx(AT_FDCWD, path, flags, mask, stx) : - EINVAL;
```
  
  and
  
 ```
 /usr/include/sys/stat.h:497:19: note: expected 'struct stat *' but argument is of type 'const char *'
  497 | int statx(char *, struct stat *, int, int);
      |                   ^~~~~~~~~~~~~
lib/path.c:417:8: error: too many arguments to function 'statx'
  417 |   rc = statx(dir, path, flags, mask, stx);
```

The configure check defines HAVE_STATX, causing the Linux statx() implementation to be compiled. However, AIX provides a different statx() interface than the Linux system call expected by util-linux.


**Proposed fix:**

Can we avoid compiling the Linux statx() implementation on AIX platforms where the statx() interface is incompatible 

For example:

`#if defined(HAVE_STATX) && !defined(_AIX)`

This allows AIX to use the existing fallback implementation while preserving the current behavior on Linux and other platforms that implement the Linux statx() API.