### PR TITLE
ipcmk: do not print a bogus errno for an unparsable --mode

### DIFF
--- a/sys-utils/ipcmk.c
+++ b/sys-utils/ipcmk.c
@@ -228,14 +228,9 @@ int main(int argc, char **argv)
 			ask_psem = 1;
 			break;
 		case 'p':
-		{
-			char *end = NULL;
-			errno = 0;
-			permission = strtoul(optarg, &end, 8);
-			if (errno || optarg == end || (end && *end))
-				err(EXIT_FAILURE, _("failed to parse mode"));
+			permission = (mode_t) str2unum_or_err(optarg, 8,
+					_("failed to parse mode"), 07777);
 			break;
-		}
 		case 'n':
 			name = optarg;
 			break;


### PR DESCRIPTION
The --mode option is the only one in ipcmk(1) that parses its argument by hand instead of using the strutils helpers, and it reports the failure with err(), which appends strerror(errno). strtoul() only sets errno on overflow, so for a malformed argument errno is still 0 and the user gets:
```sh
$ ipcmk --queue --mode abc
ipcmk: failed to parse mode: Success
```
Use str2unum_or_err(), like the other options in this file already do. It picks err()/errx() based on errno and prints the offending string:
```sh
$ ipcmk --queue --mode abc
ipcmk: failed to parse mode: 'abc'

$ ipcmk --queue --mode 100000
ipcmk: failed to parse mode: '100000': Numerical result out of range
```
The 07777 upper bound is the range of the mode bits that the resource creation calls accept; values above it were silently truncated to int before.