### PR TITLE
bits: fix the layout of the --help output

### DIFF
--- a/text-utils/bits.c
+++ b/text-utils/bits.c
@@ -227,12 +227,13 @@ static void __attribute__((__noreturn__)) usage(void)
 		stdout);
 
 	fputs(USAGE_OPTIONS, stdout);
-	fprintf(stdout, USAGE_HELP_OPTIONS(21));
 	fputsln(_(" -w <num>, --width <num>\n"
 	          "                     maximum width of bit masks (default 8192)"),
 		stdout);
-	fputsln(_(" -f, --fail-width     fail if bit list contains values wider than width"),
+	fputsln(_(" -f, --fail-width    fail if bit list contains values wider than width"),
 		stdout);
+	fputs(USAGE_SEPARATOR, stdout);
+	fprintf(stdout, USAGE_HELP_OPTIONS(21));
 
 	fputs(_("\nOutput modes:\n"), stdout);
 	fputsln(_(" -m, --mask          display bits as a hex mask value (default)"),


### PR DESCRIPTION
The -w/--width and -f/--fail-width entries are printed after USAGE_HELP_OPTIONS(), so --help and --version show up in the middle of the option list instead of at its end, unlike every other util-linux program. The description of -f is also indented by one column too many and does not line up with the rest.
```sh
	Options:
	 -h, --help          display this help
	 -V, --version       display version
	 -w <num>, --width <num>
	                     maximum width of bit masks (default 8192)
	 -f, --fail-width     fail if bit list contains values wider than width
```