### PR TITLE
Prevent erroneous spontaneous printing of issue file on console

### DIFF
--- a/agetty-cmd/issuefile.c
+++ b/agetty-cmd/issuefile.c
@@ -320,10 +320,17 @@ void agetty_print_issue_file(struct agetty_issue *ie,
 	}
 
 #ifdef AGETTY_RELOAD
-	free(ie->mem_old);
-	ie->mem_old = ie->mem;
-	ie->mem = NULL;
-	ie->mem_sz = 0;
+	/*
+	 * Pressing return at the prompt will clear ie->mem. Only set mem_old
+	 * when mem is non-NULL. That way, later invocations can compare against
+	 * the last printing of mem. Otherwise, mem is re-printed needlessly.
+	 */
+	if (ie->mem) {
+		free(ie->mem_old);
+		ie->mem_old = ie->mem;
+		ie->mem = NULL;
+		ie->mem_sz = 0;
+	}
 #else
 	free(ie->mem);
 	ie->mem = NULL;


### PR DESCRIPTION
On the console, the contents of the /etc/issue file may be printed a second time. See the following output:

```
OpenBMC Release producta-10bf5ea3f3a-dirty

bmc login:
bmc login:

OpenBMC Release producta-10bf5ea3f3a-dirty

bmc login:
```

This can cause test scripts to get confused. This can also cause annoyance to the user. When starting to type the user name, a new prompt may be printed.

One example of this is when agetty reacts to network events. These are monitored even in cases where the issue file doesn't contain ip address references.

The reason this is happening is because the old issue contents are cleared when the user presses return. Then when a network event occurs, the logic compares the contents of the issue file with the previously printed contents. Since the previous contents were cleared, it prints the issue file again.

The solution is to not clear the old contents when printing the issue file. Therefore the next time the issue file is checked, it can compare against the old contents and not print the issue file if it hasn't changed.