### PR TITLE
hwclock: use RTC_PARAM_GET and RTC_VL_READ for ifdefs

### DIFF
--- a/sys-utils/hwclock-rtc.c
+++ b/sys-utils/hwclock-rtc.c
@@ -33,27 +33,7 @@
 
 #include "hwclock.h"
 
-#ifndef __GNU__
-#ifndef RTC_PARAM_GET
-struct rtc_param {
-	__u64 param;
-	union {
-		__u64 uvalue;
-		__s64 svalue;
-		__u64 ptr;
-	};
-	__u32 index;
-	__u32 __pad;
-};
-
-# define RTC_PARAM_GET	_IOW('p', 0x13, struct rtc_param)
-# define RTC_PARAM_SET	_IOW('p', 0x14, struct rtc_param)
-
-# define RTC_PARAM_FEATURES		0
-# define RTC_PARAM_CORRECTION		1
-# define RTC_PARAM_BACKUP_SWITCH_MODE	2
-#endif /* RTC_PARAM_GET */
-
+#ifdef RTC_PARAM_GET
 static const struct hwclock_param hwclock_params[] =
 {
 	{ RTC_PARAM_FEATURES,  "features", N_("supported features") },
@@ -66,7 +46,7 @@ const struct hwclock_param *get_hwclock_params(void)
 {
 	return hwclock_params;
 }
-#endif /* __GNU__ */
+#endif /* RTC_PARAM_GET */
 
 /*
  * /dev/rtc is conventionally chardev 10/135
@@ -429,7 +409,7 @@ int set_epoch_rtc(const struct hwclock_control *ctl)
 
 
 
-#ifndef __GNU__
+#ifdef RTC_PARAM_GET
 static int resolve_rtc_param_alias(const char *alias, __u64 *value)
 {
 	const struct hwclock_param *param = &hwclock_params[0];
@@ -558,22 +538,24 @@ done:
 	free(opt);
 	return rc;
 }
+#endif /* RTC_PARAM_GET */
 
-#ifndef RTC_VL_DATA_INVALID
-#define RTC_VL_DATA_INVALID     0x1
-#endif
-#ifndef RTC_VL_BACKUP_LOW
-#define RTC_VL_BACKUP_LOW       0x2
-#endif
-#ifndef RTC_VL_BACKUP_EMPTY
-#define RTC_VL_BACKUP_EMPTY     0x4
-#endif
-#ifndef RTC_VL_ACCURACY_LOW
-#define RTC_VL_ACCURACY_LOW     0x8
-#endif
-#ifndef RTC_VL_BACKUP_SWITCH
-#define RTC_VL_BACKUP_SWITCH    0x10
-#endif
+#ifdef RTC_VL_READ
+# ifndef RTC_VL_DATA_INVALID
+#  define RTC_VL_DATA_INVALID     0x1
+# endif
+# ifndef RTC_VL_BACKUP_LOW
+#  define RTC_VL_BACKUP_LOW       0x2
+# endif
+# ifndef RTC_VL_BACKUP_EMPTY
+#  define RTC_VL_BACKUP_EMPTY     0x4
+# endif
+# ifndef RTC_VL_ACCURACY_LOW
+#  define RTC_VL_ACCURACY_LOW     0x8
+# endif
+# ifndef RTC_VL_BACKUP_SWITCH
+#  define RTC_VL_BACKUP_SWITCH    0x10
+# endif
 
 int rtc_vl_read(const struct hwclock_control *ctl)
 {
@@ -644,4 +626,4 @@ int rtc_vl_clear(const struct hwclock_control *ctl)
 
 	return 0;
 }
-#endif /* __GNU__ */
+#endif /* RTC_VL_READ */

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -1152,7 +1152,7 @@ manipulate_epoch(const struct hwclock_control *ctl)
 }
 #endif		/* __linux__ __alpha__ */
 
-#ifdef __linux__
+#ifdef RTC_PARAM_GET
 static int
 manipulate_rtc_param(const struct hwclock_control *ctl)
 {
@@ -1178,7 +1178,9 @@ manipulate_rtc_param(const struct hwclock_control *ctl)
 
 	return 1;
 }
+#endif /* RTC_PARAM_GET */
 
+#ifdef RTC_VL_READ
 static int
 manipulate_rtc_voltage_low(const struct hwclock_control *ctl)
 {
@@ -1192,7 +1194,7 @@ manipulate_rtc_voltage_low(const struct hwclock_control *ctl)
 	}
 	return 0;
 }
-#endif
+#endif /* RTC_VL_READ */
 
 static void out_version(void)
 {
@@ -1202,7 +1204,7 @@ static void out_version(void)
 static void __attribute__((__noreturn__))
 usage(void)
 {
-#ifdef __linux__
+#ifdef RTC_PARAM_GET
 	const struct hwclock_param *param = get_hwclock_params();
 #endif
 
@@ -1224,10 +1226,12 @@ usage(void)
 	puts(_("     --getepoch                  display the RTC epoch"));
 	puts(_("     --setepoch                  set the RTC epoch according to --epoch"));
 #endif
-#ifdef __linux__
+#ifdef RTC_PARAM_GET
 	puts(_("     --param-get <param>         display the RTC parameter"));
 	puts(_("     --param-set <param>=<value> set the RTC parameter"));
 	puts(_("     --param-index <number>      parameter index (default 0)"));
+#endif
+#ifdef RTC_VL_READ
 	puts(_("     --vl-read                   read voltage low information"));
 	puts(_("     --vl-clear                  clear voltage low information"));
 #endif
@@ -1257,7 +1261,7 @@ usage(void)
 	fputs(USAGE_SEPARATOR, stdout);
 	fprintf(stdout, USAGE_HELP_OPTIONS(33));
 
-#ifdef __linux__
+#ifdef RTC_PARAM_GET
 	fputs(USAGE_ARGUMENTS, stdout);
 	fputsln(_(" <param> is either a numeric RTC parameter value or one of these aliases:"), stdout);
 
@@ -1330,10 +1334,12 @@ int main(int argc, char **argv)
 		{ "setepoch",     no_argument,       NULL, OPT_SETEPOCH   },	/* IGNORECHECK=yes */
 		{ "epoch",        required_argument, NULL, OPT_EPOCH      },	/* IGNORECHECK=yes */
 #endif
-#ifdef __linux__
+#ifdef RTC_PARAM_GET
 		{ "param-get",    required_argument, NULL, OPT_PARAM_GET  },
 		{ "param-set",    required_argument, NULL, OPT_PARAM_SET  },
 		{ "param-index",  required_argument, NULL, OPT_PARAM_IDX  },
+#endif
+#ifdef RTC_VL_READ
 		{ "vl-read",      no_argument,       NULL, OPT_VL_READ    },
 		{ "vl-clear",     no_argument,       NULL, OPT_VL_CLEAR   },
 #endif
@@ -1450,7 +1456,7 @@ int main(int argc, char **argv)
 			ctl.epoch_option = optarg;	/* --epoch */
 			break;
 #endif
-#ifdef __linux__
+#ifdef RTC_PARAM_GET
 		case OPT_PARAM_GET:
 			ctl.param_get_option = optarg;
 			ctl.show = 0;
@@ -1463,6 +1469,8 @@ int main(int argc, char **argv)
 		case OPT_PARAM_IDX:
 			ctl.param_idx = strtou32_or_err(optarg, _("failed to parse param-index"));
 			break;
+#endif
+#ifdef RTC_VL_READ
 		case OPT_VL_READ:
 			ctl.vl_read = 1;
 			ctl.show = 0;
@@ -1565,14 +1573,16 @@ int main(int argc, char **argv)
 		}
 	}
 
-#ifdef __linux__
+#ifdef RTC_PARAM_GET
 	if (ctl.param_get_option || ctl.param_set_option) {
 		if (manipulate_rtc_param(&ctl))
 			hwclock_exit(&ctl, EXIT_FAILURE);
 
 		hwclock_exit(&ctl, EXIT_SUCCESS);
 	}
+#endif
 
+#ifdef RTC_VL_READ
 	if (ctl.vl_read || ctl.vl_clear) {
 		if (manipulate_rtc_voltage_low(&ctl))
 			hwclock_exit(&ctl, EXIT_FAILURE);

--- a/sys-utils/hwclock.h
+++ b/sys-utils/hwclock.h
@@ -20,6 +20,36 @@
 #include "debug.h"
 #include "nls.h"
 
+#ifdef __linux__
+# include <linux/rtc.h>
+# include <linux/types.h>
+
+# ifndef RTC_PARAM_GET
+struct rtc_param {
+	__u64 param;
+	union {
+		__u64 uvalue;
+		__s64 svalue;
+		__u64 ptr;
+	};
+	__u32 index;
+	__u32 __pad;
+};
+
+#  define RTC_PARAM_GET	_IOW('p', 0x13, struct rtc_param)
+#  define RTC_PARAM_SET	_IOW('p', 0x14, struct rtc_param)
+
+#  define RTC_PARAM_FEATURES		0
+#  define RTC_PARAM_CORRECTION		1
+#  define RTC_PARAM_BACKUP_SWITCH_MODE	2
+# endif /* RTC_PARAM_GET */
+
+# ifndef RTC_VL_READ
+#  define RTC_VL_READ	_IOR('p', 0x13, unsigned int)
+#  define RTC_VL_CLR	_IO('p', 0x14)
+# endif /* RTC_VL_READ */
+#endif /* __linux__ */
+
 #define HWCLOCK_DEBUG_INIT		(1 << 0)
 #define HWCLOCK_DEBUG_RANDOM_SLEEP	(1 << 1)
 #define HWCLOCK_DEBUG_DELTA_VS_TARGET	(1 << 2)
@@ -38,7 +68,7 @@ struct hwclock_control {
 #if defined(__linux__) || defined(__GNU__)
 	char *rtc_dev_name;
 #endif
-#ifdef __linux__
+#ifdef RTC_PARAM_GET
 	uint32_t param_idx;	/* --param-index <n> */
 #endif
 	char *param_get_option;
@@ -86,19 +116,22 @@ extern int get_epoch_rtc(const struct hwclock_control *ctl, unsigned long *epoch
 extern int set_epoch_rtc(const struct hwclock_control *ctl);
 #endif
 
+#ifdef RTC_PARAM_GET
 struct hwclock_param {
 	int id;
 	const char *name;
 	const char *help;
 };
-
 extern const struct hwclock_param *get_hwclock_params(void);
 extern int get_param_rtc(const struct hwclock_control *ctl,
 			const char *name, uint64_t *id, uint64_t *value);
 extern int set_param_rtc(const struct hwclock_control *ctl, const char *name);
+#endif
 
+#ifdef RTC_VL_READ
 extern int rtc_vl_read(const struct hwclock_control *ctl);
 extern int rtc_vl_clear(const struct hwclock_control *ctl);
+#endif
 
 extern void __attribute__((__noreturn__))
 hwclock_exit(const struct hwclock_control *ctl, int status);


### PR DESCRIPTION
Replace broad `#ifndef __GNU__` guards with feature-specific `#ifdef
RTC_PARAM_GET` and `#ifdef RTC_VL_READ` to guard the code that depends
on these ioctls.

Move the fallback definitions for `RTC_PARAM_GET`, `RTC_PARAM_SET`,
`RTC_VL_READ`, and `RTC_VL_CLR` from hwclock-rtc.c to hwclock.h under
`#ifdef __linux__`, so both hwclock.c and hwclock-rtc.c can use the
feature macros consistently.

This also makes it straightforward for PR #4513 to add new RTC
parameters — the new `RTC_PARAM_BATTERY_LOW_DETECT` define and
`hwclock_params[]` entry will naturally sit inside the existing
`#ifdef RTC_PARAM_GET` guards.