### PR TITLE
docs: fix --msglevel typo in setterm man page

### DIFF
--- a/term-utils/setterm.1.adoc
+++ b/term-utils/setterm.1.adoc
@@ -113,7 +113,7 @@ Makes the terminal continue on a new line when a line is full.
 Enables or disables the sending of kernel *printk*() messages to the console. Virtual consoles only.
 
 *--msglevel* **0**-**8**::
-Sets the console logging level for kernel *printk*(9) messages. All messages strictly more important than this will be printed, so a logging level of *0* has the same effect as *--msg on* and a logging level of *8* will print all kernel messages. *klogd*(8) may be a more convenient interface to the logging of kernel messages.
+Sets the console logging level for kernel *printk*(9) messages. All messages strictly more important than this will be printed, so a logging level of *0* has the same effect as *--msg off* and a logging level of *8* will print all kernel messages. *klogd*(8) may be a more convenient interface to the logging of kernel messages.
 +
 Virtual consoles only.
 


### PR DESCRIPTION
The setterm man page states that '--msglevel 0 has the same effect as --msg on'.
However, logging level 0 completely suppresses kernel log messages, which is
identical to the function of '--msg off'.

I think this is typo in the man page.

