### PR TITLE
libmount: report the filesystem subtype and superblock flags in listmount-based tables

### DIFF
--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -197,6 +197,42 @@ static int apply_fstype(struct libmnt_fs *fs, struct ul_statmount *sm)
 	return __mnt_fs_set_fstype_ptr(fs, p);
 }
 
+/*
+ * mountinfo's super-options field is the superblock flags followed by the filesystem's
+ * own options, and libmount keeps the two in one string. statmount() reports them
+ * separately, so join them in that order.
+ */
+static int apply_fs_optstr(struct libmnt_fs *fs, struct ul_statmount *sm)
+{
+	int rc = 0;
+
+	if (sm->mask & STATMOUNT_SB_BASIC) {
+		rc = mnt_optstr_append_option(&fs->fs_optstr,
+				sm->sb_flags & SB_RDONLY ? "ro" : "rw", NULL);
+		if (!rc && (sm->sb_flags & SB_SYNCHRONOUS))
+			rc = mnt_optstr_append_option(&fs->fs_optstr, "sync", NULL);
+		if (!rc && (sm->sb_flags & SB_DIRSYNC))
+			rc = mnt_optstr_append_option(&fs->fs_optstr, "dirsync", NULL);
+		if (!rc && (sm->sb_flags & SB_LAZYTIME))
+			rc = mnt_optstr_append_option(&fs->fs_optstr, "lazytime", NULL);
+	}
+
+	/* The kernel leaves STATMOUNT_MNT_OPTS clear when the filesystem reported no
+	 * options of its own, so there is nothing to append and no trailing comma.
+	 * unmangle() returns NULL for an empty string as well as on failure, so test the
+	 * source rather than the result and do not mistake a failure for "no options". */
+	if (!rc && (sm->mask & STATMOUNT_MNT_OPTS) && *sm_str(sm, sm->mnt_opts)) {
+		char *opts = unmangle(sm_str(sm, sm->mnt_opts), NULL);
+
+		if (!opts)
+			return -ENOMEM;
+		rc = mnt_optstr_append_option(&fs->fs_optstr, opts, NULL);
+		free(opts);
+	}
+
+	return rc;
+}
+
 static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 {
 	int rc = 0;
@@ -260,27 +296,14 @@ static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 	if (!rc && (sm->mask & STATMOUNT_MNT_NS_ID) && !fs->ns_id)
 		fs->ns_id = sm->mnt_ns_id;
 
-	if (!rc && (sm->mask & STATMOUNT_MNT_OPTS) && !fs->fs_optstr) {
-		fs->fs_optstr = unmangle(sm_str(sm, sm->mnt_opts), NULL);
+	if (!rc && (sm->mask & STATMOUNT_SB_BASIC) && !fs->devno)
+		fs->devno = makedev(sm->sb_dev_major, sm->sb_dev_minor);
+
+	if (!rc && (sm->mask & (STATMOUNT_SB_BASIC | STATMOUNT_MNT_OPTS))
+	    && !fs->fs_optstr) {
+		rc = apply_fs_optstr(fs, sm);
 		free(fs->optstr);
 		fs->optstr = NULL;
-	}
-
-	if (!rc && (sm->mask & STATMOUNT_SB_BASIC)) {
-		if (!fs->devno)
-			fs->devno = makedev(sm->sb_dev_major, sm->sb_dev_minor);
-		if (!fs->fs_optstr) {
-			rc = mnt_optstr_append_option(&fs->fs_optstr,
-					sm->sb_flags & SB_RDONLY ? "ro" : "rw", NULL);
-			if (!rc && (sm->sb_flags & SB_SYNCHRONOUS))
-				rc = mnt_optstr_append_option(&fs->fs_optstr, "sync", NULL);
-			if (!rc && (sm->sb_flags & SB_DIRSYNC))
-				rc = mnt_optstr_append_option(&fs->fs_optstr, "dirsync", NULL);
-			if (!rc && (sm->sb_flags & SB_LAZYTIME))
-				rc = mnt_optstr_append_option(&fs->fs_optstr, "lazytime", NULL);
-			free(fs->optstr);
-			fs->optstr = NULL;
-		}
 	}
 
 	fs->flags |= MNT_FS_KERNEL;

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -400,6 +400,12 @@ int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask)
 	if (mask & STATMOUNT_FS_TYPE)
 		mask |= STATMOUNT_FS_SUBTYPE;
 
+	/* The superblock flags and the filesystem's own options share fs_optstr, and
+	 * mnt_fs_get_devno() asks for SB_BASIC alone while mnt_fs_get_fs_options() asks
+	 * for both. Fetched apart, whichever arrives first defines the string for good. */
+	if (mask & (STATMOUNT_SB_BASIC | STATMOUNT_MNT_OPTS))
+		mask |= STATMOUNT_SB_BASIC | STATMOUNT_MNT_OPTS;
+
 	if (fs->ns_id)
 		ns = fs->ns_id;
 

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -242,6 +242,53 @@ static int apply_fstype(struct libmnt_fs *fs, struct ul_statmount *sm)
 	return __mnt_fs_set_fstype_ptr(fs, p);
 }
 
+/*
+ * mountinfo's super-options field is the superblock flags followed by the filesystem's
+ * own options, and libmount keeps the two in one string. statmount() reports them
+ * separately, so join them in that order. Built into a local string and assigned only
+ * once complete, for the same reason as apply_vfs_optstr().
+ */
+static int apply_fs_optstr(struct libmnt_fs *fs, struct ul_statmount *sm)
+{
+	char *str = NULL;
+	int rc = 0;
+
+	if (sm->mask & STATMOUNT_SB_BASIC) {
+		rc = mnt_optstr_append_option(&str,
+				sm->sb_flags & SB_RDONLY ? "ro" : "rw", NULL);
+		if (!rc && (sm->sb_flags & SB_SYNCHRONOUS))
+			rc = mnt_optstr_append_option(&str, "sync", NULL);
+		if (!rc && (sm->sb_flags & SB_DIRSYNC))
+			rc = mnt_optstr_append_option(&str, "dirsync", NULL);
+		if (!rc && (sm->sb_flags & SB_LAZYTIME))
+			rc = mnt_optstr_append_option(&str, "lazytime", NULL);
+	}
+
+	/* The kernel leaves STATMOUNT_MNT_OPTS clear when the filesystem reported no
+	 * options of its own, so there is nothing to append and no trailing comma.
+	 * unmangle() returns NULL for an empty string as well as on failure, so test the
+	 * source rather than the result and do not mistake a failure for "no options". */
+	if (!rc && (sm->mask & STATMOUNT_MNT_OPTS) && *sm_str(sm, sm->mnt_opts)) {
+		char *opts = unmangle(sm_str(sm, sm->mnt_opts), NULL);
+
+		if (!opts)
+			rc = -ENOMEM;
+		else {
+			rc = mnt_optstr_append_option(&str, opts, NULL);
+			free(opts);
+		}
+	}
+
+	if (rc) {
+		free(str);
+		return rc;
+	}
+
+	free(fs->fs_optstr);
+	fs->fs_optstr = str;
+	return 0;
+}
+
 static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 {
 	int rc = 0;
@@ -282,27 +329,14 @@ static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 	if (!rc && (sm->mask & STATMOUNT_MNT_NS_ID) && !fs->ns_id)
 		fs->ns_id = sm->mnt_ns_id;
 
-	if (!rc && (sm->mask & STATMOUNT_MNT_OPTS) && !fs->fs_optstr) {
-		fs->fs_optstr = unmangle(sm_str(sm, sm->mnt_opts), NULL);
+	if (!rc && (sm->mask & STATMOUNT_SB_BASIC) && !fs->devno)
+		fs->devno = makedev(sm->sb_dev_major, sm->sb_dev_minor);
+
+	if (!rc && (sm->mask & (STATMOUNT_SB_BASIC | STATMOUNT_MNT_OPTS))
+	    && !fs->fs_optstr) {
+		rc = apply_fs_optstr(fs, sm);
 		free(fs->optstr);
 		fs->optstr = NULL;
-	}
-
-	if (!rc && (sm->mask & STATMOUNT_SB_BASIC)) {
-		if (!fs->devno)
-			fs->devno = makedev(sm->sb_dev_major, sm->sb_dev_minor);
-		if (!fs->fs_optstr) {
-			rc = mnt_optstr_append_option(&fs->fs_optstr,
-					sm->sb_flags & SB_RDONLY ? "ro" : "rw", NULL);
-			if (!rc && (sm->sb_flags & SB_SYNCHRONOUS))
-				rc = mnt_optstr_append_option(&fs->fs_optstr, "sync", NULL);
-			if (!rc && (sm->sb_flags & SB_DIRSYNC))
-				rc = mnt_optstr_append_option(&fs->fs_optstr, "dirsync", NULL);
-			if (!rc && (sm->sb_flags & SB_LAZYTIME))
-				rc = mnt_optstr_append_option(&fs->fs_optstr, "lazytime", NULL);
-			free(fs->optstr);
-			fs->optstr = NULL;
-		}
 	}
 
 	fs->flags |= MNT_FS_KERNEL;

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -378,6 +378,12 @@ int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask)
 	if (mask & STATMOUNT_FS_TYPE)
 		mask |= STATMOUNT_FS_SUBTYPE;
 
+	/* The superblock flags and the filesystem's own options share fs_optstr, and
+	 * mnt_fs_get_devno() asks for SB_BASIC alone while mnt_fs_get_fs_options() asks
+	 * for both. Fetched apart, whichever arrives first defines the string for good. */
+	if (mask & (STATMOUNT_SB_BASIC | STATMOUNT_MNT_OPTS))
+		mask |= STATMOUNT_SB_BASIC | STATMOUNT_MNT_OPTS;
+
 	if (fs->ns_id)
 		ns = fs->ns_id;
 

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -179,6 +179,24 @@ static inline const char *sm_str(struct ul_statmount *sm, uint32_t offset)
 	return sm->str + offset;
 }
 
+static int apply_fstype(struct libmnt_fs *fs, struct ul_statmount *sm)
+{
+	const char *type = sm_str(sm, sm->fs_type);
+	const char *sub = sm->mask & STATMOUNT_FS_SUBTYPE ?
+				sm_str(sm, sm->fs_subtype) : "";
+	char *p = NULL;
+
+	/* /proc/self/mountinfo spells a filesystem with a subtype as "type.subtype"
+	 * (e.g. "fuse.sshfs"), while statmount() reports the two separately. */
+	if (!*sub)
+		return mnt_fs_set_fstype(fs, type);
+
+	if (asprintf(&p, "%s.%s", type, sub) < 0)
+		return -ENOMEM;
+
+	return __mnt_fs_set_fstype_ptr(fs, p);
+}
+
 static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 {
 	int rc = 0;
@@ -187,7 +205,7 @@ static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 		return -EINVAL;
 
 	if ((sm->mask & STATMOUNT_FS_TYPE) && !fs->fstype)
-		rc = mnt_fs_set_fstype(fs, sm_str(sm, sm->fs_type));
+		rc = apply_fstype(fs, sm);
 
 	if (!rc && (sm->mask & STATMOUNT_MNT_POINT) && !fs->target)
 		rc = mnt_fs_set_target(fs, sm_str(sm, sm->mnt_point));
@@ -354,6 +372,11 @@ int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask)
 		if (!fs->source)
 			mask |= STATMOUNT_SB_SOURCE;
 	}
+
+	/* The type and the subtype share one string, and the lazy accessors
+	 * (mnt_fs_get_fstype() and friends) request FS_TYPE alone. */
+	if (mask & STATMOUNT_FS_TYPE)
+		mask |= STATMOUNT_FS_SUBTYPE;
 
 	if (fs->ns_id)
 		ns = fs->ns_id;

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -224,6 +224,24 @@ static int apply_vfs_optstr(struct libmnt_fs *fs, struct ul_statmount *sm)
 	return 0;
 }
 
+static int apply_fstype(struct libmnt_fs *fs, struct ul_statmount *sm)
+{
+	const char *type = sm_str(sm, sm->fs_type);
+	const char *sub = sm->mask & STATMOUNT_FS_SUBTYPE ?
+				sm_str(sm, sm->fs_subtype) : "";
+	char *p = NULL;
+
+	/* /proc/self/mountinfo spells a filesystem with a subtype as "type.subtype"
+	 * (e.g. "fuse.sshfs"), while statmount() reports the two separately. */
+	if (!*sub)
+		return mnt_fs_set_fstype(fs, type);
+
+	if (asprintf(&p, "%s.%s", type, sub) < 0)
+		return -ENOMEM;
+
+	return __mnt_fs_set_fstype_ptr(fs, p);
+}
+
 static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 {
 	int rc = 0;
@@ -232,7 +250,7 @@ static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 		return -EINVAL;
 
 	if ((sm->mask & STATMOUNT_FS_TYPE) && !fs->fstype)
-		rc = mnt_fs_set_fstype(fs, sm_str(sm, sm->fs_type));
+		rc = apply_fstype(fs, sm);
 
 	if (!rc && (sm->mask & STATMOUNT_MNT_POINT) && !fs->target)
 		rc = mnt_fs_set_target(fs, sm_str(sm, sm->mnt_point));
@@ -376,6 +394,11 @@ int mnt_fs_fetch_statmount(struct libmnt_fs *fs, uint64_t mask)
 		if (!fs->source)
 			mask |= STATMOUNT_SB_SOURCE;
 	}
+
+	/* The type and the subtype share one string, and the lazy accessors
+	 * (mnt_fs_get_fstype() and friends) request FS_TYPE alone. */
+	if (mask & STATMOUNT_FS_TYPE)
+		mask |= STATMOUNT_FS_SUBTYPE;
 
 	if (fs->ns_id)
 		ns = fs->ns_id;

--- a/libmount/src/fs_statmount.c
+++ b/libmount/src/fs_statmount.c
@@ -179,6 +179,51 @@ static inline const char *sm_str(struct ul_statmount *sm, uint32_t offset)
 	return sm->str + offset;
 }
 
+/* Build the whole string before assigning it, so that a failed allocation half way
+ * through cannot leave fs->vfs_optstr holding a prefix of the real options: the fetch
+ * is not repeated for fields that are already set, so a partial string would be
+ * returned by mnt_fs_get_vfs_options() from then on. */
+static int apply_vfs_optstr(struct libmnt_fs *fs, struct ul_statmount *sm)
+{
+	char *str = NULL;
+	int rc;
+
+	rc = mnt_optstr_append_option(&str,
+			sm->mnt_attr & MOUNT_ATTR_RDONLY ? "ro" : "rw", NULL);
+	if (!rc && (sm->mnt_attr & MOUNT_ATTR_NOSUID))
+		rc = mnt_optstr_append_option(&str, "nosuid", NULL);
+	if (!rc && (sm->mnt_attr & MOUNT_ATTR_NODEV))
+		rc = mnt_optstr_append_option(&str, "nodev", NULL);
+	if (!rc && (sm->mnt_attr & MOUNT_ATTR_NOEXEC))
+		rc = mnt_optstr_append_option(&str, "noexec", NULL);
+	if (!rc && (sm->mnt_attr & MOUNT_ATTR_NODIRATIME))
+		rc = mnt_optstr_append_option(&str, "nodiratime", NULL);
+	if (!rc && (sm->mnt_attr & MOUNT_ATTR_NOSYMFOLLOW))
+		rc = mnt_optstr_append_option(&str, "nosymfollow", NULL);
+
+	if (!rc)
+		switch (sm->mnt_attr & MOUNT_ATTR__ATIME) {
+		case MOUNT_ATTR_STRICTATIME:
+			rc = mnt_optstr_append_option(&str, "strictatime", NULL);
+			break;
+		case MOUNT_ATTR_NOATIME:
+			rc = mnt_optstr_append_option(&str, "noatime", NULL);
+			break;
+		case MOUNT_ATTR_RELATIME:
+			rc = mnt_optstr_append_option(&str, "relatime", NULL);
+			break;
+		}
+
+	if (rc) {
+		free(str);
+		return rc;
+	}
+
+	free(fs->vfs_optstr);
+	fs->vfs_optstr = str;
+	return 0;
+}
+
 static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 {
 	int rc = 0;
@@ -210,30 +255,7 @@ static int apply_statmount(struct libmnt_fs *fs, struct ul_statmount *sm)
 		if (!fs->uniq_id)
 			fs->uniq_id = sm->mnt_id;
 		if (!fs->vfs_optstr) {
-			rc = mnt_optstr_append_option(&fs->vfs_optstr,
-					sm->mnt_attr & MOUNT_ATTR_RDONLY ? "ro" : "rw", NULL);
-			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NOSUID))
-				rc = mnt_optstr_append_option(&fs->vfs_optstr, "nosuid", NULL);
-			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NODEV))
-				rc = mnt_optstr_append_option(&fs->vfs_optstr, "nodev", NULL);
-			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NOEXEC))
-				rc = mnt_optstr_append_option(&fs->vfs_optstr, "noexec", NULL);
-			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NODIRATIME))
-				rc = mnt_optstr_append_option(&fs->vfs_optstr, "nodiratime", NULL);
-			if (!rc && (sm->mnt_attr & MOUNT_ATTR_NOSYMFOLLOW))
-				rc = mnt_optstr_append_option(&fs->vfs_optstr, "nosymfollow", NULL);
-
-			switch (sm->mnt_attr & MOUNT_ATTR__ATIME) {
-			case MOUNT_ATTR_STRICTATIME:
-				rc = mnt_optstr_append_option(&fs->vfs_optstr, "strictatime", NULL);
-				break;
-			case MOUNT_ATTR_NOATIME:
-				rc = mnt_optstr_append_option(&fs->vfs_optstr, "noatime", NULL);
-				break;
-			case MOUNT_ATTR_RELATIME:
-				rc = mnt_optstr_append_option(&fs->vfs_optstr, "relatime", NULL);
-				break;
-			}
+			rc = apply_vfs_optstr(fs, sm);
 			free(fs->optstr);
 			fs->optstr = NULL;
 		}
@@ -390,7 +412,11 @@ done:
 	else
 		free(buf);
 
-	fs->stmnt_done |= mask;
+	/* Only record the fields as done when they were actually applied. Marking them on the
+	 * failure path pins whatever the failed call left behind: the accessors for those fields
+	 * skip the fetch from then on, so a transient error becomes a permanently empty field. */
+	if (!rc)
+		fs->stmnt_done |= mask;
 	return rc;
 }
 

--- a/tests/ts/findmnt/listmount
+++ b/tests/ts/findmnt/listmount
@@ -30,6 +30,33 @@ function check_field {
 	[ -n "$data" ] || echo "$name empty"
 }
 
+# Compares one column between the two backends, keyed on the mount ID. A mount can be added or
+# removed between the two reads, and an ID can even be reused by a different mount, so a single
+# disagreement is not yet a failure: only one that survives a fresh pair of reads is reported.
+# Both reads must also return something, or an empty listmount table would compare clean.
+function compare_backends {
+	local desc="$1" mnt_cols="$2" lsmnt_cols="$3" prog="$4"
+	local out
+
+	for _ in 1 2 3; do
+		$TS_CMD_FINDMNT --noheadings --kernel=mountinfo --raw --output "$mnt_cols" \
+			2>> "$TS_ERRLOG" | sort > "$TS_OUTDIR/$desc-mountinfo"
+		$TS_CMD_FINDMNT --noheadings --kernel=listmount --raw --output "$lsmnt_cols" \
+			2>> "$TS_ERRLOG" | sed 's/^[^ ]* //' | sort > "$TS_OUTDIR/$desc-listmount"
+
+		if [ ! -s "$TS_OUTDIR/$desc-mountinfo" ] || [ ! -s "$TS_OUTDIR/$desc-listmount" ]; then
+			echo "$desc: a backend returned no mounts"
+			return
+		fi
+
+		out=$(awk "$prog" "$TS_OUTDIR/$desc-mountinfo" "$TS_OUTDIR/$desc-listmount" \
+			2>> "$TS_ERRLOG")
+		[ -n "$out" ] || return
+	done
+
+	echo "$out"
+}
+
 
 ts_init_subtest "target"
 check_field "TARGET" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
@@ -65,6 +92,24 @@ ts_finalize_subtest
 
 ts_init_subtest "id"
 check_field "ID" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+ts_finalize_subtest
+
+# Both backends have to name a filesystem the same way, subtype included, or a caller gets a
+# different answer depending on how the table was built. Key on the mount ID rather than the
+# mount point, which is not unique, and compare only the IDs both reads saw, since the table
+# can gain or lose a mount between them. MAJ:MIN is read first on the listmount side on purpose:
+# it needs only STATMOUNT_SB_BASIC, so the read also covers a fetch that asked for that alone.
+ts_init_subtest "fstype-parity"
+if ts_kernel_ver_lt 6 13 0; then
+	# STATMOUNT_FS_SUBTYPE: kernel commit ed9d95f691c2
+	ts_skip "statmount() cannot report the filesystem subtype before Linux 6.13"
+else
+	# shellcheck disable=SC2016 # $1 and $2 are awk fields, not shell parameters
+	compare_backends fstype ID,FSTYPE MAJ:MIN,ID,FSTYPE \
+		'NR==FNR { seen[$1] = $2; next }
+		 ($1 in seen) && seen[$1] != $2 { print "fstype for " $1 ": mountinfo " seen[$1] ", listmount " $2 }' \
+		>> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+fi
 ts_finalize_subtest
 
 ts_finalize

--- a/tests/ts/findmnt/listmount
+++ b/tests/ts/findmnt/listmount
@@ -112,4 +112,38 @@ else
 fi
 ts_finalize_subtest
 
+# mountinfo's super-options field is the superblock flags followed by the filesystem's own
+# options, and both backends have to produce it. MAJ:MIN is read first on purpose: it needs
+# only STATMOUNT_SB_BASIC, and fetching that without the mount options used to leave
+# fs_optstr holding nothing but "rw".
+ts_init_subtest "fs-options-parity"
+if ts_kernel_ver_lt 6 11 0; then
+	# STATMOUNT_MNT_OPTS: kernel commit f9af549d1fd3
+	ts_skip "statmount() cannot report filesystem options before Linux 6.11"
+else
+	# Two shapes are excluded from the comparison because the kernel, not libmount, makes
+	# them differ:
+	# - statmount() reports only SB_{RDONLY,SYNCHRONOUS,DIRSYNC,LAZYTIME}, so a mount
+	#   carrying SB_MANDLOCK differs by that one token. The kernel ignores -o mand anyway;
+	#   the bit is kept so that old fstab entries still mount.
+	# - LSM-supplied options: the plain "seclabel" token is dropped from both sides, and
+	#   rows carrying a value-bearing LSM option are skipped, because kernels take them
+	#   out of statmount's reach before Linux 6.15 (commits 056d33137bf9, 5eb987105357;
+	#   the fix was backported to stable kernels down to 6.11, so a version check cannot
+	#   identify the affected ones).
+	# shellcheck disable=SC2016 # $1 and $2 are awk fields, not shell parameters
+	compare_backends fsopts ID,FS-OPTIONS MAJ:MIN,ID,FS-OPTIONS \
+		'function canon(s) {
+	         s = "," s ","
+	         while (gsub(/,seclabel,/, ",", s)) continue;
+	         sub(/^,/, "", s); sub(/,$/, "", s)
+	         return s
+	     }
+	     /(^|,)(context|fscontext|defcontext|rootcontext|smackfsdef|smackfsroot|smackfshat|smackfsfloor|smackfstransmute)=/ { next }
+	     NR==FNR { if ($2 !~ /(^|,)mand(,|$)/) seen[$1] = canon($2); next }
+	     ($1 in seen) && seen[$1] != canon($2) { print "fs-options for " $1 ": mountinfo " seen[$1] ", listmount " $2 }' \
+		>> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+fi
+ts_finalize_subtest
+
 ts_finalize

--- a/tests/ts/findmnt/listmount
+++ b/tests/ts/findmnt/listmount
@@ -82,4 +82,22 @@ awk 'NR==FNR { seen[$1] = $2; next }
 	>> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_finalize_subtest
 
+# mountinfo's super-options field is the superblock flags followed by the filesystem's own
+# options, and both backends have to produce it. MAJ:MIN is read first on purpose: it needs
+# only STATMOUNT_SB_BASIC, and fetching that without the mount options used to leave
+# fs_optstr holding nothing but "rw".
+ts_init_subtest "fs-options-parity"
+$TS_CMD_FINDMNT --noheadings --kernel=mountinfo --raw --output ID,FS-OPTIONS \
+	2>> "$TS_ERRLOG" | sort > "$TS_OUTDIR/fsopts-mountinfo"
+$TS_CMD_FINDMNT --noheadings --kernel=listmount --raw --output MAJ:MIN,ID,FS-OPTIONS \
+	2>> "$TS_ERRLOG" | sed 's/^[^ ]* //' | sort > "$TS_OUTDIR/fsopts-listmount"
+# statmount() reports only SB_{RDONLY,SYNCHRONOUS,DIRSYNC,LAZYTIME}, so a mount carrying
+# SB_MANDLOCK differs by that one token and is not comparable. The kernel ignores -o mand
+# anyway; the bit is kept so that old fstab entries still mount.
+awk 'NR==FNR { if ($2 !~ /(^|,)mand(,|$)/) seen[$1] = $2; next }
+     ($1 in seen) && seen[$1] != $2 { print "fs-options for " $1 ": mountinfo " seen[$1] ", listmount " $2 }' \
+	"$TS_OUTDIR/fsopts-mountinfo" "$TS_OUTDIR/fsopts-listmount" \
+	>> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+ts_finalize_subtest
+
 ts_finalize

--- a/tests/ts/findmnt/listmount
+++ b/tests/ts/findmnt/listmount
@@ -67,4 +67,19 @@ ts_init_subtest "id"
 check_field "ID" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_finalize_subtest
 
+# Both backends have to name a filesystem the same way, subtype included, or a caller gets a
+# different answer depending on how the table was built. Key on the mount ID rather than the
+# mount point, which is not unique, and compare only the IDs both reads saw, since the table
+# can gain or lose a mount between them.
+ts_init_subtest "fstype-parity"
+$TS_CMD_FINDMNT --noheadings --kernel=mountinfo --raw --output ID,FSTYPE \
+	2>> "$TS_ERRLOG" | sort > "$TS_OUTDIR/fstype-mountinfo"
+$TS_CMD_FINDMNT --noheadings --kernel=listmount --raw --output ID,FSTYPE \
+	2>> "$TS_ERRLOG" | sort > "$TS_OUTDIR/fstype-listmount"
+awk 'NR==FNR { seen[$1] = $2; next }
+     ($1 in seen) && seen[$1] != $2 { print "fstype for " $1 ": mountinfo " seen[$1] ", listmount " $2 }' \
+	"$TS_OUTDIR/fstype-mountinfo" "$TS_OUTDIR/fstype-listmount" \
+	>> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+ts_finalize_subtest
+
 ts_finalize


### PR DESCRIPTION
NOTE: I opened this thinking I would need it for https://github.com/systemd/systemd/pull/43318, but I don't so looking for guidance if I should just close this.

A `libmnt_table` built through `listmount()`/`statmount()` should describe a mount the same way a table parsed from `/proc/self/mountinfo` does. Two fields did not, both in `apply_statmount()`, and fixing the second needed a third change first.

**1. The filesystem type of a mount with a subtype.** mountinfo spells the pair `type.subtype`, e.g. `fuse.sshfs`, while statmount() reports `fs_type` and `fs_subtype` separately and only the former was used, so the kernel table said bare `fuse`. libmount exposes no accessor for the subtype, so on that path the subtype cannot be reached at all. It also misclassifies: the bare name `fuse` is in libmount's pseudofs table, so a subtyped fuse mount answered 1 to `mnt_fs_is_pseudofs()`, and `mnt_fs_is_netfs()` stopped recognising `fuse.sshfs`.

Composing alone does not fix `findmnt --kernel=listmount`, because the lazy accessors `mnt_fs_get_fstype()`, `mnt_fs_is_pseudofs()` and `mnt_fs_is_netfs()` request `STATMOUNT_FS_TYPE` on its own, so a `FS_SUBTYPE` flag added only to the default mask is skipped. Any request for the type now asks for the subtype too.

**2. The two halves of `fs_optstr` could arrive separately.** `fs_optstr` is fed by both `STATMOUNT_SB_BASIC` and `STATMOUNT_MNT_OPTS`, each writer guarded by `if (!fs->fs_optstr)`. Fetching is lazy per accessor, so whichever arrives first defines the string, and `mask &= ~fs->stmnt_done` then prevents the other from ever being fetched. The answer depended on the order the caller read the fields:

```
$ findmnt --kernel=listmount -n -o MAJ:MIN,FS-OPTIONS --target /
    0:31  rw
$ findmnt --kernel=listmount -n -o FS-OPTIONS,MAJ:MIN --target /
  compress-force=zstd:3,ssd,discard,space_cache=v2,subvolid=5,subvol=/   0:31
```

**3. The superblock flags were dropped from `fs_optstr`.** mountinfo's super-options field is the superblock flags followed by the filesystem's own options. `MNT_OPTS` ran first, so the `rw`/`ro` prefix was lost. That reaches past the `FS-OPTIONS` column, because `mnt_fs_get_options()` merges `fs_optstr` with the VFS options, and `mnt_fs_match_options()` and `tab_diff.c` read the merged and raw strings respectively:

```
$ findmnt --kernel=listmount -n -O ro -o TARGET | wc -l
2
$ findmnt --kernel=mountinfo -n -O ro -o TARGET | wc -l
7
```

After this change both report 7.

### Measurements

All figures come from one window on one host, 1042 mounts, 12 of them subtyped, so they can be read against each other:

| after | subtyped, mountinfo/listmount | mounts differing on FSTYPE | on FS-OPTIONS | order-dependent | FS-OPTIONS starting `rw`/`ro` | `-O ro` found, mountinfo/listmount |
| --- | --- | --- | --- | --- | --- | --- |
| master | 12 / 0 | 12 | 1030 | 1030 | 12 | 7 / 2 |
| commit 1 | 12 / 12 | 0 | 1030 | 1030 | 12 | 7 / 2 |
| commit 2 | 12 / 12 | 0 | 1030 | 0 | 12 | 7 / 2 |
| commit 3 | 12 / 12 | 0 | 0 | 0 | 1042 | 7 / 7 |

`tests/ts/findmnt/listmount` gains `fstype-parity` and `fs-options-parity`. Each fails on its own parent commit and passes on its own commit; both key on the mount ID, since mount points are not unique, and compare only IDs both reads saw. `fs-options-parity` reads `MAJ:MIN` first deliberately, so it also covers a fetch that asked only for `SB_BASIC`, which a comparison in findmnt's default column order cannot catch.

On my test host no mount was setup as `sync`, `dirsync` or `lazytime`, so those were exercised in a user namespace, where both backends agree byte for byte. Every commit builds and passes standalone, so the series bisects. The suite is green for libmount, findmnt, mount, mountpoint, fsck, swapon and lsblk: 66 tests passed, 0 failed, 51 skipped because this build does not produce the binaries they need. Timing is unchanged within noise: `-o MAJ:MIN` moved +0.0% and the `-o TARGET` control -1.2%, best of 7 rounds of 40 invocations.

### Not addressed

`SB_MANDLOCK`. `statmount_sb_basic()` masks `sb_flags` to `SB_{RDONLY,SYNCHRONOUS,DIRSYNC,LAZYTIME}`, so a mount made with `-o mand` still differs by that one token. The kernel deprecated mandatory locking and `warn_mandlock()` tells the user the option is ignored, so the bit is display-only, and recovering it would cost a `statfs()` per mount for `ST_MANDLOCK`, which is the per-mount syscall this backend exists to avoid. The parity subtest skips such mounts and says why.

Option ordering within the VFS options, where statmount() places `nosymfollow` before the atime token and mountinfo places it after. Invisible through `mnt_optstr_get_flags()`.

Found while switching systemd's mount enumeration to libmount's statmount support (systemd/systemd#43318), which handles both divergences on its own side and so does not depend on this landing.
