### PR TITLE
lsfd: use ul_buffer API when building a string incrementally in loops

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -52,5 +52,49 @@ char *ul_buffer_get_pointer(struct ul_buffer *buf, unsigned short  ptr_idx);
 size_t ul_buffer_get_pointer_length(struct ul_buffer *buf, unsigned short ptr_idx);
 size_t ul_buffer_get_safe_pointer_width(struct ul_buffer *buf, unsigned short ptr_idx);
 
+/*
+ * Include xalloc.h first to use the buffer_x*() functions.
+ */
+#ifdef XALLOC_EXIT_CODE
+static inline int ul_buffer_xappend_string(struct ul_buffer *buf, const char *str)
+{
+	int r = ul_buffer_append_string(buf, str);
+	if (r < 0)
+		err(XALLOC_EXIT_CODE, "cannot allocate buffer");
+	return r;
+}
+
+static inline int ul_buffer_xappend_char(struct ul_buffer *buf, const char c)
+{
+	int r = ul_buffer_append_char(buf, c);
+	if (r < 0)
+		err(XALLOC_EXIT_CODE, "cannot allocate buffer");
+	return r;
+}
+
+static inline
+__attribute__ ((__format__ (__printf__, 2, 0)))
+int ul_buffer_xappendvf(struct ul_buffer *buf, const char *format, va_list ap)
+{
+	int r = ul_buffer_appendvf(buf, format, ap);
+	if (r < 0)
+		err(XALLOC_EXIT_CODE, "cannot allocate buffer");
+	return r;
+}
+
+static inline
+__attribute__ ((__format__ (__printf__, 2, 3)))
+int ul_buffer_xappendf(struct ul_buffer *buf, const char *format, ...)
+{
+	va_list ap;
+	int res;
+
+	va_start(ap, format);
+	res = ul_buffer_xappendvf(buf, format, ap);
+	va_end(ap);
+
+	return res;
+}
+#endif/* XALLOC_EXIT_CODE */
 
 #endif /* UTIL_LINUX_BUFFER */

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -31,6 +31,7 @@ void ul_buffer_set_chunksize(struct ul_buffer *buf, size_t sz);
 void ul_buffer_refer_string(struct ul_buffer *buf, char *str);
 int ul_buffer_alloc_data(struct ul_buffer *buf, size_t sz);
 int ul_buffer_append_data(struct ul_buffer *buf, const char *data, size_t sz);
+int ul_buffer_append_char(struct ul_buffer *buf, const char c);
 int ul_buffer_append_string(struct ul_buffer *buf, const char *str);
 int ul_buffer_append_ntimes(struct ul_buffer *buf, size_t n, const char *str);
 int ul_buffer_appendf(struct ul_buffer *buf, const char *format, ...)

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -26,6 +26,16 @@ struct ul_buffer {
 
 void ul_buffer_reset_data(struct ul_buffer *buf);
 void ul_buffer_free_data(struct ul_buffer *buf);
+
+/*
+ * This is a variant of ul_buffer_free_data(). Instead of freeing the
+ * BEGIN member, this function transfers its ownership to the caller.
+ *
+ * If the BEGIN member points to an empty C string,
+ * ul_buffer_steal_string() frees the buffer and returns NULL.
+ */
+char *ul_buffer_steal_string(struct ul_buffer *buf);
+
 int ul_buffer_is_empty(struct ul_buffer *buf);
 void ul_buffer_set_chunksize(struct ul_buffer *buf, size_t sz);
 void ul_buffer_refer_string(struct ul_buffer *buf, char *str);

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -6,6 +6,7 @@
 #define UTIL_LINUX_BUFFER
 
 #include <stddef.h>
+#include <stdarg.h>
 
 struct ul_buffer {
 	char *begin;		/* begin of the data */
@@ -32,6 +33,10 @@ int ul_buffer_alloc_data(struct ul_buffer *buf, size_t sz);
 int ul_buffer_append_data(struct ul_buffer *buf, const char *data, size_t sz);
 int ul_buffer_append_string(struct ul_buffer *buf, const char *str);
 int ul_buffer_append_ntimes(struct ul_buffer *buf, size_t n, const char *str);
+int ul_buffer_appendf(struct ul_buffer *buf, const char *format, ...)
+	__attribute__ ((__format__ (__printf__, 2, 3)));
+int ul_buffer_appendvf(struct ul_buffer *buf, const char *format, va_list ap)
+	__attribute__ ((__format__ (__printf__, 2, 0)));
 int ul_buffer_set_data(struct ul_buffer *buf, const char *data, size_t sz);
 
 char *ul_buffer_get_data(struct ul_buffer *buf,  size_t *sz, size_t *width);

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -152,6 +152,11 @@ int ul_buffer_append_data(struct ul_buffer *buf, const char *data, size_t sz)
 	return 0;
 }
 
+int ul_buffer_append_char(struct ul_buffer *buf, const char c)
+{
+	return ul_buffer_append_data(buf, &c, 1);
+}
+
 int ul_buffer_append_string(struct ul_buffer *buf, const char *str)
 {
 	if (!str)
@@ -332,6 +337,19 @@ int main(void)
 
 	ul_buffer_free_data(&buf);
 	ul_buffer_appendf(&buf, "a%se%d", "bcd", 10);
+	str = ul_buffer_get_data(&buf, &sz, NULL);
+	printf("data [%zu] '%s'\n", sz, str);
+
+	ul_buffer_free_data(&buf);
+	ul_buffer_append_char(&buf, 'x');
+	{
+		char c = 'y';
+		ul_buffer_append_char(&buf, c);
+	}
+	{
+		const char c = 'z';
+		ul_buffer_append_char(&buf, c);
+	}
 	str = ul_buffer_get_data(&buf, &sz, NULL);
 	printf("data [%zu] '%s'\n", sz, str);
 

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -18,11 +18,16 @@ void ul_buffer_reset_data(struct ul_buffer *buf)
 		memset(buf->ptrs, 0, buf->nptrs * sizeof(char *));
 }
 
-void ul_buffer_free_data(struct ul_buffer *buf)
+static inline char *ul_buffer_free_data_common(struct ul_buffer *buf, bool steal)
 {
+	char *t = NULL;
+
 	assert(buf);
 
-	free(buf->begin);
+	if (steal)
+		t = buf->begin;
+	else
+		free(buf->begin);
 	buf->begin = NULL;
 	buf->end = NULL;
 	buf->sz = 0;
@@ -34,6 +39,23 @@ void ul_buffer_free_data(struct ul_buffer *buf)
 	free(buf->encoded);
 	buf->encoded = NULL;
 	buf->encoded_sz = 0;
+
+	return t;
+}
+
+void ul_buffer_free_data(struct ul_buffer *buf)
+{
+	ul_buffer_free_data_common(buf, false);
+}
+
+char *ul_buffer_steal_string(struct ul_buffer *buf)
+{
+	if (ul_buffer_is_empty(buf)) {
+		ul_buffer_free_data(buf);
+		return NULL;
+	}
+
+	return ul_buffer_free_data_common(buf, true);
 }
 
 void ul_buffer_set_chunksize(struct ul_buffer *buf, size_t sz)

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -173,6 +173,35 @@ int ul_buffer_append_ntimes(struct ul_buffer *buf, size_t n, const char *str)
 	return 0;
 }
 
+int ul_buffer_appendf(struct ul_buffer *buf, const char *format, ...)
+{
+	va_list ap;
+	int res;
+
+	va_start(ap, format);
+	res = ul_buffer_appendvf(buf, format, ap);
+	va_end(ap);
+
+	return res;
+}
+
+int ul_buffer_appendvf(struct ul_buffer *buf, const char *format, va_list ap)
+{
+	char *val;
+	int sz;
+	int res;
+
+	sz = vasprintf(&val, format, ap);
+	if (sz < 0)
+		return -errno;
+
+	/* Like strlen(), sz doesn't include the last null byte. */
+	res = ul_buffer_append_data(buf, val, sz);
+	free(val);
+
+	return res;
+}
+
 int ul_buffer_set_data(struct ul_buffer *buf, const char *data, size_t sz)
 {
 	ul_buffer_reset_data(buf);
@@ -298,6 +327,11 @@ int main(void)
 	ul_buffer_refer_string(&buf, str);
 	ul_buffer_append_data(&buf, ",", 1);
 	ul_buffer_append_string(&buf, "bar");
+	str = ul_buffer_get_data(&buf, &sz, NULL);
+	printf("data [%zu] '%s'\n", sz, str);
+
+	ul_buffer_free_data(&buf);
+	ul_buffer_appendf(&buf, "a%se%d", "bcd", 10);
 	str = ul_buffer_get_data(&buf, &sz, NULL);
 	printf("data [%zu] '%s'\n", sz, str);
 

--- a/lsfd-cmd/cdev.c
+++ b/lsfd-cmd/cdev.c
@@ -21,6 +21,8 @@
 
 #include "lsfd.h"
 #include "pidfd-utils.h"
+#include "xalloc.h"
+#include "buffer.h"
 
 #include <sys/ioctl.h>		/* ioctl */
 #include <linux/if_tun.h>	/* TUNGETDEVNETNS */
@@ -568,14 +570,12 @@ static char * cdev_tty_get_name(struct cdev *cdev)
 	return str;
 }
 
-static inline char *cdev_tty_xstrendpoint(struct file *file)
+static inline void cdev_tty_xbufendpoint(struct file *file, struct ul_buffer *ul_buf)
 {
-	char *str = NULL;
-	xasprintf(&str, "%d,%s,%d%c%c",
-		  file->proc->pid, file->proc->command, file->association,
-		  (file->mode & S_IRUSR)? 'r': '-',
-		  (file->mode & S_IWUSR)? 'w': '-');
-	return str;
+	ul_buffer_xappendf(ul_buf, "%d,%s,%d%c%c",
+			   file->proc->pid, file->proc->command, file->association,
+			   (file->mode & S_IRUSR)? 'r': '-',
+			   (file->mode & S_IWUSR)? 'w': '-');
 }
 
 static bool cdev_tty_fill_column(struct proc *proc  __attribute__((__unused__)),
@@ -606,8 +606,8 @@ static bool cdev_tty_fill_column(struct proc *proc  __attribute__((__unused__)),
 		if (is_pty(data->drv)) {
 			struct ttydata *this = data;
 			struct list_head *e;
+			struct ul_buffer ul_buf = UL_INIT_BUFFER;
 			foreach_endpoint(e, data->endpoint) {
-				char *estr;
 				struct ttydata *other = list_entry(e, struct ttydata, endpoint.endpoints);
 				if (this == other)
 					continue;
@@ -616,12 +616,11 @@ static bool cdev_tty_fill_column(struct proc *proc  __attribute__((__unused__)),
 				    || (this->drv->is_pts && !other->drv->is_ptmx))
 					continue;
 
-				if (*str)
-					xstrputc(str, '\n');
-				estr = cdev_tty_xstrendpoint(&other->cdev->file);
-				xstrappend(str, estr);
-				free(estr);
+				if (!ul_buffer_is_empty(&ul_buf))
+					ul_buffer_xappend_char(&ul_buf, '\n');
+				cdev_tty_xbufendpoint(&other->cdev->file, &ul_buf);
 			}
+			*str = ul_buffer_steal_string(&ul_buf);
 			if (*str)
 				return true;
 		}

--- a/lsfd-cmd/fifo.c
+++ b/lsfd-cmd/fifo.c
@@ -21,6 +21,9 @@
 
 #include "lsfd.h"
 
+#include "xalloc.h"
+#include "buffer.h"
+
 struct fifo {
 	struct file file;
 	struct ipc_endpoint endpoint;
@@ -31,14 +34,12 @@ struct fifo_ipc {
 	ino_t ino;
 };
 
-static inline char *fifo_xstrendpoint(struct file *file)
+static inline void fifo_xbufendpoint(struct file *file, struct ul_buffer *ul_buf)
 {
-	char *str = NULL;
-	xasprintf(&str, "%d,%s,%d%c%c",
-		  file->proc->pid, file->proc->command, file->association,
-		  (file->mode & S_IRUSR)? 'r': '-',
-		  (file->mode & S_IWUSR)? 'w': '-');
-	return str;
+	ul_buffer_xappendf(ul_buf, "%d,%s,%d%c%c",
+			   file->proc->pid, file->proc->command, file->association,
+			   (file->mode & S_IRUSR)? 'r': '-',
+			   (file->mode & S_IWUSR)? 'w': '-');
 }
 
 static bool fifo_fill_column(struct proc *proc __attribute__((__unused__)),
@@ -64,17 +65,16 @@ static bool fifo_fill_column(struct proc *proc __attribute__((__unused__)),
 	case COL_ENDPOINTS: {
 		struct fifo *this = (struct fifo *)file;
 		struct list_head *e;
+		struct ul_buffer ul_buf = UL_INIT_BUFFER;
 		foreach_endpoint(e, this->endpoint) {
-			char *estr;
 			struct fifo *other = list_entry(e, struct fifo, endpoint.endpoints);
 			if (this == other)
 				continue;
-			if (str)
-				xstrputc(&str, '\n');
-			estr = fifo_xstrendpoint(&other->file);
-			xstrappend(&str, estr);
-			free(estr);
+			if (!ul_buffer_is_empty(&ul_buf))
+				ul_buffer_xappend_char(&ul_buf, '\n');
+			fifo_xbufendpoint(&other->file, &ul_buf);
 		}
+		str = ul_buffer_steal_string(&ul_buf);
 		if (!str)
 			return false;
 		break;
@@ -83,8 +83,6 @@ static bool fifo_fill_column(struct proc *proc __attribute__((__unused__)),
 		return false;
 	}
 
-	if (!str)
-		err(EXIT_FAILURE, _("failed to add output data"));
 	if (scols_line_refer_data(ln, column_index, str))
 		err(EXIT_FAILURE, _("failed to add output data"));
 	return true;

--- a/lsfd-cmd/file.c
+++ b/lsfd-cmd/file.c
@@ -199,9 +199,9 @@ static bool abst_fill_column(struct proc *proc,
 			return true;
 
 		file_fill_flags_buf(&buf, file->sys_flags);
-		if (ul_buffer_is_empty(&buf))
+		str = ul_buffer_steal_string(&buf);
+		if (!str)
 			return true;
-		str = ul_buffer_get_data(&buf, NULL, NULL);
 		break;
 	}
 	case COL_MAPLEN:

--- a/lsfd-cmd/file.c
+++ b/lsfd-cmd/file.c
@@ -38,6 +38,7 @@
 #include <sys/stat.h>
 #include <mqueue.h>		/* mq_open */
 
+#include "xalloc.h"
 #include "buffer.h"
 #include "idcache.h"
 #include "strutils.h"
@@ -763,14 +764,12 @@ bool is_mqueue_dev(dev_t dev)
 	return false;
 }
 
-static inline char *mqueue_file_xstrendpoint(struct file *file)
+static inline void mqueue_file_xbufendpoint(struct file *file, struct ul_buffer *ul_buf)
 {
-	char *str = NULL;
-	xasprintf(&str, "%d,%s,%d%c%c",
-		  file->proc->pid, file->proc->command, file->association,
-		  (file->mode & S_IRUSR)? 'r': '-',
-		  (file->mode & S_IWUSR)? 'w': '-');
-	return str;
+	ul_buffer_xappendf(ul_buf, "%d,%s,%d%c%c",
+			   file->proc->pid, file->proc->command, file->association,
+			   (file->mode & S_IRUSR)? 'r': '-',
+			   (file->mode & S_IWUSR)? 'w': '-');
 }
 
 static bool mqueue_file_fill_column(struct proc *proc __attribute__((__unused__)),
@@ -788,18 +787,17 @@ static bool mqueue_file_fill_column(struct proc *proc __attribute__((__unused__)
 		char *str = NULL;
 		struct mqueue_file *this = (struct mqueue_file *)file;
 		struct list_head *e;
+		struct ul_buffer ul_buf = UL_INIT_BUFFER;
 		foreach_endpoint(e, this->endpoint) {
-			char *estr;
 			struct mqueue_file *other = list_entry(e, struct mqueue_file,
 							       endpoint.endpoints);
 			if (this == other)
 				continue;
-			if (str)
-				xstrputc(&str, '\n');
-			estr = mqueue_file_xstrendpoint(&other->file);
-			xstrappend(&str, estr);
-			free(estr);
+			if (!ul_buffer_is_empty(&ul_buf))
+				ul_buffer_xappend_char(&ul_buf, '\n');
+			mqueue_file_xbufendpoint(&other->file, &ul_buf);
 		}
+		str = ul_buffer_steal_string(&ul_buf);
 		if (!str)
 			return false;
 		if (scols_line_refer_data(ln, column_index, str))

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -56,6 +56,8 @@
 #include "idcache.h"
 #include "pathnames.h"
 #include "pidfd-utils.h"
+#include "xalloc.h"
+#include "buffer.h"
 
 #include "lsfd.h"
 
@@ -2146,20 +2148,22 @@ static void read_process(struct lsfd_control *ctl, struct path_cxt *pc,
 	if (procfs_process_get_stat(pc, buf, sizeof(buf)) > 0) {
 		char *p;
 		unsigned int flags;
-		char *pat = NULL;
+		struct ul_buffer ul_buf = UL_INIT_BUFFER;
+		char *pat;
 
 		/* See proc(5) about the column in the line. */
-		xstrappend(&pat, "%*d (");
+		ul_buffer_xappend_string(&ul_buf, "%*d (");
 		for (p = proc->command; *p != '\0'; p++) {
 			if (*p == '%')
-				xstrappend(&pat, "%%");
+				ul_buffer_xappend_string(&ul_buf, "%%");
 			else
-				xstrputc(&pat, *p);
+				ul_buffer_xappend_char(&ul_buf, *p);
 		}
-		xstrappend(&pat, ") %*c %*d %*d %*d %*d %*d %u %*[^\n]");
+		ul_buffer_xappend_string(&ul_buf, ") %*c %*d %*d %*d %*d %*d %u %*[^\n]");
+		pat = ul_buffer_get_data(&ul_buf, NULL, NULL);
 		if (sscanf(buf, pat, &flags) == 1)
 			proc->kthread = !!(flags & PF_KTHREAD);
-		free(pat);
+		ul_buffer_free_data(&ul_buf);
 	}
 	if (proc->kthread && !ctl->threads) {
 		free_proc(proc);

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -2005,9 +2005,7 @@ static void mark_poll_fds_as_multiplexed(char *buf,
 		return;
 
 	local.iov_len = sizeof(struct pollfd) * nfds;
-	local.iov_base = malloc(local.iov_len);
-	if (!local.iov_base)
-		goto out;
+	local.iov_base = xmalloc(local.iov_len);
 
 	remote.iov_len = local.iov_len;
 	remote.iov_base = (void *)fds;

--- a/lsfd-cmd/sock-xinfo.c
+++ b/lsfd-cmd/sock-xinfo.c
@@ -2535,7 +2535,7 @@ static bool packet_fill_column(struct proc *proc __attribute__((__unused__)),
 		if (proto)
 			*str = xstrdup(proto);
 		else
-			xstrfappend(str, "unknown(%"PRIu16")", pkt->protocol);
+			xasprintf(str, "unknown(%"PRIu16")", pkt->protocol);
 		return true;
 	}
 	case COL_PACKET_PROTOCOL_RAW:

--- a/lsfd-cmd/sock-xinfo.c
+++ b/lsfd-cmd/sock-xinfo.c
@@ -50,6 +50,9 @@
 #include "pidfd-utils.h"
 #include "sock.h"
 
+#include "xalloc.h"
+#include "buffer.h"
+
 static void load_xinfo_from_proc_icmp(ino_t netns_inode, enum sysfs_byteorder byteorder);
 static void load_xinfo_from_proc_icmp6(ino_t netns_inode, enum sysfs_byteorder byteorder);
 static void load_xinfo_from_proc_unix(ino_t netns_inode);
@@ -586,20 +589,17 @@ static bool unix_shutdown_chars(struct unix_xinfo *ux, char rw[2])
 	return false;
 }
 
-static inline char *unix_xstrendpoint(struct sock *sock)
+static inline void unix_xbufendpoint(struct sock *sock, struct ul_buffer *ul_buf)
 {
-	char *str = NULL;
 	char shutdown_chars[3] = { 0 };
 
 	if (!unix_shutdown_chars(((struct unix_xinfo *)sock->xinfo), shutdown_chars)) {
 		shutdown_chars[0] = '?';
 		shutdown_chars[1] = '?';
 	}
-	xasprintf(&str, "%d,%s,%d%c%c",
-		  sock->file.proc->pid, sock->file.proc->command, sock->file.association,
-		  shutdown_chars[0], shutdown_chars[1]);
-
-	return str;
+	ul_buffer_xappendf(ul_buf, "%d,%s,%d%c%c",
+			   sock->file.proc->pid, sock->file.proc->command, sock->file.association,
+			   shutdown_chars[0], shutdown_chars[1]);
 }
 
 static struct ipc *unix_get_peer_ipc(struct unix_xinfo *ux,
@@ -616,19 +616,16 @@ static struct ipc *unix_get_peer_ipc(struct unix_xinfo *ux,
 	return get_ipc(&dummy_peer_sock.file);
 }
 
-static void unix_fill_column_append_endpoints(struct ipc *peer_ipc, char **str)
+static void unix_fill_column_append_endpoints(struct ipc *peer_ipc, struct ul_buffer *ul_buf)
 {
 	struct list_head *e;
 
 	list_for_each_backwardly(e, &peer_ipc->endpoints) {
 		struct sock *peer_sock = list_entry(e, struct sock, endpoint.endpoints);
-		char *estr;
 
-		if (*str)
-			xstrputc(str, '\n');
-		estr = unix_xstrendpoint(peer_sock);
-		xstrappend(str, estr);
-		free(estr);
+		if (!ul_buffer_is_empty(ul_buf))
+			ul_buffer_xappend_char(ul_buf, '\n');
+		unix_xbufendpoint(peer_sock, ul_buf);
 	}
 }
 
@@ -643,6 +640,7 @@ static bool unix_fill_column(struct proc *proc __attribute__((__unused__)),
 	struct unix_xinfo *ux = (struct unix_xinfo *)sock_xinfo;
 	struct ipc *peer_ipc;
 	char shutdown_chars[3] = { 0 };
+	struct ul_buffer ul_buf = UL_INIT_BUFFER;
 
 	switch (column_id) {
 	case COL_UNIX_PATH:
@@ -666,17 +664,18 @@ static bool unix_fill_column(struct proc *proc __attribute__((__unused__)),
 			break;
 
 		if (peer_ipc)
-			unix_fill_column_append_endpoints(peer_ipc, str);
+			unix_fill_column_append_endpoints(peer_ipc, &ul_buf);
 
 		if (ux->unix_ipc->ipeer == 0) {
 			struct list_head *e;
 			list_for_each(e, &ux->unix_ipc->unix_ipcs) {
 				struct unix_ipc *peer_unix_ipc = list_entry(e, struct unix_ipc, unix_ipcs);
 				peer_ipc = &peer_unix_ipc->ipc;
-				unix_fill_column_append_endpoints(peer_ipc, str);
+				unix_fill_column_append_endpoints(peer_ipc, &ul_buf);
 			}
 		}
 
+		*str = ul_buffer_steal_string(&ul_buf);
 		if (*str)
 			return true;
 		break;

--- a/lsfd-cmd/unkn.c
+++ b/lsfd-cmd/unkn.c
@@ -495,7 +495,7 @@ static bool anon_eventpoll_fill_column(struct proc *proc  __attribute__((__unuse
 
 	switch(column_id) {
 	case COL_EVENTPOLL_TFDS:
-		*str =anon_eventpoll_make_tfds_string(data, NULL, '\n');
+		*str = anon_eventpoll_make_tfds_string(data, NULL, '\n');
 		if (*str)
 			return true;
 		break;

--- a/lsfd-cmd/unkn.c
+++ b/lsfd-cmd/unkn.c
@@ -30,6 +30,9 @@
 #include "lsfd.h"
 #include "pidfd.h"
 
+#include "xalloc.h"
+#include "buffer.h"
+
 #define offsetofend(TYPE, MEMBER)				\
 	(offsetof(TYPE, MEMBER)	+ sizeof_member(TYPE, MEMBER))
 
@@ -334,12 +337,10 @@ static int anon_eventfd_handle_fdinfo(struct unkn *unkn, const char *key, const 
 	return 0;
 }
 
-static inline char *anon_eventfd_data_xstrendpoint(struct file *file)
+static inline void anon_eventfd_data_xbufendpoint(struct file *file, struct ul_buffer *ul_buf)
 {
-	char *str = NULL;
-	xasprintf(&str, "%d,%s,%d",
-		  file->proc->pid, file->proc->command, file->association);
-	return str;
+	ul_buffer_xappendf(ul_buf, "%d,%s,%d",
+			   file->proc->pid, file->proc->command, file->association);
 }
 
 static bool anon_eventfd_fill_column(struct proc *proc  __attribute__((__unused__)),
@@ -357,22 +358,19 @@ static bool anon_eventfd_fill_column(struct proc *proc  __attribute__((__unused_
 		return true;
 	case COL_ENDPOINTS: {
 		struct list_head *e;
-		char *estr;
+		struct ul_buffer ul_buf = UL_INIT_BUFFER;
 		foreach_endpoint(e, data->endpoint) {
 			struct anon_eventfd_data *other = list_entry(e,
 								     struct anon_eventfd_data,
 								     endpoint.endpoints);
 			if (data == other)
 				continue;
-			if (*str)
-				xstrputc(str, '\n');
-			estr = anon_eventfd_data_xstrendpoint(&other->backptr->file);
-			xstrappend(str, estr);
-			free(estr);
+			if (!ul_buffer_is_empty(&ul_buf))
+				ul_buffer_xappend_char(&ul_buf, '\n');
+			anon_eventfd_data_xbufendpoint(&other->backptr->file, &ul_buf);
 		}
-		if (!*str)
-			return false;
-		return true;
+		*str = ul_buffer_steal_string(&ul_buf);
+		return *str ? true : false;
 	}
 	default:
 		return false;
@@ -462,20 +460,16 @@ static char *anon_eventpoll_make_tfds_string(struct anon_eventpoll_data *data,
 					     const char *prefix,
 					     const char sep)
 {
-	char *str = prefix? xstrdup(prefix): NULL;
+	struct ul_buffer ul_buf = UL_INIT_BUFFER;
 
-	char buf[256];
+	if (prefix)
+		ul_buffer_xappend_string(&ul_buf, prefix);
 	for (size_t i = 0; i < data->count; i++) {
-		size_t offset = 0;
-
-		if (i > 0) {
-			buf[0] = sep;
-			offset = 1;
-		}
-		snprintf(buf + offset, sizeof(buf) - offset, "%d", data->tfds[i]);
-		xstrappend(&str, buf);
+		if (i > 0)
+			ul_buffer_xappend_char(&ul_buf, sep);
+		ul_buffer_xappendf(&ul_buf, "%d", data->tfds[i]);
 	}
-	return str;
+	return ul_buffer_steal_string(&ul_buf);
 }
 
 static char *anon_eventpoll_get_name(struct unkn *unkn)
@@ -731,29 +725,26 @@ static int anon_signalfd_handle_fdinfo(struct unkn *unkn, const char *key, const
 
 static char *anon_signalfd_make_mask_string(const char* prefix, uint64_t sigmask)
 {
-	char *str = NULL;
+	struct ul_buffer ul_buf = UL_INIT_BUFFER;
 
 	for (size_t i = 0; i < sizeof(sigmask) * 8; i++) {
 		if ((((uint64_t)0x1) << i) & sigmask) {
 			const int signum = i + 1;
 			const char *signame = signum_to_signame(signum);
 
-			if (str)
-				xstrappend(&str, ",");
+			if (!ul_buffer_is_empty(&ul_buf))
+				ul_buffer_xappend_char(&ul_buf, ',');
 			else if (prefix)
-				xstrappend(&str, prefix);
+				ul_buffer_xappend_string(&ul_buf, prefix);
 
-			if (signame) {
-				xstrappend(&str, signame);
-			} else {
-				char buf[BUFSIZ];
-				snprintf(buf, sizeof(buf), "%d", signum);
-				xstrappend(&str, buf);
-			}
+			if (signame)
+				ul_buffer_xappend_string(&ul_buf, signame);
+			else
+				ul_buffer_xappendf(&ul_buf, "%d", signum);
 		}
 	}
 
-	return str;
+	return ul_buffer_steal_string(&ul_buf);
 }
 
 static char *anon_signalfd_get_name(struct unkn *unkn)
@@ -823,9 +814,8 @@ static char *anon_inotify_make_inodes_string(const char *prefix,
 					     enum decode_source_level decode_level,
 					     struct anon_inotify_data *data)
 {
-	char *str = NULL;
 	char buf[BUFSIZ] = {'\0'};
-	bool first_element = true;
+	struct ul_buffer ul_buf = UL_INIT_BUFFER;
 
 	struct list_head *i;
 	list_for_each(i, &data->inodes) {
@@ -833,18 +823,19 @@ static char *anon_inotify_make_inodes_string(const char *prefix,
 		struct anon_inotify_inode *inode = list_entry(i,
 							      struct anon_inotify_inode,
 							      inodes);
+		ul_buffer_xappend_string(&ul_buf,
+					 ul_buffer_is_empty(&ul_buf) ? prefix : sep);
 
 		decode_source(source, sizeof(source),
 			      ANON_INOTIFY_MAJOR(inode->sdev), ANON_INOTIFY_MINOR(inode->sdev),
 			      decode_level);
-		snprintf(buf, sizeof(buf), "%s%llu@%s", first_element? prefix: sep,
+		snprintf(buf, sizeof(buf), "%llu@%s",
 			 (unsigned long long)inode->ino, source);
-		first_element = false;
 
-		xstrappend(&str, buf);
+		ul_buffer_xappend_string(&ul_buf, buf);
 	}
 
-	return str;
+	return ul_buffer_steal_string(&ul_buf);
 }
 
 static char *anon_inotify_get_name(struct unkn *unkn)


### PR DESCRIPTION
The pull request is derived from https://github.com/util-linux/util-linux/pull/4491 .
I struggled to extend functions in strutils.h to optimize the code by building strings incrementally in loops in lsfd.

As Karel suggested, extending functions in buffer.h and applying them to lsfd is a better approach.