### PR TITLE
login(1): document NSS user database, not only /etc/passwd

### DIFF
--- a/login-utils/login.1.adoc
+++ b/login-utils/login.1.adoc
@@ -28,7 +28,7 @@ The user is then prompted for a password, where appropriate. Echoing is disabled
 
 If password aging has been enabled for the account, the user may be prompted for a new password before proceeding. In such a case, the old password must be provided and the new password entered before continuing. Please refer to *passwd*(1) for more information.
 
-The user and group ID will be set according to the account's password entry from the system user database (typically configured via *nsswitch*(5); local files such as _/etc/passwd_ are only one possible backend). There is one exception if the user ID is zero. In this case, only the primary group ID of the account is set. This should allow the system administrator to login even in case of network problems. The environment variable values for *$HOME*, *$USER*, *$SHELL*, *$PATH*, *$LOGNAME*, and *$MAIL* are set according to the appropriate fields in the password entry. *$PATH* defaults to _/usr/local/bin:/bin:/usr/bin_ for normal users, and to _/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin_ for root, if not otherwise configured.
+The user and group ID will be set according to the account's password entry from the system password database (see *nsswitch.conf*(5) and *nss*(5)). There is one exception if the user ID is zero. In this case, only the primary group ID of the account is set. This should allow the system administrator to login even in case of network problems. The environment variable values for *$HOME*, *$USER*, *$SHELL*, *$PATH*, *$LOGNAME*, and *$MAIL* are set according to the appropriate fields in the password entry. *$PATH* defaults to _/usr/local/bin:/bin:/usr/bin_ for normal users, and to _/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin_ for root, if not otherwise configured.
 
 The environment variable *$TERM* will be preserved, if it exists, else it will be initialized to the terminal type on your tty. The environment variables *$COLORTERM* and *$NO_COLOR* will be preserved if they exist.
 
@@ -186,6 +186,8 @@ Derived from BSD login 5.40 (5/9/89) by mailto:glad@daimi.dk[Michael Glad] for H
 *mail*(1),
 *passwd*(1),
 *passwd*(5),
+*nss*(5),
+*nsswitch.conf*(5),
 *utmp*(5),
 *environ*(7),
 *getty*(8),

--- a/login-utils/login.1.adoc
+++ b/login-utils/login.1.adoc
@@ -28,7 +28,7 @@ The user is then prompted for a password, where appropriate. Echoing is disabled
 
 If password aging has been enabled for the account, the user may be prompted for a new password before proceeding. In such a case, the old password must be provided and the new password entered before continuing. Please refer to *passwd*(1) for more information.
 
-The user and group ID will be set according to their values in the _/etc/passwd_ file. There is one exception if the user ID is zero. In this case, only the primary group ID of the account is set. This should allow the system administrator to login even in case of network problems. The environment variable values for *$HOME*, *$USER*, *$SHELL*, *$PATH*, *$LOGNAME*, and *$MAIL* are set according to the appropriate fields in the password entry. *$PATH* defaults to _/usr/local/bin:/bin:/usr/bin_ for normal users, and to _/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin_ for root, if not otherwise configured.
+The user and group ID will be set according to the account's password entry from the system user database (typically configured via *nsswitch*(5); local files such as _/etc/passwd_ are only one possible backend). There is one exception if the user ID is zero. In this case, only the primary group ID of the account is set. This should allow the system administrator to login even in case of network problems. The environment variable values for *$HOME*, *$USER*, *$SHELL*, *$PATH*, *$LOGNAME*, and *$MAIL* are set according to the appropriate fields in the password entry. *$PATH* defaults to _/usr/local/bin:/bin:/usr/bin_ for normal users, and to _/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin_ for root, if not otherwise configured.
 
 The environment variable *$TERM* will be preserved, if it exists, else it will be initialized to the terminal type on your tty. The environment variables *$COLORTERM* and *$NO_COLOR* will be preserved if they exist.
 
@@ -36,7 +36,7 @@ Other environment variables are preserved if the *-p* option is given or if *LOG
 
 The environment variables defined by PAM are always preserved.
 
-Then the user's shell is started. If no shell is specified for the user with *-s* or in _/etc/passwd_, then _/bin/sh_ is used. If the specified shell contains a space, it is treated as a shell script. If there is no home directory specified in _/etc/passwd_, then _/_ is used, followed by _.hushlogin_ check as described below.
+Then the user's shell is started. If no shell is specified for the user with *-s* or in the password entry, then _/bin/sh_ is used. If the specified shell contains a space, it is treated as a shell script. If there is no home directory specified in the password entry, then _/_ is used, followed by _.hushlogin_ check as described below.
 
 If the file _.hushlogin_ exists, then a "quiet" login is performed. This disables the checking of mail and the printing of the last login time and message of the day. Otherwise, if _/var/log/lastlog_ exists, the last login time is printed, and the current login is recorded.
 
@@ -57,7 +57,7 @@ Note that the *-h* option has an impact on the *PAM service* *name*. The standar
 Used by other servers (for example, *telnetd*(8)) to tell *login* that printing the hostname should be suppressed in the login: prompt. See also *LOGIN_PLAIN_PROMPT* below.
 
 *-s*, *--shell* _shell_::
-Specify a _shell_, other than the one defined in _/etc/passwd_, to log in to.
+Specify a _shell_, other than the one defined in the password entry, to log in to.
 
 include::man-common/help-version.adoc[]
 


### PR DESCRIPTION
The man page said UIDs and shells come from `/etc/passwd`. They come from the system password database (`getpwnam_r` / NSS), of which `/etc/passwd` is only one possible backend.

Updated the DESCRIPTION wording and linked `nsswitch(5)` in SEE ALSO.

Fixes #4537