### PR TITLE
lscpu: add flags to ARM implementer and part tables

### DIFF
--- a/sys-utils/lscpu-arm.c
+++ b/sys-utils/lscpu-arm.c
@@ -18,9 +18,18 @@
 #include "lscpu.h"
 #include <libsmartcols.h>
 
+/*
+ * Flags for id_part and hw_impl. The effective flags for a part are
+ * (hw_impl.flags | id_part.flags), so a flag set at either level applies.
+ */
+#define FL_FOLLOW_KERNEL	(1 << 0)  /* prefer /proc/cpuinfo modelname */
+#define FL_FOLLOW_BIOS		(1 << 1)  /* prefer DMI bios_modelname */
+
 struct id_part {
     const int id;
     const char* name;
+    const unsigned int flags;
+    const char *bios_modelname_match;	/* substring required in DMI model name */
 };
 
 static const struct id_part arm_part[] = {
@@ -267,10 +276,13 @@ static const struct id_part fujitsu_part[] = {
 };
 
 static const struct id_part hisi_part[] = {
-    { 0xd01, "TaiShan-v110" },	/* used in Kunpeng-920 SoC */
-    { 0xd02, "TaiShan-v120" },	/* used in Kirin 990A and 9000S SoCs */
-    { 0xd40, "Cortex-A76" },	/* HiSilicon uses this ID though advertises A76 */
-    { 0xd41, "Cortex-A77" },	/* HiSilicon uses this ID though advertises A77 */
+    { 0xd01, "Kunpeng-920",  FL_FOLLOW_BIOS, "Kunpeng" },
+    { 0xd02, "Kunpeng-920",  FL_FOLLOW_BIOS, "Kunpeng" },
+    { 0xd03, "Kunpeng-920",  FL_FOLLOW_BIOS, "Kunpeng" },
+    { 0xd06, "Kunpeng-950",  FL_FOLLOW_BIOS, "Kunpeng" },
+    { 0xd22, "Kunpeng-920",  FL_FOLLOW_BIOS, "Kunpeng" },
+    { 0xd40, "Cortex-A76" },				/* HiSilicon uses this ID though advertises A76 */
+    { 0xd41, "Cortex-A77" },				/* HiSilicon uses this ID though advertises A77 */
     { -1, "unknown" },
 };
 
@@ -300,13 +312,11 @@ static const struct id_part unknown_part[] = {
     { -1, "unknown" },
 };
 
-#define HW_IMPL_NOOVERWRITE	true	/* don't overwrite vendor and model from /proc/cpuinfo */
-
 struct hw_impl {
    const int    id;
    const struct id_part     *parts;
    const char   *name;
-   const bool   nooverwrite;
+   const unsigned int flags;
 };
 
 static const struct hw_impl hw_implementer[] = {
@@ -327,7 +337,7 @@ static const struct hw_impl hw_implementer[] = {
     { 0x66, faraday_part, "Faraday" },
     { 0x69, intel_part,   "Intel" },
     { 0x6d, ms_part,      "Microsoft" },
-    { 0x70, ft_part,      "Phytium",  HW_IMPL_NOOVERWRITE },
+    { 0x70, ft_part,      "Phytium",  FL_FOLLOW_KERNEL },
     { 0xc0, ampere_part,  "Ampere" },
     { -1,   unknown_part, "unknown" },
 };
@@ -381,6 +391,14 @@ static const struct hw_impl *find_implementer(int id)
 	return NULL;
 }
 
+static bool bios_modelname_is_compatible(const struct id_part *part,
+					 const char *bios_modelname)
+{
+	return bios_modelname &&
+	       (!part->bios_modelname_match ||
+		strstr(bios_modelname, part->bios_modelname_match));
+}
+
 int is_arm(struct lscpu_cxt *cxt)
 {
 	size_t i;
@@ -416,7 +434,9 @@ static int arm_ids_decode(struct lscpu_cputype *ct)
 		return 0;
 
 	/* decode vendor */
-	if (!ct->vendor || !hw->nooverwrite) {
+	if ((hw->flags & FL_FOLLOW_KERNEL) && ct->vendor)
+		;	/* keep vendor from /proc/cpuinfo */
+	else {
 		free(ct->vendor);
 		ct->vendor = xstrdup(hw->name);
 	}
@@ -428,10 +448,16 @@ static int arm_ids_decode(struct lscpu_cputype *ct)
 
 	for (j = 0; hw->parts[j].id != -1; j++) {
 		if (hw->parts[j].id == part) {
-			if (!ct->modelname || !hw->nooverwrite) {
-				free(ct->modelname);
+			unsigned int flags = hw->flags | hw->parts[j].flags;
+
+			if ((flags & FL_FOLLOW_KERNEL) && ct->modelname)
+				break;
+			free(ct->modelname);
+			if ((flags & FL_FOLLOW_BIOS) &&
+			    bios_modelname_is_compatible(&hw->parts[j], ct->bios_modelname))
+				ct->modelname = xstrdup(ct->bios_modelname);
+			else
 				ct->modelname = xstrdup(hw->parts[j].name);
-			}
 			break;
 		}
 	}


### PR DESCRIPTION
## Summary

- Replace the boolean `nooverwrite` field in `struct hw_impl` with an `unsigned int flags` field, shared between `hw_impl` and `id_part` structs. The effective flags for a part are `(hw_impl.flags | id_part.flags)`, so a flag set at either level applies.
- Define `FL_FOLLOW_KERNEL` (prefer `/proc/cpuinfo` modelname) and `FL_FOLLOW_BIOS` (prefer DMI `bios_modelname`), with the table name as fallback in both cases.
- Convert the existing Phytium `nooverwrite` to `FL_FOLLOW_KERNEL`.
- Add HiSilicon Kunpeng part IDs (`0xd02`, `0xd03`, `0xd06`, `0xd22`) with `FL_FOLLOW_BIOS` to prefer DMI-provided model name.

Based on discussion in https://github.com/util-linux/util-linux/pull/4531.
