### PR TITLE
treewide: use proper types for microsecond and millisecond values

### DIFF
--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -51,6 +51,7 @@
 #include "rpmatch.h"
 #include "optutils.h"
 #include "ttyutils.h"
+#include "timeutils.h"
 
 #include "libfdisk.h"
 #include "fdisk-list.h"
@@ -577,7 +578,7 @@ static int move_partition_data(struct sfdisk *sf, size_t partno, struct fdisk_pa
 			fprintf(f, "%05zu: %12ju %12ju\n", cc, src, dst);
 
 		if (progress && i % 10 == 0) {
-			unsigned int elapsed = 0;	/* usec */
+			usec_t elapsed = 0;
 			struct timeval cur_time;
 
 			gettimeofday(&cur_time, NULL);

--- a/include/all-io.h
+++ b/include/all-io.h
@@ -18,6 +18,7 @@
 #endif
 
 #include "c.h"
+#include "timeutils.h"
 #include "vfs.h"
 
 static inline int __write_all(const struct ul_vfs_ops *vfs, int fd,

--- a/include/c.h
+++ b/include/c.h
@@ -473,28 +473,6 @@ static inline bool is_privileged_execution(void)
 #endif
 }
 
-/*
- * The usleep function was marked obsolete in POSIX.1-2001 and was removed
- * in POSIX.1-2008.  It was replaced with nanosleep() that provides more
- * advantages (like no interaction with signals and other timer functions).
- */
-#include <time.h>
-
-static inline int xusleep(useconds_t usec)
-{
-#ifdef HAVE_NANOSLEEP
-	struct timespec waittime = {
-		.tv_sec   =  usec / 1000000L,
-		.tv_nsec  = (usec % 1000000L) * 1000
-	};
-	return nanosleep(&waittime, NULL);
-#elif defined(HAVE_USLEEP)
-	return usleep(usec);
-#else
-# error	"System with usleep() or nanosleep() required!"
-#endif
-}
-
 /* ul_sig_printf is signal safe as long you don't use floating point formats,
    positional arguments or wide characters.*/
 #define ul_sig_printf(fmt, ...) ignore_result(dprintf(STDERR_FILENO, fmt, __VA_ARGS__))

--- a/include/timeutils.h
+++ b/include/timeutils.h
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <inttypes.h>
+#include <time.h>
 #include <sys/time.h>
 #include <stdbool.h>
 
@@ -117,4 +118,25 @@ static inline double time_diff(const struct timeval *a, const struct timeval *b)
 {
 	return (a->tv_sec - b->tv_sec) + (a->tv_usec - b->tv_usec) / (double) USEC_PER_SEC;
 }
+
+/*
+ * The usleep function was marked obsolete in POSIX.1-2001 and was removed
+ * in POSIX.1-2008.  It was replaced with nanosleep() that provides more
+ * advantages (like no interaction with signals and other timer functions).
+ */
+static inline int xusleep(usec_t usec)
+{
+#ifdef HAVE_NANOSLEEP
+	struct timespec waittime = {
+		.tv_sec   =  usec / USEC_PER_SEC,
+		.tv_nsec  = (usec % USEC_PER_SEC) * NSEC_PER_USEC
+	};
+	return nanosleep(&waittime, NULL);
+#elif defined(HAVE_USLEEP)
+	return usleep(usec);
+#else
+# error	"System with usleep() or nanosleep() required!"
+#endif
+}
+
 #endif /* UTIL_LINUX_TIME_UTIL_H */

--- a/include/timeutils.h
+++ b/include/timeutils.h
@@ -20,6 +20,7 @@
 #include <sys/time.h>
 #include <stdbool.h>
 
+typedef uint64_t msec_t;
 typedef uint64_t usec_t;
 typedef uint64_t nsec_t;
 

--- a/lib/loopdev.c
+++ b/lib/loopdev.c
@@ -35,6 +35,7 @@
 
 #include "linux_version.h"
 #include "c.h"
+#include "timeutils.h"
 #include "sysfs.h"
 #include "pathnames.h"
 #include "loopdev.h"

--- a/lib/randutils.c
+++ b/lib/randutils.c
@@ -17,6 +17,7 @@
 #include <sys/syscall.h>
 #endif
 #include "c.h"
+#include "timeutils.h"
 #include "randutils.h"
 #include "nls.h"
 

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -144,7 +144,7 @@ static int parse_sec(const char *t, usec_t *usec)
 static int parse_subseconds(const char *t, usec_t *usec)
 {
 	usec_t ret = 0;
-	int factor = USEC_PER_SEC / 10;
+	usec_t factor = USEC_PER_SEC / 10;
 
 	if (*t != '.' && *t != ',')
 		return -1;

--- a/libmount/src/lock.c
+++ b/libmount/src/lock.c
@@ -340,7 +340,7 @@ static int test_lock(struct libmnt_test *ts __attribute__((unused)),
 		     int argc, char *argv[])
 {
 	time_t synctime = 0;
-	unsigned int usecs;
+	usec_t usecs;
 	const char *datafile = NULL;
 	int verbose = 0, loops = 0, l, idx = 1;
 

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -55,6 +55,7 @@
 #endif
 
 #include "c.h"
+#include "timeutils.h"
 #include "closestream.h"
 #include "env.h"
 #include "nls.h"

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -444,9 +444,15 @@ static void server_loop(const char *socket_path, const char *pidfile_path,
 	pfd[POLLFD_SIGNAL].events = pfd[POLLFD_SOCKET].events = POLLIN | POLLERR | POLLHUP;
 
 	while (1) {
-		ret = poll(pfd, ARRAY_SIZE(pfd),
-				uuidd_cxt->timeout ?
-					(int) uuidd_cxt->timeout * 1000 : -1);
+		int poll_timeout = -1;
+
+		if (uuidd_cxt->timeout) {
+			msec_t msec = (msec_t) uuidd_cxt->timeout * MSEC_PER_SEC;
+
+			poll_timeout = msec > INT_MAX ? INT_MAX : (int) msec;
+		}
+
+		ret = poll(pfd, ARRAY_SIZE(pfd), poll_timeout);
 		if (ret < 0) {
 			if (errno == EAGAIN)
 				continue;

--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -70,7 +70,7 @@
  * time or less, the tray was probably already ejected, so we close it
  * again.
  */
-#define TRAY_WAS_ALREADY_OPEN_USECS  200000	/* about 0.2 seconds */
+#define TRAY_WAS_ALREADY_OPEN_USECS  ((usec_t) 200000)	/* about 0.2 seconds */
 
 struct eject_control {
 	struct libmnt_table *mtab;
@@ -443,7 +443,7 @@ static void toggle_tray(int fd)
 	}
 #else
 	struct timeval time_start, time_stop;
-	int time_elapsed;
+	usec_t time_elapsed;
 
 	/* Try to open the CDROM tray and measure the time therefore
 	 * needed.  In my experience the function needs less than 0.05

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -152,9 +152,9 @@ static void hwclock_init_debug(const char *str)
 /* FOR TESTING ONLY: inject random delays of up to 1000ms */
 static void up_to_1000ms_sleep(void)
 {
-	int usec = random() % 1000000;
+	usec_t usec = (usec_t) random() % USEC_PER_SEC;
 
-	DBG(RANDOM_SLEEP, ul_debug("sleeping ~%d usec", usec));
+	DBG(RANDOM_SLEEP, ul_debug("sleeping ~%ju usec", (uintmax_t) usec));
 	xusleep(usec);
 }
 

--- a/sys-utils/losetup.c
+++ b/sys-utils/losetup.c
@@ -26,6 +26,7 @@
 #include <libsmartcols.h>
 
 #include "c.h"
+#include "timeutils.h"
 #include "cctype.h"
 #include "nls.h"
 #include "strutils.h"


### PR DESCRIPTION
Introduce `msec_t` and fix variables holding microsecond or millisecond
values that used `int` or `unsigned int` instead of `usec_t`/`msec_t`. This
avoids potential overflow on large time differences and improves type
consistency with the `timeutils.h` conventions.

 - eject: use `usec_t` for `time_elapsed` and `TRAY_WAS_ALREADY_OPEN_USECS`
 - sfdisk: use `usec_t` for `elapsed` (was `unsigned int`, overflow after ~71 min)
 - timeutils: use `usec_t` for `factor` in `parse_subseconds()`
 - libmount: use `usec_t` for `usecs` in `test_lock()`
 - hwclock: use `usec_t` for `usec` in `up_to_1000ms_sleep()`
 - uuidd: fix poll timeout overflow by using `msec_t` with `INT_MAX` clamp