### PR TITLE
setpriv: report disabled landlock feature or missing sys support

### DIFF
--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -126,9 +126,18 @@ static int supported_landlock_abi(void)
 	static int abi = -1;
 
 	if (abi < 0) {
+		errno = 0;
 		abi = landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION);
-		if (abi <= 0)
-			err(EXIT_FAILURE, _("landlock is not supported"));
+		if (abi <= 0) {
+			switch (errno) {
+			case ENOSYS:
+				err(EXIT_FAILURE, _("landlock is not supported"));
+			case EOPNOTSUPP:
+				err(EXIT_FAILURE, _("landlock is supported but currently disabled"));
+			default:
+				err(EXIT_FAILURE, _("failed to obtain Landlock ABI version"));
+			}
+		}
 	}
 	return abi;
 }

--- a/sys-utils/setpriv-landlock.c
+++ b/sys-utils/setpriv-landlock.c
@@ -131,9 +131,9 @@ static int supported_landlock_abi(void)
 		if (abi <= 0) {
 			switch (errno) {
 			case ENOSYS:
-				err(EXIT_FAILURE, _("landlock is not supported"));
+				err(EXIT_FAILURE, _("Landlock is not supported"));
 			case EOPNOTSUPP:
-				err(EXIT_FAILURE, _("landlock is supported but currently disabled"));
+				err(EXIT_FAILURE, _("Landlock is supported but currently disabled"));
 			default:
 				err(EXIT_FAILURE, _("failed to obtain Landlock ABI version"));
 			}
@@ -169,7 +169,7 @@ static uint64_t parse_landlock_fs_access(const char *list)
 
 	if (string_to_bitmask(list, &r, landlock_access_to_mask))
 		errx(EXIT_FAILURE,
-		     _("could not parse landlock fs access: %s"), list);
+		     _("could not parse Landlock fs access: %s"), list);
 
 	return r;
 }
@@ -199,10 +199,10 @@ void parse_landlock_rule(struct setpriv_landlock_opts *opts, const char *str)
 
 	accesses = ul_startswith(str, "path-beneath:");
 	if (!accesses)
-		errx(EXIT_FAILURE, _("invalid landlock rule: %s"), str);
+		errx(EXIT_FAILURE, _("invalid Landlock rule: %s"), str);
 	path = strchr(accesses, ':');
 	if (!path)
-		errx(EXIT_FAILURE, _("invalid landlock rule: %s"), str);
+		errx(EXIT_FAILURE, _("invalid Landlock rule: %s"), str);
 	rule->rule_type = LANDLOCK_RULE_PATH_BENEATH;
 
 	accesses_part = xstrndup(accesses, path - accesses);
@@ -216,7 +216,7 @@ void parse_landlock_rule(struct setpriv_landlock_opts *opts, const char *str)
 
 	parent_fd = open(path, O_RDONLY | O_PATH | O_CLOEXEC);
 	if (parent_fd == -1)
-		err(EXIT_FAILURE, _("could not open file for landlock: %s"), path);
+		err(EXIT_FAILURE, _("could not open file for Landlock: %s"), path);
 
 	rule->path_beneath_attr.parent_fd = parent_fd;
 
@@ -265,11 +265,11 @@ void do_landlock(const struct setpriv_landlock_opts *opts)
 
 		ret = landlock_add_rule(fd, rule->rule_type, &path_beneath_attr, 0);
 		if (ret == -1)
-			err(SETPRIV_EXIT_PRIVERR, _("adding landlock rule failed"));
+			err(SETPRIV_EXIT_PRIVERR, _("adding Landlock rule failed"));
 	}
 
 	if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == -1)
-		err(SETPRIV_EXIT_PRIVERR, _("disallow granting new privileges for landlock failed"));
+		err(SETPRIV_EXIT_PRIVERR, _("disallow granting new privileges for Landlock failed"));
 
 	if (landlock_restrict_self(fd, 0) == -1)
 		err(SETPRIV_EXIT_PRIVERR, _("landlock_restrict_self failed"));
@@ -280,16 +280,16 @@ void usage_landlock(FILE *out)
 	size_t i;
 
 	fputs(USAGE_ARGUMENTS, out);
-	fputs(_(" <access> is a landlock access; syntax is fs[:<right>, ...>]\n"), out);
-	fputs(_(" <rule> is a landlock rule; syntax is <type>:<right>:<argument>\n"), out);
+	fputs(_(" <access> is a Landlock access; syntax is fs[:<right>, ...>]\n"), out);
+	fputs(_(" <rule> is a Landlock rule; syntax is <type>:<right>:<argument>\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	fputs(_(" available landlock rule types are:\n"), out);
+	fputs(_(" available Landlock rule types are:\n"), out);
 	/* TRANSLATORS: Keep *{path-beneath}* untranslated, it's a type name */
 	fputs(_("  path-beneath - filesystem based rule; <argument> is a path\n"), out);
 
 	fputs(USAGE_SEPARATOR, out);
-	fputs(_(" available landlock filesystems rights are:\n"), out);
+	fputs(_(" available Landlock filesystems rights are:\n"), out);
 	for (i = 0; i < ARRAY_SIZE(landlock_access_fs); i++) {
 		fprintf(out, "  %12s - %s\n", landlock_access_fs[i].type,
 					_(landlock_access_fs[i].help));
@@ -338,7 +338,7 @@ void list_landlock_rights(const char *access)
 	size_t i;
 
 	if (strcmp(access, "fs") != 0)
-		errx(EXIT_FAILURE, _("unknown landlock access: %s"), access);
+		errx(EXIT_FAILURE, _("unknown Landlock access: %s"), access);
 
 	mask = landlock_abi_fs_mask();
 	for (i = 0; i < ARRAY_SIZE(landlock_access_fs); i++)

--- a/sys-utils/setpriv-landlock.h
+++ b/sys-utils/setpriv-landlock.h
@@ -44,19 +44,19 @@ static inline void parse_landlock_access(
 		void *opts __attribute__((unused)),
 		const char *str __attribute__((unused)))
 {
-	errx(EXIT_FAILURE, _("no support for landlock"));
+	errx(EXIT_FAILURE, _("no support for Landlock"));
 }
 #define parse_landlock_rule parse_landlock_access
 static inline void init_landlock_opts(void *opts __attribute__((unused))) {}
 static inline void usage_landlock(FILE *out __attribute__((unused))) {}
 static inline void list_landlock_support(void)
 {
-	errx(EXIT_FAILURE, _("no support for landlock"));
+	errx(EXIT_FAILURE, _("no support for Landlock"));
 }
 #define list_landlock_access list_landlock_support
 static inline void list_landlock_rights(const char *access __attribute__((unused)))
 {
-	errx(EXIT_FAILURE, _("no support for landlock"));
+	errx(EXIT_FAILURE, _("no support for Landlock"));
 }
 
 #endif /* HAVE_LANDLOCK */

--- a/sys-utils/setpriv.1.adoc
+++ b/sys-utils/setpriv.1.adoc
@@ -102,7 +102,7 @@ Request a particular SELinux transition (using a transition on exec, not dyntran
 Request a particular AppArmor profile (using a transition on exec). This will fail and cause *setpriv* to abort if AppArmor is not in use, and the transition may be ignored or cause *execve*(2) to fail at AppArmor's whim.
 
 *--landlock-access* _access_::
-Enable landlock restrictions for a specific set of system accesses.
+Enable Landlock restrictions for a specific set of system accesses.
 To allow specific subgroups of accesses use *--landlock-rule*.
 +
 Block all filesystem access:
@@ -131,14 +131,14 @@ For example grant file read access to everything under */boot*:
 *--landlock-rule path-beneath:read-file:/boot*
 
 *--landlock-support*::
-List the landlock ABI version supported by the running kernel, together with the access
+List the Landlock ABI version supported by the running kernel, together with the access
 categories, rights, and rule types that *setpriv* understands. Must be specified alone.
 
 *--list-landlock-access*::
-List the landlock access categories supported by *--landlock-access* and *--landlock-rule*.
+List the Landlock access categories supported by *--landlock-access* and *--landlock-rule*.
 
 *--list-landlock-rights* _access_::
-List the rights of the given landlock access category that are supported by the running
+List the rights of the given Landlock access category that are supported by the running
 kernel.
 
 *--seccomp-filter* _file_::


### PR DESCRIPTION
On systems where landlock is supported but disabled via kernel command line options or else, we report missing support. Let's be more precise and let users know whether the feature is disabled or really missing system support.