### PR TITLE
libmount: don't ignore "/" target in mount --all when target prefix is set

### DIFF
--- a/libmount/src/context_mount.c
+++ b/libmount/src/context_mount.c
@@ -1187,8 +1187,9 @@ int mnt_context_next_mount(struct libmnt_context *cxt,
 	/*  ignore swap */
 	if (mnt_fs_is_swaparea(*fs) ||
 
-	/* ignore root filesystem */
-	   (tgt && (strcmp(tgt, "/") == 0 || strcmp(tgt, "root") == 0)) ||
+	/* ignore root filesystem (but not with --target-prefix) */
+	   (tgt && !mnt_context_get_target_prefix(cxt) &&
+		   (strcmp(tgt, "/") == 0 || strcmp(tgt, "root") == 0)) ||
 
 	/* ignore noauto filesystems */
 	   (o && mnt_optstr_get_option(o, "noauto", NULL, NULL) == 0) ||


### PR DESCRIPTION
When `--target-prefix` is used with `mount --all`, the root filesystem
entry (`/`) should not be skipped because the actual mount target will
be the prefix path (e.g., `/mnt`), not `/`.

The check in `mnt_context_next_mount()` now skips the "ignore root"
logic when a target prefix is set.

Fixes: https://github.com/util-linux/util-linux/issues/4545