### PR TITLE
treewide: replace magic numbers with USEC_PER_SEC and friends

### DIFF
--- a/disk-utils/sfdisk.c
+++ b/disk-utils/sfdisk.c
@@ -583,11 +583,11 @@ static int move_partition_data(struct sfdisk *sf, size_t partno, struct fdisk_pa
 
 			gettimeofday(&cur_time, NULL);
 			if (cur_time.tv_sec - prev_time.tv_sec > 1) {
-				elapsed = ((cur_time.tv_sec - prev_time.tv_sec) * 1000000) +
+				elapsed = ((cur_time.tv_sec - prev_time.tv_sec) * USEC_PER_SEC) +
 					  (cur_time.tv_usec - prev_time.tv_usec);
 
 				bytes_per_sec = ((i - prev) * ss) / elapsed;	/* per usec */
-				bytes_per_sec *= 1000000;			/* per sec */
+				bytes_per_sec *= USEC_PER_SEC;			/* per sec */
 
 				prev_time = cur_time;
 				prev = i;

--- a/lib/monotonic.c
+++ b/lib/monotonic.c
@@ -70,7 +70,7 @@ int gettime_monotonic(struct timeval *tv)
 	/* Linux specific, can't slew */
 	if (!(ret = clock_gettime(UL_CLOCK_MONOTONIC, &ts))) {
 		tv->tv_sec = ts.tv_sec;
-		tv->tv_usec = ts.tv_nsec / 1000;
+		tv->tv_usec = ts.tv_nsec / NSEC_PER_USEC;
 	}
 	return ret;
 #else

--- a/lib/strutils.c
+++ b/lib/strutils.c
@@ -19,6 +19,7 @@
 #include "cctype.h"
 #include "nls.h"
 #include "strutils.h"
+#include "timeutils.h"
 #include "bitops.h"
 #include "pathnames.h"
 
@@ -547,7 +548,7 @@ void strtotimeval_or_err(const char *str, struct timeval *tv, const char *errmes
 
 	user_input = strtold_or_err(str, errmesg);
 	tv->tv_sec = (time_t) user_input;
-	tv->tv_usec = (suseconds_t)((user_input - tv->tv_sec) * 1000000);
+	tv->tv_usec = (suseconds_t)((user_input - tv->tv_sec) * USEC_PER_SEC);
 }
 
 void strtotimespec_or_err(const char *str, struct timespec *ts, const char *errmesg)
@@ -556,7 +557,7 @@ void strtotimespec_or_err(const char *str, struct timespec *ts, const char *errm
 
 	user_input = strtold_or_err(str, errmesg);
 	ts->tv_sec = (time_t) user_input;
-	ts->tv_nsec = (long)((user_input - ts->tv_sec) * 1000000000);
+	ts->tv_nsec = (long)((user_input - ts->tv_sec) * NSEC_PER_SEC);
 }
 
 time_t strtotime_or_err(const char *str, const char *errmesg)

--- a/lib/timer.c
+++ b/lib/timer.c
@@ -11,6 +11,7 @@
 #include <sys/time.h>
 
 #include "c.h"
+#include "timeutils.h"
 #include "timer.h"
 
 /*
@@ -44,9 +45,9 @@ int setup_timer(struct ul_timer *timer,
 	};
 	struct itimerspec val = {
 		.it_value.tv_sec = sec,
-		.it_value.tv_nsec = usec * 1000,
+		.it_value.tv_nsec = usec * NSEC_PER_USEC,
 		.it_interval.tv_sec = sec / 100,
-		.it_interval.tv_nsec = (sec ? sec % 100 : 1) * 10*1000*1000
+		.it_interval.tv_nsec = (sec ? sec % 100 : 1) * 10 * NSEC_PER_MSEC
 	};
 
 	if (sigemptyset(&sig_a.sa_mask))

--- a/libblkid/src/verify.c
+++ b/libblkid/src/verify.c
@@ -22,6 +22,7 @@
 
 #include "blkidP.h"
 #include "sysfs.h"
+#include "timeutils.h"
 
 static void blkid_probe_to_tags(blkid_probe pr, blkid_dev dev)
 {
@@ -82,7 +83,7 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 #ifdef HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC
 	    (st.st_mtime < dev->bid_time ||
 	        (st.st_mtime == dev->bid_time &&
-		 st.st_mtim.tv_nsec / 1000 <= dev->bid_utime)) &&
+		 (suseconds_t) (st.st_mtim.tv_nsec / NSEC_PER_USEC) <= dev->bid_utime)) &&
 #else
 	    st.st_mtime <= dev->bid_time &&
 #endif
@@ -101,7 +102,7 @@ blkid_dev blkid_verify(blkid_cache cache, blkid_dev dev)
 		   "time since last check %lld)",
 		   dev->bid_name,
 		   (long long)dev->bid_time, (long long)dev->bid_utime,
-		   (long long)st.st_mtime, (long long)st.st_mtim.tv_nsec / 1000,
+		   (long long)st.st_mtime, (long long) (st.st_mtim.tv_nsec / NSEC_PER_USEC),
 		   (long long)diff));
 #endif
 

--- a/libuuid/src/gen_uuid.c
+++ b/libuuid/src/gen_uuid.c
@@ -108,11 +108,11 @@ static void gettimeofday (struct timeval *tv, void *dummy)
 	     + (uint64_t) ftime.dwLowDateTime);
 	if (n) {
 		n /= 10;
-		n -= ((369 * 365 + 89) * (uint64_t) 86400) * 1000000;
+		n -= ((369 * 365 + 89) * (uint64_t) 86400) * USEC_PER_SEC;
 	}
 
-	tv->tv_sec = n / 1000000;
-	tv->tv_usec = n % 1000000;
+	tv->tv_sec = n / USEC_PER_SEC;
+	tv->tv_usec = n % USEC_PER_SEC;
 }
 
 static int getuid (void)
@@ -337,8 +337,8 @@ try_again:
 		adjustment += *num - 1;
 		last.tv_usec += adjustment / 10;
 		adjustment = adjustment % 10;
-		last.tv_sec += last.tv_usec / 1000000;
-		last.tv_usec = last.tv_usec % 1000000;
+		last.tv_sec += last.tv_usec / USEC_PER_SEC;
+		last.tv_usec = last.tv_usec % USEC_PER_SEC;
 	}
 
 	if (state_fd >= 0) {

--- a/login-utils/last.c
+++ b/login-utils/last.c
@@ -1090,17 +1090,17 @@ int main(int argc, char **argv)
 		case 'p':
 			if (ul_parse_timestamp(optarg, &p) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
-			ctl.present = (time_t) (p / 1000000);
+			ctl.present = (time_t) (p / USEC_PER_SEC);
 			break;
 		case 's':
 			if (ul_parse_timestamp(optarg, &p) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
-			ctl.since = (time_t) (p / 1000000);
+			ctl.since = (time_t) (p / USEC_PER_SEC);
 			break;
 		case 't':
 			if (ul_parse_timestamp(optarg, &p) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
-			ctl.until = (time_t) (p / 1000000);
+			ctl.until = (time_t) (p / USEC_PER_SEC);
 			break;
 		case 'w':
 			ctl.fullnames_mode = true;

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -1423,7 +1423,7 @@ static void print_journal_tail(const char *journal_path, uid_t uid, size_t len, 
 		time_t t;
 
 		systemd_call(sd_journal_get_realtime_usec)(j, &x);
-		t = x / 1000000;
+		t = x / USEC_PER_SEC;
 		ts = make_time(time_mode, t);
 
 		id = get_journal_data(j, "SYSLOG_IDENTIFIER");

--- a/misc-utils/cal.c
+++ b/misc-utils/cal.c
@@ -464,7 +464,7 @@ int main(int argc, char **argv)
 		usec_t x;
 		/* cal <timestamp> */
 		if (ul_parse_timestamp(*argv, &x) == 0)
-			now = (time_t) (x / 1000000);
+			now = (time_t) (x / USEC_PER_SEC);
 		/* cal <monthname> */
 		else if ((ctl.req.month = monthname_to_number(&ctl, *argv)) > 0)
 			cal_time(&now);	/* this year */

--- a/sys-utils/hwclock.c
+++ b/sys-utils/hwclock.c
@@ -1565,7 +1565,7 @@ int main(int argc, char **argv)
 		usec_t usec;
 
 		if (ul_parse_timestamp(ctl.date_opt, &usec) == 0)
-			set_time = (time_t) (usec / 1000000);
+			set_time = (time_t) (usec / USEC_PER_SEC);
 #endif
 		else {
 			warnx(_("invalid date '%s'"), ctl.date_opt);

--- a/sys-utils/rtcwake.c
+++ b/sys-utils/rtcwake.c
@@ -521,7 +521,7 @@ int main(int argc, char **argv)
 			usec_t p;
 			if (ul_parse_timestamp(optarg, &p) < 0)
 				errx(EXIT_FAILURE, _("invalid time value \"%s\""), optarg);
-			alarm = (time_t) (p / 1000000);
+			alarm = (time_t) (p / USEC_PER_SEC);
 			break;
 		}
 		case 'u':

--- a/term-utils/script-playutils.c
+++ b/term-utils/script-playutils.c
@@ -15,6 +15,7 @@
 #include "closestream.h"
 #include "nls.h"
 #include "strutils.h"
+#include "timeutils.h"
 #include "script-playutils.h"
 
 UL_DEBUG_DEFINE_MASK(scriptreplay);
@@ -499,14 +500,14 @@ done:
 		 * 1.000000 s delay scaled by divisor 2 became 0.000000 s rather
 		 * than the expected 0.500000 s.
 		 */
-		double total = (double) step->delay.tv_sec * 1000000.0
+		double total = (double) step->delay.tv_sec * (double) USEC_PER_SEC
 				+ (double) step->delay.tv_usec;
 
 		DBG(TIMING, ul_debug(" normalize delay: divide"));
 		total /= stp->delay_div;
-		step->delay.tv_sec  = (time_t) (total / 1000000.0);
+		step->delay.tv_sec  = (time_t) (total / (double) USEC_PER_SEC);
 		step->delay.tv_usec = (suseconds_t) (total
-				- (double) step->delay.tv_sec * 1000000.0);
+				- (double) step->delay.tv_sec * (double) USEC_PER_SEC);
 	}
 	if (timerisset(&stp->delay_max) &&
 	    timercmp(&step->delay, &stp->delay_max, >)) {

--- a/term-utils/scriptreplay.c
+++ b/term-utils/scriptreplay.c
@@ -38,6 +38,7 @@
 #include "closestream.h"
 #include "nls.h"
 #include "strutils.h"
+#include "timeutils.h"
 #include "optutils.h"
 #include "script-playutils.h"
 
@@ -101,7 +102,7 @@ delay_for(const struct timeval *delay)
 #ifdef HAVE_NANOSLEEP
 	struct timespec ts, remainder;
 	ts.tv_sec = (time_t) delay->tv_sec;
-	ts.tv_nsec = delay->tv_usec * 1000;
+	ts.tv_nsec = delay->tv_usec * NSEC_PER_USEC;
 
 	DBG(TIMING, ul_debug("going to sleep for %"PRId64".%06"PRId64,
 			(int64_t) delay->tv_sec, (int64_t) delay->tv_usec));


### PR DESCRIPTION
Use USEC_PER_SEC, NSEC_PER_SEC, NSEC_PER_USEC, and NSEC_PER_MSEC
constants from timeutils.h instead of hardcoded magic numbers for
time unit conversions.