### PR TITLE
lsfd: remove the entire " (deleted)" suffix from file names

### DIFF
--- a/lsfd-cmd/file.c
+++ b/lsfd-cmd/file.c
@@ -314,13 +314,13 @@ static bool file_fill_column(struct proc *proc __attribute__((__unused__)),
 	switch(column_id) {
 	case COL_NAME:
 		if (file->name && file->stat.st_nlink == 0) {
-			char *d = strnrstr(file->name, "(deleted)",
-					   sizeof("(deleted)") - 1);
+			char *d = strnrstr(file->name, " (deleted)",
+					   sizeof(" (deleted)") - 1);
 			if (d) {
 				int r;
 				*d = '\0';
 				r = scols_line_set_data(ln, column_index, file->name);
-				*d = '(';
+				*d = ' ';
 				if (r)
 					err(EXIT_FAILURE, _("failed to add output data"));
 				return true;

--- a/tests/expected/lsfd/column-name-deleted-file
+++ b/tests/expected/lsfd/column-name-deleted-file
@@ -1,2 +1,2 @@
-tmp-column-name 
+tmp-column-name
 make-regular-file: DELETED,NAME:  0

--- a/tests/expected/lsfd/option-hyperlink-deleted-file
+++ b/tests/expected/lsfd/option-hyperlink-deleted-file
@@ -1,7 +1,7 @@
 # NAME
 00000000  2e 2f 74 6d 70 2d 6f 70  74 69 6f 6e 2d 68 79 70  |./tmp-option-hyp|
-00000010  65 72 6c 69 6e 6b 20 0a                           |erlink .|
-00000018
+00000010  65 72 6c 69 6e 6b 0a                              |erlink.|
+00000017
 # KNAME
 00000000  2e 2f 74 6d 70 2d 6f 70  74 69 6f 6e 2d 68 79 70  |./tmp-option-hyp|
 00000010  65 72 6c 69 6e 6b 20 28  64 65 6c 65 74 65 64 29  |erlink (deleted)|


### PR DESCRIPTION
The /proc/pid/fd symlink target for a deleted file has " (deleted)" appended to the original file name. lsfd removed only "(deleted)", leaving the preceding space in the displayed name.

Remove the leading space together with "(deleted)" to restore the original file name.