### PR TITLE
unshare: support for systemd-nsresourced, `--map-foreign` option

### DIFF
--- a/bash-completion/unshare
+++ b/bash-completion/unshare
@@ -10,7 +10,7 @@ _unshare_module()
 
 	REQARGOPTS_SHORT="-l|-R|-w|-S|-G"
 
-	NOARGOPTS="--clear-env|--fork|--forward-signals|--map-root-user|--map-current-user|--map-auto|--map-subids|--keep-caps|--help|--version|${OPTARGOPTS//=/}"
+	NOARGOPTS="--clear-env|--fork|--forward-signals|--map-root-user|--map-current-user|--map-auto|--map-subids|--map-foreign|--keep-caps|--help|--version|${OPTARGOPTS//=/}"
 
 	NOARGOPTS_SHORT="-r|-f|-c|-h|-V|-m|-u|-i|-n|-p|-U|-C|-T"
 

--- a/configure.ac
+++ b/configure.ac
@@ -2777,6 +2777,7 @@ AC_ARG_WITH([systemd],
 )
 
 have_systemd=no
+have_systemd_varlink=no
 AS_IF([test "x$with_systemd" != xno], [
   # if 257 or newer, use locked system user accounts
   PKG_CHECK_MODULES([SYSTEMD], [libsystemd >= 257], [
@@ -2795,10 +2796,15 @@ AS_IF([test "x$with_systemd" != xno], [
        AC_CHECK_DECLS([sd_session_get_username], [], [], [#include <systemd/sd-login.h>])
        AC_CHECK_DECLS([sd_device_new_from_syspath], [], [], [#include <systemd/sd-device.h>])
        AC_CHECK_DECLS([sd_device_open], [], [], [#include <systemd/sd-device.h>])
+       dnl sd-varlink and sd-json are available since systemd-257
+       AC_CHECK_DECLS([sd_varlink_connect_address],
+		      [have_systemd_varlink=yes], [],
+		      [#include <systemd/sd-varlink.h>])
        AC_SUBST([SYSTEMD_USER_LOCK])
   )
 ])
 AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$have_systemd" = xyes])
+AM_CONDITIONAL([HAVE_SYSTEMD_VARLINK], [test "x$have_systemd_varlink" = xyes])
 
 AC_ARG_ENABLE([systemd-dlopen],
   AS_HELP_STRING([--enable-systemd-dlopen], [dlopen systemd at runtime instead of linking]),

--- a/include/Makemodule.am
+++ b/include/Makemodule.am
@@ -26,6 +26,7 @@ dist_noinst_HEADERS += \
 	include/dl-econf.h \
 	include/dl-selinux.h \
 	include/dl-systemd.h \
+	include/dl-systemd-varlink.h \
 	include/dl-utils.h \
 	include/encode.h \
 	include/env.h \

--- a/include/dl-systemd-varlink.h
+++ b/include/dl-systemd-varlink.h
@@ -1,0 +1,54 @@
+/*
+ * No copyright is claimed.  This code is in the public domain; do with
+ * it what you wish.
+ */
+#ifndef UTIL_LINUX_DL_SYSTEMD_VARLINK_H
+#define UTIL_LINUX_DL_SYSTEMD_VARLINK_H
+
+/*
+ * sd-varlink and sd-json are only available since systemd-257; users of this
+ * header have to check for HAVE_SYSTEMD_VARLINK rather than HAVE_LIBSYSTEMD.
+ */
+#if defined(HAVE_LIBSYSTEMD) && HAVE_DECL_SD_VARLINK_CONNECT_ADDRESS
+# define HAVE_SYSTEMD_VARLINK 1
+#endif
+
+#ifdef HAVE_SYSTEMD_VARLINK
+
+#include <systemd/sd-json.h>
+#include <systemd/sd-varlink.h>
+
+#ifdef USE_DLOPEN_SYSTEMD
+
+#include "dl-utils.h"
+
+/* Pointers to libsystemd functions (initialized by dlsym()) */
+struct ul_systemd_varlink_opers {
+	/* sd-varlink */
+	int (*sd_varlink_connect_address)(sd_varlink **, const char *);
+	int (*sd_varlink_set_allow_fd_passing_output)(sd_varlink *, int);
+	int (*sd_varlink_push_dup_fd)(sd_varlink *, int);
+	int (*sd_varlink_callb)(sd_varlink *, const char *, sd_json_variant **, const char **, ...);
+	sd_varlink *(*sd_varlink_close_unref)(sd_varlink *);
+	/* sd-json */
+	sd_json_variant *(*sd_json_variant_unref)(sd_json_variant *);
+};
+
+typedef struct ul_systemd_varlink_opers ul_systemd_varlink_opers;
+
+extern struct ul_systemd_varlink_opers ul_systemd_varlink;
+
+extern int ul_dlopen_libsystemd_varlink(void);
+
+#define systemd_varlink_call(_func)	(ul_systemd_varlink._func)
+
+#else /* !USE_DLOPEN_SYSTEMD */
+
+static inline int ul_dlopen_libsystemd_varlink(void) { return 0; }
+
+#define systemd_varlink_call(_func)	(_func)
+
+#endif /* USE_DLOPEN_SYSTEMD */
+
+#endif /* HAVE_SYSTEMD_VARLINK */
+#endif /* UTIL_LINUX_DL_SYSTEMD_VARLINK_H */

--- a/lib/Makemodule.am
+++ b/lib/Makemodule.am
@@ -110,6 +110,11 @@ if USE_DLOPEN_SYSTEMD
 systemd_sources += lib/dl-systemd.c
 endif
 
+systemd_varlink_sources = include/dl-systemd-varlink.h
+if USE_DLOPEN_SYSTEMD
+systemd_varlink_sources += lib/dl-systemd-varlink.c
+endif
+
 econf_sources = include/dl-econf.h
 if USE_DLOPEN_ECONF
 econf_sources += lib/dl-econf.c

--- a/lib/dl-systemd-varlink.c
+++ b/lib/dl-systemd-varlink.c
@@ -1,0 +1,50 @@
+/*
+ * No copyright is claimed.  This code is in the public domain; do with
+ * it what you wish.
+ */
+#include <dlfcn.h>
+
+#include "c.h"
+#include "dl-systemd-varlink.h"
+
+#if defined(HAVE_SYSTEMD_VARLINK) && defined(USE_DLOPEN_SYSTEMD)
+
+UL_ELF_NOTE_DLOPEN("systemd",
+		    "Support for systemd",
+		    UL_ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED,
+		    "libsystemd.so.0");
+
+struct ul_systemd_varlink_opers ul_systemd_varlink;
+
+static const struct ul_dlsym ul_systemd_varlink_symbols[] =
+{
+	UL_DLSYM( ul_systemd_varlink_opers, sd_varlink_connect_address ),
+	UL_DLSYM( ul_systemd_varlink_opers, sd_varlink_set_allow_fd_passing_output ),
+	UL_DLSYM( ul_systemd_varlink_opers, sd_varlink_push_dup_fd ),
+	UL_DLSYM( ul_systemd_varlink_opers, sd_varlink_callb ),
+	UL_DLSYM( ul_systemd_varlink_opers, sd_varlink_close_unref ),
+	UL_DLSYM( ul_systemd_varlink_opers, sd_json_variant_unref ),
+};
+
+int ul_dlopen_libsystemd_varlink(void)
+{
+	/* 0 = not tried, 1 = loaded, -1 = failed */
+	static int status = 0;
+	static void *dl = NULL;
+	int flags = RTLD_LAZY | RTLD_LOCAL;
+
+	if (status)
+		return status > 0 ? 0 : -ENOSYS;
+
+#ifdef RTLD_NODELETE
+	flags |= RTLD_NODELETE;
+#endif
+	status = ul_dlopen_symbols("libsystemd.so.0", flags,
+				   ul_systemd_varlink_symbols,
+				   ARRAY_SIZE(ul_systemd_varlink_symbols),
+				   &ul_systemd_varlink, &dl) == 0 ? 1 : -1;
+
+	return status > 0 ? 0 : -ENOSYS;
+}
+
+#endif /* HAVE_SYSTEMD_VARLINK && USE_DLOPEN_SYSTEMD */

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -56,6 +56,7 @@ dl_utils_c = files('dl-utils.c')
 dl_cryptsetup_c = files('dl-cryptsetup.c')
 dl_selinux_c = files('dl-selinux.c')
 dl_systemd_c = files('dl-systemd.c')
+dl_systemd_varlink_c = files('dl-systemd-varlink.c')
 dl_econf_c = files('dl-econf.c')
 
 logindefs_c = files('logindefs.c')

--- a/meson.build
+++ b/meson.build
@@ -452,6 +452,13 @@ have = cc.has_function(
   dependencies : lib_systemd)
 conf.set('HAVE_DECL_SD_SESSION_GET_USERNAME', have ? 1 : false)
 
+# Since systemd-257, which provides sd-varlink and sd-json.
+have_systemd_varlink = cc.has_header_symbol(
+  'systemd/sd-varlink.h',
+  'sd_varlink_connect_address',
+  dependencies : lib_systemd)
+conf.set('HAVE_DECL_SD_VARLINK_CONNECT_ADDRESS', have_systemd_varlink ? 1 : false)
+
 have = cc.has_function(
   'sd_device_new_from_devname',
   dependencies : lib_systemd)
@@ -1139,6 +1146,15 @@ endif
 selinux_sources = use_dlopen_selinux ? [dl_selinux_c] : []
 cryptsetup_sources = use_dlopen_cryptsetup ? [dl_cryptsetup_c] : []
 systemd_sources = use_dlopen_systemd ? [dl_systemd_c] : []
+
+systemd_varlink_sources = []
+systemd_varlink_deps = []
+if have_systemd_varlink
+  systemd_varlink_deps = systemd_deps
+  if use_dlopen_systemd
+    systemd_varlink_sources = [dl_systemd_varlink_c] + common_dl_sources
+  endif
+endif
 econf_sources = use_dlopen_econf ? [dl_econf_c] : []
 
 subdir('libblkid')
@@ -2276,10 +2292,10 @@ endif
 opt = get_option('build-unshare').allowed()
 exe = executable(
   'unshare',
-  unshare_sources,
+  unshare_sources, systemd_varlink_sources,
   include_directories : includes,
   link_with : [lib_common],
-  dependencies : [mount_dep],
+  dependencies : [mount_dep] + systemd_varlink_deps,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)
@@ -2292,10 +2308,10 @@ endif
 opt = opt and 'unshare' in static_programs
 exe = executable(
   'unshare.static',
-  unshare_sources,
+  unshare_sources, systemd_varlink_sources,
   include_directories : includes,
   link_with : [lib_common],
-  dependencies : [mount_dep],
+  dependencies : [mount_dep] + systemd_varlink_deps,
   install_dir : usrbin_exec_dir,
   install : opt,
   build_by_default : opt)

--- a/sys-utils/Makemodule.am
+++ b/sys-utils/Makemodule.am
@@ -542,6 +542,17 @@ unshare_SOURCES = sys-utils/unshare.c \
 unshare_LDADD = $(LDADD) libcommon.la
 unshare_CFLAGS = $(AM_CFLAGS) -I$(ul_libmount_incdir)
 
+if HAVE_SYSTEMD_VARLINK
+unshare_SOURCES += $(systemd_varlink_sources)
+if USE_DLOPEN_SYSTEMD
+unshare_SOURCES += $(common_dl_sources)
+unshare_LDADD += $(common_dl_ldadd)
+else
+unshare_LDADD += $(SYSTEMD_LIBS)
+endif
+unshare_CFLAGS += $(SYSTEMD_CFLAGS)
+endif
+
 if HAVE_STATIC_UNSHARE
 usrbin_exec_PROGRAMS += unshare.static
 unshare_static_SOURCES = $(unshare_SOURCES)

--- a/sys-utils/unshare.1.adoc
+++ b/sys-utils/unshare.1.adoc
@@ -142,6 +142,18 @@ Run the program only after the current effective user and group IDs have been ma
 *-c*, *--map-current-user*::
 Run the program only after the current effective user and group IDs have been mapped to the same UID and GID in the newly created user namespace. This option implies *--setgroups=deny* and *--user*. This option is equivalent to *--map-user=$(id -ru) --map-group=$(id -rg)*.
 
+*--map-foreign*::
+Map the foreign user ID range 1:1 into the new user namespace using *systemd-nsresourced.service*(8), so that processes inside can access files owned by that range. This option implies *--user* and *--map-current-user*.
+
+*systemd-nsresourced.service*(8) always maps the current uid and gid, so *--map-current-user* is enabled by default.
+The *--map-root-user* option is also supported.
++
+Unlike the other mapping options, the maps are installed by *systemd-nsresourced.service*(8) rather than by *unshare* itself. Since they are written by a privileged process, *--setgroups=deny* is _not_ implied; use *--setgroups=deny* explicitly if that is required.
++
+The remaining mapping options (*--map-user*, *--map-group*, *--map-users*, *--map-groups*, *--map-auto*, *--map-subids*) and *--owner* cannot be combined with *--map-foreign*.
++
+This option requires *unshare* to be built against systemd 257 or newer; mapping the foreign UID range additionally requires a *systemd-nsresourced.service*(8) that supports it.
+
 *--owner* __uid__**:**__gid__::
 Set the owner user and group when creating a user namespace. These determine which user in the parent namespace has CAP_SYS_ADMIN in the new child namespace and can *setns*(2) into it. This option allows a privileged user to create a namespace on behalf of an unprivileged one, using its privileges to map ids and/or bind mount the namespace into the filesystem. It implies *--user*.
 
@@ -235,6 +247,22 @@ $ ls -ln --time-style=+ file
 -rw-r--r-- 1 100000 100000 0  file
 ....
 
+The following example maps the current user to uid 0 and the foreign uid range 1:1 using *systemd-nsresourced.service*(8).
+
+....
+$ id -u
+1000
+$ id -u foreign-0
+2147352576
+$ unshare --user --map-foreign --map-root-user
+# id -u
+0
+# cat /proc/self/uid_map
+         0       1000          1
+2147352576 2147352576      65536
+# exit
+....
+
 The first of the following commands creates a new persistent UTS namespace and modifies the hostname as seen in that namespace. The namespace is then entered with *nsenter*(1) in order to display the modified hostname; this step demonstrates that the UTS namespace continues to exist even though the namespace had no member processes after the *unshare* command terminated. The namespace is then destroyed by removing the bind mount.
 
 ....
@@ -326,7 +354,8 @@ mailto:kzak@redhat.com[Karel Zak]
 *clone*(2),
 *unshare*(2),
 *namespaces*(7),
-*mount*(8)
+*mount*(8),
+*systemd-nsresourced.service*(8)
 
 include::man-common/bugreports.adoc[]
 

--- a/sys-utils/unshare.c
+++ b/sys-utils/unshare.c
@@ -50,6 +50,8 @@
 #include "pwdutils.h"
 #include "env.h"
 
+#include "dl-systemd-varlink.h"
+
 #ifndef HAVE_ENVIRON_DECL
 extern char **environ;
 #endif
@@ -87,6 +89,16 @@ enum {
 	SETGROUPS_DENY = 0,
 	SETGROUPS_ALLOW = 1,
 };
+
+#ifdef HAVE_SYSTEMD_VARLINK
+/* Request parameters for io.systemd.NamespaceResource.AllocateUserRange */
+struct userns_alloc {
+	int	target;		/* uid inside the namespace, -1 to leave unset */
+	bool	foreign;	/* map the foreign uid range */
+};
+
+static void allocate_user_range(int userns_fd, const struct userns_alloc *req);
+#endif
 
 static const char *setgroups_strings[] =
 {
@@ -791,6 +803,8 @@ static void __attribute__((__noreturn__)) usage(void)
 		"                           map count users from outeruid to inneruid (implies --user)\n"), out);
 	fputs(_(" --map-groups <innergid>:<outergid>:<count>\n"
 		"                           map count groups from outergid to innergid (implies --user)\n"), out);
+	fputs(_(" --map-foreign             map the foreign uid range via systemd-nsresourced\n"
+		"                           (implies --user and --map-current-user)\n"), out);
 	fputs(_(" --owner <uid>:<gid>       set the user namespace owner (implies --user)\n"), out);
 	fputs(USAGE_SEPARATOR, out);
 	fputs(_(" -f, --fork                fork before launching <program>\n"), out);
@@ -830,6 +844,7 @@ int main(int argc, char *argv[])
 		OPT_MAPGROUPS,
 		OPT_MAPAUTO,
 		OPT_MAPSUBIDS,
+		OPT_MAP_FOREIGN,
 		OPT_OWNER,
 		OPT_FORWARD_SIGNALS,
 		OPT_CLEAR_ENV,
@@ -861,6 +876,7 @@ int main(int argc, char *argv[])
 		{ "map-current-user", no_argument,    NULL, 'c'             },
 		{ "map-auto",      no_argument,       NULL, OPT_MAPAUTO     },
 		{ "map-subids",    no_argument,       NULL, OPT_MAPSUBIDS   },
+		{ "map-foreign",   no_argument,       NULL, OPT_MAP_FOREIGN },
 		{ "owner",         required_argument, NULL, OPT_OWNER       },
 		{ "propagation",   required_argument, NULL, OPT_PROPAGATION },
 		{ "setgroups",     required_argument, NULL, OPT_SETGROUPS   },
@@ -884,6 +900,15 @@ int main(int argc, char *argv[])
 	gid_t mapgroup = -1, ownergroup = -1;
 	struct map_range *usermap = NULL;
 	struct map_range *groupmap = NULL;
+	/* How the uid inside the namespace was requested; with
+	 * systemd-nsresourced this selects the "target" of the allocation. */
+	enum {
+		TARGET_UNSET = 0,	/* no mapping option given */
+		TARGET_ROOT,		/* --map-root-user */
+		TARGET_CURRENT,		/* --map-current-user */
+	} target_mode = TARGET_UNSET;
+	int map_foreign = 0;
+	int nsresourced_target = -1;
 	struct ul_env_list *env_whitelist = NULL; /* environment whitelist */
 	int kill_child_signo = 0; /* 0 means --kill-child was not used */
 	const char *procmnt = NULL;
@@ -985,11 +1010,13 @@ int main(int argc, char *argv[])
 			unshare_flags |= CLONE_NEWUSER;
 			mapuser = 0;
 			mapgroup = 0;
+			target_mode = TARGET_ROOT;
 			break;
 		case 'c':
 			unshare_flags |= CLONE_NEWUSER;
 			mapuser = real_euid;
 			mapgroup = real_egid;
+			target_mode = TARGET_CURRENT;
 			break;
 		case OPT_MAPUSERS:
 			unshare_flags |= CLONE_NEWUSER;
@@ -1026,6 +1053,10 @@ int main(int argc, char *argv[])
 			unshare_flags |= CLONE_NEWUSER;
 			insert_map_range(&usermap, read_subid_range(_PATH_SUBUID, real_euid, 1));
 			insert_map_range(&groupmap, read_subid_range(_PATH_SUBGID, real_euid, 1));
+			break;
+		case OPT_MAP_FOREIGN:
+			unshare_flags |= CLONE_NEWUSER;
+			map_foreign = 1;
 			break;
 		case OPT_OWNER:
 			unshare_flags |= CLONE_NEWUSER;
@@ -1106,6 +1137,51 @@ int main(int argc, char *argv[])
 	if ((force_monotonic || force_boottime) && !(unshare_flags & CLONE_NEWTIME))
 		errx(EXIT_FAILURE, _("options --monotonic and --boottime require "
 			"unsharing of a time namespace (-T)"));
+
+#ifndef HAVE_SYSTEMD_VARLINK
+	(void)nsresourced_target;
+	if (map_foreign)
+		errx(EXIT_FAILURE, _("systemd-nsresourced support is not available"));
+#endif
+
+	if (map_foreign) {
+		/* systemd-nsresourced installs the whole map itself, so
+		 * newuidmap/newgidmap cannot be combined with it. */
+		if (usermap || groupmap)
+			errx(EXIT_FAILURE, _("options --map-users, --map-groups, --map-auto "
+					     "and --map-subids are not supported with "
+					     "--map-foreign"));
+
+		/* only the "type": "self" allocation is available, so an
+		 * arbitrary --map-user/--map-group cannot be requested.  Note
+		 * that --map-root-user and --map-current-user set mapuser and
+		 * mapgroup too; those are distinguished by target_mode. */
+		if (target_mode == TARGET_UNSET &&
+		    (mapuser != MAX_OF_UINT_TYPE(uid_t) ||
+		     mapgroup != MAX_OF_UINT_TYPE(gid_t)))
+			errx(EXIT_FAILURE, _("options --map-user and --map-group "
+					     "are not supported with --map-foreign"));
+
+		/* --owner would make unshare fold the mapping into a
+		 * newuidmap/newgidmap child, which conflicts with letting
+		 * systemd-nsresourced install the map. */
+		if (owneruser != (uid_t) -1 || ownergroup != (gid_t) -1)
+			errx(EXIT_FAILURE, _("options --owner and --map-foreign "
+					     "are mutually exclusive"));
+
+		/* --map-root-user/--map-current-user select the "target" uid
+		 * of the systemd-nsresourced allocation.  Leaving the target
+		 * unset makes nsresourced map the caller to itself, which is
+		 * what --map-current-user asks for. */
+		switch (target_mode) {
+		case TARGET_UNSET:
+		case TARGET_CURRENT:
+			break;
+		case TARGET_ROOT:
+			nsresourced_target = 0;
+			break;
+		}
+	}
 
 	/* clear any inherited settings */
 	signal(SIGCHLD, SIG_DFL);
@@ -1273,19 +1349,41 @@ int main(int argc, char *argv[])
 #endif
 	}
 
-	if (mapuser != MAX_OF_UINT_TYPE(uid_t) && !usermap)
-		map_id(_PATH_PROC_UIDMAP, mapuser, real_euid);
+#ifdef HAVE_SYSTEMD_VARLINK
+	if (map_foreign) {
+		const struct userns_alloc req = {
+			.target    = nsresourced_target,
+			.foreign   = map_foreign,
+		};
+		int userns_fd;
 
-	/* Since Linux 3.19 unprivileged writing of /proc/self/gid_map
-	 * has been disabled unless /proc/self/setgroups is written
-	 * first to permanently disable the ability to call setgroups
-	 * in that user namespace. */
-	if (mapgroup != MAX_OF_UINT_TYPE(gid_t) && !groupmap) {
-		if (setgrpcmd == SETGROUPS_ALLOW)
-			errx(EXIT_FAILURE, _("options --setgroups=allow and "
-					"--map-group are mutually exclusive"));
-		setgroups_control(SETGROUPS_DENY);
-		map_id(_PATH_PROC_GIDMAP, mapgroup, real_egid);
+		if (ul_dlopen_libsystemd_varlink() < 0)
+			errx(EXIT_FAILURE, _("failed to load libsystemd"));
+
+		userns_fd = open(_PATH_PROC_NSDIR "/user", O_RDONLY | O_CLOEXEC);
+		if (userns_fd < 0)
+			err(EXIT_FAILURE, _("cannot open %s"), _PATH_PROC_NSDIR "/user");
+
+		allocate_user_range(userns_fd, &req);
+		close(userns_fd);
+	}
+#endif
+
+	if (!map_foreign) {
+		if (mapuser != MAX_OF_UINT_TYPE(uid_t) && !usermap)
+			map_id(_PATH_PROC_UIDMAP, mapuser, real_euid);
+
+		/* Since Linux 3.19 unprivileged writing of /proc/self/gid_map
+		 * has been disabled unless /proc/self/setgroups is written
+		 * first to permanently disable the ability to call setgroups
+		 * in that user namespace. */
+		if (mapgroup != MAX_OF_UINT_TYPE(gid_t) && !groupmap) {
+			if (setgrpcmd == SETGROUPS_ALLOW)
+				errx(EXIT_FAILURE, _("options --setgroups=allow and "
+						"--map-group are mutually exclusive"));
+			setgroups_control(SETGROUPS_DENY);
+			map_id(_PATH_PROC_GIDMAP, mapgroup, real_egid);
+		}
 	}
 
 	if (setgrpcmd != SETGROUPS_NONE)
@@ -1363,3 +1461,52 @@ int main(int argc, char *argv[])
 	}
 	exec_shell();
 }
+
+#ifdef HAVE_SYSTEMD_VARLINK
+
+#define NSRESOURCE_VARLINK_ADDRESS	"/run/systemd/io.systemd.NamespaceResource"
+
+static void allocate_user_range(int userns_fd, const struct userns_alloc *req)
+{
+	int r, userns_idx;
+	const char *error_id = NULL;
+	char name[32];
+	sd_varlink *vl = NULL;
+	sd_json_variant *reply = NULL;
+
+	r = systemd_varlink_call(sd_varlink_connect_address)(&vl, NSRESOURCE_VARLINK_ADDRESS);
+	if (r < 0)
+		errx(EXIT_FAILURE, _("unable to connect to %s: %s; "
+				     "is systemd-nsresourced.service running?"),
+				   NSRESOURCE_VARLINK_ADDRESS, strerror(-r));
+
+	r = systemd_varlink_call(sd_varlink_set_allow_fd_passing_output)(vl, true);
+	if (r < 0)
+		errx(EXIT_FAILURE, _("unable to allow fd passing: %s"), strerror(-r));
+
+	userns_idx = systemd_varlink_call(sd_varlink_push_dup_fd)(vl, userns_fd);
+	if (userns_idx < 0)
+		errx(EXIT_FAILURE, _("unable to push fd: %s"), strerror(-userns_idx));
+
+	snprintf(name, sizeof(name), "unshare-%d", (int) getpid());
+
+	r = systemd_varlink_call(sd_varlink_callb)(vl, "io.systemd.NamespaceResource.AllocateUserRange",
+		&reply,
+		&error_id,
+		SD_JSON_BUILD_OBJECT(
+			SD_JSON_BUILD_PAIR_STRING("name", name),
+			SD_JSON_BUILD_PAIR_UNSIGNED("size", 1),
+			SD_JSON_BUILD_PAIR_UNSIGNED("userNamespaceFileDescriptor", userns_idx),
+			SD_JSON_BUILD_PAIR_CONDITION(req->foreign, "mapForeign", SD_JSON_BUILD_BOOLEAN(true)),
+			SD_JSON_BUILD_PAIR_CONDITION(req->target >= 0, "target", SD_JSON_BUILD_UNSIGNED(req->target)),
+			SD_JSON_BUILD_PAIR_STRING("type", "self")));
+	if (r < 0)
+		errx(EXIT_FAILURE, _("unable to make varlink call: %s"), strerror(-r));
+	if (error_id)
+		errx(EXIT_FAILURE, _("io.systemd.NamespaceResource.AllocateUserRange failed: %s"), error_id);
+
+	systemd_varlink_call(sd_json_variant_unref)(reply);
+	systemd_varlink_call(sd_varlink_close_unref)(vl);
+}
+
+#endif /* HAVE_SYSTEMD_VARLINK */


### PR DESCRIPTION
Adds the `--map-foreign` option, which uses [`systemd-nsresourced.service(8)`](https://www.freedesktop.org/software/systemd/man/latest/systemd-nsresourced.service.html) to setup the uid and gid maps, specifically for asking the service to map the foreign UID range. The `--map-current-user` and `--map-root-user` options are also compatible: `--map-current-user` is the default, and `--map-root-user` translates into `"target": 0`.

`systemd-nsresourced` has other options, but the primary use case that I envision `unshare` to be used for is to manage files owned by the `foreign-0`-`foreign-65534` UIDs and GIDs.
Specifically, running `unshare --map-foreign --map-root-user -- rm -rf ./dir` to delete local files that were created using [`systemd-nspawn(1)`](https://www.freedesktop.org/software/systemd/man/latest/systemd-nspawn.html) or [`systemd-mountfsd.service(8)`](https://www.freedesktop.org/software/systemd/man/latest/systemd-mountfsd.service.html)'s `io.systemd.MountFileSystem.MakeDirectory` Varlink method.

The important thing to note is that the foreign UID range is a systemd concept, so `newuidmap` is not usually able to map those uids into the user namespace.

This is a draft PR to garner feedback, as this is a new idea.