### PR TITLE
hardlink: fix sparse file handling, add --real-size

### DIFF
--- a/bash-completion/hardlink
+++ b/bash-completion/hardlink
@@ -68,6 +68,7 @@ _hardlink_module()
 			--ignore-mode
 			--quiet
 			--prioritize-trees
+			--real-size
 			--ignore-time
 			--reflink
 			--verbose

--- a/misc-utils/hardlink.1.adoc
+++ b/misc-utils/hardlink.1.adoc
@@ -116,6 +116,9 @@ which means that only reflinks are allowed.
 *--skip-reflinks*::
 Ignore already cloned files. This option may be used without *--reflink* when creating classic hardlinks.
 
+*--real-size*::
+Use real file size (blocks allocated on disk) rather than apparent file size when applying *--minimum-size* and *--maximum-size* filters. This is useful for excluding sparse files that have large apparent size but use little or no actual disk space.
+
 *-s*, *--minimum-size* _size_::
 The minimum size to consider. By default this is 1, so empty files will not be linked. The _size_ argument may be followed by the multiplicative suffixes KiB (=1024), MiB (=1024*1024), and so on for GiB, TiB, PiB, EiB, ZiB and YiB (the "iB" is optional, e.g., "K" has the same meaning as "KiB").
 

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -198,6 +198,7 @@ static struct options {
 	bool dry_run;
 	bool list_duplicates;
 	bool within_mount;
+	bool real_size;
 	char line_delim;
 	uintmax_t min_size;
 	uintmax_t max_size;
@@ -881,10 +882,21 @@ static int inserter(const char *fpath, const struct stat *sb,
 
 	stats.files++;
 
-	if ((uintmax_t) sb->st_size < opts.min_size) {
-		jlog(VERBOSE1,
-			printf(_("Skipped (smaller than configured size) %s"), fpath));
-		return 0;
+	{
+		uintmax_t sz = opts.real_size ?
+				(uintmax_t) sb->st_blocks * 512 :
+				(uintmax_t) sb->st_size;
+
+		if (sz < opts.min_size) {
+			jlog(VERBOSE1,
+				printf(_("Skipped (smaller than configured size) %s"), fpath));
+			return 0;
+		}
+		if ((opts.max_size > 0) && (sz > opts.max_size)) {
+			jlog(VERBOSE1,
+			     printf(_("Skipped (greater than configured size) %s"), fpath));
+			return 0;
+		}
 	}
 
 	if (sb->st_blocks == 0) {
@@ -896,12 +908,6 @@ static int inserter(const char *fpath, const struct stat *sb,
 	jlog(VERBOSE2, printf(" %5zu: [%" PRIu64 "/%" PRIu64 "/%zu] %s",
 			stats.files, (uint64_t)sb->st_dev, sb->st_ino,
 			(size_t) sb->st_nlink, fpath));
-
-	if ((opts.max_size > 0) && ((uintmax_t) sb->st_size > opts.max_size)) {
-		jlog(VERBOSE1,
-		     printf(_("Skipped (greater than configured size) %s"), fpath));
-		return 0;
-	}
 
 	pathlen = strlen(fpath) + 1;
 
@@ -1253,6 +1259,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_("     --reflink[=<when>]     create clone/CoW copies (auto, always, never)\n"), out);
 	fputs(_("     --skip-reflinks        skip already cloned files (enabled on --reflink)\n"), out);
 #endif
+	fputs(_("     --real-size            filter by real size on disk (use with -s/-S)\n"), out);
 	fputs(_(" -s, --minimum-size <size>  minimum size for files\n"), out);
 	fputs(_(" -S, --maximum-size <size>  maximum size for files\n"), out);
 	fputs(_(" -t, --ignore-time          ignore timestamps (when testing for equality)\n"), out);
@@ -1285,7 +1292,8 @@ static int parse_options(int argc, char *argv[])
 		OPT_REFLINK = CHAR_MAX + 1,
 		OPT_SKIP_RELINKS,
 		OPT_EXCLUDE_SUBTREE,
-		OPT_MOUNT
+		OPT_MOUNT,
+		OPT_REAL_SIZE
 	};
 	static const char optstr[] = "VhvndfpotXcmMFOlzx:y:i:r:S:s:b:q";
 	static const struct option long_options[] = {
@@ -1309,6 +1317,7 @@ static int parse_options(int argc, char *argv[])
 		{"exclude-subtree", required_argument, NULL, OPT_EXCLUDE_SUBTREE},
 #endif
 		{"mount", no_argument, NULL, OPT_MOUNT},
+		{"real-size", no_argument, NULL, OPT_REAL_SIZE},
 		{"method", required_argument, NULL, 'y' },
 		{"minimum-size", required_argument, NULL, 's'},
 		{"maximum-size", required_argument, NULL, 'S'},
@@ -1434,6 +1443,9 @@ static int parse_options(int argc, char *argv[])
 #endif
 		case OPT_MOUNT:
 			opts.within_mount = 1;
+			break;
+		case OPT_REAL_SIZE:
+			opts.real_size = TRUE;
 			break;
 		case 'h':
 			usage();

--- a/misc-utils/hardlink.c
+++ b/misc-utils/hardlink.c
@@ -766,7 +766,8 @@ static int file_link(struct file *a, struct file *b, int reflink)
 	if (is_log_enabled(INFO)) {
 		char *ssz = size_to_human_string(SIZE_SUFFIX_3LETTER |
 				   SIZE_SUFFIX_SPACE |
-				   SIZE_DECIMAL_2DIGITS, a->st.st_size);
+				   SIZE_DECIMAL_2DIGITS,
+				   (uint64_t) a->st.st_blocks * 512);
 		jlog(INFO, printf(_("%s%sLinking %s to %s (-%s)"),
 		     opts.dry_run ? _("[DryRun] ") : "",
 		     reflink ? "Ref" : "",
@@ -803,7 +804,7 @@ static int file_link(struct file *a, struct file *b, int reflink)
 	b->st.st_nlink--;
 
 	if (b->st.st_nlink == 0)
-		stats.saved += a->st.st_size;
+		stats.saved += (uint64_t) a->st.st_blocks * 512;
 
 	/* Move the link from file b to a */
 	{
@@ -883,6 +884,12 @@ static int inserter(const char *fpath, const struct stat *sb,
 	if ((uintmax_t) sb->st_size < opts.min_size) {
 		jlog(VERBOSE1,
 			printf(_("Skipped (smaller than configured size) %s"), fpath));
+		return 0;
+	}
+
+	if (sb->st_blocks == 0) {
+		jlog(VERBOSE1,
+			printf(_("Skipped (no blocks allocated) %s"), fpath));
 		return 0;
 	}
 
@@ -1042,9 +1049,12 @@ static int is_reflink(struct file *xa, struct file *xb)
 		if (ioctl(bf, FS_IOC_FIEMAP, (unsigned long) bmap) < 0)
 			goto done;
 
-		if (amap->fm_mapped_extents == 0 ||
-		    amap->fm_mapped_extents != bmap->fm_mapped_extents)
+		if (amap->fm_mapped_extents != bmap->fm_mapped_extents)
 			goto done;
+		if (amap->fm_mapped_extents == 0) {
+			rc = 1;
+			goto done;
+		}
 
 		for (i = 0; i < amap->fm_mapped_extents; i++) {
 			struct fiemap_extent *a = &amap->fm_extents[i];

--- a/tests/expected/hardlink/options-real-size
+++ b/tests/expected/hardlink/options-real-size
@@ -1,0 +1,9 @@
+Mode:                     real
+Method: [Redacted]
+Files:                    4
+Linked:                   1 files
+Compared: [Redacted] files
+Saved:                    8 KiB
+Duration: [Redacted]
+file-a links: 2
+sparse-a links: 1

--- a/tests/expected/hardlink/options-sparse-skip
+++ b/tests/expected/hardlink/options-sparse-skip
@@ -1,0 +1,11 @@
+Linking [Redacted] (-4 KiB)
+Mode:                     real
+Method: [Redacted]
+Files:                    4
+Linked:                   1 files
+Compared: [Redacted] files
+Saved:                    4 KiB
+Duration: [Redacted]
+sparse-a blocks: 0
+sparse-a inode: unique
+real-a links: 2

--- a/tests/ts/hardlink/options
+++ b/tests/ts/hardlink/options
@@ -47,8 +47,11 @@ summary_clean()
 		-e 's/^Method:.*/Method: [Redacted]/' \
 		-e 's/^Compared:.*files/Compared: [Redacted] files/' \
 		-e '/^Compared:.*xattrs/d' \
+		-e 's|.*Linking .* (\(.*\))$|Linking [Redacted] (\1)|' \
 		"$TS_OUTPUT"
 }
+
+FSBLKSIZE=$(stat --file-system --format=%s "$TS_OUTDIR")
 
 create_srcdir
 
@@ -96,13 +99,55 @@ show_srcdir >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_finalize_subtest
 
 ts_init_subtest "maximum-size-8192"
-create_srcdir
-echo "Number of test files: $(find "$SRCDIR" -type f | wc -l)" >> "$TS_OUTPUT"
-$TS_CMD_HARDLINK --maximum-size 8192 "$SRCDIR" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
-summary_clean
-show_srcdir >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+if [ "$FSBLKSIZE" -ne 4096 ]; then
+	ts_skip "filesystem block size != 4096"
+else
+	create_srcdir
+	echo "Number of test files: $(find "$SRCDIR" -type f | wc -l)" >> "$TS_OUTPUT"
+	$TS_CMD_HARDLINK --maximum-size 8192 "$SRCDIR" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+	summary_clean
+	show_srcdir >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+fi
 ts_finalize_subtest
 
+ts_init_subtest "sparse-skip"
+if [ "$FSBLKSIZE" -ne 4096 ]; then
+	ts_skip "filesystem block size != 4096"
+else
+	SPDIR="$TS_OUTDIR/sparsedir"
+	rm -rf "$SPDIR"
+	mkdir -p "$SPDIR"
+	truncate -s 1M "$SPDIR"/sparse-a
+	truncate -s 1M "$SPDIR"/sparse-b
+	echo "content" > "$SPDIR"/real-a
+	cp "$SPDIR"/real-a "$SPDIR"/real-b
+	$TS_CMD_HARDLINK -v "$SPDIR" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+	summary_clean
+	echo "sparse-a blocks: $(stat -c %b "$SPDIR"/sparse-a)" >> "$TS_OUTPUT"
+	echo "sparse-a inode: unique" >> "$TS_OUTPUT"
+	echo "real-a links: $(stat -c %h "$SPDIR"/real-a)" >> "$TS_OUTPUT"
+	rm -rf "$SPDIR"
+fi
+ts_finalize_subtest
+
+ts_init_subtest "real-size"
+if [ "$FSBLKSIZE" -ne 4096 ]; then
+	ts_skip "filesystem block size != 4096"
+else
+	SPDIR="$TS_OUTDIR/sparsedir"
+	rm -rf "$SPDIR"
+	mkdir -p "$SPDIR"
+	dd if=/dev/zero of="$SPDIR"/file-a bs=4096 count=2 2>/dev/null
+	cp "$SPDIR"/file-a "$SPDIR"/file-b
+	truncate -s 1M "$SPDIR"/sparse-a
+	truncate -s 1M "$SPDIR"/sparse-b
+	$TS_CMD_HARDLINK --real-size --minimum-size 4096 "$SPDIR" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+	summary_clean
+	echo "file-a links: $(stat -c %h "$SPDIR"/file-a)" >> "$TS_OUTPUT"
+	echo "sparse-a links: $(stat -c %h "$SPDIR"/sparse-a)" >> "$TS_OUTPUT"
+	rm -rf "$SPDIR"
+fi
+ts_finalize_subtest
 
 rm -rf "$SRCDIR"
 ts_finalize


### PR DESCRIPTION
## Summary

Fix hardlink's handling of sparse files and add a new `--real-size` option.

- **Fix saved space reporting**: use `st_blocks * 512` (actual disk usage) instead of `st_size` (apparent size) for the "Saved" statistic and per-link verbose message. Previously, sparse files would report misleading savings based on apparent size.
- **Skip files with no allocated blocks**: files with `st_blocks == 0` are skipped entirely since linking them cannot save any disk space.
- **Fix `is_reflink()` for 0-extent files**: treat files with no mapped extents as already reflinked, preventing repeated no-op reflink attempts on all-hole sparse files.
- **Add `--real-size` option**: makes `--minimum-size` / `--maximum-size` filters use real disk usage instead of apparent file size, allowing users to filter out sparse files.
- **Add regression tests** for sparse file skipping and `--real-size` filtering.

Addresses: https://github.com/util-linux/util-linux/issues/4563