### PR TITLE
tests: (lsfd) fix ShellCheck warnings

### DIFF
--- a/tests/ts/lsfd/column-source-btrfs
+++ b/tests/ts/lsfd/column-source-btrfs
@@ -44,7 +44,7 @@ fi
 if ! mount $IMG $MNTPNT; then
     ts_skip "failed to mount a btrfs image, $IMG to $MNTPNT"
 fi
-trap "umount $MNTPNT; rm -f $IMG" EXIT
+trap 'umount $MNTPNT; rm -f $IMG' EXIT
 
 if ! touch $FILE; then
     ts_skip "failed to touch a file on a btrfs filesystem: $FILE"

--- a/tests/ts/lsfd/mkfds-cdev-tun
+++ b/tests/ts/lsfd/mkfds-cdev-tun
@@ -35,7 +35,8 @@ ts_cd "$TS_OUTDIR"
 PID=
 FD=3
 IFNAME=
-readonly MYNETNS=$($TS_CMD_LSNS -r -n -t net -p $$ -oNS)
+MYNETNS=$($TS_CMD_LSNS -r -n -t net -p $$ -oNS)
+readonly MYNETNS
 
 if [[ -z "$MYNETNS" ]]; then
     ts_skip "the current netns is unknown"

--- a/tests/ts/lsfd/mkfds-inotify-btrfs
+++ b/tests/ts/lsfd/mkfds-inotify-btrfs
@@ -40,7 +40,7 @@ fi
 if ! mount $IMG $MNTPNT; then
     ts_skip "failed to mount a btrfs image, $IMG to $MNTPNT"
 fi
-trap "umount $MNTPNT; rm -f $IMG" EXIT
+trap 'umount $MNTPNT; rm -f $IMG' EXIT
 
 if ! touch $MNTPNT/fstab; then
     ts_skip "failed to touch a file on a btrfs filesystem: $MNTPNT/fstab"

--- a/tests/ts/lsfd/mkfds-inotify-many
+++ b/tests/ts/lsfd/mkfds-inotify-many
@@ -38,7 +38,7 @@ DIR=
 ts_init_subtest "0xA-inodes"
 {
     DIR=0xA
-    trap "rm -r $DIR" EXIT
+    trap 'rm -r $DIR' EXIT
     mkdir -p "$DIR"
 
     coproc MKFDS { "$TS_HELPER_MKFDS" inotify-many $FD count=10 tempdir=$DIR; }


### PR DESCRIPTION
Use single quotes in trap commands to avoid SC2064 (variables expand
at definition time rather than when signalled). Separate declaration
and assignment of readonly variable to avoid SC2155 (masking return
values).