### PR TITLE
column: add --table-minout option

### DIFF
--- a/bash-completion/column
+++ b/bash-completion/column
@@ -42,6 +42,7 @@ _column_module()
 				--table-noextreme
 				--table-noheadings
 				--table-maxout
+				--table-minout
 				--table-header-as-columns
 				--table-header-repeat
 				--table-hide

--- a/text-utils/column.1.adoc
+++ b/text-utils/column.1.adoc
@@ -202,6 +202,9 @@ Specify the table name used for JSON output. The default is "table".
 *-m, --table-maxout*::
 Fill all available space on output.
 
+*--table-minout*::
+Minimize output width. The last column separator is not padded, which removes trailing whitespace from lines where the last column is shorter than the column width. This option is mutually exclusive with *--table-maxout*.
+
 *-L, --keep-empty-lines*::
 Preserve whitespace-only lines in the input. The default is to ignore all empty lines. This option's original name was *--table-empty-lines*, but has since been deprecated because it gives the false impression that the option only applies to table mode.
 

--- a/text-utils/column.c
+++ b/text-utils/column.c
@@ -103,6 +103,7 @@ struct column_control {
 		header_as_columns,	/* --table-header-as-columns */
 		hide_unnamed,
 		maxout,
+		minout,			/* --table-minout */
 		keep_empty_lines,	/* --keep-empty-lines */
 		tab_noheadings,
 		use_spaces;
@@ -389,7 +390,10 @@ static void init_table(struct column_control *ctl)
 	} else
 		scols_table_enable_noencoding(ctl->tab, 1);
 
-	scols_table_enable_maxout(ctl->tab, ctl->maxout ? 1 : 0);
+	if (ctl->maxout)
+		scols_table_enable_maxout(ctl->tab, 1);
+	else if (ctl->minout)
+		scols_table_enable_minout(ctl->tab, 1);
 	scols_table_enable_colors(ctl->tab, colors_wanted() ? 1 : 0);
 
 	if (ctl->tab_columns) {
@@ -1036,6 +1040,7 @@ static void __attribute__((__noreturn__)) usage(void)
 		"                                    to the column's width\n"), out);
 	fputs(_(" -d, --table-noheadings           don't print header\n"), out);
 	fputs(_(" -m, --table-maxout               fill all available space\n"), out);
+	fputs(_("     --table-minout               minimize output width\n"), out);
 	fputs(_(" -e, --table-header-repeat        repeat header for each page\n"), out);
 	fputs(_(" -K, --table-header-as-columns    use the first row as table header\n"), out);
 	fputs(_(" -H, --table-hide <columns>       don't print the columns\n"), out);
@@ -1086,6 +1091,7 @@ int main(int argc, char **argv)
 		OPT_COLOR	= CHAR_MAX + 1,
 		OPT_COLORSCHEME,
 		OPT_WRAP_SEPARATOR,
+		OPT_MINOUT,
 	};
 
 	static const struct option longopts[] =
@@ -1108,6 +1114,7 @@ int main(int argc, char **argv)
 		{ "table-hide",          required_argument, NULL, 'H' },
 		{ "table-name",          required_argument, NULL, 'n' },
 		{ "table-maxout",        no_argument,       NULL, 'm' },
+		{ "table-minout",        no_argument,       NULL, OPT_MINOUT },
 		{ "table-noextreme",     required_argument, NULL, 'E' },
 		{ "table-noheadings",    no_argument,       NULL, 'd' },
 		{ "table-order",         required_argument, NULL, 'O' },
@@ -1197,6 +1204,9 @@ int main(int argc, char **argv)
 		case 'm':
 			ctl.maxout = 1;
 			break;
+		case OPT_MINOUT:
+			ctl.minout = 1;
+			break;
 		case 'O':
 			ctl.tab_order = optarg;
 			break;
@@ -1260,6 +1270,10 @@ int main(int argc, char **argv)
 
 	if (ctl.termwidth == (size_t) -1)
 		ctl.termwidth = get_terminal_width(80);
+
+	if (ctl.maxout && ctl.minout)
+		errx(EXIT_FAILURE, _("options --table-maxout and --table-minout are "
+				     "mutually exclusive"));
 
 	if (ctl.tree) {
 		ctl.mode = COLUMN_MODE_TABLE;


### PR DESCRIPTION
## Description

This PR adds a new `--table-minout` option to the `column` command, as suggested by @kzak in #3372.

The option enables `scols_table_enable_minout()` from libsmartcols, which removes trailing whitespace from output lines by not padding the last visible column separator.

### Behavior

- **Without `--table-minout`** (default): last column is padded to fill the column width, producing trailing whitespace
- **With `--table-minout`**: last column is not padded, minimizing output width and removing trailing whitespace

### Example

```shell
# Default (trailing whitespace)
$ echo -e "A B C D\na b" | column -t -o '|'
A|B|C|D
a|b| | 

# With --table-minout (no trailing whitespace)
$ echo -e "A B C D\na b" | column -t -o '|' --table-minout
A|B|C|D
a|b
```

### Implementation

- Added `minout` boolean field to `struct column_control`
- Added `OPT_MINOUT` enum value and `--table-minout` long option
- Modified `init_table()` to call `scols_table_enable_minout()` when the option is set
- Added mutual exclusivity check between `--table-maxout` and `--table-minout`
- Updated `usage()` help text
- Updated `column.1.adoc` man page

### Notes

The `scols_table_enable_minout()` API already exists in libsmartcols (used by the sample program `libsmartcols/samples/fromfile.c`); this PR simply exposes it through the `column` command-line interface.

Addresses: https://github.com/util-linux/util-linux/issues/3372