### PR TITLE
Secure login and sulogin on S390x

### DIFF
--- a/lib/ttyutils.c
+++ b/lib/ttyutils.c
@@ -21,7 +21,7 @@
 #  if defined (__s390__) || defined (__s390x__)
 #    define DEFAULT_TTYS0  "dumb"
 #    define DEFAULT_TTY32  "ibm327x"
-#    define DEFAULT_TTYS1  "vt220"
+#    define DEFAULT_TTYS1  "vt220"	/* Fallback for sclp, though users may set TERM=sclp if ncurses >= 6.5-20250405 */
 #  endif
 #  ifndef DEFAULT_STERM
 #    define DEFAULT_STERM  "vt102"
@@ -176,13 +176,15 @@ char *get_terminal_default_type(const char *ttyname, int is_serial)
 		 * Special terminal on first serial line on a S/390(x) which
 		 * is due legacy reasons a block terminal of type 3270 or
 		 * higher.  Whereas the second serial line on a S/390(x) is
-		 * a real character terminal which is compatible with VT220.
+		 * a real character terminal which is compatible with "vt220"
+		 * (or "sclp" if color support is desired via modern ncurses).
 		 */
 		if (strcmp(ttyname, "ttyS0") == 0)		/* linux/drivers/s390/char/con3215.c */
 			return strdup(DEFAULT_TTYS0);
 		else if (strncmp(ttyname, "3270/tty", 8) == 0)	/* linux/drivers/s390/char/con3270.c */
 			return strdup(DEFAULT_TTY32);
-		else if (strcmp(ttyname, "ttyS1") == 0)		/* linux/drivers/s390/char/sclp_vt220.c */
+		else if (strcmp(ttyname, "ttyS1") == 0||	/* linux/drivers/s390/char/sclp_vt220.c (legacy) */
+			 strncmp(ttyname, "ttysclp", 7) == 0)	/* linux/drivers/s390/char/sclp_vt220.c (v5.14+) */
 			return strdup(DEFAULT_TTYS1);
 #endif
 	}

--- a/login-utils/Makemodule.am
+++ b/login-utils/Makemodule.am
@@ -33,7 +33,9 @@ dist_noinst_DATA += login-utils/sulogin.8.adoc
 sulogin_SOURCES = \
 	login-utils/sulogin.c \
 	login-utils/sulogin-consoles.c \
-	login-utils/sulogin-consoles.h
+	login-utils/sulogin-consoles.h \
+	login-utils/vmcp.c \
+	login-utils/vmcp.h
 if USE_PLYMOUTH_SUPPORT
 sulogin_SOURCES += lib/plymouth-ctrl.c
 endif
@@ -66,6 +68,8 @@ MANPAGES += login-utils/login.1
 dist_noinst_DATA += login-utils/login.1.adoc
 login_SOURCES = \
 	login-utils/login.c \
+	login-utils/vmcp.c \
+	login-utils/vmcp.h \
 	lib/logindefs.c \
 	lib/shells.c
 login_LDADD = $(LDADD) libcommon.la -lpam

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -85,6 +85,10 @@
 #include "pwdutils.h"
 
 #include "logindefs.h"
+#include "vmcp.h"
+#if defined(__s390__) || defined(__s390x__)
+# include "sulogin-consoles.h"	/* For CON_3215, CON_3270, and CON_SCLP */
+#endif
 
 #if defined (HAVE_LIBECONF) && defined (USE_VENDORDIR)
 # include "shells.h"
@@ -165,6 +169,52 @@ static int is_consoletty(int fd)
 }
 #endif
 
+#if defined(__s390__) || defined(__s390x__)
+/* Avoid that passwords are logged on the hypervisors console log */
+
+static struct s390con {
+	uint32_t flags;
+	int vmcpfd;
+} s390_vmcp = { .flags = 0, .vmcpfd = -1 };
+
+static void s390_console_spool_restore(void)
+{
+	if (s390_vmcp.vmcpfd >= 0) {
+		vmcp_restore_and_close(s390_vmcp.vmcpfd, s390_vmcp.flags);
+		s390_vmcp.vmcpfd = -1;
+		s390_vmcp.flags = 0;
+	}
+}
+
+static void s390_console_spool_stop(int fd)
+{
+	struct stat stb;
+
+	if ((fstat(fd, &stb) >= 0) && S_ISCHR(stb.st_mode)) {
+		s390_vmcp.flags |= get_s390_con_flags(stb.st_rdev);
+	}
+	if (s390_vmcp.flags & (CON_3215|CON_3270)) {
+		s390_vmcp.vmcpfd = vmcp_open();
+		if (s390_vmcp.vmcpfd >= 0) {
+			vmcp_stop_console_logging(s390_vmcp.vmcpfd);
+		}
+	}
+	if (s390_vmcp.flags & CON_3215) {
+		if (s390_vmcp.vmcpfd >= 0) {
+			vmcp_prepare_terminal_for_password(s390_vmcp.vmcpfd);
+			vmcp_warning3215(s390_vmcp.vmcpfd);
+		}
+	}
+	/* Catch all regular exit() calls (like sleepexit) */
+	atexit(s390_console_spool_restore);
+}
+# define PREPARE_CONSOLE(fd)	s390_console_spool_stop(fd)
+# define RESTORE_CONSOLE()	s390_console_spool_restore()
+#else
+# define PREPARE_CONSOLE(fd)	/* */
+# define RESTORE_CONSOLE()	/* */
+#endif
+
 /*
  * Robert Ambrose writes:
  * A couple of my users have a problem with login processes hanging around
@@ -178,6 +228,8 @@ static void __attribute__((__noreturn__))
     timedout2(int sig __attribute__((__unused__)))
 {
 	struct termios ti;
+
+	RESTORE_CONSOLE();
 
 	/* reset echo */
 	if (tcgetattr(0, &ti) >= 0) {
@@ -1584,8 +1636,11 @@ int main(int argc, char **argv)
 	/* login -f, then the user has already been authenticated */
 	cxt.noauth = cxt.noauth && getuid() == 0 ? 1 : 0;
 
-	if (!cxt.noauth)
+	if (!cxt.noauth) {
+		PREPARE_CONSOLE(0);
 		loginpam_auth(&cxt);
+		RESTORE_CONSOLE();
+        }
 
 	/*
 	 * Authentication may be skipped (for example, during krlogin, rlogin,

--- a/login-utils/meson.build
+++ b/login-utils/meson.build
@@ -69,6 +69,8 @@ last_manadocs = files('last.1.adoc')
 
 login_sources = files(
   'login.c',
+  'vmcp.c',
+  'vmcp.h',
 )
 login_manadocs = files('login.1.adoc')
 
@@ -76,6 +78,8 @@ sulogin_sources = files(
   'sulogin.c',
   'sulogin-consoles.c',
   'sulogin-consoles.h',
+  'vmcp.c',
+  'vmcp.h',
 )
 sulogin_manadocs = files('sulogin.8.adoc')
 

--- a/login-utils/sulogin-consoles.c
+++ b/login-utils/sulogin-consoles.c
@@ -312,7 +312,7 @@ static
 #ifdef __GNUC__
 __attribute__((__hot__))
 #endif
-int append_console(struct list_head *consoles, const char * const name)
+int append_console(struct list_head *consoles, const char * const name, dev_t dev __attribute__((__unused__)))
 {
 	struct console *restrict tail;
 	const struct console *last = NULL;
@@ -343,7 +343,22 @@ int append_console(struct list_head *consoles, const char * const name)
 	tail->reset_tty_context = NULL;
 	tail->user_tty_context = NULL;
 #endif
-
+#if defined(__s390__) || defined(__s390x__)
+	/*
+	 * Stat the device path to determine its major/minor numbers.
+	 * This ensures we detect s390x terminal types regardless of whether
+	 * the console was found via /proc, /sys, cmdline, or a direct stdin
+	 * fallback (e.g. sulogin < /dev/ttyS0).
+	 */
+	if (!dev) {
+		struct stat st;
+		if (stat(name, &st) == 0 && S_ISCHR(st.st_mode))
+			dev = st.st_rdev;
+	}
+	if (dev) {
+		tail->flags |= get_s390_con_flags(dev);
+	}
+#endif
 	return 0;
 }
 
@@ -385,7 +400,7 @@ static int detect_consoles_from_proc(struct list_head *consoles)
 		name = scandev(dir, comparedev);
 		if (!name)
 			continue;
-		rc = append_console(consoles, name);
+		rc = append_console(consoles, name, comparedev);
 		free(name);
 		if (rc < 0)
 			goto done;
@@ -447,7 +462,7 @@ static int detect_consoles_from_sysfs(struct list_head *consoles)
 		name = scandev(dir, comparedev);
 		if (!name)
 			continue;
-		rc = append_console(consoles, name);
+		rc = append_console(consoles, name, comparedev);
 		free(name);
 		if (rc < 0)
 			goto done;
@@ -535,7 +550,7 @@ static int detect_consoles_from_cmdline(struct list_head *consoles)
 		name = scandev(dir, comparedev);
 		if (!name)
 			continue;
-		rc = append_console(consoles, name);
+		rc = append_console(consoles, name, comparedev);
 		free(name);
 		if (rc < 0)
 			goto done;
@@ -593,7 +608,7 @@ static int detect_consoles_from_tiocgdev(struct list_head *consoles,
 			goto done;
 		}
 	}
-	rc = append_console(consoles, name);
+	rc = append_console(consoles, name, comparedev);
 	free(name);
 	if (rc < 0)
 		goto done;
@@ -707,7 +722,7 @@ int detect_consoles(const char *device, const int fallback, struct list_head *co
 		closedir(dir);
 
 		if (name) {
-			rc = append_console(consoles, name);
+			rc = append_console(consoles, name, comparedev);
 			free(name);
 			if (rc < 0)
 				return rc;
@@ -784,7 +799,7 @@ fallback:
 		n = strdup(name);
 		if (!n)
 			return -ENOMEM;
-		rc = append_console(consoles, n);
+		rc = append_console(consoles, n, 0);
 		free(n);
 		if (rc < 0)
 			return rc;
@@ -806,6 +821,14 @@ int main(int argc, char *argv[])
 	char *name = NULL;
 	int fd, re;
 	struct list_head *p, consoles;
+
+#if defined(__s390__) || defined(__s390x__)
+	/* Pure function tests for get_s390_con_flags() */
+	if (get_s390_con_flags(makedev(4, 64)) != CON_3215) return EXIT_FAILURE;
+	if (get_s390_con_flags(makedev(4, 65)) != CON_SCLP) return EXIT_FAILURE;
+	if (get_s390_con_flags(makedev(227, 1)) != CON_3270) return EXIT_FAILURE;
+	if (get_s390_con_flags(makedev(4, 63)) != 0) return EXIT_FAILURE;
+#endif
 
 	if (argc == 2) {
 		name = argv[1];

--- a/login-utils/sulogin-consoles.h
+++ b/login-utils/sulogin-consoles.h
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <termios.h>
 
+#include "c.h"
 #include "list.h"
 #include "ttyutils.h"
 
@@ -39,6 +40,9 @@ struct console {
 #define	CON_SERIAL	0x0001
 #define	CON_NOTTY	0x0002
 #define	CON_EIO		0x0004
+#define	CON_3215	0x0010	/* s390x 3215 halfduplex console */
+#define	CON_3270	0x0020  /* s390x 3270 console */
+#define	CON_SCLP	0x0040	/* s390x sclp terminals */
 	pid_t pid;
 	struct chardata cp;
 	struct termios tio;
@@ -47,6 +51,23 @@ struct console {
 	char *user_tty_context;
 #endif
 };
+
+#if defined(__s390__) || defined(__s390x__)
+static inline uint32_t get_s390_con_flags(dev_t dev)
+{
+	unsigned int maj = major(dev);
+	unsigned int min = minor(dev);
+
+	if (maj == 4 && min == 64)
+		return CON_3215;
+	else if (maj == 4 && min >= 65)
+		return CON_SCLP;
+	else if (maj == 227 && min >= 1)
+		return CON_3270;
+
+	return 0;
+}
+#endif
 
 extern int detect_consoles(const char *device, int fallback,
 			   struct list_head *consoles);

--- a/login-utils/sulogin.c
+++ b/login-utils/sulogin.c
@@ -65,6 +65,7 @@
 #include "strutils.h"
 #include "ttyutils.h"
 #include "sulogin-consoles.h"
+#include "vmcp.h"
 #define CONMAX		16
 
 static unsigned int timeout;
@@ -221,7 +222,7 @@ static void tcinit(struct console *con)
 #endif
 
 #ifdef KDGKBMODE
-	if (!(con->flags & CON_SERIAL)
+	if (!(con->flags & (CON_SERIAL|CON_3215|CON_3270))
 	    && ioctl(fd, KDGKBMODE, &mode) < 0)
 		con->flags |= CON_SERIAL;
 	errno = 0;
@@ -268,6 +269,13 @@ static void tcinit(struct console *con)
 		}
 	}
 
+#if defined(__s390__) || defined(__s390x__)
+	if (con->flags & (CON_3215|CON_3270)) {
+		setlocale(LC_CTYPE, "POSIX");
+		setlocale(LC_MESSAGES, "POSIX");
+		goto setattr;
+	}
+#endif
 	/* Handle lines other than virtual consoles here */
 #if defined(KDGKBMODE) || defined(TIOCGSERIAL)
 	if (con->flags & CON_SERIAL)
@@ -367,6 +375,10 @@ static void tcfinal(struct console *con)
 		free(term);
 	}
 
+#if defined(__s390__) || defined(__s390x__)
+	if (con->flags & (CON_3215|CON_3270))
+		return;
+#endif
 	if (!(con->flags & CON_SERIAL) || (con->flags & CON_NOTTY))
 		return;
 
@@ -1200,10 +1212,29 @@ int main(int argc, char **argv)
 				char *answer;
 				int doshell = 0;
 				int deny = !opt_e && locked_account_password(pwd->pw_passwd);
-
+#if defined(__s390__) || defined(__s390x__)
+				int vmcpfd = -1;
+				if (con->flags & (CON_3215|CON_3270)) {
+					vmcpfd = vmcp_open();
+					if (vmcpfd >= 0) {
+						vmcp_stop_console_logging(vmcpfd);
+					}
+				}
+				if (con->flags & CON_3215) {
+					if (vmcpfd >= 0) {
+						vmcp_prepare_terminal_for_password(vmcpfd);
+						vmcp_warning3215(vmcpfd);
+					}
+				}
+#endif
 				doprompt(passwd, con, deny);
 
-				if ((answer = getpasswd(con)) == NULL)
+				answer = getpasswd(con);
+#if defined(__s390__) || defined(__s390x__)
+				vmcp_restore_and_close(vmcpfd, con->flags);
+				vmcpfd = -1;
+#endif
+				if (answer == NULL)
 					break;
 				if (deny) {
 #ifdef HAVE_EXPLICIT_BZERO

--- a/login-utils/vmcp.c
+++ b/login-utils/vmcp.c
@@ -1,0 +1,261 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * vmcp.c - s390x 3215 console spool and terminal management
+ *
+ * Copyright 2026 Werner Fink, SUSE Software Solutions Germany GmbH
+ *
+ * Based on:
+ *
+ * Copyright IBM Corp. 2018
+ * s390-tools is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ *
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include "all-io.h"
+#include "xalloc.h"
+#include "vmcp.h"
+#include "sulogin-consoles.h"
+
+#if defined(__s390__) || defined(__s390x__)
+
+#define	VMCP_DEVICE_NODE	"/dev/vmcp"
+#define	VMCP_GETSIZE		_IOR(0x10, 3, int)
+#define	VMCP_SETBUF		_IOW(0x10, 2, int)
+#define	VMCP_GETCODE		_IOR(0x10, 1, int)
+
+static struct {
+	char *more;
+	char *hold;
+	int spooling;
+} vmcp_state;
+
+int vmcp_open(void)
+{
+	return open(VMCP_DEVICE_NODE, O_RDWR | O_NOCTTY | O_CLOEXEC);
+}
+
+static void clearvmcp(void)
+{
+	if (vmcp_state.more) {
+		free(vmcp_state.more);
+		vmcp_state.more = NULL;
+	}
+	if (vmcp_state.hold) {
+		free(vmcp_state.hold);
+		vmcp_state.hold = NULL;
+	}
+}
+
+static char *askvmcp(int fd, const char *question)
+{
+	long pagesize = sysconf(_SC_PAGESIZE);
+	int rc = 0;
+	size_t buffersize;
+	char *ret = NULL;
+
+	if (pagesize <= 0)
+		return NULL;
+
+	buffersize = (size_t)pagesize;
+
+	if (ioctl(fd, VMCP_SETBUF, &buffersize) == -1)
+		goto out;
+	if (ul_write_all(fd, question, strlen(question)) != 0)
+		goto out;
+	if (ioctl(fd, VMCP_GETCODE, &rc) == -1)
+		goto out;
+	if (rc != 0)
+		goto out;
+	if (ioctl(fd, VMCP_GETSIZE, &buffersize) == -1 || buffersize == 0)
+		goto out;
+	ret = (char *)xmalloc(buffersize+1);
+	ret[buffersize] = '\0';
+	if (ul_read_all(fd, ret, buffersize) != 0) {
+		free(ret);
+		ret = NULL;
+	}
+ out:
+	return ret;
+}
+
+static char *queryterm(int fd)
+{
+	const char *question = "QUERY TERMINAL";
+	/* Reset cached terminal state before reparsing a fresh QUERY TERMINAL reply. */
+	clearvmcp();
+	return askvmcp(fd, question);
+}
+
+static char *queryspool(int fd)
+{
+	const char *question = "QUERY VIRTUAL CONSOLE";
+	return askvmcp(fd, question);
+}
+
+static int writevmcp(int fd, const char *instruction)
+{
+	long pagesize = sysconf(_SC_PAGESIZE);
+	int rc = 0;
+	size_t buffersize;
+	int ret = -1;
+
+	if (pagesize <= 0)
+		goto out;
+
+	buffersize = (size_t)pagesize;
+
+	if (ioctl(fd, VMCP_SETBUF, &buffersize) == -1)
+		goto out;
+	if (ul_write_all(fd, instruction, strlen(instruction)) != 0)
+		goto out;
+	if (ioctl(fd, VMCP_GETCODE, &rc) == -1)
+		goto out;
+	if (ioctl(fd, VMCP_GETSIZE, &buffersize) == -1)
+		goto out;
+	if (rc == 0 && buffersize == 0)
+		ret = 0;
+ out:
+	return ret;
+}
+
+static int setterm(int fd, const char *tout)
+{
+	char *instruction;
+	int ret;
+
+	/*
+	 * Note on z/VM CP command syntax:
+	 * TERMINAL MORE <initial_time> <interval_time> HOLD <ON|OFF>
+	 * The '0' is the mandatory interval_time parameter. Setting both
+	 * times to 0 (and HOLD OFF) prevents the console from entering
+	 * the "MORE..." state and waiting for user input (e.g. pressing CLEAR)
+	 * during the password prompt.
+	 */
+	xasprintf(&instruction, "TERMINAL MORE %s 0 HOLD OFF", tout);
+
+	ret = writevmcp(fd, instruction);
+	free(instruction);
+
+	return ret;
+}
+
+static int restoreterm(int fd)
+{
+	char *instruction;
+	int ret = -1;
+
+	if (!vmcp_state.more || !vmcp_state.hold)
+		goto out;
+	xasprintf(&instruction, "TERMINAL %s %s", vmcp_state.more, vmcp_state.hold);
+
+	ret = writevmcp(fd, instruction);
+	free(instruction);
+ out:
+	return ret;
+}
+
+static int stopspool(int fd)
+{
+	const char *instruction = "SPOOL CONSOLE STOP";
+	if (!vmcp_state.spooling)
+		return 1;
+	return writevmcp(fd, instruction);
+}
+
+static int restorespool(int fd)
+{
+	const char *instruction = "SPOOL CONSOLE START";
+	if (!vmcp_state.spooling)
+		return 1;
+	return writevmcp(fd, instruction);
+}
+
+static void parseterm(char *msg)
+{
+	char *token;
+
+	for (token = strtok(msg, ",\n"); token != NULL;
+	     token = strtok(NULL, ",\n")) {
+		if (vmcp_state.hold && vmcp_state.more)
+			break;
+
+		while (*token == ' ')
+			token++;
+
+		if (strncmp("MORE ", token, 5) == 0) {
+			free(vmcp_state.more);
+			vmcp_state.more = xstrdup(token);
+		}
+		if (strncmp("HOLD ", token, 5) == 0) {
+			free(vmcp_state.hold);
+			vmcp_state.hold = xstrdup(token);
+		}
+	}
+}
+
+static void parsespool(char *msg)
+{
+	vmcp_state.spooling = 0;
+	if (strstr(msg, " TERM START ") != NULL)
+		vmcp_state.spooling = 1;
+}
+
+void vmcp_warning3215(int fd)
+{
+	/*
+	 * Warning: Do not translate this test as it might inlude then so called
+	 * umlauts which in fact can not be encoded for the 3215 console interface.
+	 * The 3215 console driver work in fact with EBCDIC codepage and the
+	 * kernel has to translate such umlauts (multi or single bytes) with the
+	 * correct EBCDIC character table (for german e.g. IBM-1141 or IBM-273).
+	 */
+	(void)writevmcp(fd, "MESSAGE * WARNING: 3215 mode. Password visible!");
+	(void)writevmcp(fd, "MESSAGE * Ensure nobody is watching the screen.");
+}
+
+/* Query spool state, parse it, and stop logging */
+void vmcp_stop_console_logging(int fd)
+{
+	char *msg = queryspool(fd);
+	if (msg) {
+		parsespool(msg);
+		free(msg);
+	}
+	if (vmcp_state.spooling)
+		stopspool(fd);
+}
+
+/* Query terminal state, parse it, and configure for password input */
+void vmcp_prepare_terminal_for_password(int fd)
+{
+	char *msg = queryterm(fd);
+	if (msg) {
+		parseterm(msg);
+		free(msg);
+	}
+	if (vmcp_state.more && vmcp_state.hold)
+		setterm(fd, "0");
+}
+
+/* Restore terminal and spool states, cleanup, and close fd */
+void vmcp_restore_and_close(int fd, int flags)
+{
+	if (fd < 0)
+		return;
+	if (flags & CON_3215)
+		restoreterm(fd);
+	if (flags & (CON_3215|CON_3270))
+		restorespool(fd);
+	clearvmcp();
+	close(fd);
+}
+#endif

--- a/login-utils/vmcp.h
+++ b/login-utils/vmcp.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * vmcp.c - s390x 3215 console spool and terminal management
+ *
+ * Copyright 2026 Werner Fink, SUSE Software Solutions Germany GmbH
+ *
+ * Based on:
+ *
+ * Copyright IBM Corp. 2018
+ * s390-tools is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ *
+ */
+
+#if defined(__s390__) || defined(__s390x__)
+extern int vmcp_open(void);
+extern void vmcp_warning3215(int fd);
+extern void vmcp_stop_console_logging(int fd);
+extern void vmcp_prepare_terminal_for_password(int fd);
+extern void vmcp_restore_and_close(int fd, int flags);
+#endif


### PR DESCRIPTION
Some remarks: on S390x architecture of modern zSeries the hypervisor
does log the console I/O.  For both the 3215 half duplex line mode as
well as the 3270 full-screen/block mode console type the I/O is logged
on the hypervisor's side.  To control this there are command send via 
/dev/vmcp to tell the  z/VM control program of the hypervisor not to
log during entering the password.  For the 3215 console also automatic
scroll is enabled which avoid to press CLEAR to get the password prompt
if on the next block.
    
Beside this for the ttysclp0, the serial ASCII terminal accessed via 
a websocket has since ncurses 6.5-20250405 a new terminfo entry called
"sclp" to support not only the vt220 like behaviour but also the 
colouring feature of ttysclp0.
    
Ensure to detect all special console case on S390x
    
Include vmcp.h as well
    
Not reintegrate lib/logindefs.c
    
Resolve conflict in login-utils/Makemodule.am

Handle error case and avoid compiler warnings