### PR TITLE
build-sys: improve portability for non-Linux platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -563,9 +563,13 @@ AC_CHECK_MEMBERS([struct termios.c_line],,,
 AC_CHECK_MEMBERS([struct stat.st_mtim.tv_nsec],,,
     [[#include <sys/stat.h>]])
 
-AC_CHECK_TYPES([struct statx], [have_struct_statx=yes], [have_struct_statx=no], [[#include <sys/stat.h>]])
-AC_CHECK_MEMBERS([struct statx.stx_mnt_id],,,
-    [[#include <sys/stat.h>]])
+AS_IF([test "x$linux_os" = xyes], [
+  AC_CHECK_TYPES([struct statx], [have_struct_statx=yes], [have_struct_statx=no], [[#include <sys/stat.h>]])
+  AC_CHECK_MEMBERS([struct statx.stx_mnt_id],,,
+      [[#include <sys/stat.h>]])
+], [
+  have_struct_statx=no
+])
 
 AC_CHECK_DECLS([_NL_TIME_WEEK_1STDAY],[],[],[[#include <langinfo.h>]])
 
@@ -706,7 +710,11 @@ AC_CHECK_FUNCS([open_memstream], [have_open_memstream=yes],[have_open_memstream=
 AC_CHECK_FUNCS([posix_fallocate], [have_posix_fallocate=yes], [have_posix_fallocate=no])
 AC_CHECK_FUNCS([reboot], [have_reboot=yes],[have_reboot=no])
 AC_CHECK_FUNCS([updwtmpx updwtmpx], [have_gnu_utmpx=yes], [have_gnu_utmpx=no])
-AC_CHECK_FUNCS([statx], [have_statx=yes], [have_statx=no])
+AS_IF([test "x$linux_os" = xyes], [
+  AC_CHECK_FUNCS([statx], [have_statx=yes], [have_statx=no])
+], [
+  have_statx=no
+])
 
 AM_CONDITIONAL([HAVE_OPENAT], [test "x$have_openat" = xyes])
 AM_CONDITIONAL([HAVE_SYS_PRCTL_H], [test "x$ac_cv_header_sys_prctl_h" = xyes])

--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -70,8 +70,8 @@
 #include <termios.h>
 #include <sys/stat.h>
 #include <getopt.h>
-#include <err.h>
 
+#include "c.h"
 #include "blkdev.h"
 #include "minix_programs.h"
 #include "nls.h"

--- a/lib/configs.c
+++ b/lib/configs.c
@@ -1,7 +1,6 @@
 /*
  * configs_file.c instantiates functions defined and described in configs_file.h
  */
-#include <err.h>
 #include <errno.h>
 #include <sys/syslog.h>
 #include <sys/stat.h>

--- a/lib/fileeq.c
+++ b/lib/fileeq.c
@@ -568,7 +568,6 @@ done:
 
 #ifdef TEST_PROGRAM_FILEEQ
 # include <getopt.h>
-# include <err.h>
 
 int main(int argc, char *argv[])
 {

--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -11,7 +11,9 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <sys/syscall.h>
+#ifdef HAVE_SYS_SYSCALL_H
+# include <sys/syscall.h>
+#endif
 #include <string.h>
 #include <sys/wait.h>
 #include <fcntl.h>

--- a/lib/pager.c
+++ b/lib/pager.c
@@ -14,7 +14,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <err.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>

--- a/lib/pidfd-utils.c
+++ b/lib/pidfd-utils.c
@@ -9,7 +9,6 @@
 #include <sys/vfs.h>
 #include <sys/types.h>
 #include <errno.h>
-#include <err.h>
 
 #include "c.h"
 #include "nls.h"

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -1206,7 +1206,6 @@ int sysfs_get_address_bits(struct path_cxt *pc)
 
 #ifdef TEST_PROGRAM_SYSFS
 #include <errno.h>
-#include <err.h>
 #include <stdlib.h>
 
 int main(int argc, char *argv[])

--- a/login-utils/lslogins.c
+++ b/login-utils/lslogins.c
@@ -32,7 +32,6 @@
 #include <time.h>
 #include <utmpx.h>
 #include <signal.h>
-#include <err.h>
 #include <limits.h>
 #include <search.h>
 #include <lastlog.h>

--- a/login-utils/su-common.c
+++ b/login-utils/su-common.c
@@ -51,8 +51,6 @@
 # define USE_PTY
 #endif
 
-#include "err.h"
-
 #include <stdbool.h>
 
 #include "c.h"

--- a/meson.build
+++ b/meson.build
@@ -215,11 +215,17 @@ have_mountfd_api = cc.has_type('struct mount_attr', prefix : '#include <linux/mo
 conf.set('HAVE_STRUCT_MOUNT_ATTR', have_mountfd_api ? 1 : false)
 conf.set('HAVE_MOUNTFD_API', have_mountfd_api ? 1 : false)
 
-have_struct_statx = cc.has_type('struct statx', args : '-D_GNU_SOURCE', prefix : '#include <sys/stat.h>')
+have_struct_statx = false
+have_statx_mnt_id = false
+if host_machine.system() == 'linux'
+  have_struct_statx = cc.has_type('struct statx', args : '-D_GNU_SOURCE', prefix : '#include <sys/stat.h>')
+  if have_struct_statx
+    have_statx_mnt_id = cc.has_member('struct statx', 'stx_mnt_id',
+                                       prefix : '#include <sys/stat.h>')
+  endif
+endif
 conf.set('HAVE_STRUCT_STATX', have_struct_statx ? 1 : false)
-have = cc.has_member('struct statx', 'stx_mnt_id',
-                     prefix : '#include <sys/stat.h>')
-conf.set('HAVE_STRUCT_STATX_STX_MNT_ID', have ? 1 : false)
+conf.set('HAVE_STRUCT_STATX_STX_MNT_ID', have_statx_mnt_id ? 1 : false)
 
 
 have_statmount = cc.has_type('struct statmount', prefix : '#include <linux/mount.h>')
@@ -764,7 +770,6 @@ funcs = '''
         sched_setscheduler
         sigqueue
         srandom
-        statx
         strnchr
         strndup
         strnlen
@@ -803,6 +808,12 @@ foreach func: funcs
   # redefined macros from Python.h, which uses this convention.
   conf.set('HAVE_' + func.to_upper(), have ? 1 : false)
 endforeach
+
+have_statx = false
+if host_machine.system() == 'linux'
+  have_statx = cc.has_function('statx')
+endif
+conf.set('HAVE_STATX', have_statx ? 1 : false)
 
 # scandirat() may exist in the SDK but be gated behind availability
 # annotations (e.g. macOS); verify it is actually usable at compile time.

--- a/misc-utils/uuidd.c
+++ b/misc-utils/uuidd.c
@@ -30,7 +30,6 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <errno.h>
-#include <err.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/socket.h>

--- a/sys-utils/eject.c
+++ b/sys-utils/eject.c
@@ -24,7 +24,6 @@
 #include <string.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <err.h>
 #include <stdarg.h>
 
 #include <getopt.h>

--- a/sys-utils/pivot_root.c
+++ b/sys-utils/pivot_root.c
@@ -8,7 +8,6 @@
  *
  * Copyright (C) 2000 Werner Almesberger
  */
-#include <err.h>
 #include <errno.h>
 #include <getopt.h>
 #include <stdio.h>

--- a/tests/helpers/test_child_create.c
+++ b/tests/helpers/test_child_create.c
@@ -21,7 +21,6 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <err.h>
 #include <getopt.h>
 #include <errno.h>
 #include "strutils.h"

--- a/tests/helpers/test_enosys.c
+++ b/tests/helpers/test_enosys.c
@@ -15,10 +15,11 @@
  * along with this program.  If not, see <https://gnu.org/licenses/>.
  */
 
-#include <err.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+
+#include "c.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/tests/helpers/test_md5.c
+++ b/tests/helpers/test_md5.c
@@ -6,8 +6,8 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include <err.h>
 
+#include "c.h"
 #include "md5.h"
 
 int main(void)

--- a/tests/helpers/test_mkfds_ppoll.c
+++ b/tests/helpers/test_mkfds_ppoll.c
@@ -38,8 +38,9 @@
 
 #include "test_mkfds.h"
 
+/* c.h conflicts with raw kernel headers used below */
+#include <err.h>
 #include <string.h>		/* memset */
-#include <err.h>		/* err */
 #include <errno.h>		/* EINTR */
 #include <linux/poll.h>		/* struct pollfd */
 #include <asm/signal.h>		/* sigset_t */

--- a/tests/helpers/test_open_twice.c
+++ b/tests/helpers/test_open_twice.c
@@ -27,7 +27,6 @@
  * After another character is given, the program exits.
  */
 
-#include <err.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <stdbool.h>
@@ -35,6 +34,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+#include "c.h"
 
 static void __attribute__((__noreturn__)) usage(const char *prog, FILE *fp, int eval)
 {

--- a/tests/helpers/test_sha1.c
+++ b/tests/helpers/test_sha1.c
@@ -5,9 +5,9 @@
  */
 #include <stdio.h>
 #include <unistd.h>
-#include <err.h>
 #include <stdlib.h>
 
+#include "c.h"
 #include "sha1.h"
 
 int main(void)

--- a/tests/helpers/test_sigreceive.c
+++ b/tests/helpers/test_sigreceive.c
@@ -6,9 +6,10 @@
  * Written by Sami Kerola <kerolasa@iki.fi>
  */
 
-#include <err.h>
 #include <getopt.h>
 #include <pwd.h>
+
+#include "c.h"
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/helpers/test_sigstate.c
+++ b/tests/helpers/test_sigstate.c
@@ -12,7 +12,6 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <errno.h>
-#include <err.h>
 
 #define _U_ __attribute__((__unused__))
 

--- a/tests/helpers/test_threads_create.c
+++ b/tests/helpers/test_threads_create.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
-#include <err.h>
 #include <getopt.h>
 #include <errno.h>
 

--- a/text-utils/hexdump.c
+++ b/text-utils/hexdump.c
@@ -38,7 +38,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <err.h>
 #include <limits.h>
 #include <getopt.h>
 #include "hexdump.h"


### PR DESCRIPTION
Restrict statx() and struct statx detection to Linux only, as some
platforms (e.g. AIX) provide an incompatible statx() interface.

Remove redundant #include <err.h> from files that already include
"c.h" (which provides err.h guarded by HAVE_ERR_H). For files that
lacked "c.h" entirely, replace <err.h> with "c.h".

Guard <sys/syscall.h> with HAVE_SYS_SYSCALL_H in lib/fileutils.c.

Addresses: #4519, #4520