### PR TITLE
libmount: properly end act file in mnt_free_update

### DIFF
--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -1058,6 +1058,11 @@ int mnt_update_start(struct libmnt_update *upd)
 	    asprintf(&upd->act_filename, "%s.act", upd->filename) <= 0)
 		return -ENOMEM;
 
+	if (upd->act_fd >= 0) {
+		DBG_OBJ(UPDATE, upd, ul_debug("reusing existing act file"));
+		return 0;
+	}
+
 	/* Use exclusive lock to avoid some other process will remove the the
 	 * file before it's marked as used by LOCK_SH (below) */
 	rc = update_init_lock(upd, NULL);

--- a/libmount/src/tab_update.c
+++ b/libmount/src/tab_update.c
@@ -80,11 +80,15 @@ void mnt_free_update(struct libmnt_update *upd)
 
 	DBG_OBJ(UPDATE, upd, ul_debug("free"));
 
+	if (upd->act_fd >= 0) {
+		mnt_update_end(upd);
+		if (upd->act_fd >= 0)
+			close(upd->act_fd);
+		upd->act_fd = -1;
+	}
 	mnt_unref_lock(upd->lock);
 	mnt_unref_fs(upd->fs);
 	mnt_unref_table(upd->mountinfo);
-	if (upd->act_fd >= 0)
-		close(upd->act_fd);
 	free(upd->target);
 	free(upd->filename);
 	free(upd->act_filename);


### PR DESCRIPTION
When mnt_context_mount() fails in mnt_context_do_mount(), the mnt_context_update_tabs() call is guarded by if (!rc) and gets skipped. This means mnt_update_end() -- the only function that unlinks /run/mount/utab.act -- never runs, leaving the act file orphaned on disk.

mnt_free_update() only close()s act_fd without releasing the lock or unlinking the act file. Fix this by calling mnt_update_end() before unreffing members, which properly unlocks, unlinks and closes the act file. Add a fallback close() for the case where mnt_update_end() fails to acquire the lock and returns early without closing the fd.

The utab.act file was introduced in v2.40 (commit 9218c9678a6a) and this leak has been present since then through the current master. A leftover utab.act causes mnt_monitor's
kernel_event_verify() to veil all subsequent kernel mount events (monitor.c: kernel_veiled + access(utab.act)==0), making consumers like udisksd miss real mount/umount notifications.