### PR TITLE
lscpu: prefer model over revision for the Model field

### DIFF
--- a/sys-utils/lscpu-cputype.c
+++ b/sys-utils/lscpu-cputype.c
@@ -686,6 +686,13 @@ int lscpu_read_cpuinfo(struct lscpu_cxt *cxt)
 				lscpu_add_cputype(cxt, pr->curr_type);
 			}
 
+			/* On PowerPC, "model" contains the machine/server
+			 * model rather than the CPU model; use revision */
+			if (pattern->id == PAT_MODEL
+			    && pr->curr_type->revision
+			    && strstr(pr->curr_type->revision, "pvr"))
+				break;
+
 			strdup_to_offset(pr->curr_type, pattern->offset, value);
 			break;
 		case CPUINFO_LINE_CACHE:

--- a/sys-utils/lscpu.c
+++ b/sys-utils/lscpu.c
@@ -910,7 +910,7 @@ print_summary_cputype(struct lscpu_cxt *cxt,
 	if (ct->family)
 		add_summary_s(tb, sec, _("CPU family:"), ct->family);
 	if (ct->model || ct->revision)
-		add_summary_s(tb, sec, _("Model:"), ct->revision ? ct->revision : ct->model);
+		add_summary_s(tb, sec, _("Model:"), ct->model ?: ct->revision);
 
 	add_summary_n(tb, sec, _("Thread(s) per core:"), ct->nthreads_per_core);
 	if (cxt->is_cluster)

--- a/tests/expected/lscpu/lscpu-arm-A510-A710-A715-X3
+++ b/tests/expected/lscpu/lscpu-arm-A510-A710-A715-X3
@@ -2,7 +2,7 @@ CPU(s):                          8
 On-line CPU(s) list:             0-7
 Vendor ID:                       ARM
 Model name:                      Cortex-A510
-Model:                           1
+Model:                           0xd46
 Thread(s) per core:              1
 Core(s) per socket:              3
 Socket(s):                       1
@@ -14,7 +14,7 @@ CPU min MHz:                     307.2000
 BogoMIPS:                        38.40
 Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint i8mm bf16 bti
 Model name:                      Cortex-A710
-Model:                           0
+Model:                           0xd47
 Thread(s) per core:              1
 Core(s) per socket:              2
 Socket(s):                       1
@@ -25,7 +25,7 @@ CPU min MHz:                     499.2000
 BogoMIPS:                        38.40
 Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint i8mm bf16 bti
 Model name:                      Cortex-A715
-Model:                           0
+Model:                           0xd4d
 Thread(s) per core:              1
 Core(s) per socket:              2
 Socket(s):                       1
@@ -36,7 +36,7 @@ CPU min MHz:                     499.2000
 BogoMIPS:                        38.40
 Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint i8mm bf16 bti
 Model name:                      Cortex-X3
-Model:                           0
+Model:                           0xd4e
 Thread(s) per core:              1
 Core(s) per socket:              1
 Socket(s):                       1

--- a/tests/expected/lscpu/lscpu-armv7
+++ b/tests/expected/lscpu/lscpu-armv7
@@ -2,7 +2,7 @@ CPU(s):              2
 On-line CPU(s) list: 0,1
 Vendor ID:           ARM
 Model name:          Cortex-A15
-Model:               4
+Model:               0xc0f
 Thread(s) per core:  1
 Core(s) per socket:  2
 Socket(s):           1


### PR DESCRIPTION
Based on the patch from Lokanadha M R <lokanadha.r@oss.qualcomm.com>.

The current logic prefers ct->revision over ct->model whenever revision is
set. This is not appropriate for architectures like ARM that populate both
fields, because the CPU model (part number) is the meaningful identifier
for the "Model:" line, not the revision.

On PowerPC, the "model" field in /proc/cpuinfo contains the machine/server
model (e.g., "IBM,8233-E8B") rather than the CPU model. A preparatory
commit skips reading this field when "revision" contains "pvr", so the
revision (PVR info) is still used on that platform.

Changes:
- lscpu: ignore model field on PowerPC
- lscpu: prefer model over revision for the Model field
- tests: update lscpu expected output for ARM