### PR TITLE
docs: wall: correct claim about mesg(1) and message delivery

### DIFF
--- a/term-utils/wall.1.adoc
+++ b/term-utils/wall.1.adoc
@@ -52,7 +52,7 @@ wall - write a message to all users
 
 *wall* displays a _message_, or the contents of a _file_, or otherwise its standard input, on the terminals of all currently logged in users. The command will wrap lines that are longer than 79 characters. Short lines are whitespace padded to have 79 characters. The command will always put a carriage return and new line at the end of each line.
 
-Only the superuser can write on the terminals of users who have chosen to deny messages or are using a program which automatically denies messages.
+*wall* performs no message-permission check of its own, unlike *write*(1): a terminal is written whenever *wall* can open it for writing, and skipped silently otherwise. *mesg n* therefore restrains *wall* only where access depends on the terminal's group write bit -- that is, when *wall* is installed set-group-ID *tty*, or when the invoker is a member of that group -- and never on a terminal the invoker owns, because it leaves the owner write bit set and *open*(2) matches the owner class first. The superuser is not restricted by terminal permissions.
 
 Reading from a _file_ is refused when the invoker is not superuser and the program is set-user-ID or set-group-ID.
 

--- a/term-utils/wall.1.adoc
+++ b/term-utils/wall.1.adoc
@@ -59,7 +59,7 @@ Reading from a _file_ is refused when the invoker is not superuser and the progr
 == OPTIONS
 
 *-n*, *--nobanner*::
-Suppress the banner.
+Suppress the banner. Works only for root; for other users the option is ignored.
 
 *-t*, *--timeout* _timeout_::
 Abandon the write attempt to the terminals after _timeout_ seconds. This _timeout_ must be a positive integer. The default value is 300 seconds, which is a legacy from the time when people ran terminals over modem lines.


### PR DESCRIPTION
`wall.1.adoc` states:

> Only the superuser can write on the terminals of users who have chosen to deny
> messages or are using a program which automatically denies messages.

This is false for a terminal the invoker owns, and it is false in the default
`--enable-use-tty-group` build — it is not a question of how a distribution packages
`wall`.

`wall` performs no message-permission check. `term-utils/wall.c` has only two privilege
tests: `geteuid() == 0` gating `--nobanner`, and `getuid() && is_privileged_execution()`
gating reads from a file. Neither affects delivery. Delivery is decided at
`term-utils/ttymsg.c:99`, `open(device, O_WRONLY|O_NONBLOCK)`, with `EBUSY`/`EACCES`/`ENOENT`
skipped silently.

`mesg n` clears the group and other write bits (`term-utils/mesg.c:168`) but leaves the
owner bit set, and `open(2)` matches the owner class before the group class. So for a
terminal the invoker owns, `mesg` is not in the path at all — the set-group-ID `tty` egid
never gets consulted.

Compare `write(1)`, which does test the bit before writing (`term-utils/write.c:118-126`,
`s.st_mode & S_IWGRP`, and the `skip ttys with msgs off` check at `write.c:246`). The
sentence in `wall.1.adoc` is inherited verbatim from `@(#)wall.1 6.5 (Berkeley) 4/23/91`
and has never been edited; it accurately describes `write`, not `wall`.

Note also the asymmetry inside this same DESCRIPTION — the very next sentence does state
its precondition:

> Reading from a _file_ is refused when the invoker is not superuser and the program is
> set-user-ID or set-group-ID.

and `mesg.1.adoc` states the same precondition from its side ("a less secure solution is
to set utilities like `write`(1) or `wall`(1) to setgid for the 'tty' group"). Only this
one sentence asserts an unconditional guarantee.

## Reproducer

Two sessions as the same non-root user, `mesg n` on the second:

```
$ tty                  # session 2
/dev/pts/1
$ mesg n
$ ls -l /dev/pts/1
crw------- 1 user tty 136, 1 ... /dev/pts/1

$ wall "still delivered"   # session 1, same user
```

The message appears on `pts/1`. The invoker is not the superuser and the terminal is mode
`0600` with messages denied.

## Changes

Two commits, both documentation only, no behaviour change:

1. `docs: wall: correct claim about mesg(1) and message delivery` — replaces the
   DESCRIPTION sentence with one that says what actually gates delivery, when `mesg` is
   and is not in the path, and that the superuser is not restricted by terminal
   permissions.
2. `docs: wall: note that --nobanner works only for root` — the OPTIONS entry says only
   "Suppress the banner"; `wall.c` refuses the option for non-root and warns.

The second commit is independent — please cherry-pick it even if you disagree with the
first. Happy to shorten either if the wording is longer than you want.

`wall.1.adoc` has had no content change since 2022, so this wording predates the
rework `mesg.1.adoc` received in Nov 2024, which is likely why the two pages drifted.
