### PR TITLE
docs: mesg: correct the standard stream references

### DIFF
--- a/term-utils/mesg.1.adoc
+++ b/term-utils/mesg.1.adoc
@@ -49,7 +49,7 @@ mesg - display (or do not display) messages from other users
 
 == DESCRIPTION
 
-The *mesg* utility is invoked by a user to control write access others have to the terminal device associated with standard error output. If write access is allowed, then programs such as *talk*(1) and *write*(1) may display messages on the terminal.
+The *mesg* utility is invoked by a user to control write access others have to the terminal device associated with its standard input, standard output or standard error, whichever is a terminal. If write access is allowed, then programs such as *talk*(1) and *write*(1) may display messages on the terminal.
 
 Traditionally, write access is allowed by default. However, as users become
 more conscious of various security risks, there is a trend to remove write
@@ -79,7 +79,7 @@ Disallow messages.
 *y*::
 Allow messages to be displayed.
 
-If no arguments are given, *mesg* shows the current message status on standard error output.
+If no arguments are given, *mesg* shows the current message status on standard output.
 
 
 == OPTIONS


### PR DESCRIPTION
Two places in `mesg.1.adoc` name standard error where the code uses a different stream.

**DESCRIPTION** (`mesg.1.adoc:52`) — "the terminal device associated with standard error
output". `mesg` calls `get_terminal_stdfd()` (`term-utils/mesg.c:124`), which takes the
first of stdin, stdout and stderr that is a terminal (`lib/ttyutils.c:103-113`):

```c
if (isatty(STDIN_FILENO))  return STDIN_FILENO;
if (isatty(STDOUT_FILENO)) return STDOUT_FILENO;
if (isatty(STDERR_FILENO)) return STDERR_FILENO;
```

**ARGUMENTS** (`mesg.1.adoc:84`) — "shows the current message status on standard error
output". It is written with `puts()` (`term-utils/mesg.c:145,148`), so it goes to standard
output. Visible with `mesg 2>/dev/null`, which still prints the status.

`mesg.c:36-37` credits the change that moved this to stdout ("writing to stdout as
suggested by Michael Meskes"), so the man page appears to have kept the older wording.

Documentation only, no behaviour change.
