### PR TITLE
docs: mesg: note that "mesg n" also clears the other-write bit

### DIFF
--- a/term-utils/mesg.1.adoc
+++ b/term-utils/mesg.1.adoc
@@ -69,6 +69,9 @@ The usual setup is to use a "tty" group and add relevant users to this group.
 Alternatively, a less secure solution is to set utilities like *write*(1) or
 *wall*(1) to setgid for the "tty" group.
 
+*mesg n* additionally clears the _other_ write bit, so a terminal that was made
+world-writable by other means is not left writable.
+
 The *mesg* utility silently exits with error status 2 if not executed on a terminal. In this case executing *mesg* is pointless. The command line option *--verbose* forces *mesg* to print a warning in this situation. This behaviour has been introduced in version 2.33.
 
 == ARGUMENTS


### PR DESCRIPTION
`mesg.1.adoc` DESCRIPTION says *mesg* "strictly modifies only _group_ permissions".

That holds for `mesg y`, which sets `S_IWGRP` alone and leaves other bits as they are
(`term-utils/mesg.c:161`). `mesg n` clears both (`term-utils/mesg.c:168`):

```c
fchmod(fd, sb.st_mode & ~(S_IWGRP|S_IWOTH))
```

so it also drops an other-write bit the terminal already carried.

That looks like the point rather than an oversight: the `~(S_IWGRP|S_IWOTH)` mask is much
older than 2.41 — it arrived as `st_mode &= ~022` in the util-linux 2.7.1 import — and
2362bfa5f removed the `S_IWOTH` *grant* from the `y` path only, so `n` remains the way to
turn off a tty that an older build had made world-writable. It just isn't covered by that
sentence.

This adds one sentence for that case in a new paragraph, which leaves the existing
sentence — and its six translated `po-man` entries — untouched. Documentation only, no
behaviour change.
