### PR TITLE
tests: hardlink sparse-skip use block-sized file

### DIFF
--- a/tests/ts/hardlink/options
+++ b/tests/ts/hardlink/options
@@ -119,7 +119,7 @@ else
 	mkdir -p "$SPDIR"
 	truncate -s 1M "$SPDIR"/sparse-a
 	truncate -s 1M "$SPDIR"/sparse-b
-	echo "content" > "$SPDIR"/real-a
+	dd if=/dev/zero of="$SPDIR"/real-a bs=4096 count=1 2>/dev/null
 	cp "$SPDIR"/real-a "$SPDIR"/real-b
 	$TS_CMD_HARDLINK -v "$SPDIR" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 	summary_clean


### PR DESCRIPTION
Filesystems with inline inode data (ext4, btrfs) may store tiny files
directly in the inode, resulting in `st_blocks == 0`.  The `real-a` file
created by `echo "content"` (8 bytes) can hit this, causing hardlink to
skip it as a zero-block file and the sparse-skip test to fail.

Use `dd` to create a 4096-byte file that always allocates at least one
disk block.

Addresses CI failure on armv7/qemu-user.