### PR TITLE
[WIP] lsfd: do not block on hung file systems (statx dont_sync & map_files)

### DIFF
--- a/.github/workflows/cibuild-setup-ubuntu.sh
+++ b/.github/workflows/cibuild-setup-ubuntu.sh
@@ -13,6 +13,7 @@ PACKAGES=(
 	btrfs-progs
 	dnsutils
 	libcap-ng-dev
+	libfuse-dev
 	libncursesw5-dev
 	libpam-dev
 	libudev-dev

--- a/bash-completion/lsfd
+++ b/bash-completion/lsfd
@@ -40,6 +40,7 @@ _lsfd_module()
 	case $cur in
 		-*)
 			OPTS="
+				--abort-if-blockable
 				--noheadings
 				--output
 				--version

--- a/configure.ac
+++ b/configure.ac
@@ -1734,6 +1734,28 @@ AS_IF([test "x$with_cap_ng" = xno], [
 AC_SUBST([CAP_NG_LIBS])
 
 
+AC_ARG_WITH([fuse],
+  AS_HELP_STRING([--without-fuse], [compile test_mkfds without libfuse]),
+  [], [with_fuse=auto]
+)
+have_fuse=no
+AS_IF([test "x$with_fuse" = xno], [
+  AM_CONDITIONAL([HAVE_FUSE], [false])
+],[
+  PKG_CHECK_MODULES_STATIC([FUSE], [fuse >= 2.6], [have_fuse=yes], [have_fuse=no])
+  AS_CASE([$with_fuse:$have_fuse],
+    [yes:no],
+      [AC_MSG_ERROR([fuse selected, but required library not found])]
+  )
+  AS_IF([test "x$have_fuse" = xyes], [
+    AC_DEFINE([HAVE_LIBFUSE], [1], [Define if libfuse is available])
+  ])
+  AM_CONDITIONAL([HAVE_FUSE], [test "x$have_fuse" = xyes])
+])
+AC_SUBST([FUSE_CFLAGS])
+AC_SUBST([FUSE_LIBS])
+
+
 AC_ARG_ENABLE([setpriv],
   AS_HELP_STRING([--disable-setpriv], [do not build setpriv]),
   [], [UL_DEFAULT_ENABLE([setpriv], [check])]

--- a/lsfd-cmd/cdev.c
+++ b/lsfd-cmd/cdev.c
@@ -500,7 +500,7 @@ static void cdev_tun_inspect_target_fd(struct cdev *cdev, int fd)
 	if (nsfd < 0)
 		return;
 
-	if (fstat(nsfd, &sb) == 0) {
+	if (lsfd_fstat(nsfd, &sb) == 0) {
 		tundata->devnetns = sb.st_ino;
 		load_fdsk_xinfo(tundata->devnetns, nsfd);
 	}

--- a/lsfd-cmd/file.c
+++ b/lsfd-cmd/file.c
@@ -516,8 +516,8 @@ static unsigned long get_minor_for_sysvipc(void)
 	if (procfs_process_init_path(pc, self) != 0)
 		goto out;
 
-	if (ul_path_statf(pc, &sb, 0, "map_files/%lx-%lx",
-			  (long)start, (long)start + pagesize) < 0)
+	if (lsfd_path_statf(pc, &sb, 0, "map_files/%lx-%lx",
+			    (long)start, (long)start + pagesize) < 0)
 		goto out;
 
 	m = minor(sb.st_dev);
@@ -546,7 +546,7 @@ static unsigned long get_minor_for_mqueue(void)
 	if (mq < 0)
 		return 0;
 
-	if (fstat((int)mq, &sb) < 0) {
+	if (lsfd_fstat((int)mq, &sb) < 0) {
 		mq_close(mq);
 		mq_unlink(mq_name);
 		return 0;
@@ -566,7 +566,7 @@ static unsigned long get_minor_for_pidfs(void)
 	if (fd < 0)
 		return 0;
 
-	if (fstat(fd, &sb) == 0 && (sb.st_mode & S_IFMT) == S_IFREG)
+	if (lsfd_fstat(fd, &sb) == 0 && (sb.st_mode & S_IFMT) == S_IFREG)
 		ret = minor(sb.st_dev);
 
 	close(fd);

--- a/lsfd-cmd/lsfd.1.adoc
+++ b/lsfd-cmd/lsfd.1.adoc
@@ -52,7 +52,9 @@ to abort immediately if *AT_STATX_DONT_SYNC* is unavailable.
 
 *-b*, *--abort-if-blockable*::
 Exit immediately with exit status 2 if the kernel or build does not
-support *statx*(2) with *AT_STATX_DONT_SYNC*.
+support *statx*(2) with *AT_STATX_DONT_SYNC*. When this option is specified,
+*lsfd* also avoids falling back to pathnames in _/proc/pid/maps_ if
+_/proc/pid/map_files_ is inaccessible, preventing potential pathname resolution hangs.
 
 *-l*, *--threads*::
 List in threads level.

--- a/lsfd-cmd/lsfd.1.adoc
+++ b/lsfd-cmd/lsfd.1.adoc
@@ -39,7 +39,20 @@ default outputs in your scripts. Always explicitly define expected columns by us
 option for customizing the output format, and *--filter* option for filtering. Use *lsfd --list-columns*
 to get a list of all available columns.
 
+Since util-linux v2.43, *lsfd* uses *statx*(2) with the *AT_STATX_DONT_SYNC*
+flag by default to collect file attributes without synchronizing with remote
+(e.g., NFS) or user-space (e.g., FUSE) file systems, reducing the risk of
+hanging on unresponsive storage. On platforms or environments where *statx*(2)
+or *AT_STATX_DONT_SYNC* is not available, *lsfd* falls back to traditional
+*stat*(2) calls without *AT_STATX_DONT_SYNC*, where synchronization with
+underlying file systems may still occur. The *-b* option can be specified
+to abort immediately if *AT_STATX_DONT_SYNC* is unavailable.
+
 == OPTIONS
+
+*-b*, *--abort-if-blockable*::
+Exit immediately with exit status 2 if the kernel or build does not
+support *statx*(2) with *AT_STATX_DONT_SYNC*.
 
 *-l*, *--threads*::
 List in threads level.
@@ -827,6 +840,14 @@ Do the same but print in JSON format: ::
 ....
 
 
+== EXIT STATUS
+*0*::
+Success.
+*1*::
+Failure.
+*2*::
+Non-blocking feature (*AT_STATX_DONT_SYNC*) is unavailable when *-b* is specified.
+
 == HISTORY
 
 The *lsfd* command is part of the util-linux package since v2.38.
@@ -847,6 +868,7 @@ mailto:kzak@redhat.com[Karel Zak]
 *socket*(2),
 *ss*(8),
 *stat*(2),
+*statx*(2),
 *vsock*(7)
 
 include::man-common/bugreports.adoc[]

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -651,7 +651,8 @@ struct lsfd_control {
 			show_main : 1,		/* print main table */
 			show_summary : 1,	/* print summary/counters */
 			sockets_only : 1,	/* display only SOCKETS */
-			show_xmode : 1;		/* XMODE column is enabled. */
+			show_xmode : 1,		/* XMODE column is enabled. */
+			abort_if_blockable : 1;
 
 	char *uri;
 
@@ -2385,6 +2386,7 @@ static void __attribute__((__noreturn__)) usage(void)
 	fputs(_(" -u, --notruncate             don't truncate text in columns\n"), out);
 	fputs(_(" -p, --pid <list>             collect information only for specified processes\n"), out);
 	fputs(_(" -i[4|6], --inet[=4|=6]       list only IPv4 and/or IPv6 sockets\n"), out);
+	fputs(_(" -b, --abort-if-blockable     exit immediately if stat with AT_STATX_DONT_SYNC is unavailable\n"), out);
 	fputs(_(" -Q, --filter <expr>          apply display filter\n"), out);
 	fputs(_("     --debug-filter           dump the internal data structure of filter and exit\n"), out);
 	fputs(_(" -C, --counter <name>:<expr>  define custom counter for --summary output\n"), out);
@@ -2748,6 +2750,7 @@ int main(int argc, char *argv[])
 		{ "notruncate", no_argument, NULL, 'u' },
 		{ "pid",        required_argument, NULL, 'p' },
 		{ "inet",       optional_argument, NULL, 'i' },
+		{ "abort-if-blockable", no_argument, NULL, 'b' },
 		{ "filter",     required_argument, NULL, 'Q' },
 		{ "debug-filter",no_argument, NULL, OPT_DEBUG_FILTER },
 		{ "summary",    optional_argument, NULL,  OPT_SUMMARY },
@@ -2772,7 +2775,7 @@ int main(int argc, char *argv[])
 	textdomain(PACKAGE);
 	close_stdout_atexit();
 
-	while ((c = getopt_long(argc, argv, "no:JrVhluQ:p:i::C:sH", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "no:JrVhluQ:p:i::C:sHb", longopts, NULL)) != -1) {
 		err_exclusive_options(c, longopts, excl, excl_st);
 
 		switch (c) {
@@ -2796,6 +2799,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'p':
 			parse_pids(optarg, &pids, &n_pids);
+			break;
+		case 'b':
+			ctl.abort_if_blockable = 1;
 			break;
 		case 'i': {
 			const char *subexpr = NULL;
@@ -2864,7 +2870,9 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	lsfd_init_stat_system();
+	if (!lsfd_init_stat_system() && ctl.abort_if_blockable)
+		errx(LSFD_EX_NONBLOCK_UNAVAIL,
+		     _("the kernel or build does not support statx with AT_STATX_DONT_SYNC"));
 
 	if (ctl.uri) {
 		char *badopt =

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -1039,14 +1039,14 @@ static void collect_fd_files(struct path_cxt *pc, struct proc *proc,
 	}
 }
 
-static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
+static void parse_maps_line(struct lsfd_control *ctl, struct path_cxt *pc, char *buf, struct proc *proc)
 {
 	uint64_t start, end, offset, ino;
 	unsigned long major, minor;
 	enum association assoc = ASSOC_MEM;
 	struct stat sb = { .st_mode = 0 };
-	struct file *f, *prev;
-	char *path, modestr[5];
+	struct file *f = NULL, *prev;
+	char *path = NULL, modestr[5];
 	dev_t devno;
 
 	/* read rest of the map */
@@ -1078,33 +1078,39 @@ static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
 	if (prev && (!is_error_object(prev))
 	    && prev->stat.st_dev == devno && prev->stat.st_ino == ino)
 		f = copy_file(prev, -assoc);
-	else if ((path = strchr(buf, '/'))) {
-		rtrim_whitespace((unsigned char *) path);
-		if (lsfd_stat(path, &sb) < 0)
-			/* If a file is mapped but deleted from the file system,
-			 * "stat by the file name" may not work. In that case,
-			 */
-			goto try_map_files;
-		if (sb.st_ino != ino || sb.st_dev != devno)
-			/* There are two files having the same absolute file names!
-			 *
-			 * Maybe the file is bind-mount'ed after mapped.
-			 */
-			goto try_map_files;
-		f = new_file(proc, stat2class(&sb), &sb, path, -assoc);
-	} else {
-		/* As used in tcpdump, AF_PACKET socket can be mmap'ed. */
+	else {
 		char sym[PATH_MAX] = { '\0' };
+		int readlink_err = 0;
+		int stat_err = 0;
 
-	try_map_files:
+		/* Prefer map_files to bypass pathname lookup and avoid hangs */
 		if (ul_path_readlinkf(pc, sym, sizeof(sym),
-				      "map_files/%"PRIx64"-%"PRIx64, start, end) < 0)
-			f = new_readlink_error_file(proc, errno, -assoc);
-		else if (lsfd_path_statf(pc, &sb, 0,
-				       "map_files/%"PRIx64"-%"PRIx64, start, end) < 0)
-			f = new_stat_error_file(proc, sym, errno, -assoc);
-		else
-			f = new_file(proc, stat2class(&sb), &sb, sym, -assoc);
+				      "map_files/%"PRIx64"-%"PRIx64, start, end) >= 0) {
+			if (lsfd_path_statf(pc, &sb, 0,
+					    "map_files/%"PRIx64"-%"PRIx64, start, end) == 0)
+				f = new_file(proc, stat2class(&sb), &sb, sym, -assoc);
+			else
+				stat_err = errno;
+		} else
+			readlink_err = errno;
+
+		if (!f && !ctl->abort_if_blockable && (path = strchr(buf, '/'))) {
+			/* Fallback to pathname from /proc/PID/maps if map_files is not accessible */
+			rtrim_whitespace((unsigned char *) path);
+			if (lsfd_stat(path, &sb) == 0 && sb.st_ino == ino && sb.st_dev == devno)
+				f = new_file(proc, stat2class(&sb), &sb, path, -assoc);
+		}
+
+		if (!f) {
+			if (stat_err)
+				f = new_stat_error_file(proc, sym, stat_err, -assoc);
+			else if (readlink_err)
+				f = new_readlink_error_file(proc, readlink_err, -assoc);
+			else if (path)
+				f = new_stat_error_file(proc, path, ENOENT, -assoc);
+			else
+				f = new_readlink_error_file(proc, ENOENT, -assoc);
+		}
 	}
 
 	if (modestr[0] == 'r')
@@ -1132,7 +1138,7 @@ static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
 	file_init_content(f);
 }
 
-static void collect_mem_files(struct path_cxt *pc, struct proc *proc)
+static void collect_mem_files(struct lsfd_control *ctl, struct path_cxt *pc, struct proc *proc)
 {
 	FILE *fp;
 	char buf[BUFSIZ];
@@ -1142,7 +1148,7 @@ static void collect_mem_files(struct path_cxt *pc, struct proc *proc)
 		return;
 
 	while (fgets(buf, sizeof(buf), fp))
-		parse_maps_line(pc, buf, proc);
+		parse_maps_line(ctl, pc, buf, proc);
 
 	fclose(fp);
 }
@@ -2232,7 +2238,7 @@ static void read_process(struct lsfd_control *ctl, struct path_cxt *pc,
 	if ((!ctl->sockets_only)
 	    && (proc->pid == proc->leader->pid
 		|| kcmp(proc->leader->pid, proc->pid, KCMP_VM, 0, 0) != 0))
-		collect_mem_files(pc, proc);
+		collect_mem_files(ctl, pc, proc);
 
 	if (proc->pid == proc->leader->pid
 	    || kcmp(proc->leader->pid, proc->pid, KCMP_FILES, 0, 0) != 0)

--- a/lsfd-cmd/lsfd.c
+++ b/lsfd-cmd/lsfd.c
@@ -963,7 +963,7 @@ static struct file *collect_file_symlink(struct path_cxt *pc,
 
 	if (ul_path_readlink(pc, sym, sizeof(sym), name) < 0)
 		f = new_readlink_error_file(proc, errno, assoc);
-	else if (ul_path_stat(pc, &sb, 0, name) < 0)
+	else if (lsfd_path_stat(pc, &sb, 0, name) < 0)
 		f = new_stat_error_file(proc, sym, errno, assoc);
 	else {
 		const struct file_class *class = stat2class(&sb);
@@ -995,7 +995,7 @@ static struct file *collect_file_symlink(struct path_cxt *pc,
 		/* file-descriptor based association */
 		FILE *fdinfo;
 
-		if (ul_path_stat(pc, &sb, AT_SYMLINK_NOFOLLOW, name) == 0)
+		if (lsfd_path_stat(pc, &sb, AT_SYMLINK_NOFOLLOW, name) == 0)
 			f->mode = sb.st_mode;
 
 		if (is_nsfs_dev(f->stat.st_dev))
@@ -1079,7 +1079,7 @@ static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
 		f = copy_file(prev, -assoc);
 	else if ((path = strchr(buf, '/'))) {
 		rtrim_whitespace((unsigned char *) path);
-		if (stat(path, &sb) < 0)
+		if (lsfd_stat(path, &sb) < 0)
 			/* If a file is mapped but deleted from the file system,
 			 * "stat by the file name" may not work. In that case,
 			 */
@@ -1099,7 +1099,7 @@ static void parse_maps_line(struct path_cxt *pc, char *buf, struct proc *proc)
 		if (ul_path_readlinkf(pc, sym, sizeof(sym),
 				      "map_files/%"PRIx64"-%"PRIx64, start, end) < 0)
 			f = new_readlink_error_file(proc, errno, -assoc);
-		else if (ul_path_statf(pc, &sb, 0,
+		else if (lsfd_path_statf(pc, &sb, 0,
 				       "map_files/%"PRIx64"-%"PRIx64, start, end) < 0)
 			f = new_stat_error_file(proc, sym, errno, -assoc);
 		else
@@ -1197,7 +1197,7 @@ static int collect_pidfs_file(struct proc *proc, bool sockets_only)
 		struct stat sb;
 		const int assoc = ASSOC_PIDFS * -1;
 
-		if (fstat(pidfd, &sb) < 0) {
+		if (lsfd_fstat(pidfd, &sb) < 0) {
 			/* Even fstat fails here, the pidfd is still
 			 * usable in the caller side. */
 			return pidfd;
@@ -1495,7 +1495,7 @@ static void process_mountinfo_entry(unsigned long major, unsigned long minor,
 {
 	if (mnt_ns != NULL) {
 		struct stat sb;
-		if (stat(mntpoint_filename, &sb) == 0)
+		if (lsfd_stat(mntpoint_filename, &sb) == 0)
 			add_cooked_bdev(mnt_ns, sb.st_dev, makedev(major, minor), filesystem);
 	}
 
@@ -2863,6 +2863,8 @@ int main(int argc, char *argv[])
 			errtryhelp(EXIT_FAILURE);
 		}
 	}
+
+	lsfd_init_stat_system();
 
 	if (ctl.uri) {
 		char *badopt =

--- a/lsfd-cmd/lsfd.h
+++ b/lsfd-cmd/lsfd.h
@@ -370,4 +370,11 @@ int call_with_foreign_fd(pid_t target_pid, int target_fd,
 int call_with_foreign_fd_via_pidfd(int pidfd, int target_fd,
 				   int (*fn)(int, void*), void *data);
 
+void lsfd_init_stat_system(void);
+int lsfd_stat(const char *path, struct stat *sb);
+int lsfd_path_stat(struct path_cxt *pc, struct stat *sb, int flags, const char *path);
+int lsfd_path_statf(struct path_cxt *pc, struct stat *sb, int flags, const char *path, ...)
+	__attribute__ ((__format__ (__printf__, 4, 5)));
+int lsfd_fstat(int fd, struct stat *sb);
+
 #endif /* UTIL_LINUX_LSFD_H */

--- a/lsfd-cmd/lsfd.h
+++ b/lsfd-cmd/lsfd.h
@@ -362,6 +362,8 @@ bool is_multiplexed_by_eventpoll(int fd, struct list_head *eventpolls);
  */
 bool is_pidfs_dev(dev_t dev);
 
+#define LSFD_EX_NONBLOCK_UNAVAIL 2
+
 /*
  * Utility
  */
@@ -370,7 +372,7 @@ int call_with_foreign_fd(pid_t target_pid, int target_fd,
 int call_with_foreign_fd_via_pidfd(int pidfd, int target_fd,
 				   int (*fn)(int, void*), void *data);
 
-void lsfd_init_stat_system(void);
+bool lsfd_init_stat_system(void);
 int lsfd_stat(const char *path, struct stat *sb);
 int lsfd_path_stat(struct path_cxt *pc, struct stat *sb, int flags, const char *path);
 int lsfd_path_statf(struct path_cxt *pc, struct stat *sb, int flags, const char *path, ...)

--- a/lsfd-cmd/sock-xinfo.c
+++ b/lsfd-cmd/sock-xinfo.c
@@ -253,7 +253,7 @@ void initialize_sock_xinfos(void)
 	if (self_netns_fd < 0)
 		load_sock_xinfo_no_nsswitch(NULL);
 	else {
-		if (fstat(self_netns_fd, &self_netns_sb) == 0) {
+		if (lsfd_fstat(self_netns_fd, &self_netns_sb) == 0) {
 			unsigned long m;
 			struct netns *nsobj = mark_sock_xinfo_loaded(self_netns_sb.st_ino);
 			load_sock_xinfo_no_nsswitch(nsobj);
@@ -279,7 +279,7 @@ void initialize_sock_xinfos(void)
 		struct stat sb;
 		int fd;
 		struct netns *nsobj;
-		if (ul_path_stat(pc, &sb, 0, d->d_name) < 0)
+		if (lsfd_path_stat(pc, &sb, 0, d->d_name) < 0)
 			continue;
 		if (is_sock_xinfo_loaded(sb.st_ino))
 			continue;

--- a/lsfd-cmd/sock.c
+++ b/lsfd-cmd/sock.c
@@ -154,7 +154,7 @@ ino_t get_netns_from_socket(int sk)
 	if (nsfd < 0)
 		return 0;
 
-	if (fstat(nsfd, &sb) < 0) {
+	if (lsfd_fstat(nsfd, &sb) < 0) {
 		close(nsfd);
 		return 0;
 	}

--- a/lsfd-cmd/util.c
+++ b/lsfd-cmd/util.c
@@ -20,6 +20,7 @@
  */
 #include "lsfd.h"		/* prototype decl for call_with_foreign_fd */
 #include "pidfd-utils.h"
+#include "fileutils.h"
 
 int call_with_foreign_fd_via_pidfd(int pidfd, int target_fd,
 				   int (*fn)(int, void*), void *data)
@@ -49,4 +50,108 @@ int call_with_foreign_fd(pid_t target_pid, int target_fd,
 
 	close(pidfd);
 	return r;
+}
+
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX)
+
+static bool statx_available = false;
+
+static void statx_to_stat(const struct statx *stx, struct stat *st)
+{
+	memset(st, 0, sizeof(*st));
+	st->st_dev = makedev(stx->stx_dev_major, stx->stx_dev_minor);
+	st->st_ino = stx->stx_ino;
+	st->st_mode = stx->stx_mode;
+	st->st_nlink = stx->stx_nlink;
+	st->st_uid = stx->stx_uid;
+	st->st_gid = stx->stx_gid;
+	st->st_rdev = makedev(stx->stx_rdev_major, stx->stx_rdev_minor);
+	st->st_size = stx->stx_size;
+	st->st_blksize = stx->stx_blksize;
+	st->st_blocks = stx->stx_blocks;
+	st->st_atim.tv_sec = stx->stx_atime.tv_sec;
+	st->st_atim.tv_nsec = stx->stx_atime.tv_nsec;
+	st->st_mtim.tv_sec = stx->stx_mtime.tv_sec;
+	st->st_mtim.tv_nsec = stx->stx_mtime.tv_nsec;
+	st->st_ctim.tv_sec = stx->stx_ctime.tv_sec;
+	st->st_ctim.tv_nsec = stx->stx_ctime.tv_nsec;
+}
+
+void lsfd_init_stat_system(void)
+{
+	struct statx stx;
+
+	if (statx(AT_FDCWD, "/proc/self", 0, STATX_BASIC_STATS, &stx) == 0)
+		statx_available = true;
+}
+#else
+void lsfd_init_stat_system(void)
+{
+}
+#endif
+
+int lsfd_stat(const char *path, struct stat *sb)
+{
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX)
+	if (statx_available) {
+		struct statx stx;
+		int rc;
+
+		rc = statx(AT_FDCWD, path, 0, STATX_BASIC_STATS, &stx);
+		if (rc == 0)
+			statx_to_stat(&stx, sb);
+		return rc;
+	}
+#endif
+	return stat(path, sb);
+}
+
+int lsfd_path_stat(struct path_cxt *pc, struct stat *sb, int flags, const char *path)
+{
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX)
+	if (statx_available) {
+		struct statx stx;
+		int rc;
+
+		rc = ul_path_statx(pc, &stx, flags, STATX_BASIC_STATS, path);
+		if (rc == 0)
+			statx_to_stat(&stx, sb);
+		return rc;
+	}
+#endif
+	return ul_path_stat(pc, sb, flags, path);
+}
+
+int lsfd_path_statf(struct path_cxt *pc, struct stat *sb, int flags, const char *path, ...)
+{
+	char buf[PATH_MAX];
+	va_list ap;
+	int rc;
+
+	va_start(ap, path);
+	rc = vsnprintf(buf, sizeof(buf), path, ap);
+	va_end(ap);
+
+	if (rc < 0 || (size_t)rc >= sizeof(buf)) {
+		errno = ENAMETOOLONG;
+		return -errno;
+	}
+
+	return lsfd_path_stat(pc, sb, flags, buf);
+}
+
+int lsfd_fstat(int fd, struct stat *sb)
+{
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX)
+	if (statx_available) {
+		struct statx stx;
+		int rc;
+
+		rc = statx(fd, "", AT_EMPTY_PATH, STATX_BASIC_STATS, &stx);
+		if (rc == 0)
+			statx_to_stat(&stx, sb);
+		return rc;
+	}
+#endif
+	return fstat(fd, sb);
 }

--- a/lsfd-cmd/util.c
+++ b/lsfd-cmd/util.c
@@ -52,9 +52,9 @@ int call_with_foreign_fd(pid_t target_pid, int target_fd,
 	return r;
 }
 
-#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX)
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(AT_STATX_DONT_SYNC)
 
-static bool statx_available = false;
+static bool dont_sync_available = false;
 
 static void statx_to_stat(const struct statx *stx, struct stat *st)
 {
@@ -77,27 +77,30 @@ static void statx_to_stat(const struct statx *stx, struct stat *st)
 	st->st_ctim.tv_nsec = stx->stx_ctime.tv_nsec;
 }
 
-void lsfd_init_stat_system(void)
+bool lsfd_init_stat_system(void)
 {
 	struct statx stx;
 
-	if (statx(AT_FDCWD, "/proc/self", 0, STATX_BASIC_STATS, &stx) == 0)
-		statx_available = true;
+	if (statx(AT_FDCWD, "/proc/self", AT_STATX_DONT_SYNC, STATX_BASIC_STATS, &stx) == 0)
+		dont_sync_available = true;
+
+	return dont_sync_available;
 }
 #else
-void lsfd_init_stat_system(void)
+bool lsfd_init_stat_system(void)
 {
+	return false;
 }
 #endif
 
 int lsfd_stat(const char *path, struct stat *sb)
 {
-#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX)
-	if (statx_available) {
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(AT_STATX_DONT_SYNC)
+	if (dont_sync_available) {
 		struct statx stx;
 		int rc;
 
-		rc = statx(AT_FDCWD, path, 0, STATX_BASIC_STATS, &stx);
+		rc = statx(AT_FDCWD, path, AT_STATX_DONT_SYNC, STATX_BASIC_STATS, &stx);
 		if (rc == 0)
 			statx_to_stat(&stx, sb);
 		return rc;
@@ -108,12 +111,12 @@ int lsfd_stat(const char *path, struct stat *sb)
 
 int lsfd_path_stat(struct path_cxt *pc, struct stat *sb, int flags, const char *path)
 {
-#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX)
-	if (statx_available) {
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(AT_STATX_DONT_SYNC)
+	if (dont_sync_available) {
 		struct statx stx;
 		int rc;
 
-		rc = ul_path_statx(pc, &stx, flags, STATX_BASIC_STATS, path);
+		rc = ul_path_statx(pc, &stx, flags | AT_STATX_DONT_SYNC, STATX_BASIC_STATS, path);
 		if (rc == 0)
 			statx_to_stat(&stx, sb);
 		return rc;
@@ -142,12 +145,12 @@ int lsfd_path_statf(struct path_cxt *pc, struct stat *sb, int flags, const char 
 
 int lsfd_fstat(int fd, struct stat *sb)
 {
-#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX)
-	if (statx_available) {
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(AT_STATX_DONT_SYNC)
+	if (dont_sync_available) {
 		struct statx stx;
 		int rc;
 
-		rc = statx(fd, "", AT_EMPTY_PATH, STATX_BASIC_STATS, &stx);
+		rc = statx(fd, "", AT_EMPTY_PATH | AT_STATX_DONT_SYNC, STATX_BASIC_STATS, &stx);
 		if (rc == 0)
 			statx_to_stat(&stx, sb);
 		return rc;

--- a/meson.build
+++ b/meson.build
@@ -600,6 +600,16 @@ lib_audit = dependency(
   required : get_option('audit'))
 conf.set('HAVE_LIBAUDIT', lib_audit.found() ? 1 : false)
 
+lib_fuse = dependency(
+  'fuse',
+  version : '>= 2.6',
+  required : get_option('fuse'))
+conf.set('HAVE_LIBFUSE', lib_fuse.found() ? 1 : false)
+
+summary('libfuse',
+        lib_fuse.found() ? 'enabled' : 'disabled',
+        section : 'components')
+
 conf.set('HAVE_SMACK', get_option('smack').allowed())
 
 header = 'linux/btrfs.h'
@@ -4196,6 +4206,10 @@ if LINUX
   endif
   if cc.has_header('linux/io_uring.h')
     test_mkfds_c_args += ['-DHAVE_LINUX_IO_URING_H']
+  endif
+  if lib_fuse.found()
+    test_mkfds_sources += ['tests/helpers/test_mkfds_hungfs.c']
+    test_mkfds_deps += [lib_fuse]
   endif
   exe = executable(
     'test_mkfds',

--- a/meson.build
+++ b/meson.build
@@ -4177,8 +4177,17 @@ if not is_disabler(exe)
   exes += exe
 endif
 
-if LINUX and lib_rt.found()
+if LINUX
   test_mkfds_c_args = []
+  test_mkfds_deps = []
+  test_mkfds_sources = [
+    'tests/helpers/test_mkfds.c',
+    'tests/helpers/test_mkfds.h',
+    'tests/helpers/test_mkfds_ppoll.c',
+  ]
+  if lib_rt.found()
+    test_mkfds_deps += [lib_rt]
+  endif
   if cc.has_header_symbol('linux/bpf.h', 'BPF_LINK_CREATE')
     test_mkfds_c_args += ['-DHAVE_BPF_LINK_CREATE']
   endif
@@ -4190,12 +4199,10 @@ if LINUX and lib_rt.found()
   endif
   exe = executable(
     'test_mkfds',
-    'tests/helpers/test_mkfds.c',
-    'tests/helpers/test_mkfds.h',
-    'tests/helpers/test_mkfds_ppoll.c',
+    test_mkfds_sources,
     include_directories : includes,
     link_with : lib_smartcols.get_static_lib(),
-    dependencies : [lib_rt],
+    dependencies : test_mkfds_deps,
     c_args : test_mkfds_c_args,
     build_by_default: program_tests)
   exes += exe

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,6 +34,8 @@ option('widechar',    type : 'feature',
        description : 'compile with wide character support')
 option('translate-docs', type : 'feature',
        description : 'translate documentation')
+option('fuse',           type : 'feature',
+       description : 'build test_mkfds with libfuse')
 
 # enable building of various programs and features ("build-" prefix)
 

--- a/tests/expected/lsfd/mkfds-fuse-hungfs-fd
+++ b/tests/expected/lsfd/mkfds-fuse-hungfs-fd
@@ -1,0 +1,2 @@
+3 REG fuse.hungfs
+ASSOC,TYPE,SOURCE: 0

--- a/tests/expected/lsfd/mkfds-fuse-hungfs-mem
+++ b/tests/expected/lsfd/mkfds-fuse-hungfs-mem
@@ -1,0 +1,2 @@
+mem REG fuse.hungfs
+ASSOC,TYPE,SOURCE: 0

--- a/tests/expected/lsfd/option-abort-if-blockable
+++ b/tests/expected/lsfd/option-abort-if-blockable
@@ -1,0 +1,2 @@
+lsfd: the kernel or build does not support statx with AT_STATX_DONT_SYNC
+RC: 2

--- a/tests/helpers/Makemodule.am
+++ b/tests/helpers/Makemodule.am
@@ -48,12 +48,19 @@ test_kill_pidfdino_SOURCES = tests/helpers/test_kill_pidfdino.c
 test_kill_pidfdino_LDADD = $(LDADD) libcommon.la
 
 if LINUX
+if !OSS_FUZZ
 check_PROGRAMS += test_mkfds
 test_mkfds_SOURCES = tests/helpers/test_mkfds.c tests/helpers/test_mkfds.h \
 	tests/helpers/test_mkfds_ppoll.c
 test_mkfds_LDFLAGS = -static
 test_mkfds_LDADD = $(LDADD) $(MQ_LIBS) libsmartcols.la
 test_mkfds_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
+if HAVE_FUSE
+test_mkfds_SOURCES += tests/helpers/test_mkfds_hungfs.c
+test_mkfds_LDADD += $(FUSE_LIBS)
+test_mkfds_CFLAGS += $(FUSE_CFLAGS)
+endif
+endif
 
 check_PROGRAMS += test_enosys
 test_enosys_SOURCES = tests/helpers/test_enosys.c

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -805,6 +805,8 @@ struct hungfs_ctl {
 	char *mountpoint;
 	char *targetfile;
 	bool hung;
+	void *mmap_addr;
+	size_t mmap_len;
 };
 
 static void stop_hungfs(struct hungfs_ctl *ctl)
@@ -843,14 +845,23 @@ static void *make_fuse_hungfs(const struct factory *factory, struct fdesc fdescs
 	int fd;
 	int sv[2];
 	pid_t pid;
-	struct hungfs_ctl ctl;
-
+	struct hungfs_ctl ctl = {
+		.pid = 0,
+		.fd = -1,
+		.mountpoint = NULL,
+		.targetfile = NULL,
+		.hung = false,
+		.mmap_addr = NULL,
+		.mmap_len = 0,
+	};
 	struct arg mountpoint = decode_arg("mountpoint", factory->params, argc, argv);
 	const char *sMountpoint = ARG_STRING(mountpoint);
 	struct arg file = decode_arg("file", factory->params, argc, argv);
 	const char *sFile = ARG_STRING(file);
 	struct arg hung = decode_arg("hung", factory->params, argc, argv);
 	bool bHung = ARG_BOOLEAN(hung);
+	struct arg mmap_arg = decode_arg("mmap", factory->params, argc, argv);
+	bool bMmap = ARG_BOOLEAN(mmap_arg);
 
 	{
 		struct stat sb;
@@ -893,6 +904,7 @@ static void *make_fuse_hungfs(const struct factory *factory, struct fdesc fdescs
 	free_arg(&mountpoint);
 	free_arg(&file);
 	free_arg(&hung);
+	free_arg(&mmap_arg);
 
 	wait_hungfs(&ctl);
 
@@ -909,6 +921,21 @@ static void *make_fuse_hungfs(const struct factory *factory, struct fdesc fdescs
 
 		errno = e;
 		err(EXIT_FAILURE, "failed to open %s", t);
+	}
+
+	if (bMmap) {
+		ctl.mmap_len = 1024;
+		ctl.mmap_addr = mmap(NULL, ctl.mmap_len, PROT_READ, MAP_PRIVATE, fd, 0);
+		if (ctl.mmap_addr == MAP_FAILED) {
+			int e = errno;
+			char *t = ctl.targetfile;
+
+			ctl.targetfile = NULL;
+			stop_hungfs(&ctl);
+
+			errno = e;
+			err(EXIT_FAILURE, "failed in mmap %s", t);
+		}
 	}
 
 	/* Release the reservation and duplicate the opened fd into fdescs[0].fd */
@@ -930,6 +957,9 @@ static void *make_fuse_hungfs(const struct factory *factory, struct fdesc fdescs
 static void free_fuse_hungfs(const struct factory *factory _U_, void *data)
 {
 	struct hungfs_ctl *ctl = data;
+
+	if (ctl->mmap_addr && ctl->mmap_addr != MAP_FAILED)
+		munmap(ctl->mmap_addr, ctl->mmap_len);
 
 	if (ctl->hung)
 		go_hungfs(ctl);
@@ -5353,6 +5383,12 @@ static const struct factory factories[] = {
 				.name = "hung",
 				.type = PTYPE_BOOLEAN,
 				.desc = "hang on getattr after open",
+				.defv.boolean = false,
+			},
+			{
+				.name = "mmap",
+				.type = PTYPE_BOOLEAN,
+				.desc = "mmap the opened file into memory privately (MAP_PRIVATE)",
 				.defv.boolean = false,
 			},
 			PARAM_END

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -99,6 +99,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out, int status)
 	fputs(" -q, --quiet                   don't print pid(s)\n", out);
 	fputs(" -X, --dont-monitor-stdin      don't monitor stdin when pausing\n", out);
 	fputs(" -c, --dont-pause              don't pause after making fd(s)\n", out);
+	fputs(" -t, --timeout <sec>           timeout in seconds\n", out);
 	fputs(" -w, --wait-with <multiplexer> use MULTIPLEXER for waiting events\n", out);
 	fputs(" -W, --multiplexers            list multiplexers\n", out);
 
@@ -5447,7 +5448,7 @@ static void do_nothing(int signum _U_)
  */
 struct multiplexer {
 	const char *name;
-	void (*fn)(bool, struct fdesc *fdescs, size_t n_fdescs);
+	bool (*fn)(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs);
 };
 
 #if defined(__NR_select) || defined(__NR_poll)
@@ -5458,13 +5459,14 @@ static void sighandler_nop(int si _U_)
 #endif
 
 #define DEFUN_WAIT_EVENT_SELECT(NAME,SYSCALL,XDECLS,SETUP_SIG_HANDLER,SYSCALL_INVOCATION) \
-	static void wait_event_##NAME(bool add_stdin, struct fdesc *fdescs, size_t n_fdescs) \
+	static bool wait_event_##NAME(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs) \
 	{								\
 		fd_set readfds;						\
 		fd_set writefds;					\
 		fd_set exceptfds;					\
 		XDECLS							\
 		int n = 0;						\
+		bool expired = false;					\
 									\
 		FD_ZERO(&readfds);					\
 		FD_ZERO(&writefds);					\
@@ -5474,6 +5476,10 @@ static void sighandler_nop(int si _U_)
 		if (add_stdin) {					\
 			n = 1;						\
 			FD_SET(0, &readfds);				\
+		}							\
+		if (tfd >= 0) {						\
+			n = max(n, tfd + 1);				\
+			FD_SET(tfd, &readfds);				\
 		}							\
 									\
 		for (size_t i = 0; i < n_fdescs; i++) {			\
@@ -5499,6 +5505,9 @@ static void sighandler_nop(int si _U_)
 				errx(EXIT_ENOSYS, "no syscall: " SYSCALL); \
 			err(EXIT_FAILURE, "failed in " SYSCALL);	\
 		}							\
+		if (tfd >= 0 && FD_ISSET(tfd, &readfds))		\
+			expired = true;					\
+		return expired;						\
 	}
 
 DEFUN_WAIT_EVENT_SELECT(default,
@@ -5621,6 +5630,9 @@ int main(int argc, char **argv)
 	bool cont  = false;
 	void *data;
 	bool monitor_stdin = true;
+	unsigned int timeout = 0;
+	int tfd = -1;
+	bool expired = false;
 
 	struct multiplexer *wait_event = NULL;
 
@@ -5633,6 +5645,7 @@ int main(int argc, char **argv)
 		{ "quiet",	no_argument, NULL, 'q' },
 		{ "dont-monitor-stdin", no_argument, NULL, 'X' },
 		{ "dont-pause", no_argument, NULL, 'c' },
+		{ "timeout",	required_argument, NULL, 't' },
 		{ "wait-with",  required_argument, NULL, 'w' },
 		{ "multiplexers",no_argument,NULL, 'W' },
 		{ "help",	no_argument, NULL, 'h' },
@@ -5640,12 +5653,13 @@ int main(int argc, char **argv)
 	};
 
 	static const ul_excl_t excl[] = {
+		{ 'c', 't' },
 		{ 'c', 'w' },
 		{ 0 }
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;
 
-	while ((c = getopt_long(argc, argv, "a:lhqcI:O:r:w:WX", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "a:lhqcI:O:r:t:w:WX", longopts, NULL)) != -1) {
 		err_exclusive_options(c, longopts, excl, excl_st);
 
 		switch (c) {
@@ -5667,6 +5681,9 @@ int main(int argc, char **argv)
 			break;
 		case 'c':
 			cont = true;
+			break;
+		case 't':
+			timeout = strtou32_or_err(optarg, "failed to parse timeout");
 			break;
 		case 'w':
 			wait_event = lookup_multiplexer(optarg);
@@ -5755,9 +5772,25 @@ int main(int argc, char **argv)
 		fflush(stdout);
 	}
 
+	if (timeout > 0) {
+		struct itimerspec its = {
+			.it_value = { .tv_sec = timeout, .tv_nsec = 0 },
+			.it_interval = { 0, 0 }
+		};
+
+		tfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+		if (tfd < 0)
+			err(EXIT_FAILURE, "failed in timerfd_create(2)");
+		if (timerfd_settime(tfd, 0, &its, NULL) < 0)
+			err(EXIT_FAILURE, "failed in timerfd_settime(2)");
+	}
+
 	if (!cont)
-		wait_event->fn(monitor_stdin,
-			       fdescs, factory->N + factory->EX_N);
+		expired = wait_event->fn(monitor_stdin, tfd,
+					 fdescs, factory->N + factory->EX_N);
+
+	if (tfd >= 0)
+		close(tfd);
 
 	for (int i = 0; i < factory->N + factory->EX_N; i++)
 		if (fdescs[i].fd >= 0 && fdescs[i].close)
@@ -5765,6 +5798,9 @@ int main(int argc, char **argv)
 
 	if (factory->free)
 		factory->free(factory, data);
+
+	if (expired)
+		errx(EXIT_EXPIRED, "timed out after %u seconds", timeout);
 
 	exit(EXIT_SUCCESS);
 }

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -76,6 +76,7 @@
 #include "cctype.h"
 #include "exitcodes.h"
 #include "libsmartcols.h"
+#include "optutils.h"
 #include "pidfd-utils.h"
 #include "test_mkfds.h"
 #include "xalloc.h"
@@ -5639,7 +5640,15 @@ int main(int argc, char **argv)
 		{ NULL, 0, NULL, 0 },
 	};
 
+	static const ul_excl_t excl[] = {
+		{ 'c', 'w' },
+		{ 0 }
+	};
+	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;
+
 	while ((c = getopt_long(argc, argv, "a:lhqcI:O:r:w:WX", longopts, NULL)) != -1) {
+		err_exclusive_options(c, longopts, excl, excl_st);
+
 		switch (c) {
 		case 'h':
 			usage(stdout, EXIT_SUCCESS);
@@ -5682,8 +5691,6 @@ int main(int argc, char **argv)
 	if (optind == argc)
 		errx(EXIT_FAILURE, "no file descriptor specification given");
 
-	if (cont && wait_event)
-		errx(EXIT_FAILURE, "don't specify both -c/--dont-puase and -w/--wait-with options");
 	if (wait_event == NULL)
 		wait_event = multiplexers + DEFAULT_MULTIPLEXER;
 

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -19,20 +19,11 @@
  * along with this program.  If not, see <https://gnu.org/licenses/>.
  */
 
-#include "c.h"
-#include "cctype.h"
-#include "xalloc.h"
-#include "test_mkfds.h"
-#include "exitcodes.h"
-#include "pidfd-utils.h"
-#include "libsmartcols.h"
-
 #include <arpa/inet.h>
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <sys/file.h>
 #include <getopt.h>
 #include <linux/bpf.h>
 #ifdef HAVE_LINUX_IO_URING_H
@@ -62,6 +53,7 @@
 #include <string.h>
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
+#include <sys/file.h>
 #include <sys/inotify.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -79,6 +71,14 @@
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
+
+#include "c.h"
+#include "cctype.h"
+#include "exitcodes.h"
+#include "libsmartcols.h"
+#include "pidfd-utils.h"
+#include "test_mkfds.h"
+#include "xalloc.h"
 
 #define _U_ __attribute__((__unused__))
 

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <linux/bpf.h>
+#include <sys/mount.h>
 #ifdef HAVE_LINUX_IO_URING_H
 #include <linux/io_uring.h>
 #endif
@@ -796,6 +797,147 @@ static void free_after_closing_duplicated_fd(const struct factory * factory _U_,
 		free(data);
 	}
 }
+
+#ifdef HAVE_LIBFUSE
+struct hungfs_ctl {
+	int fd;
+	pid_t pid;
+	char *mountpoint;
+	char *targetfile;
+	bool hung;
+};
+
+static void stop_hungfs(struct hungfs_ctl *ctl)
+{
+	close(ctl->fd);
+	kill(ctl->pid, SIGTERM);
+	waitpid(ctl->pid, NULL, 0);
+	umount2(ctl->mountpoint, MNT_DETACH);
+	free(ctl->mountpoint);
+	free(ctl->targetfile);
+}
+
+static void wait_hungfs(struct hungfs_ctl *ctl)
+{
+	char c;
+
+	/* Wait for READY signal from FUSE server's init callback */
+	if (read(ctl->fd, &c, 1) != 1 || c != HUNGFS_READY) {
+		stop_hungfs(ctl);
+		errx(EXIT_FAILURE, "failed to receive READY from fuse server");
+	}
+}
+
+static void go_hungfs(struct hungfs_ctl *ctl)
+{
+	char c = HUNGFS_UNHUNG;
+	if (write(ctl->fd, &c, 1) != 1) {
+		stop_hungfs(ctl);
+		errx(EXIT_FAILURE, "failed to send the \'unhung\' message to fuse server");
+	}
+}
+
+static void *make_fuse_hungfs(const struct factory *factory, struct fdesc fdescs[],
+			      int argc, char **argv)
+{
+	int fd;
+	int sv[2];
+	pid_t pid;
+	struct hungfs_ctl ctl;
+
+	struct arg mountpoint = decode_arg("mountpoint", factory->params, argc, argv);
+	const char *sMountpoint = ARG_STRING(mountpoint);
+	struct arg file = decode_arg("file", factory->params, argc, argv);
+	const char *sFile = ARG_STRING(file);
+	struct arg hung = decode_arg("hung", factory->params, argc, argv);
+	bool bHung = ARG_BOOLEAN(hung);
+
+	{
+		struct stat sb;
+		if (stat(sMountpoint, &sb) < 0)
+			err(EXIT_FAILURE, "failed to access mountpoint: %s", sMountpoint);
+		if (!S_ISDIR(sb.st_mode))
+			errx(EXIT_FAILURE, "mountpoint is not a directory: %s", sMountpoint);
+	}
+
+	/* Reserve the requested fd so socketpair won't occupy it */
+	reserve_fd(fdescs[0].fd);
+
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) < 0)
+		err(EXIT_FAILURE, "failed in socketpair for fuse IPC");
+
+	ctl.targetfile = NULL;
+	xasprintf(&ctl.targetfile, "%s/%s", sMountpoint, sFile);
+
+	pid = fork();
+	if (pid < 0)
+		err(EXIT_FAILURE, "failed in fork");
+
+	if (pid == 0) {
+		close(sv[0]);
+		run_hungfs(&(struct hungfs_args) {
+				.ctlfd = sv[1],
+				.mountpoint = sMountpoint,
+				.file = sFile,
+				.hung = bHung
+			});
+		exit(0);
+	}
+
+	close(sv[1]);
+	ctl.pid = pid;
+	ctl.fd = sv[0];
+	ctl.mountpoint = xstrdup(sMountpoint);
+	ctl.hung = bHung;
+
+	free_arg(&mountpoint);
+	free_arg(&file);
+	free_arg(&hung);
+
+	wait_hungfs(&ctl);
+
+	if (ctl.hung)
+		go_hungfs(&ctl);
+
+	fd = open(ctl.targetfile, O_RDONLY);
+	if (fd < 0) {
+		int e = errno;
+		char *t = ctl.targetfile;
+
+		ctl.targetfile = NULL;
+		stop_hungfs(&ctl);
+
+		errno = e;
+		err(EXIT_FAILURE, "failed to open %s", t);
+	}
+
+	/* Release the reservation and duplicate the opened fd into fdescs[0].fd */
+	if (fd != fdescs[0].fd) {
+		if (dup2(fd, fdescs[0].fd) < 0)
+			err(EXIT_FAILURE, "failed to dup %d -> %d", fd, fdescs[0].fd);
+		close(fd);
+	}
+
+	fdescs[0] = (struct fdesc){
+		.fd    = fdescs[0].fd,
+		.close = close_fdesc,
+		.data  = NULL
+	};
+
+	return xmemdup(&ctl, sizeof(ctl));
+}
+
+static void free_fuse_hungfs(const struct factory *factory _U_, void *data)
+{
+	struct hungfs_ctl *ctl = data;
+
+	if (ctl->hung)
+		go_hungfs(ctl);
+
+	stop_hungfs(ctl);
+	free(ctl);
+}
+#endif /* HAVE_LIBFUSE */
 
 static void *make_pipe(const struct factory *factory, struct fdesc fdescs[],
 		       int argc, char ** argv)
@@ -5185,6 +5327,38 @@ static const struct factory factories[] = {
 			PARAM_END
 		}
 	},
+#ifdef HAVE_LIBFUSE
+	{
+		.name = "fuse-hungfs",
+		.desc = "open a file in user mode file system reproducing process hung",
+		.priv = true,
+		.N    = 1,
+		.EX_N = 0,
+		.make = make_fuse_hungfs,
+		.free = free_fuse_hungfs,
+		.params = (struct parameter []) {
+			{
+				.name = "mountpoint",
+				.type = PTYPE_STRING,
+				.desc = "mount point for fuse file system",
+				.defv.string = "./test_mkfds_fuse_mnt",
+			},
+			{
+				.name = "file",
+				.type = PTYPE_STRING,
+				.desc = "file to be opened in fuse mount",
+				.defv.string = "test_file",
+			},
+			{
+				.name = "hung",
+				.type = PTYPE_BOOLEAN,
+				.desc = "hang on getattr after open",
+				.defv.boolean = false,
+			},
+			PARAM_END
+		},
+	},
+#endif
 };
 
 static int count_parameters(const struct factory *factory)

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -404,11 +404,10 @@ static void close_fdesc(int fd, void *data _U_)
 	close(fd);
 }
 
-volatile ssize_t unused_result_ok;
 static void abort_with_child_death_message(int signum _U_)
 {
 	const char msg[] = "the child process exits unexpectedly";
-	unused_result_ok = write(2, msg, sizeof(msg));
+	ignore_result(write(2, msg, sizeof(msg)));
 	_exit(EXIT_FAILURE);
 }
 

--- a/tests/helpers/test_mkfds.h
+++ b/tests/helpers/test_mkfds.h
@@ -23,6 +23,10 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+/* Exit code for test_mkfds execution control (distinct from errno-based
+ * exit codes returned when factories fail to construct file descriptors). */
+#define EXIT_EXPIRED 2
+
 /* Update the constants in
  * tests/ts/lsfd/lsfd-functions.bash when changing
  * the following error definitions. */
@@ -49,10 +53,12 @@ struct fdesc {
 };
 
 #define DEFUN_WAIT_EVENT_POLL(NAME,SYSCALL,XDECLS,SETUP_SIG_HANDLER,SYSCALL_INVOCATION) \
-	void wait_event_##NAME(bool add_stdin, struct fdesc *fdescs, size_t n_fdescs) \
+	bool wait_event_##NAME(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs) \
 	{								\
-		int n = add_stdin? 1: 0;				\
+		int n = (add_stdin ? 1 : 0) + (tfd >= 0 ? 1 : 0);	\
 		int n0 = 0;						\
+		int tfd_idx = -1;					\
+		bool expired = false;					\
 		struct pollfd *pfds = NULL;				\
 									\
 		XDECLS							\
@@ -79,6 +85,14 @@ struct fdesc {
 		if (add_stdin) {					\
 			pfds[n0].fd = 0;				\
 			pfds[n0].events |= POLLIN;			\
+			n0++;						\
+		}							\
+									\
+		if (tfd >= 0) {						\
+			tfd_idx = n0;					\
+			pfds[n0].fd = tfd;				\
+			pfds[n0].events |= POLLIN;			\
+			n0++;						\
 		}							\
 									\
 		SETUP_SIG_HANDLER					\
@@ -89,11 +103,14 @@ struct fdesc {
 				errx(EXIT_ENOSYS, "no syscall: " SYSCALL); \
 			err(EXIT_FAILURE, "failed in " SYSCALL);	\
 		}							\
+		if (tfd_idx >= 0 && (pfds[tfd_idx].revents & (POLLIN | POLLERR | POLLHUP))) \
+			expired = true;					\
 		free(pfds);						\
+		return expired;						\
 	}
 
 #ifdef __NR_ppoll
-void wait_event_ppoll(bool add_stdin, struct fdesc *fdescs, size_t n_fdescs);
+bool wait_event_ppoll(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs);
 #endif
 
 #endif	/* TEST_MKFDS_H */

--- a/tests/helpers/test_mkfds.h
+++ b/tests/helpers/test_mkfds.h
@@ -23,6 +23,10 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#ifndef _U_
+#define _U_ __attribute__((__unused__))
+#endif
+
 /* Exit code for test_mkfds execution control (distinct from errno-based
  * exit codes returned when factories fail to construct file descriptors). */
 #define EXIT_EXPIRED 2
@@ -111,6 +115,20 @@ struct fdesc {
 
 #ifdef __NR_ppoll
 bool wait_event_ppoll(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs);
+#endif
+
+#ifdef HAVE_LIBFUSE
+#define HUNGFS_UNHUNG 'G'
+#define HUNGFS_READY 'R'
+
+struct hungfs_args {
+	int ctlfd;
+	const char *mountpoint;
+	const char *file;
+	bool hung;
+};
+
+void run_hungfs(struct hungfs_args *args);
 #endif
 
 #endif	/* TEST_MKFDS_H */

--- a/tests/helpers/test_mkfds_hungfs.c
+++ b/tests/helpers/test_mkfds_hungfs.c
@@ -1,0 +1,127 @@
+/*
+ * test_mkfds_hungfs - user mode file system reproducing process hung
+ *
+ * Written by Masatake YAMATO <yamato@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://gnu.org/licenses/>.
+ */
+
+#include "c.h"
+#include "xalloc.h"
+#include "test_mkfds.h"
+
+#ifdef HAVE_LIBFUSE
+
+#define FUSE_USE_VERSION 26
+#include <fuse.h>
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void *hungfs_init(struct fuse_conn_info *conn _U_)
+{
+	struct fuse_context *ctx = fuse_get_context();
+	struct hungfs_args *args = ctx->private_data;
+	char c = HUNGFS_READY;
+
+	/* Signal parent that FUSE mount is ready */
+	ignore_result(write(args->ctlfd, &c, 1));
+
+	return args;
+}
+
+static int hungfs_getattr(const char *path, struct stat *stbuf)
+{
+	struct fuse_context *ctx = fuse_get_context();
+	struct hungfs_args *args = ctx->private_data;
+	char c;
+
+	memset(stbuf, 0, sizeof(struct stat));
+	if (strcmp(path, "/") == 0) {
+		stbuf->st_mode = S_IFDIR | 0755;
+		stbuf->st_nlink = 2;
+		return 0;
+	}
+	if (args->file && strcmp(path + 1, args->file) == 0) {
+		if (args->hung)
+			ignore_result(read(args->ctlfd, &c, 1));
+		stbuf->st_mode = S_IFREG | 0644;
+		stbuf->st_nlink = 1;
+		stbuf->st_size = 1024;
+		return 0;
+	}
+	return -ENOENT;
+}
+
+static int hungfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
+			  off_t offset _U_, struct fuse_file_info *fi _U_)
+{
+	struct fuse_context *ctx = fuse_get_context();
+	struct hungfs_args *args = ctx->private_data;
+
+	if (strcmp(path, "/") != 0)
+		return -ENOENT;
+
+	filler(buf, ".", NULL, 0);
+	filler(buf, "..", NULL, 0);
+	if (args && args->file)
+		filler(buf, args->file, NULL, 0);
+	return 0;
+}
+
+static int hungfs_open(const char *path, struct fuse_file_info *fi _U_)
+{
+	struct fuse_context *ctx = fuse_get_context();
+	struct hungfs_args *args = ctx->private_data;
+
+	if (strcmp(path + 1, args->file) == 0)
+		return 0;
+	return -ENOENT;
+}
+
+static struct fuse_operations hungfs_ops = {
+	.init    = hungfs_init,
+	.getattr = hungfs_getattr,
+	.readdir = hungfs_readdir,
+	.open    = hungfs_open,
+};
+
+void run_hungfs(struct hungfs_args *args)
+{
+	int r;
+	char *mountpoint = xstrdup(args->mountpoint);
+	/*
+	 * Disable kernel attribute and dentry caching (attr_timeout=0,
+	 * entry_timeout=0) so that pathname lookups and getattr operations
+	 * are deterministically forwarded to the FUSE server without
+	 * relying on cached VFS entries.
+	 */
+	char *fuse_argv[] = {
+		"hungfs",
+		"-f",          /* foreground */
+		"-s",          /* single-threaded */
+		"-o", "attr_timeout=0,entry_timeout=0",
+		mountpoint,
+		NULL
+	};
+
+	r = fuse_main(ARRAY_SIZE(fuse_argv) - 1, fuse_argv, &hungfs_ops, args);
+	free(mountpoint);
+	exit(r);
+}
+
+#endif /* HAVE_LIBFUSE */

--- a/tests/helpers/test_sysinfo.c
+++ b/tests/helpers/test_sysinfo.c
@@ -52,6 +52,7 @@
 #endif
 
 #include "xalloc.h"
+#include "fileutils.h"
 #include "namespace.h"
 
 typedef struct {
@@ -228,6 +229,18 @@ static int hlp_get_userns_ok(void)
 	return 0;
 }
 
+static int hlp_statx_dontsync_ok(void)
+{
+#if defined(HAVE_STATX) && defined(HAVE_STRUCT_STATX) && defined(AT_STATX_DONT_SYNC)
+	struct statx stx;
+	int rc = statx(AT_FDCWD, "/proc/self", AT_STATX_DONT_SYNC, STATX_BASIC_STATS, &stx);
+	printf("%d\n", rc == 0);
+#else
+	printf("0\n");
+#endif
+	return 0;
+}
+
 static int hlp_hostname(void)
 {
 	char * h = xgethostname();
@@ -339,6 +352,7 @@ static const mntHlpfnc hlps[] =
 	{ "sz(time_t)", hlp_sz_time     },
 	{ "ns-gettype-ok", hlp_get_nstype_ok },
 	{ "ns-getuserns-ok", hlp_get_userns_ok },
+	{ "statx-dontsync-ok", hlp_statx_dontsync_ok },
 	{ "hostname", hlp_hostname, },
 	{ "fts", hlp_fts, },
 	{ NULL, NULL }

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -19,6 +19,7 @@
 #
 # Update the following constants when changing
 # the error definitions in tests/helpers/test_mkfds.h.
+readonly EXPIRED=2
 readonly EPERM=18
 readonly ENOPROTOOPT=19
 readonly EPROTONOSUPPORT=20

--- a/tests/ts/lsfd/mkfds-fuse-hungfs
+++ b/tests/ts/lsfd/mkfds-fuse-hungfs
@@ -71,4 +71,28 @@ ts_init_subtest "fd"
 } > "$TS_OUTPUT" 2>&1
 ts_finalize_subtest
 
+ts_init_subtest "mem"
+{
+    mkdir -p "$MNTDIR"
+    coproc MKFDS { "$TS_HELPER_MKFDS" -t "$TMO" fuse-hungfs $FD mountpoint="$MNTDIR" file="stalled_file" hung=true mmap=true; }
+    if read -u ${MKFDS[0]} PID; then
+	EXPR='(NAME =~ "stalled_file") and (ASSOC == "mem")'
+	${TS_CMD_LSFD} -b -r -n -p "${PID}" -o ASSOC,TYPE,SOURCE -Q "${EXPR}"
+	RC=$?
+	echo 'ASSOC,TYPE,SOURCE': $RC
+	if [ $RC -ne 0 ]; then
+	    echo "lsfd failed (PID: ${PID}, RC: ${RC})"
+	fi
+
+	echo DONE >&"${MKFDS[1]}"
+    fi
+    wait ${MKFDS_PID}
+    MKFDS_RC=$?
+    if [ "${MKFDS_RC}" -eq "${EXPIRED}" ]; then
+	echo "test_mkfds timed out"
+    fi
+    rmdir "$MNTDIR" 2>/dev/null || true
+} > "$TS_OUTPUT" 2>&1
+ts_finalize_subtest
+
 ts_finalize

--- a/tests/ts/lsfd/mkfds-fuse-hungfs
+++ b/tests/ts/lsfd/mkfds-fuse-hungfs
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="hung fuse file system"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_skip_nonroot
+ts_skip_qemu_user
+
+ts_check_test_command "$TS_CMD_LSFD"
+ts_check_test_command "$TS_HELPER_MKFDS"
+ts_check_test_command "$TS_HELPER_SYSINFO"
+
+if [ "$("$TS_HELPER_SYSINFO" statx-dontsync-ok)" != "1" ]; then
+    ts_skip "statx(2) with AT_STATX_DONT_SYNC is not supported on this kernel"
+fi
+
+if [ ! -c /dev/fuse ] || [ ! -r /dev/fuse ] || [ ! -w /dev/fuse ]; then
+    ts_skip "FUSE (/dev/fuse) is not accessible"
+fi
+
+. "$TS_SELF/lsfd-functions.bash"
+lsfd_check_mkfds_factory fuse-hungfs
+
+ts_cd "$TS_OUTDIR"
+
+MNTDIR="$TS_OUTDIR/mnt-hungfs"
+
+PID=
+FD=3
+EXPR=
+TMO=10
+
+ts_init_subtest "fd"
+{
+    mkdir -p "$MNTDIR"
+    coproc MKFDS { "$TS_HELPER_MKFDS" -t "$TMO" fuse-hungfs $FD mountpoint="$MNTDIR" file="stalled_file" hung=true; }
+    if read -u ${MKFDS[0]} PID; then
+	EXPR='(FD == '"$FD"')'
+	${TS_CMD_LSFD} -b -r -n -p "${PID}" -o ASSOC,TYPE,SOURCE -Q "${EXPR}"
+	RC=$?
+	echo 'ASSOC,TYPE,SOURCE': $RC
+	if [ $RC -ne 0 ]; then
+	    echo "lsfd failed (PID: ${PID}, RC: ${RC})"
+	fi
+
+	echo DONE >&"${MKFDS[1]}"
+    fi
+    wait ${MKFDS_PID}
+    MKFDS_RC=$?
+    if [ "${MKFDS_RC}" -eq "${EXPIRED}" ]; then
+	echo "test_mkfds timed out"
+    fi
+    rmdir "$MNTDIR" 2>/dev/null || true
+} > "$TS_OUTPUT" 2>&1
+ts_finalize_subtest
+
+ts_finalize

--- a/tests/ts/lsfd/option-abort-if-blockable
+++ b/tests/ts/lsfd/option-abort-if-blockable
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Masatake YAMATO <yamato@redhat.com>
+#
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="option -b/--abort-if-blockable"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_LSFD"
+ts_check_test_command "$TS_CMD_ENOSYS"
+ts_check_enosys_syscalls statx
+
+ts_cd "$TS_OUTDIR"
+
+export LC_ALL=C
+
+{
+    "$TS_CMD_ENOSYS" --syscall statx -- "$TS_CMD_LSFD" -b -p $$
+    echo "RC: $?"
+} > "$TS_OUTPUT" 2>&1
+
+sed -i -e 's/^.*lsfd: /lsfd: /' "$TS_OUTPUT"
+
+ts_finalize


### PR DESCRIPTION
This pull request is still a draft; it's only for running CI.

This patch set improves lsfd's resilience against stalled or hung
file systems (such as unresponsive FUSE or NFS mounts), preventing
lsfd from blocking indefinitely while inspecting file descriptors
and memory mappings.

Summary of changes:

1. Stat wrappers with AT_STATX_DONT_SYNC:
   - Introduce lsfd_stat(), lsfd_fstat(), lsfd_path_stat(), and
     lsfd_path_statf() wrappers that use statx(2) with AT_STATX_DONT_SYNC.
   - This retrieves cached file attributes without requesting on-the-wire
     synchronization from underlying remote or FUSE file systems.
   - Add -b/--abort-if-blockable option to exit immediately (status 2)
     if non-blocking attribute retrieval is unsupported by the kernel
     or build.

2. Inspect memory mappings via map_files:
   - In parse_maps_line(), prefer inspecting memory-mapped files via
     /proc/PID/map_files/ magic symlinks rather than pathnames from
     /proc/PID/maps.
   - Directly referencing the kernel struct file via procfs bypasses
     pathname resolution (link_path_walk) and prevents hangs caused
     by dentry revalidation (d_revalidate) on hung file systems.
   - Inhibit fallback to maps pathnames when -b is specified.

3. Testing infrastructure (test_mkfds & hungfs):
   - Add -t/--timeout option to test_mkfds to protect regression test runs
     from hanging processes.
   - Implement hungfs, a minimal FUSE file system controlled via IPC
     that can deterministically hang on getattr requests after file
     open and mmap operations.
   - Add fuse-hungfs factory supporting both open file descriptors
     and memory mappings (mmap=true).
   - Add tests/ts/lsfd/mkfds-fuse-hungfs test case covering both
     open file descriptor ('fd' subtest) and memory mapping ('mem' subtest)
     inspection on a hung file system.


