### PR TITLE
pipesz: report the 2 GiB pipe buffer size correctly

### DIFF
--- a/misc-utils/pipesz.1.adoc
+++ b/misc-utils/pipesz.1.adoc
@@ -38,7 +38,7 @@ The kernel imposes limits on the amount of pipe buffer space unprivileged proces
 Report the size of pipe buffers to standard output and exit. As a special behavior, if neither *--file* nor *--fd* are specified, standard input is examined. It is an error to specify this option in combination with *--set*.
 
 *-s*, *--set* _size_::
-Set the size of the pipe buffers, in bytes. This option may be suffixed by *K*, *M*, *G*, *KiB*, *MiB*, or *GiB* to indicate multiples of 1024. Fractional values are supported in this case. Additional suffixes are supported but are unlikely to be useful. If this option is not specified, a default value is used, as described above. If this option is specified multiple times, a warning is emitted and only the last-specified _size_ is used. As a special behavior, if neither *--file* nor *--fd* are specified, standard output is adjusted. It is an error to specify this option in combination with *--get*.
+Set the size of the pipe buffers, in bytes. This option may be suffixed by *K*, *M*, *G*, *KiB*, *MiB*, or *GiB* to indicate multiples of 1024. Fractional values are supported in this case. Additional suffixes are supported but are unlikely to be useful. If this option is not specified, a default value is used, as described above. If this option is specified multiple times, a warning is emitted and only the last-specified _size_ is used. The kernel refuses any _size_ above 2,147,483,648 bytes (2 GiB). *pipesz* reduces a larger _size_ to this maximum and emits a warning. As a special behavior, if neither *--file* nor *--fd* are specified, standard output is adjusted. It is an error to specify this option in combination with *--get*.
 
 *-f*, *--file* _path_::
 Set the buffer size of the FIFO or pipe at _path_, relative to the current working directory. You may specify this option multiple times to affect different files, and you may do so in combination with *--fd*. Generally, this option is used with FIFOs, but it will also operate on anonymous pipes such as those found in */proc/PID/fd*. Changes to the buffer size of FIFOs are not preserved across system restarts.
@@ -87,6 +87,8 @@ Linux supports adjusting the size of pipe buffers since kernel 2.6.35. This rele
 This program uses *fcntl*(2) *F_GETPIPE_SZ*/*F_SETPIPE_SZ* to get and set pipe buffer sizes.
 
 This program uses *ioctl*(2) *FIONREAD* to report the amount of unread data in pipes. If for some reason this fails, the amount of unread data is reported as 0.
+
+The kernel handles pipe buffer sizes and unread byte counts as an *unsigned int*, but *fcntl*(2) and *FIONREAD* return them in an *int*. The largest buffer the kernel grants, 2,147,483,648 bytes (2 GiB), therefore arrives as a negative number, and *fcntl*(2) leaves *errno* unchanged. *pipesz* treats such a result as unsigned and reports the size correctly. Other programs that call *fcntl*(2) directly can report a spurious error instead.
 
 == BUGS
 

--- a/misc-utils/pipesz.c
+++ b/misc-utils/pipesz.c
@@ -240,6 +240,7 @@ int main(int argc, char **argv)
 	};
 
 	int c, fd, n_opt_pipe = 0, n_opt_size = 0;
+	char size_clamped = FALSE;
 	uintmax_t sz;
 
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;
@@ -280,8 +281,8 @@ int main(int argc, char **argv)
 			break;
 		case 's':
 			sz = strtosize_or_err(optarg, _("invalid size"));
-			opt_size = sz > PIPESZ_MAX_SIZE ?
-					PIPESZ_MAX_SIZE : (unsigned int) sz;
+			size_clamped = sz > PIPESZ_MAX_SIZE;
+			opt_size = size_clamped ? PIPESZ_MAX_SIZE : (unsigned int) sz;
 			opt_size_set = TRUE;
 			++n_opt_size;
 			break;
@@ -325,6 +326,11 @@ int main(int argc, char **argv)
 
 		if (!opt_quiet && n_opt_size > 1)
 			warnx(_("using last specified size"));
+
+		if (!opt_quiet && size_clamped)
+			/* TRANSLATORS: '%u' refers to a buffer size in bytes */
+			warnx(_("size reduced to the maximum of %u bytes"),
+			      PIPESZ_MAX_SIZE);
 
 		/* special behavior for --set */
 		if (!n_opt_pipe) {

--- a/misc-utils/pipesz.c
+++ b/misc-utils/pipesz.c
@@ -26,20 +26,24 @@
 
 #include "closestream.h"	/* close_stdout_atexit */
 #include "optutils.h"		/* err_exclusive_options */
-#include "path.h"		/* ul_path_read_s32 */
+#include "path.h"		/* ul_path_read_u32 */
 #include "pathnames.h"		/* _PATH_PROC_PIPE_MAX_SIZE */
 #include "strutils.h"		/* strtos32_or_err strtosize_or_err */
 
 static char opt_check = 0;	/* --check */
 static char opt_get = 0;	/* --get */
 static char opt_quiet = 0;	/* --quiet */
-static int opt_size = -1;	/* --set <size> */
+static unsigned int opt_size = 0;	/* --set <size> */
+static char opt_size_set = 0;	/* --set was specified */
 static char opt_verbose = 0;	/* --verbose */
 
 /* fallback file for default size */
 #ifndef PIPESZ_DEFAULT_SIZE_FILE
 #define PIPESZ_DEFAULT_SIZE_FILE _PATH_PROC_PIPE_MAX_SIZE
 #endif
+
+/* the largest buffer the kernel accepts; it rejects larger sizes with EINVAL */
+#define PIPESZ_MAX_SIZE		(1U << 31)
 
 /* convenience macros, since pipesz is by default very lenient */
 #define check(FMT...) do {			\
@@ -50,17 +54,13 @@ static char opt_verbose = 0;	/* --verbose */
 	}					\
 } while (0)
 
-#define checkx(FMT...) do {			\
-	if (opt_check) {			\
-		errx(EXIT_FAILURE, FMT);	\
-	} else if (!opt_quiet) {		\
-		warnx(FMT);			\
-	}					\
-} while (0)
-
 static void __attribute__((__noreturn__)) usage(void)
 {
-	if (ul_path_read_s32(NULL, &opt_size, PIPESZ_DEFAULT_SIZE_FILE))
+	unsigned int def_size = 0;
+	int rc;
+
+	rc = ul_path_read_u32(NULL, &def_size, PIPESZ_DEFAULT_SIZE_FILE);
+	if (rc)
 		warn(_("cannot parse %s"), PIPESZ_DEFAULT_SIZE_FILE);
 
 	fputs(USAGE_HEADER, stdout);
@@ -73,8 +73,11 @@ static void __attribute__((__noreturn__)) usage(void)
 
 	fputs(USAGE_OPTIONS, stdout);
 	fputsln(_(" -g, --get          examine pipe buffers"), stdout);
-	fprintf(stdout,
-		_(" -s, --set <size>   the buffer size to be used (default: %d)\n"), opt_size);
+	if (rc)
+		fputsln(_(" -s, --set <size>   the buffer size to be used"), stdout);
+	else
+		fprintf(stdout,
+			_(" -s, --set <size>   the buffer size to be used (default: %u)\n"), def_size);
 
 	fputs(USAGE_SEPARATOR, stdout);
 	fputsln(_(" -f, --file <path>  act on a file"), stdout);
@@ -97,24 +100,46 @@ static void __attribute__((__noreturn__)) usage(void)
 }
 
 /*
+ * interprets the result of an fcntl() pipe buffer size operation
+ *
+ * The kernel handles pipe buffer sizes as an unsigned int, but libc fcntl()
+ * returns an int. The maximum size, PIPESZ_MAX_SIZE, therefore comes back as
+ * a negative number and errno stays unchanged. Read such a result as
+ * unsigned. Set errno to 0 before the fcntl() call.
+ *
+ * returns FALSE on error, otherwise stores the size in res
+ */
+static char pipe_size_result(int ret, unsigned int *res)
+{
+	if (ret < 0 && errno != 0)
+		return FALSE;
+
+	*res = (unsigned int) ret;
+	return TRUE;
+}
+
+/*
  * performs F_GETPIPE_SZ and FIONREAD
  * outputs a table row
  */
 static void do_get(int fd, const char *name)
 {
-	int sz, used;
+	int ret;
+	unsigned int sz, used;
 
-	sz = fcntl(fd, F_GETPIPE_SZ);
-	if (sz < 0) {
+	errno = 0;
+	ret = fcntl(fd, F_GETPIPE_SZ);
+	if (!pipe_size_result(ret, &sz)) {
 		/* TRANSLATORS: '%s' refers to a file */
 		check(_("cannot get pipe buffer size of %s"), name);
 		return;
 	}
 
+	/* the kernel also reports the unread byte count as an unsigned int */
 	if (ioctl(fd, FIONREAD, &used))
 		used = 0;
 
-	printf("%s\t%d\t%d\n", name, sz, used);
+	printf("%s\t%u\t%u\n", name, sz, used);
 }
 
 /*
@@ -122,15 +147,17 @@ static void do_get(int fd, const char *name)
  */
 static void do_set(int fd, const char *name)
 {
-	int sz;
+	int ret;
+	unsigned int sz;
 
-	sz = fcntl(fd, F_SETPIPE_SZ, opt_size);
-	if (sz < 0)
+	errno = 0;
+	ret = fcntl(fd, F_SETPIPE_SZ, opt_size);
+	if (!pipe_size_result(ret, &sz))
 		/* TRANSLATORS: '%s' refers to a file */
 		check(_("cannot set pipe buffer size of %s"), name);
 	else if (opt_verbose)
-		/* TRANSLATORS: '%s' refers to a file, '%d' to a buffer size in bytes */
-		warnx(_("%s pipe buffer size set to %d"), name, sz);
+		/* TRANSLATORS: '%s' refers to a file, '%u' to a buffer size in bytes */
+		warnx(_("%s pipe buffer size set to %u"), name, sz);
 }
 
 /*
@@ -176,18 +203,13 @@ static void do_file(const char *path)
  */
 static char set_size_default(void)
 {
-	if (opt_size >= 0)
+	if (opt_size_set)
 		return TRUE;
 
-	if (ul_path_read_s32(NULL, &opt_size, PIPESZ_DEFAULT_SIZE_FILE)) {
+	/* the kernel stores this limit as an unsigned int too */
+	if (ul_path_read_u32(NULL, &opt_size, PIPESZ_DEFAULT_SIZE_FILE)) {
 		/* TRANSLATORS: '%s' refers to a system file */
 		check(_("cannot parse %s"), PIPESZ_DEFAULT_SIZE_FILE);
-		return FALSE;
-	}
-
-	if (opt_size < 0) {
-		/* TRANSLATORS: '%s' refers to a system file */
-		checkx(_("cannot parse %s"), PIPESZ_DEFAULT_SIZE_FILE);
 		return FALSE;
 	}
 
@@ -258,7 +280,9 @@ int main(int argc, char **argv)
 			break;
 		case 's':
 			sz = strtosize_or_err(optarg, _("invalid size"));
-			opt_size = sz >= INT_MAX ? INT_MAX : (int)sz;
+			opt_size = sz > PIPESZ_MAX_SIZE ?
+					PIPESZ_MAX_SIZE : (unsigned int) sz;
+			opt_size_set = TRUE;
 			++n_opt_size;
 			break;
 		case 'v':

--- a/tests/expected/pipesz/pipesz-set-too-large.err
+++ b/tests/expected/pipesz/pipesz-set-too-large.err
@@ -1,0 +1,2 @@
+pipesz: size reduced to the maximum of 2147483648 bytes
+pipesz: cannot set pipe buffer size of fd 42: Bad file descriptor

--- a/tests/ts/pipesz/pipesz
+++ b/tests/ts/pipesz/pipesz
@@ -65,6 +65,10 @@ echo -n | $TS_CMD_PIPESZ --check --get --file "/dev/stdin" 2>> "$TS_ERRLOG" \
         || ts_logerr "expected success"
 ts_finalize_subtest
 
+ts_init_subtest "set-too-large"
+$TS_CMD_PIPESZ --set 4G --fd 42 >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+ts_finalize_subtest
+
 ts_init_subtest "pipe-max-size"
 echo -n | $TS_CMD_PIPESZ --check --stdin >> "$TS_OUTPUT" 2>> "$TS_ERRLOG" \
         || ts_logerr "expected success"


### PR DESCRIPTION
The kernel handles pipe buffer sizes as an `unsigned int` and grants at most 2^31 bytes. libc `fcntl()` returns an `int`, so that maximum comes back as a negative number with `errno` untouched. `pipesz` read the negative result as an error and reported it with `strerror(errno)`:

```
$ echo | pipesz -s 2G -i pipesz --get -i
pipesz: cannot set pipe buffer size of fd 0: Success
pipesz: cannot get pipe buffer size of fd 0: Success
```

The buffer was set. Only the report was wrong. With `--check` the command also exited 1.

After the change:

```
$ echo | pipesz -s 2G -i pipesz --get -i
fd 0	2147483648	2147483648
```

The series covers three sites with the same mismatch:

- `F_SETPIPE_SZ` and `F_GETPIPE_SZ` in `do_set()` and `do_get()`. `errno` is now set to 0 before each call. A negative result with an unchanged `errno` is read as an unsigned size.
- `FIONREAD`. The kernel counts unread bytes as an `unsigned int` and stores the count through an `int` pointer, so a full 2^31 buffer printed `-2147483648`.
- `/proc/sys/fs/pipe-max-size`. The kernel accepts 2147483648 there, but `ul_path_read_s32()` cannot parse it. `pipesz` then failed with `cannot parse /proc/sys/fs/pipe-max-size` and `--help` printed `default: -2147483648`. The file is now read with `ul_path_read_u32()`.

Two further changes:

- `--set` is capped at 2^31 instead of `INT_MAX`. The kernel rounds `INT_MAX` up to 2^31 anyway, so the resulting buffer is unchanged, but a valid request is no longer reduced.
- A larger `--set` value is still reduced to the maximum. That reduction was silent; it now emits a warning, which `--quiet` suppresses.

The man page records the 2 GiB maximum and the `int`/`unsigned int` mismatch.

A `set-too-large` subtest covers the new warning. It fails on master and passes with the series. The 2^31 `fcntl()` and `FIONREAD` paths are not covered, because they need a kernel that can really allocate a 2^31 buffer.
