### PR TITLE
setpriv error message option name; mkfs.minix bad-blocks bounds check

### DIFF
--- a/disk-utils/mkfs.minix.c
+++ b/disk-utils/mkfs.minix.c
@@ -677,6 +677,11 @@ static void get_list_blocks(struct fs_control *ctl, char *filename)
 			errx(MKFS_EX_ERROR, _("%s: cannot read badblocks file"),
 					ctl->device_name);
 		}
+		if (blockno < (unsigned long) get_first_zone() ||
+		    blockno >= get_nzones())
+			errx(MKFS_EX_ERROR,
+			     _("%s: bad block number %lu is outside of the file system"),
+			     ctl->device_name, blockno);
 		mark_zone(blockno);
 		ctl->fs_bad_blocks++;
 	}

--- a/sys-utils/setpriv.c
+++ b/sys-utils/setpriv.c
@@ -1030,7 +1030,7 @@ int main(int argc, char **argv)
 		case PDEATHSIG:
 			if (opts.pdeathsig)
 				errx(EXIT_FAILURE,
-				     _("duplicate --keep-pdeathsig option"));
+				     _("duplicate --pdeathsig option"));
 			parse_pdeathsig(&opts, optarg);
 			break;
 		case PTRACER:


### PR DESCRIPTION
Two fixes:

**1. setpriv: fix option name in duplicate --pdeathsig error**

The duplicate-option error message said `--keep-pdeathsig`, an option that
does not exist — the long option is `--pdeathsig` (as in the option table and
setpriv(1)). Example with this patch:

```
$ setpriv --pdeathsig clear --pdeathsig keep
setpriv: duplicate --pdeathsig option
```

(before: `setpriv: duplicate --keep-pdeathsig option`)

**2. mkfs.minix: bounds-check bad block numbers read from -l file**

Block numbers read from the bad-blocks file were passed unchecked to
`mark_zone()` → `setbit(zone_map, x - first_zone + 1)`, so out-of-range values
write past the zone map (tests/ts/minix/fsck even documents "gives a lot
segfaults"). Each number is now validated against [first data zone, zones)
before marking, and a bad entry fails mkfs.minix with a clear error, matching
check_blocks()' treatment of bad blocks below the data area:

```
1440-block image (first data zone 19):
-l {99999}      -> mkfs.minix: img: bad block number 99999 is outside of the file system (exit 8; master segfaults / silently miscounts)
-l {0}, {18}    -> exit 8 (below data area)
-l {19}, {1439} -> "1 bad block", works
-l {1440}       -> exit 8 (at/above nzones)
valid list      -> still marks correctly
```

Full tree builds clean (meson, 838/838 targets, no warnings in touched code).