### PR TITLE
nsenter: read --env after the credential change when needed

### DIFF
--- a/sys-utils/nsenter.c
+++ b/sys-utils/nsenter.c
@@ -139,6 +139,7 @@ static pid_t namespace_target_pid = 0;
 static int root_fd = -1;
 static int wd_fd = -1;
 static int env_fd = -1;
+static int env_dir_fd = -1;
 static int uid_gid_fd = -1;
 static int cgroup_procs_fd = -1;
 
@@ -166,7 +167,7 @@ static inline struct namespace_file *__next_nsfile(struct namespace_file *n, int
 #define get_nsfile(_ns)			__next_nsfile(NULL, _ns, 0)
 #define get_enabled_nsfile(_ns)		__next_nsfile(NULL, _ns, 1)
 
-static void open_target_fd(int *fd, const char *type, const char *path)
+static int open_target_fd(int *fd, const char *type, const char *path, bool quiet)
 {
 	char pathbuf[PATH_MAX];
 
@@ -175,17 +176,43 @@ static void open_target_fd(int *fd, const char *type, const char *path)
 			 namespace_target_pid, type);
 		path = pathbuf;
 	}
-	if (!path)
+	if (!path) {
+		if (quiet)
+			return -1;
 		errx(EXIT_FAILURE,
 		     _("neither filename nor target pid supplied for %s"),
 		     type);
+	}
 
 	if (*fd >= 0)
 		close(*fd);
 
 	*fd = open(path, O_RDONLY | O_CLOEXEC);
-	if (*fd < 0)
+	if (*fd < 0) {
+		if (quiet)
+			return -1;
 		err(EXIT_FAILURE, _("cannot open %s"), path);
+	}
+	return *fd;
+}
+
+/* Read the environment from @fd and replace our own with it. Closes @fd. */
+static void setenv_from_fd(int fd)
+{
+	struct ul_env_list *ls;
+
+	ls = env_list_from_fd(fd);
+	if (!ls && errno)
+		err(EXIT_FAILURE, _("failed to get environment variables"));
+#ifdef HAVE_CLEARENV
+	clearenv();
+#else
+	environ = NULL;
+#endif
+	if (ls && env_list_setenv(ls, 0) < 0)
+		err(EXIT_FAILURE, _("failed to set environment variables"));
+	env_list_free(ls);
+	close(fd);
 }
 
 #ifdef USE_NAMESPACE_ID_SUPPORT
@@ -269,7 +296,7 @@ static void enable_nsfile(struct namespace_file *n, const char *path)
 			open_target_fd_by_nsid(&n->fd, path + 1);
 		else
 #endif
-			open_target_fd(&n->fd, n->name, path);
+			open_target_fd(&n->fd, n->name, path, false);
 	}
 	n->enabled = true;
 }
@@ -335,7 +362,7 @@ static void open_namespaces(int namespaces)
 
 	while ((n = next_enabled_nsfile(n, namespaces))) {
 		if (n->fd < 0)
-			open_target_fd(&n->fd, n->name, NULL);
+			open_target_fd(&n->fd, n->name, NULL, false);
 	}
 }
 
@@ -402,7 +429,7 @@ static void open_parent_user_ns_fd(int pid_fd)
 
 	/* try directly open the NS */
 	if (fd < 0) {
-		open_target_fd(&fd, "ns/user", NULL);
+		open_target_fd(&fd, "ns/user", NULL, false);
 		islocal = true;
 	}
 
@@ -473,7 +500,7 @@ static void open_cgroup_procs(void)
 	int cgroup_fd = 0;
 	char fdpath[PATH_MAX];
 
-	open_target_fd(&cgroup_fd, "cgroup", optarg);
+	open_target_fd(&cgroup_fd, "cgroup", optarg, false);
 
 	if (ul_read_all_alloc(cgroup_fd, &buf) < 1)
 		err(EXIT_FAILURE, _("failed to get cgroup path"));
@@ -721,7 +748,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'r':
 			if (optarg)
-				open_target_fd(&root_fd, "root", optarg);
+				open_target_fd(&root_fd, "root", optarg, false);
 			else
 				do_rd = true;
 			break;
@@ -729,7 +756,7 @@ int main(int argc, char *argv[])
 			if (optarg) {
 				if (*optarg == '=')
 					optarg++;
-				open_target_fd(&wd_fd, "cwd", optarg);
+				open_target_fd(&wd_fd, "cwd", optarg, false);
 			} else
 				do_wd = true;
 			break;
@@ -825,13 +852,11 @@ int main(int argc, char *argv[])
 	}
 
 	if (do_rd)
-		open_target_fd(&root_fd, "root", NULL);
+		open_target_fd(&root_fd, "root", NULL, false);
 	if (do_wd)
-		open_target_fd(&wd_fd, "cwd", NULL);
-	if (do_env)
-		open_target_fd(&env_fd, "environ", NULL);
+		open_target_fd(&wd_fd, "cwd", NULL, false);
 	if (do_uid || do_gid)
-		open_target_fd(&uid_gid_fd, "", NULL);
+		open_target_fd(&uid_gid_fd, "", NULL, false);
 	if (do_join_cgroup) {
 		if (!is_cgroup2())
 			errx(EXIT_FAILURE, _("--join-cgroup is only supported in cgroup v2"));
@@ -864,6 +889,25 @@ int main(int argc, char *argv[])
 		 * let's complain only if both fail */
 		if (setgroups(0, NULL) != 0)
 			setgroups_nerrs++;
+	}
+
+	/*
+	 * Read the target's environment now that we know whether the
+	 * credentials will be changed, and while /proc is still ours (this runs
+	 * before any setns()).
+	 */
+	if (do_env && open_target_fd(&env_fd, "environ", NULL, true) < 0) {
+		/*
+		 * The environ file is owned by the target's UID as mapped in our
+		 * user namespace, so it may only become readable once we run with
+		 * the requested UID. Keep a descriptor on our own /proc/<pid> so
+		 * the retry does not depend on the target's mount namespace.
+		 */
+		if ((errno != EACCES && errno != EPERM)
+		    || !(force_uid || force_gid))
+			err(EXIT_FAILURE, _("cannot open /proc/%d/environ"),
+			    namespace_target_pid);
+		open_target_fd(&env_dir_fd, "", NULL, false);
 	}
 
 	/*
@@ -930,20 +974,8 @@ int main(int argc, char *argv[])
 
 	/* Pass environment variables of the target process to the spawned process */
 	if (env_fd >= 0) {
-		struct ul_env_list *ls;
-
-		ls = env_list_from_fd(env_fd);
-		if (!ls && errno)
-			err(EXIT_FAILURE, _("failed to get environment variables"));
-#ifdef HAVE_CLEARENV
-		clearenv();
-#else
-		environ = NULL;
-#endif
-		if (ls && env_list_setenv(ls, 0) < 0)
-			err(EXIT_FAILURE, _("failed to set environment variables"));
-		env_list_free(ls);
-		close(env_fd);
+		setenv_from_fd(env_fd);
+		env_fd = -1;
 	}
 
 	// Join into the target cgroup
@@ -975,6 +1007,18 @@ int main(int argc, char *argv[])
 			err(EXIT_FAILURE, _("setgid() failed"));
 		if (force_uid && setuid(uid) < 0)		/* change UID */
 			err(EXIT_FAILURE, _("setuid() failed"));
+	}
+
+	/* Retry the environ read that was not permitted before the UID change */
+	if (env_dir_fd >= 0) {
+		int fd = openat(env_dir_fd, "environ", O_RDONLY);
+
+		if (fd < 0)
+			err(EXIT_FAILURE, _("cannot open /proc/%d/environ"),
+			    namespace_target_pid);
+		close(env_dir_fd);
+		env_dir_fd = -1;
+		setenv_from_fd(fd);
 	}
 
 	if (keepcaps && (namespaces & CLONE_NEWUSER))

--- a/tests/expected/nsenter/env
+++ b/tests/expected/nsenter/env
@@ -1,0 +1,2 @@
+UL_TEST_ENV=inherited
+rc=0

--- a/tests/ts/nsenter/env
+++ b/tests/ts/nsenter/env
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This file is part of util-linux.
+#
+# This file is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="inherit environment from a target in a user namespace"
+
+. "$TS_TOPDIR/functions.sh"
+ts_init "$*"
+
+ts_check_test_command "$TS_CMD_NSENTER"
+ts_check_test_command "$TS_CMD_UNSHARE"
+ts_check_prog "newuidmap"
+ts_check_prog "newgidmap"
+
+# The target's environ is only unreadable to the caller when the caller is
+# unprivileged and the target's UID maps to a different one.
+[ "$(id -u)" -eq 0 ] && ts_skip "test needs an unprivileged caller"
+grep -q "^$(id -un):" /etc/subuid 2>/dev/null || ts_skip "no /etc/subuid entry"
+grep -q "^$(id -un):" /etc/subgid 2>/dev/null || ts_skip "no /etc/subgid entry"
+
+ts_cd "$TS_OUTDIR"
+
+PIDFILE="$TS_OUTDIR/$(basename "$0").pid"
+rm -f "$PIDFILE"
+
+# Target runs as UID 0 inside its own user namespace, so its /proc/<pid>/environ
+# is owned by a subuid and is not readable by us.
+UL_TEST_ENV=inherited "$TS_CMD_UNSHARE" \
+	--map-auto --map-current-user --setuid=0 --setgid=0 -- \
+	/bin/sh -c 'echo $$; sleep 30' > "$PIDFILE" 2>>"$TS_ERRLOG" &
+TARGET_SHELL=$!
+trap 'kill $TARGET_SHELL &>/dev/null' EXIT
+
+for _ in $(seq 1 50); do
+	read -r TARGET_PID < "$PIDFILE" 2>/dev/null && [ -n "$TARGET_PID" ] && break
+	sleep 0.1
+done
+
+if [ -z "${TARGET_PID:-}" ] || [ ! -d "/proc/$TARGET_PID" ]; then
+	ts_skip "cannot set up an unprivileged user namespace"
+fi
+
+if [ -r "/proc/$TARGET_PID/environ" ]; then
+	ts_skip "target environ is readable, mapping does not exercise this"
+fi
+
+"$TS_CMD_NSENTER" --user --setuid=0 --setgid=0 --target="$TARGET_PID" --env -- \
+	/bin/sh -c 'echo "UL_TEST_ENV=${UL_TEST_ENV:-UNSET}"' >>"$TS_OUTPUT" 2>>"$TS_ERRLOG"
+echo "rc=$?" >>"$TS_OUTPUT"
+
+kill $TARGET_SHELL &>/dev/null
+wait $TARGET_SHELL &>/dev/null
+rm -f "$PIDFILE"
+
+ts_finalize


### PR DESCRIPTION

---

Closes #4558.

`nsenter --user ... --env` fails for an unprivileged caller:

```
nsenter: cannot open /proc/<pid>/environ: Permission denied
```

The target's `environ` is owned by the target's UID as mapped in the caller's user namespace, and
`open_target_fd()` opens it before the credentials are changed, so the open is attempted with the
caller's UID against a file it does not own. The file is readable once nsenter runs with the
requested UID inside the namespace. This affects `--user` in general, not only an explicit
`--setuid`, because nsenter sets UID and GID by default when entering a user namespace
(`nsenter.c`, the `CLONE_NEWUSER && !preserve_cred` branch).

The environ open moves to after the namespace set is known, so it is clear whether the credentials
will change, and stays before any `setns()`, so it still refers to the caller's `/proc`. On
`EACCES`/`EPERM`, when a credential change is coming, a descriptor on the caller's `/proc/<pid>` is
kept and the environment is read through `openat()` after `setgid()`/`setuid()`. Keeping the
directory descriptor is what makes the retry independent of the target's mount namespace. Without a
credential change the original error is reported exactly as before.

## Verification

Linux 6.18.44, gcc 15.3.0, both binaries built from this tree and run against the **same** target
process. `stock` is `master`, `patched` is this branch.

Target: `unshare --map-auto --map-current-user --setuid=0 --setgid=0`, whose `environ` is owned by
subuid 100000 while the caller is UID 1000. No root anywhere.

| case | stock | patched |
|---|---|---|
| `--user --setuid=0 --setgid=0 --env` (the report) | exit 1, `cannot open ... Permission denied` | exit 0, `probe=hello vars=118` |
| `--user --env`, no explicit `--setuid` | exit 1, same error | exit 0, `probe=implicit vars=118` |
| target in its own **mount namespace**, entered with `--mount` | exit 1, same error | exit 0, `probe=inmnt vars=118` |
| early open succeeds (environ owned by the caller) | exit 0, `probe=yes vars=118` | exit 0, identical |
| `--pid --env`, denied, no credential change | exit 1, `cannot open ... Permission denied` | exit 1, identical message |
| nonexistent pid | exit 1, `cannot open /proc/999999/ns/user: ...` | exit 1, identical message |

The mount-namespace row is the one that matters for the approach: the target's mnt ns differs from
the caller's, and the environment is still read correctly after `setns(CLONE_NEWNS)` because the
directory descriptor was taken first.

The last three rows are the regression cases: the early-open path, the genuinely-denied path and the
error text are all unchanged.

## Test

`tests/ts/nsenter/env` is a second commit so the fix can be taken without it. It builds the same
unreadable-environ situation and checks the variable arrives:

```
nsenter: inherit environment from a target in a user namespace ... OK        # this branch
nsenter: inherit environment from a target in a user namespace ... FAILED    # master
  -UL_TEST_ENV=inherited
  -rc=0
  +rc=1
```

Reproducing this needs an unprivileged caller with a `/etc/subuid` range and the `newuidmap` and
`newgidmap` helpers, so it skips when run as root, when no subuid range is configured, or if the
resulting `environ` turns out to be readable anyway. It will therefore skip in a root CI container.
Say the word if you would rather not carry a test with that many skip conditions.

`tests/ts/nsenter/enter-via-socket` is root-only and covers `--net-socket`, so it does not touch this
path. I could not link `test_mkfds` in a `--disable-all-programs --enable-nsenter` build because it
needs libsmartcols.
