### PR TITLE
test_mkfds: add timeout option and fuse-hungfs factory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1734,6 +1734,28 @@ AS_IF([test "x$with_cap_ng" = xno], [
 AC_SUBST([CAP_NG_LIBS])
 
 
+AC_ARG_WITH([fuse],
+  AS_HELP_STRING([--without-fuse], [compile the test_mkfds helper without libfuse]),
+  [], [with_fuse=auto]
+)
+have_fuse=no
+AS_IF([test "x$with_fuse" = xno], [
+  AM_CONDITIONAL([HAVE_FUSE], [false])
+],[
+  PKG_CHECK_MODULES_STATIC([FUSE], [fuse >= 2.6], [have_fuse=yes], [have_fuse=no])
+  AS_CASE([$with_fuse:$have_fuse],
+    [yes:no],
+      [AC_MSG_ERROR([fuse selected, but required library not found])]
+  )
+  AS_IF([test "x$have_fuse" = xyes], [
+    AC_DEFINE([HAVE_LIBFUSE], [1], [Define if libfuse is available])
+  ])
+  AM_CONDITIONAL([HAVE_FUSE], [test "x$have_fuse" = xyes])
+])
+AC_SUBST([FUSE_CFLAGS])
+AC_SUBST([FUSE_LIBS])
+
+
 AC_ARG_ENABLE([setpriv],
   AS_HELP_STRING([--disable-setpriv], [do not build setpriv]),
   [], [UL_DEFAULT_ENABLE([setpriv], [check])]

--- a/meson.build
+++ b/meson.build
@@ -600,6 +600,16 @@ lib_audit = dependency(
   required : get_option('audit'))
 conf.set('HAVE_LIBAUDIT', lib_audit.found() ? 1 : false)
 
+lib_fuse = dependency(
+  'fuse',
+  version : '>= 2.6',
+  required : get_option('fuse'))
+conf.set('HAVE_LIBFUSE', lib_fuse.found() ? 1 : false)
+
+summary('libfuse',
+        lib_fuse.found() ? 'enabled' : 'disabled',
+        section : 'components')
+
 conf.set('HAVE_SMACK', get_option('smack').allowed())
 
 header = 'linux/btrfs.h'
@@ -4196,6 +4206,10 @@ if LINUX
   endif
   if cc.has_header('linux/io_uring.h')
     test_mkfds_c_args += ['-DHAVE_LINUX_IO_URING_H']
+  endif
+  if lib_fuse.found()
+    test_mkfds_sources += ['tests/helpers/test_mkfds_hungfs.c']
+    test_mkfds_deps += [lib_fuse]
   endif
   exe = executable(
     'test_mkfds',

--- a/meson.build
+++ b/meson.build
@@ -4177,8 +4177,17 @@ if not is_disabler(exe)
   exes += exe
 endif
 
-if LINUX and lib_rt.found()
+if LINUX
   test_mkfds_c_args = []
+  test_mkfds_deps = []
+  test_mkfds_sources = [
+    'tests/helpers/test_mkfds.c',
+    'tests/helpers/test_mkfds.h',
+    'tests/helpers/test_mkfds_ppoll.c',
+  ]
+  if lib_rt.found()
+    test_mkfds_deps += [lib_rt]
+  endif
   if cc.has_header_symbol('linux/bpf.h', 'BPF_LINK_CREATE')
     test_mkfds_c_args += ['-DHAVE_BPF_LINK_CREATE']
   endif
@@ -4190,12 +4199,10 @@ if LINUX and lib_rt.found()
   endif
   exe = executable(
     'test_mkfds',
-    'tests/helpers/test_mkfds.c',
-    'tests/helpers/test_mkfds.h',
-    'tests/helpers/test_mkfds_ppoll.c',
+    test_mkfds_sources,
     include_directories : includes,
     link_with : lib_smartcols.get_static_lib(),
-    dependencies : [lib_rt],
+    dependencies : test_mkfds_deps,
     c_args : test_mkfds_c_args,
     build_by_default: program_tests)
   exes += exe

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,6 +34,8 @@ option('widechar',    type : 'feature',
        description : 'compile with wide character support')
 option('translate-docs', type : 'feature',
        description : 'translate documentation')
+option('fuse',           type : 'feature',
+       description : 'build the test_mkfds helper with libfuse')
 
 # enable building of various programs and features ("build-" prefix)
 

--- a/tests/helpers/Makemodule.am
+++ b/tests/helpers/Makemodule.am
@@ -48,12 +48,19 @@ test_kill_pidfdino_SOURCES = tests/helpers/test_kill_pidfdino.c
 test_kill_pidfdino_LDADD = $(LDADD) libcommon.la
 
 if LINUX
+if !OSS_FUZZ
 check_PROGRAMS += test_mkfds
 test_mkfds_SOURCES = tests/helpers/test_mkfds.c tests/helpers/test_mkfds.h \
 	tests/helpers/test_mkfds_ppoll.c
 test_mkfds_LDFLAGS = -static
 test_mkfds_LDADD = $(LDADD) $(MQ_LIBS) libsmartcols.la
 test_mkfds_CFLAGS = $(AM_CFLAGS) -I$(ul_libsmartcols_incdir)
+if HAVE_FUSE
+test_mkfds_SOURCES += tests/helpers/test_mkfds_hungfs.c
+test_mkfds_LDADD += $(FUSE_LIBS)
+test_mkfds_CFLAGS += $(FUSE_CFLAGS)
+endif
+endif
 
 check_PROGRAMS += test_enosys
 test_enosys_SOURCES = tests/helpers/test_enosys.c

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -5477,6 +5477,9 @@ static void sighandler_nop(int si _U_)
 		}							\
 									\
 		for (size_t i = 0; i < n_fdescs; i++) {			\
+			if (fdescs[i].fd >= FD_SETSIZE)			\
+				errx(EXIT_FAILURE,			\
+				     "fd %d exceeds FD_SETSIZE; use -w poll/ppoll", fdescs[i].fd); \
 			if (fdescs[i].mx_modes & MX_READ) {		\
 				n = max(n, fdescs[i].fd + 1);		\
 				FD_SET(fdescs[i].fd, &readfds);		\

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -81,8 +81,6 @@
 #include "test_mkfds.h"
 #include "xalloc.h"
 
-#define _U_ __attribute__((__unused__))
-
 static void do_nothing(int signum _U_);
 
 static void __attribute__((__noreturn__)) usage(FILE *out, int status)

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -99,6 +99,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out, int status)
 	fputs(" -q, --quiet                   don't print pid(s)\n", out);
 	fputs(" -X, --dont-monitor-stdin      don't monitor stdin when pausing\n", out);
 	fputs(" -c, --dont-pause              don't pause after making fd(s)\n", out);
+	fputs(" -t, --timeout <sec>           timeout in seconds\n", out);
 	fputs(" -w, --wait-with <multiplexer> use MULTIPLEXER for waiting events\n", out);
 	fputs(" -W, --multiplexers            list multiplexers\n", out);
 
@@ -5447,7 +5448,12 @@ static void do_nothing(int signum _U_)
  */
 struct multiplexer {
 	const char *name;
-	void (*fn)(bool, struct fdesc *fdescs, size_t n_fdescs);
+
+	/*
+	 * Wait on fdescs and stdin. If tfd >= 0 (timerfd), returns true on
+	 * timeout expiry, or false otherwise.
+	 */
+	bool (*fn)(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs);
 };
 
 #if defined(__NR_select) || defined(__NR_poll)
@@ -5458,7 +5464,7 @@ static void sighandler_nop(int si _U_)
 #endif
 
 #define DEFUN_WAIT_EVENT_SELECT(NAME,SYSCALL,XDECLS,SETUP_SIG_HANDLER,SYSCALL_INVOCATION) \
-	static void wait_event_##NAME(bool add_stdin, struct fdesc *fdescs, size_t n_fdescs) \
+	static bool wait_event_##NAME(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs) \
 	{								\
 		fd_set readfds;						\
 		fd_set writefds;					\
@@ -5474,6 +5480,13 @@ static void sighandler_nop(int si _U_)
 		if (add_stdin) {					\
 			n = 1;						\
 			FD_SET(0, &readfds);				\
+		}							\
+		if (tfd >= 0) {						\
+			if (tfd >= FD_SETSIZE)				\
+				errx(EXIT_FAILURE,			\
+				     "timerfd fd %d exceeds FD_SETSIZE; use -w poll/ppoll", tfd); \
+			n = max(n, tfd + 1);				\
+			FD_SET(tfd, &readfds);				\
 		}							\
 									\
 		for (size_t i = 0; i < n_fdescs; i++) {			\
@@ -5496,12 +5509,16 @@ static void sighandler_nop(int si _U_)
 									\
 		SETUP_SIG_HANDLER					\
 									\
-		if (SYSCALL_INVOCATION < 0				\
-		    && errno != EINTR) {				\
+		if (SYSCALL_INVOCATION < 0) {				\
+			if (errno == EINTR)				\
+				return false;				\
 			if (errno == ENOSYS)				\
 				errx(EXIT_ENOSYS, "no syscall: " SYSCALL); \
 			err(EXIT_FAILURE, "failed in " SYSCALL);	\
 		}							\
+		if (tfd >= 0 && FD_ISSET(tfd, &readfds))		\
+			return true;					\
+		return false;						\
 	}
 
 DEFUN_WAIT_EVENT_SELECT(default,
@@ -5624,6 +5641,9 @@ int main(int argc, char **argv)
 	bool cont  = false;
 	void *data;
 	bool monitor_stdin = true;
+	unsigned int timeout = 0;
+	int tfd = -1;
+	bool expired = false;
 
 	struct multiplexer *wait_event = NULL;
 
@@ -5636,6 +5656,7 @@ int main(int argc, char **argv)
 		{ "quiet",	no_argument, NULL, 'q' },
 		{ "dont-monitor-stdin", no_argument, NULL, 'X' },
 		{ "dont-pause", no_argument, NULL, 'c' },
+		{ "timeout",	required_argument, NULL, 't' },
 		{ "wait-with",  required_argument, NULL, 'w' },
 		{ "multiplexers",no_argument,NULL, 'W' },
 		{ "help",	no_argument, NULL, 'h' },
@@ -5643,12 +5664,13 @@ int main(int argc, char **argv)
 	};
 
 	static const ul_excl_t excl[] = {
+		{ 'c', 't' },
 		{ 'c', 'w' },
 		{ 0 }
 	};
 	int excl_st[ARRAY_SIZE(excl)] = UL_EXCL_STATUS_INIT;
 
-	while ((c = getopt_long(argc, argv, "a:lhqcI:O:r:w:WX", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "a:lhqcI:O:r:t:w:WX", longopts, NULL)) != -1) {
 		err_exclusive_options(c, longopts, excl, excl_st);
 
 		switch (c) {
@@ -5670,6 +5692,9 @@ int main(int argc, char **argv)
 			break;
 		case 'c':
 			cont = true;
+			break;
+		case 't':
+			timeout = strtou32_or_err(optarg, "failed to parse timeout");
 			break;
 		case 'w':
 			wait_event = lookup_multiplexer(optarg);
@@ -5758,9 +5783,23 @@ int main(int argc, char **argv)
 		fflush(stdout);
 	}
 
+	if (timeout > 0) {
+		tfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+		if (tfd < 0)
+			err(EXIT_FAILURE, "failed in timerfd_create(2)");
+		if (timerfd_settime(tfd, 0, &(struct itimerspec){
+					.it_value = { .tv_sec = timeout, .tv_nsec = 0 },
+					.it_interval = { 0, 0 }
+				}, NULL) < 0)
+			err(EXIT_FAILURE, "failed in timerfd_settime(2)");
+	}
+
 	if (!cont)
-		wait_event->fn(monitor_stdin,
-			       fdescs, factory->N + factory->EX_N);
+		expired = wait_event->fn(monitor_stdin, tfd,
+					 fdescs, factory->N + factory->EX_N);
+
+	if (tfd >= 0)
+		close(tfd);
 
 	for (int i = 0; i < factory->N + factory->EX_N; i++)
 		if (fdescs[i].fd >= 0 && fdescs[i].close)
@@ -5768,6 +5807,9 @@ int main(int argc, char **argv)
 
 	if (factory->free)
 		factory->free(factory, data);
+
+	if (expired)
+		errx(EXIT_EXPIRED, "timed out after %u seconds", timeout);
 
 	exit(EXIT_SUCCESS);
 }

--- a/tests/helpers/test_mkfds.c
+++ b/tests/helpers/test_mkfds.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <linux/bpf.h>
+#include <sys/mount.h>
 #ifdef HAVE_LINUX_IO_URING_H
 #include <linux/io_uring.h>
 #endif
@@ -795,6 +796,351 @@ static void free_after_closing_duplicated_fd(const struct factory * factory _U_,
 	}
 }
 
+struct munmap_data {
+	void *ptr;
+	size_t len;
+};
+
+static void close_fdesc_after_munmap(int fd, void *data)
+{
+	struct munmap_data *munmap_data = data;
+	if (munmap_data) {
+		munmap(munmap_data->ptr, munmap_data->len);
+		free(data);
+	}
+	close(fd);
+}
+
+#ifdef HAVE_LIBFUSE
+struct hungfs_ctl {
+	int fd;
+	pid_t pid;
+	char *mountpoint;
+	char *targetfile;
+	bool hung;
+	dev_t orig_dev;
+};
+
+static void stop_hungfs(struct hungfs_ctl *ctl)
+{
+	if (ctl->fd >= 0)
+		close(ctl->fd);
+	if (ctl->pid > 0) {
+		kill(ctl->pid, SIGTERM);
+		while (waitpid(ctl->pid, NULL, 0) < 0 && errno == EINTR)
+			;
+	}
+	/*
+	 * When the FUSE server process terminates, its FUSE mount is
+	 * automatically cleaned up by the kernel. If a pre-existing bind mount
+	 * exists on the same filesystem (sharing st_dev with its parent),
+	 * calling umount2 unconditionally here would mistakenly unmount that
+	 * underlying bind mount instead. Therefore, only unmount if the
+	 * mountpoint device still differs from the original pre-mount device.
+	 */
+	if (ctl->mountpoint) {
+		struct stat st;
+		if (stat(ctl->mountpoint, &st) == 0 && st.st_dev != ctl->orig_dev) {
+			if (umount2(ctl->mountpoint, MNT_DETACH) < 0
+			    && errno != EINVAL && errno != ENOENT)
+				warn("failed to unmount: %s", ctl->mountpoint);
+		}
+	}
+	free(ctl->mountpoint);
+	free(ctl->targetfile);
+}
+
+static void wait_hungfs(struct hungfs_ctl *ctl)
+{
+	int pfd;
+	struct pollfd pfds[2];
+	char c;
+
+	pfd = pidfd_open(ctl->pid, 0);
+	if (pfd < 0) {
+		int e = errno;
+		stop_hungfs(ctl);
+		errno = e;
+		err_nosys(EXIT_FAILURE, "failed to open pidfd for fuse server");
+	}
+
+	pfds[0] = (struct pollfd){ .fd = ctl->fd, .events = POLLIN };
+	pfds[1] = (struct pollfd){ .fd = pfd,     .events = POLLIN };
+
+	while (poll(pfds, 2, -1) < 0) {
+		if (errno == EINTR)
+			continue;
+		int e = errno;
+		close(pfd);
+		stop_hungfs(ctl);
+		errno = e;
+		err(EXIT_FAILURE, "failed in poll for fuse server");
+	}
+
+	close(pfd);
+
+	/* If fuse server terminated before sending READY, fail immediately */
+	if (pfds[1].revents & (POLLIN | POLLHUP | POLLERR)) {
+		int status;
+		pid_t r;
+		while ((r = waitpid(ctl->pid, &status, WNOHANG)) < 0 && errno == EINTR)
+			;
+		if (r > 0 && WIFEXITED(status)) {
+			ctl->pid = 0;
+			stop_hungfs(ctl);
+			errx(EXIT_FAILURE, "fuse server exited with status %d",
+			     WEXITSTATUS(status));
+		}
+		stop_hungfs(ctl);
+		errx(EXIT_FAILURE, "fuse server terminated unexpectedly");
+	}
+
+	/* Read READY signal from FUSE server's init callback */
+	ssize_t r;
+	while ((r = read(ctl->fd, &c, 1)) < 0 && errno == EINTR)
+		;
+	if (r != 1 || c != HUNGFS_READY) {
+		stop_hungfs(ctl);
+		errx(EXIT_FAILURE, "failed to receive READY from fuse server");
+	}
+}
+
+static void arm_hungfs(struct hungfs_ctl *ctl)
+{
+	char c = HUNGFS_HANG;
+	if (send(ctl->fd, &c, 1, MSG_NOSIGNAL) != 1) {
+		stop_hungfs(ctl);
+		errx(EXIT_FAILURE, "failed to send the 'hang' message to fuse server");
+	}
+}
+
+static void unarm_hungfs(struct hungfs_ctl *ctl)
+{
+	char c = HUNGFS_UNHUNG;
+	ignore_result(send(ctl->fd, &c, 1, MSG_NOSIGNAL));
+}
+
+static enum hungfs_target decode_hung_target(const char *target)
+{
+	if (strcmp(target, "file") == 0)
+		return HUNGFS_TARGET_FILE;
+	if (strcmp(target, "root") == 0)
+		return HUNGFS_TARGET_ROOT;
+	if (strcmp(target, "all") == 0)
+		return HUNGFS_TARGET_ALL;
+
+	errx(EXIT_FAILURE, "unknown hung-target value: %s", target);
+}
+
+static dev_t check_mountpoint(const char *mountpoint)
+{
+	struct stat sb, parent_sb;
+	char *parent;
+
+	if (strcmp(mountpoint, "/") == 0)
+		errx(EXIT_FAILURE, "refusing to use '/' as mountpoint");
+
+	if (lstat(mountpoint, &sb) < 0)
+		err(EXIT_FAILURE, "failed to access mountpoint: %s", mountpoint);
+	/*
+	 * Do not allow symbolic links for mountpoint to avoid any trouble
+	 * or pitfalls with path resolution (e.g. symlink pointing to '/').
+	 */
+	if (S_ISLNK(sb.st_mode))
+		errx(EXIT_FAILURE, "mountpoint must not be a symbolic link: %s", mountpoint);
+	if (!S_ISDIR(sb.st_mode))
+		errx(EXIT_FAILURE, "mountpoint is not a directory: %s", mountpoint);
+
+	xasprintf(&parent, "%s/..", mountpoint);
+	if (stat(parent, &parent_sb) == 0 && sb.st_dev != parent_sb.st_dev) {
+		free(parent);
+		errx(EXIT_FAILURE, "mountpoint is already a mountpoint: %s", mountpoint);
+	}
+	free(parent);
+
+	return sb.st_dev;
+}
+
+static void check_file_name(const char *file)
+{
+	if (!file || *file == '\0')
+		errx(EXIT_FAILURE, "file name must not be empty");
+	if (strchr(file, '/'))
+		errx(EXIT_FAILURE, "file name must not contain '/': %s", file);
+	if (strcmp(file, ".") == 0 || strcmp(file, "..") == 0)
+		errx(EXIT_FAILURE, "file name must not be '.' or '..': %s", file);
+}
+
+static void start_hungfs(struct hungfs_ctl *ctl,
+			 const char *mountpoint,
+			 const char *file,
+			 bool hung,
+			 enum hungfs_target hung_target)
+{
+	int sv[2];
+	pid_t pid;
+
+	if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sv) < 0)
+		err(EXIT_FAILURE, "failed in socketpair for fuse IPC");
+
+	pid = fork();
+	if (pid < 0)
+		err(EXIT_FAILURE, "failed in fork");
+
+	if (pid == 0) {
+		close(sv[0]);
+		run_hungfs(&(struct hungfs_args) {
+				.ctlfd = sv[1],
+				.mountpoint = mountpoint,
+				.file = file,
+				.hung = hung,
+				.hung_target = hung_target
+			});
+		exit(EXIT_FAILURE);
+	}
+
+	close(sv[1]);
+	ctl->pid = pid;
+	ctl->fd = sv[0];
+	ctl->mountpoint = xstrdup(mountpoint);
+	ctl->hung = hung;
+	xasprintf(&ctl->targetfile, "%s/%s", mountpoint, file);
+
+	wait_hungfs(ctl);
+}
+
+static int open_hungfs_file(struct hungfs_ctl *ctl, struct munmap_data *mdata)
+{
+	int fd;
+
+	fd = open(ctl->targetfile, O_RDONLY);
+	if (fd < 0) {
+		int e = errno;
+		char *t = ctl->targetfile;
+
+		ctl->targetfile = NULL;
+		stop_hungfs(ctl);
+
+		free(mdata);
+		errno = e;
+		err(EXIT_FAILURE, "failed to open %s", t);
+	}
+
+	if (mdata) {
+		mdata->len = HUNGFS_FILE_SIZE;
+		mdata->ptr = mmap(NULL, mdata->len, PROT_READ, MAP_PRIVATE, fd, 0);
+		if (mdata->ptr == MAP_FAILED) {
+			int e = errno;
+			char *t = ctl->targetfile;
+
+			ctl->targetfile = NULL;
+			stop_hungfs(ctl);
+
+			free(mdata);
+			errno = e;
+			err(EXIT_FAILURE, "failed in mmap %s", t);
+		}
+	}
+
+	return fd;
+}
+
+/*
+ * make_fuse_hungfs:
+ * Spawn a hungfs FUSE server child, wait for it to be ready, open (and
+ * optionally mmap) a file within the mountpoint, and optionally arm the
+ * hang on subsequent getattr requests.
+ *
+ * Cleanup notes:
+ * - When test_mkfds exits normally (via timeout, EOF on stdin, or regular
+ *   termination signals), the FUSE child is terminated and its mount is
+ *   cleaned up.
+ * - If the FUSE child is killed abruptly from outside with SIGKILL,
+ *   libfuse cannot run its normal unmount sequence and a dead FUSE mount
+ *   may remain, requiring manual 'umount' or 'umount -l' cleanup.
+ */
+static void *make_fuse_hungfs(const struct factory *factory, struct fdesc fdescs[],
+			      int argc, char **argv)
+{
+	int fd;
+	struct hungfs_ctl ctl = {
+		.pid = 0,
+		.fd = -1,
+		.mountpoint = NULL,
+		.targetfile = NULL,
+		.hung = false,
+		.orig_dev = 0,
+	};
+	struct arg mountpoint  = decode_arg("mountpoint", factory->params, argc, argv);
+	struct arg file        = decode_arg("file", factory->params, argc, argv);
+	struct arg hung        = decode_arg("hung", factory->params, argc, argv);
+	struct arg hung_target = decode_arg("hung-target", factory->params, argc, argv);
+	struct arg mmap_arg    = decode_arg("mmap", factory->params, argc, argv);
+
+	const char *sMountpoint        = ARG_STRING(mountpoint);
+	const char *sFile              = ARG_STRING(file);
+	bool bHung                     = ARG_BOOLEAN(hung);
+	enum hungfs_target eHungTarget = decode_hung_target(ARG_STRING(hung_target));
+	bool bMmap                     = ARG_BOOLEAN(mmap_arg);
+
+	struct munmap_data *mdata = NULL;
+
+	ctl.orig_dev = check_mountpoint(sMountpoint);
+	check_file_name(sFile);
+
+	/* Reserve the requested fd so socketpair won't occupy it */
+	reserve_fd(fdescs[0].fd);
+
+	start_hungfs(&ctl, sMountpoint, sFile, bHung, eHungTarget);
+
+	free_arg(&mountpoint);
+	free_arg(&file);
+	free_arg(&hung);
+	free_arg(&hung_target);
+	free_arg(&mmap_arg);
+
+	if (bMmap)
+		mdata = xmalloc(sizeof(*mdata));
+	fd = open_hungfs_file(&ctl, mdata);
+
+	if (ctl.hung)
+		arm_hungfs(&ctl);
+
+	/* Release the reservation and duplicate the opened fd into fdescs[0].fd */
+	if (fd != fdescs[0].fd) {
+		if (dup2(fd, fdescs[0].fd) < 0) {
+			int e = errno;
+			close(fd);
+			stop_hungfs(&ctl);
+
+			free(mdata);
+			errno = e;
+			err(EXIT_FAILURE, "failed to dup %d -> %d", fd, fdescs[0].fd);
+		}
+		close(fd);
+	}
+
+	fdescs[0] = (struct fdesc){
+		.fd    = fdescs[0].fd,
+		.close = close_fdesc_after_munmap,
+		.data  = mdata
+	};
+
+	return xmemdup(&ctl, sizeof(ctl));
+}
+
+static void free_fuse_hungfs(const struct factory *factory _U_, void *data)
+{
+	struct hungfs_ctl *ctl = data;
+
+	if (ctl->hung)
+		unarm_hungfs(ctl);
+
+	stop_hungfs(ctl);
+	free(ctl);
+}
+#endif /* HAVE_LIBFUSE */
+
 static void *make_pipe(const struct factory *factory, struct fdesc fdescs[],
 		       int argc, char ** argv)
 {
@@ -1088,19 +1434,6 @@ static int make_packet_socket(int socktype, const char *interface, int protocol)
 	}
 
 	return sd;
-}
-
-struct munmap_data {
-	void *ptr;
-	size_t len;
-};
-
-static void close_fdesc_after_munmap(int fd, void *data)
-{
-	struct munmap_data *munmap_data = data;
-	munmap(munmap_data->ptr, munmap_data->len);
-	free(data);
-	close(fd);
 }
 
 static void *make_mmapped_packet_socket(const struct factory *factory, struct fdesc fdescs[],
@@ -5183,6 +5516,50 @@ static const struct factory factories[] = {
 			PARAM_END
 		}
 	},
+#ifdef HAVE_LIBFUSE
+	{
+		.name = "fuse-hungfs",
+		.desc = "open a file in user-mode file system reproducing process hangs",
+		.priv = true,
+		.N    = 1,
+		.EX_N = 0,
+		.make = make_fuse_hungfs,
+		.free = free_fuse_hungfs,
+		.params = (struct parameter []) {
+			{
+				.name = "mountpoint",
+				.type = PTYPE_STRING,
+				.desc = "mount point for fuse file system",
+				.defv.string = "./test_mkfds_fuse_mnt",
+			},
+			{
+				.name = "file",
+				.type = PTYPE_STRING,
+				.desc = "file to be opened in fuse mount",
+				.defv.string = "test_file",
+			},
+			{
+				.name = "hung",
+				.type = PTYPE_BOOLEAN,
+				.desc = "hang on getattr after open",
+				.defv.boolean = false,
+			},
+			{
+				.name = "hung-target",
+				.type = PTYPE_STRING,
+				.desc = "target node to hang on getattr: \"file\" (default), \"root\", or \"all\"",
+				.defv.string = "file",
+			},
+			{
+				.name = "mmap",
+				.type = PTYPE_BOOLEAN,
+				.desc = "mmap the opened file into memory privately (MAP_PRIVATE)",
+				.defv.boolean = false,
+			},
+			PARAM_END
+		},
+	},
+#endif	/* HAVE_LIBFUSE */
 };
 
 static int count_parameters(const struct factory *factory)

--- a/tests/helpers/test_mkfds.h
+++ b/tests/helpers/test_mkfds.h
@@ -23,6 +23,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+/* Exit code for test_mkfds execution control (distinct from errno-based
+ * exit codes returned when factories fail to construct file descriptors).
+ * 124 matches GNU timeout(1) exit status for expired timeout. */
+#define EXIT_EXPIRED 124
+
 /* Update the constants in
  * tests/ts/lsfd/lsfd-functions.bash when changing
  * the following error definitions. */
@@ -49,10 +54,12 @@ struct fdesc {
 };
 
 #define DEFUN_WAIT_EVENT_POLL(NAME,SYSCALL,XDECLS,SETUP_SIG_HANDLER,SYSCALL_INVOCATION) \
-	void wait_event_##NAME(bool add_stdin, struct fdesc *fdescs, size_t n_fdescs) \
+	bool wait_event_##NAME(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs) \
 	{								\
-		int n = add_stdin? 1: 0;				\
+		int n = (add_stdin ? 1 : 0) + (tfd >= 0 ? 1 : 0);	\
 		int n0 = 0;						\
+		int tfd_idx = -1;					\
+		bool expired = false;					\
 		struct pollfd *pfds = NULL;				\
 									\
 		XDECLS							\
@@ -79,21 +86,35 @@ struct fdesc {
 		if (add_stdin) {					\
 			pfds[n0].fd = 0;				\
 			pfds[n0].events |= POLLIN;			\
+			n0++;						\
+		}							\
+									\
+		if (tfd >= 0) {						\
+			tfd_idx = n0;					\
+			pfds[n0].fd = tfd;				\
+			pfds[n0].events |= POLLIN;			\
+			n0++;						\
 		}							\
 									\
 		SETUP_SIG_HANDLER					\
 									\
-		if (SYSCALL_INVOCATION < 0				\
-		    && errno != EINTR) {				\
+		if (SYSCALL_INVOCATION < 0) {				\
+			if (errno == EINTR) {				\
+				free(pfds);				\
+				return false;				\
+			}						\
 			if (errno == ENOSYS)				\
 				errx(EXIT_ENOSYS, "no syscall: " SYSCALL); \
 			err(EXIT_FAILURE, "failed in " SYSCALL);	\
 		}							\
+		if (tfd_idx >= 0 && (pfds[tfd_idx].revents & (POLLIN | POLLERR | POLLHUP))) \
+			expired = true;					\
 		free(pfds);						\
+		return expired;						\
 	}
 
 #ifdef __NR_ppoll
-void wait_event_ppoll(bool add_stdin, struct fdesc *fdescs, size_t n_fdescs);
+bool wait_event_ppoll(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs);
 #endif
 
 #endif	/* TEST_MKFDS_H */

--- a/tests/helpers/test_mkfds.h
+++ b/tests/helpers/test_mkfds.h
@@ -23,6 +23,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#define _U_ __attribute__((__unused__))
+
 /* Exit code for test_mkfds execution control (distinct from errno-based
  * exit codes returned when factories fail to construct file descriptors).
  * 124 matches GNU timeout(1) exit status for expired timeout. */
@@ -115,6 +117,31 @@ struct fdesc {
 
 #ifdef __NR_ppoll
 bool wait_event_ppoll(bool add_stdin, int tfd, struct fdesc *fdescs, size_t n_fdescs);
+#endif
+
+#ifdef HAVE_LIBFUSE
+#define HUNGFS_FILE_SIZE 1024
+
+#define HUNGFS_READY  'R'
+#define HUNGFS_HANG   'H'
+#define HUNGFS_UNHUNG 'G'
+
+enum hungfs_target {
+	HUNGFS_TARGET_FILE = (1 << 0),
+	HUNGFS_TARGET_ROOT = (1 << 1),
+	HUNGFS_TARGET_ALL  = HUNGFS_TARGET_FILE | HUNGFS_TARGET_ROOT,
+};
+
+struct hungfs_args {
+	int ctlfd;
+	const char *mountpoint;
+	const char *file;
+	bool hung;
+	enum hungfs_target hung_target;
+	bool is_hung;
+};
+
+void run_hungfs(struct hungfs_args *args);
 #endif
 
 #endif	/* TEST_MKFDS_H */

--- a/tests/helpers/test_mkfds_hungfs.c
+++ b/tests/helpers/test_mkfds_hungfs.c
@@ -1,0 +1,217 @@
+/*
+ * test_mkfds_hungfs - user-mode file system reproducing process hangs
+ *
+ * Written by Masatake YAMATO <yamato@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://gnu.org/licenses/>.
+ */
+
+/*
+ * Protocol for hungfs state and hang control:
+ *
+ * Communication between the test_mkfds runner (parent) and the FUSE server
+ * (child) is conducted via an AF_UNIX socketpair (ctlfd):
+ *
+ * 1. Startup synchronization:
+ *    - Child sends HUNGFS_READY ('R') in hungfs_init() once the FUSE mount
+ *      initialization is complete.
+ *    - Parent waits for HUNGFS_READY (monitored along with the child's pidfd)
+ *      before opening files on the mount point.
+ *
+ * 2. Arming hang:
+ *    - Parent sends HUNGFS_HANG ('H') to transition the file system to
+ *      hung state (args->is_hung = true).
+ *    - Subsequent getattr requests for matching targets (HUNGFS_TARGET_FILE,
+ *      HUNGFS_TARGET_ROOT, or HUNGFS_TARGET_ALL) block in
+ *      hungfs_wait_unhung().
+ *
+ * 3. Disarming hang:
+ *    - Parent sends HUNGFS_UNHUNG ('G') to transition back to normal state
+ *      (args->is_hung = false), immediately unblocking any in-flight or
+ *      subsequent getattr operations.
+ *
+ * 4. Teardown:
+ *    - When the control socket is closed (EOF) by the parent during cleanup
+ *      or termination, blocked getattr operations unblock immediately to allow
+ *      clean unmounting and exit.
+ */
+
+#include "c.h"
+
+#ifdef HAVE_LIBFUSE
+
+#define FUSE_USE_VERSION 26
+#include <fuse.h>
+
+#include <errno.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "test_mkfds.h"
+#include "xalloc.h"
+
+static void *hungfs_init(struct fuse_conn_info *conn _U_)
+{
+	struct fuse_context *ctx = fuse_get_context();
+	struct hungfs_args *args = ctx->private_data;
+	char c = HUNGFS_READY;
+	ssize_t r;
+
+	/* Signal parent that FUSE mount is ready */
+	while ((r = write(args->ctlfd, &c, 1)) < 0 && errno == EINTR)
+		;
+	if (r != 1)
+		_exit(EXIT_FAILURE);
+
+	return args;
+}
+
+static void hungfs_update_state(struct hungfs_args *args)
+{
+	struct pollfd pfd = { .fd = args->ctlfd, .events = POLLIN };
+	ssize_t r;
+	char c;
+	int pr;
+
+	while (1) {
+		do {
+			pr = poll(&pfd, 1, 0);
+		} while (pr < 0 && errno == EINTR);
+
+		if (pr <= 0 || !(pfd.revents & POLLIN))
+			break;
+
+		while ((r = read(args->ctlfd, &c, 1)) < 0 && errno == EINTR)
+			;
+		if (r != 1)
+			break;
+		if (c == HUNGFS_HANG)
+			args->is_hung = true;
+		else if (c == HUNGFS_UNHUNG)
+			args->is_hung = false;
+	}
+}
+
+static void hungfs_wait_unhung(struct hungfs_args *args)
+{
+	ssize_t r;
+	char c;
+
+	while (1) {
+		while ((r = read(args->ctlfd, &c, 1)) < 0 && errno == EINTR)
+			;
+		if (r <= 0 || c == HUNGFS_UNHUNG) {
+			args->is_hung = false;
+			break;
+		}
+		/*
+		 * If we read HUNGFS_HANG ('H'), the parent sent a hang command
+		 * that arrived while or just after we started waiting. Keep the
+		 * hung state and continue blocking until an UNHUNG command ('G')
+		 * or EOF is received.
+		 */
+		if (c == HUNGFS_HANG)
+			args->is_hung = true;
+	}
+}
+
+static int hungfs_getattr(const char *path, struct stat *stbuf)
+{
+	struct fuse_context *ctx = fuse_get_context();
+	struct hungfs_args *args = ctx->private_data;
+
+	hungfs_update_state(args);
+
+	memset(stbuf, 0, sizeof(struct stat));
+	if (strcmp(path, "/") == 0) {
+		if (args->hung && args->is_hung
+		    && (args->hung_target & HUNGFS_TARGET_ROOT))
+			hungfs_wait_unhung(args);
+		stbuf->st_mode = S_IFDIR | 0755;
+		stbuf->st_nlink = 2;
+		return 0;
+	}
+	if (args->file && strcmp(path + 1, args->file) == 0) {
+		if (args->hung && args->is_hung
+		    && (args->hung_target & HUNGFS_TARGET_FILE))
+			hungfs_wait_unhung(args);
+		stbuf->st_mode = S_IFREG | 0644;
+		stbuf->st_nlink = 1;
+		stbuf->st_size = HUNGFS_FILE_SIZE;
+		return 0;
+	}
+	return -ENOENT;
+}
+
+static int hungfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
+			  off_t offset _U_, struct fuse_file_info *fi _U_)
+{
+	struct fuse_context *ctx = fuse_get_context();
+	struct hungfs_args *args = ctx->private_data;
+
+	if (strcmp(path, "/") != 0)
+		return -ENOENT;
+
+	filler(buf, ".", NULL, 0);
+	filler(buf, "..", NULL, 0);
+	if (args && args->file)
+		filler(buf, args->file, NULL, 0);
+	return 0;
+}
+
+static int hungfs_open(const char *path, struct fuse_file_info *fi _U_)
+{
+	struct fuse_context *ctx = fuse_get_context();
+	struct hungfs_args *args = ctx->private_data;
+
+	if (strcmp(path + 1, args->file) == 0)
+		return 0;
+	return -ENOENT;
+}
+
+static struct fuse_operations hungfs_ops = {
+	.init    = hungfs_init,
+	.getattr = hungfs_getattr,
+	.readdir = hungfs_readdir,
+	.open    = hungfs_open,
+};
+
+void run_hungfs(struct hungfs_args *args)
+{
+	int r;
+	char *mountpoint = xstrdup(args->mountpoint);
+	/*
+	 * Disable kernel attribute and dentry caching (attr_timeout=0,
+	 * entry_timeout=0) so that pathname lookups and getattr operations
+	 * are deterministically forwarded to the FUSE server without
+	 * relying on cached VFS entries.
+	 */
+	char *fuse_argv[] = {
+		"hungfs",
+		"-f",          /* foreground */
+		"-s",          /* single-threaded */
+		"-o", "attr_timeout=0,entry_timeout=0",
+		mountpoint,
+		NULL
+	};
+
+	r = fuse_main(ARRAY_SIZE(fuse_argv) - 1, fuse_argv, &hungfs_ops, args);
+	free(mountpoint);
+	exit(r);
+}
+
+#endif /* HAVE_LIBFUSE */

--- a/tests/ts/lsfd/lsfd-functions.bash
+++ b/tests/ts/lsfd/lsfd-functions.bash
@@ -19,6 +19,8 @@
 #
 # Update the following constants when changing
 # the error definitions in tests/helpers/test_mkfds.h.
+readonly EXIT_EXPIRED=124
+
 readonly EPERM=18
 readonly ENOPROTOOPT=19
 readonly EPROTONOSUPPORT=20


### PR DESCRIPTION
This patch set introduces testing infrastructure improvements to test_mkfds
to safely reproduce stalled or hung file systems as a foundation for future
lsfd improvements:

1. Motivation:
   - When inspecting processes holding file descriptors or memory mappings
     on unresponsive file systems (such as hung FUSE or remote NFS mounts),
     tools like lsfd risk blocking indefinitely during metadata retrieval
     or pathname resolution.
   - Developing, verifying, and testing non-blocking improvements in lsfd
     requires a reliable and safe way to reproduce hanging conditions
     without wedging the test runner or host system.
   - This patch set introduces the necessary testing infrastructure as a
     standalone preparation for upcoming lsfd resilience improvements.

2. Timeout option (-t/--timeout):
   - Add -t/--timeout option to test_mkfds to protect regression test runs
     from hanging processes. If the timeout expires while waiting on events,
     test_mkfds exits with status 124 (EXIT_EXPIRED).

3. hungfs FUSE file system:
   - Implement hungfs, a minimal user-mode FUSE file system controlled
     via an IPC socketpair that transitions to hung state on command
     and deterministically hangs on getattr requests (for files,
     mount points, or both) after open/mmap operations.

4. fuse-hungfs factory:
   - Add fuse-hungfs factory supporting parameters 'mountpoint', 'file',
     'hung', 'hung-target' ('file', 'root', 'all'), and 'mmap' (MAP_PRIVATE).

5. Build system support:
   - Add HAVE_LIBFUSE checks and conditional compilation to both
     Autotools and Meson build systems.
