### PR TITLE
libmount: fix build failures after CVE-2026-78410

### DIFF
--- a/lib/fileutils.c
+++ b/lib/fileutils.c
@@ -501,10 +501,10 @@ FILE *fopen_at_no_link(int dir, const char *filename,
 }
 #endif /* HAVE_OPENAT */
 
+#if defined(SYS_openat2)
 int ul_openat_resolve(int dirfd, const char *path, int flags,
 		      mode_t mode, unsigned long long resolve)
 {
-#if defined(SYS_openat2)
 	struct open_how how = {
 		.flags = (__u64) flags,
 		.mode = (__u64) mode,
@@ -512,11 +512,19 @@ int ul_openat_resolve(int dirfd, const char *path, int flags,
 	};
 
 	return syscall(SYS_openat2, dirfd, path, &how, sizeof(how));
+}
 #else
+int ul_openat_resolve(
+		int dirfd __attribute__((__unused__)),
+		const char *path __attribute__((__unused__)),
+		int flags __attribute__((__unused__)),
+		mode_t mode __attribute__((__unused__)),
+		unsigned long long resolve __attribute__((__unused__)))
+{
 	errno = ENOSYS;
 	return -1;
-#endif
 }
+#endif
 
 int ul_open_no_symlinks(const char *path, int flags, mode_t mode)
 {

--- a/libmount/src/hook_idmap.c
+++ b/libmount/src/hook_idmap.c
@@ -32,7 +32,7 @@
 # include <linux/nsfs.h>
 #endif
 
-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
+#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
 
 typedef enum idmap_type_t {
 	ID_TYPE_UID,	/* uidmap entry */
@@ -317,7 +317,6 @@ static int hook_mount_post(
 	 * Once a mount has been attached to the filesystem it can't be
 	 * idmapped anymore. So create a new detached mount.
 	 */
-#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
 	{
 		struct libmnt_sysapi *api = mnt_context_get_sysapi(cxt);
 
@@ -327,7 +326,6 @@ static int hook_mount_post(
 			DBG_OBJ(HOOK, hs, ul_debug(" reuse tree FD"));
 		}
 	}
-#endif
 	if (fd_tree < 0)
 		fd_tree = mnt_open_tree(AT_FDCWD, target,
 			    OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC |
@@ -544,4 +542,4 @@ const struct libmnt_hookset hookset_idmap =
 	.deinit = hookset_deinit
 };
 
-#endif /* HAVE_MOUNTFD_API && HAVE_LINUX_MOUNT_H */
+#endif /* USE_LIBMOUNT_MOUNTFD_SUPPORT */

--- a/libmount/src/hooks.c
+++ b/libmount/src/hooks.c
@@ -45,7 +45,7 @@ static const struct libmnt_hookset *const hooksets[] =
 	&hookset_mount,
 #endif
 	&hookset_mount_legacy,
-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
+#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
 	&hookset_idmap,
 #endif
 	&hookset_owner

--- a/libmount/src/version.c
+++ b/libmount/src/version.c
@@ -45,7 +45,7 @@ static const char *lib_features[] = {
 #ifdef USE_LIBMOUNT_SUPPORT_NAMESPACES
 	"namespaces",
 #endif
-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
+#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
 	"idmapping",
 #endif
 #ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -826,6 +826,7 @@ Set _mountpoint_'s mode after mounting.
 
 *X-mount.idmap*=__id-type__:__id-mount__:__id-host__:__id-range__ [__id-type__:__id-mount__:__id-host__:__id-range__], *X-mount.idmap*=__file__::
 Use this option to create an idmapped mount.
+This feature requires the new file-descriptor-based mount API (available since Linux 5.2).
 An idmapped mount allows the ownership of all files located under a mount to be changed according to the ID-mapping associated with a user namespace.
 The ownership change is tied to the lifetime of, and localized to, the relevant mount.
 The relevant ID-mapping can be specified in two ways:

--- a/tools/config-gen.d/non-newmount.conf
+++ b/tools/config-gen.d/non-newmount.conf
@@ -1,0 +1,3 @@
+include:core.conf
+
+--disable-libmount-mountfd-support


### PR DESCRIPTION
## Summary

Fix build failures introduced by the CVE-2026-78410 security patches:

- **Missing `fileutils.h` include in `hook_idmap.c`** — `RESOLVE_NO_SYMLINKS` is
  undeclared on systems where glibc does not transitively include `<linux/openat2.h>`
  through `<fcntl.h>` (e.g., Ubuntu, Debian). On Fedora (glibc 2.40+) the build
  succeeds because `<bits/fcntl-linux.h>` pulls in `<linux/openat2.h>`, masking
  the issue. *(already in master)*

- **Unused parameter warnings in `ul_openat_resolve()`** — on systems without
  `SYS_openat2`, all parameters are unused in the fallback stub, causing
  `-Werror=unused-parameter` failures on older Ubuntu/Gentoo.

- **`hook_idmap.c` guarded by wrong macro** — the idmap hookset was guarded by
  `HAVE_MOUNTFD_API` instead of `USE_LIBMOUNT_MOUNTFD_SUPPORT`. This was
  originally intentional (commit 9040c0900, 2022) to keep idmap working with
  `--disable-libmount-mountfd-support` via raw `open_tree()` calls. The CVE fix
  replaced `open_tree()` with `mnt_open_tree()` (only available under
  `USE_LIBMOUNT_MOUNTFD_SUPPORT`), breaking this configuration. Since idmap
  fundamentally depends on the new mount API, the entire hookset is now gated
  on `USE_LIBMOUNT_MOUNTFD_SUPPORT`, consistent with `hookset_mount`.

- Add `non-newmount.conf` config-gen profile for testing builds with
  `--disable-libmount-mountfd-support`.

Closes #4598