### PR TITLE
libfdisk: fix memory leak of string result in ask reset

### DIFF
--- a/libfdisk/src/ask.c
+++ b/libfdisk/src/ask.c
@@ -60,6 +60,9 @@ void fdisk_reset_ask(struct fdisk_ask *ask)
 	if (fdisk_is_ask(ask, MENU))
 		fdisk_ask_menu_reset_items(ask);
 
+	if (fdisk_is_ask(ask, STRING))
+		free(ask->data.str.result);
+
 	memset(ask, 0, sizeof(*ask));
 	ask->refcount = refcount;
 }


### PR DESCRIPTION
The fdisk_ask_string_set_result() API documents that libfdisk will
deallocate the result buffer when the ask instance is destroyed. However,
fdisk_reset_ask() did not free ask->data.str.result, causing a memory
leak each time a string dialog was used (e.g fdisk_ask_string()).