### PR TITLE
hexdump: add free_colorlist() to fix leak on color_fmt() error

### DIFF
--- a/text-utils/hexdump-parse.c
+++ b/text-utils/hexdump-parse.c
@@ -503,8 +503,10 @@ static struct list_head *color_fmt(char *cfmt, int bcnt)
 		hcnext->fmt = color_sequence_from_colorname(clr);
 		free(clr);
 
-		if (!hcnext->fmt)
+		if (!hcnext->fmt) {
+			free_colorlist(ret_head);
 			return NULL;
+		}
 
 		/* only colorize this specific value */
 		if (*cfmt == ':') {

--- a/text-utils/hexdump.c
+++ b/text-utils/hexdump.c
@@ -243,13 +243,27 @@ int main(int argc, char **argv)
 	return ret;
 }
 
+void free_colorlist(struct list_head *head)
+{
+	struct list_head *p, *pn;
+
+	if (!head)
+		return;
+	list_for_each_safe(p, pn, head) {
+		struct hexdump_clr *clr = list_entry(p, struct hexdump_clr, colorlist);
+
+		free(clr->str);
+		free(clr);
+	}
+	free(head);
+}
+
 void hex_free(struct hexdump *hex)
 {
-	struct list_head *p, *pn, *q, *qn, *r, *rn, *s, *sn;
+	struct list_head *p, *pn, *q, *qn, *r, *rn;
 	struct hexdump_fs *fs;
 	struct hexdump_fu *fu;
 	struct hexdump_pr *pr;
-	struct hexdump_clr *clr;
 
 	list_for_each_safe(p, pn, &hex->fshead) {
 		fs = list_entry(p, struct hexdump_fs, fslist);
@@ -257,14 +271,7 @@ void hex_free(struct hexdump *hex)
 			fu = list_entry(q, struct hexdump_fu, fulist);
 			list_for_each_safe(r, rn, &fu->prlist) {
 				pr = list_entry(r, struct hexdump_pr, prlist);
-				if (pr->colorlist) {
-					list_for_each_safe(s, sn, pr->colorlist) {
-						clr = list_entry (s, struct hexdump_clr, colorlist);
-						free(clr->str);
-						free(clr);
-					}
-					free(pr->colorlist);
-				}
+				free_colorlist(pr->colorlist);
 				free(pr->fmt);
 				free(pr);
 			}

--- a/text-utils/hexdump.h
+++ b/text-utils/hexdump.h
@@ -112,6 +112,7 @@ void __attribute__((__noreturn__)) usage(void);
 void conv_c(struct hexdump_pr *, u_char *);
 void conv_u(struct hexdump_pr *, u_char *);
 int  next(char **, struct hexdump *);
+void free_colorlist(struct list_head *);
 int parse_args(int, char **, struct hexdump *);
 
 #endif /* UTIL_LINUX_HEXDUMP_H */


### PR DESCRIPTION
Extract colorlist deallocation into free_colorlist() and use it in
hex_free() and on the color_fmt() error path where ret_head and all
linked nodes were leaked when color_sequence_from_colorname() failed.