### PR TITLE
tests: hardlink use /dev/urandom for non-sparse test files

### DIFF
--- a/tests/expected/hardlink/options-real-size
+++ b/tests/expected/hardlink/options-real-size
@@ -5,5 +5,6 @@ Linked:                   1 files
 Compared: [Redacted] files
 Saved:                    8 KiB
 Duration: [Redacted]
+file-a st_blocks: non-zero
 file-a links: 2
 sparse-a links: 1

--- a/tests/expected/hardlink/options-sparse-skip
+++ b/tests/expected/hardlink/options-sparse-skip
@@ -6,6 +6,7 @@ Linked:                   1 files
 Compared: [Redacted] files
 Saved:                    4 KiB
 Duration: [Redacted]
-sparse-a blocks: 0
+sparse-a st_blocks: zero
+real-a st_blocks: non-zero
 sparse-a inode: unique
 real-a links: 2

--- a/tests/ts/hardlink/options
+++ b/tests/ts/hardlink/options
@@ -119,11 +119,12 @@ else
 	mkdir -p "$SPDIR"
 	truncate -s 1M "$SPDIR"/sparse-a
 	truncate -s 1M "$SPDIR"/sparse-b
-	dd if=/dev/zero of="$SPDIR"/real-a bs=4096 count=1 2>/dev/null
+	dd if=/dev/urandom of="$SPDIR"/real-a bs=4096 count=1 2>/dev/null
 	cp "$SPDIR"/real-a "$SPDIR"/real-b
 	$TS_CMD_HARDLINK -v "$SPDIR" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 	summary_clean
-	echo "sparse-a blocks: $(stat -c %b "$SPDIR"/sparse-a)" >> "$TS_OUTPUT"
+	echo "sparse-a st_blocks: $(test "$(stat -c %b "$SPDIR"/sparse-a)" -gt 0 && echo non-zero || echo zero)" >> "$TS_OUTPUT"
+	echo "real-a st_blocks: $(test "$(stat -c %b "$SPDIR"/real-a)" -gt 0 && echo non-zero || echo zero)" >> "$TS_OUTPUT"
 	echo "sparse-a inode: unique" >> "$TS_OUTPUT"
 	echo "real-a links: $(stat -c %h "$SPDIR"/real-a)" >> "$TS_OUTPUT"
 	rm -rf "$SPDIR"
@@ -137,12 +138,13 @@ else
 	SPDIR="$TS_OUTDIR/sparsedir"
 	rm -rf "$SPDIR"
 	mkdir -p "$SPDIR"
-	dd if=/dev/zero of="$SPDIR"/file-a bs=4096 count=2 2>/dev/null
+	dd if=/dev/urandom of="$SPDIR"/file-a bs=4096 count=2 2>/dev/null
 	cp "$SPDIR"/file-a "$SPDIR"/file-b
 	truncate -s 1M "$SPDIR"/sparse-a
 	truncate -s 1M "$SPDIR"/sparse-b
 	$TS_CMD_HARDLINK --real-size --minimum-size 4096 "$SPDIR" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 	summary_clean
+	echo "file-a st_blocks: $(test "$(stat -c %b "$SPDIR"/file-a)" -gt 0 && echo non-zero || echo zero)" >> "$TS_OUTPUT"
 	echo "file-a links: $(stat -c %h "$SPDIR"/file-a)" >> "$TS_OUTPUT"
 	echo "sparse-a links: $(stat -c %h "$SPDIR"/sparse-a)" >> "$TS_OUTPUT"
 	rm -rf "$SPDIR"


### PR DESCRIPTION
Some filesystems (e.g., on OpenWrt CI) optimize all-zero blocks and
report st_blocks == 0 even for files written with `dd if=/dev/zero`.
This causes hardlink to skip them as sparse, failing the sparse-skip
and real-size subtests.

Use `/dev/urandom` instead of `/dev/zero` so the test files always get
real disk blocks allocated.

Also add `st_blocks` diagnostics (non-zero/zero) to both subtests to
make future failures immediately obvious.

Addresses the OpenWrt x86/generic CI failure in `tests/ts/hardlink/options`.