### PR TITLE
libfdisk: fix free() of uninitialized pointer in ask string API

### DIFF
--- a/libfdisk/src/ask.c
+++ b/libfdisk/src/ask.c
@@ -612,8 +612,9 @@ char *fdisk_ask_string_get_result(struct fdisk_ask *ask)
  * @ask: ask instance
  * @result: pointer to allocated buffer with string
  *
- * You don't have to care about the @result deallocation, libfdisk is going to
- * deallocate the result when destroy @ask instance.
+ * The @ask instance does not own the @result buffer and it never deallocates
+ * it. The buffer is returned to the fdisk_ask_string() caller which is
+ * responsible for the deallocation.
  *
  * Returns: 0 on success, <0 on error
  */
@@ -628,7 +629,7 @@ int fdisk_ask_string_set_result(struct fdisk_ask *ask, char *result)
  * fdisk_ask_string:
  * @cxt: context:
  * @query: question string
- * @result: returns allocated buffer
+ * @result: returns allocated buffer, or NULL on error
  *
  * High-level API to ask for strings. Don't forget to deallocate the @result.
  *
@@ -642,6 +643,9 @@ int fdisk_ask_string(struct fdisk_context *cxt,
 	int rc;
 
 	assert(cxt);
+	assert(result);
+
+	*result = NULL;
 
 	ask = fdisk_new_ask();
 	if (!ask)

--- a/libfdisk/src/bsd.c
+++ b/libfdisk/src/bsd.c
@@ -666,7 +666,7 @@ int fdisk_bsd_write_bootstrap(struct fdisk_context *cxt)
 	struct fdisk_bsd_label *l = self_label(cxt);
 	char *name = d->d_type == BSD_DTYPE_SCSI ? "sd" : "wd";
 	char buf[BUFSIZ];
-	char *res, *dp, *p;
+	char *res = NULL, *dp, *p;
 	int rc;
 	fdisk_sector_t sector;
 


### PR DESCRIPTION
fdisk_ask_string() assigns *result on success only, but this is not documented and fdisk_bsd_write_bootstrap() expects the pointer to be always initialized, so free() may be called on an uninitialized stack variable. The dialog fails for example on EOF, reproducible with:

```
printf 'b\ni\n' | fdisk <image-with-nested-BSD-label>
```

```
==90295== Conditional jump or move depends on uninitialised value(s)
==90295==    at 0x4844D26: free (vg_replace_malloc.c:950)
==90295==    by 0x4887259: fdisk_bsd_write_bootstrap (bsd.c:734)
==90295==  Uninitialised value was created by a stack allocation
==90295==    at 0x48870F0: fdisk_bsd_write_bootstrap (bsd.c:664)
```

*result is now always initialized in fdisk_ask_string(). This also fixes an uninitialized read in the debug message.

The commit also fixes the wrong fdisk_ask_string_set_result() description. libfdisk never deallocates the result; the ownership is moved to the fdisk_ask_string() caller. The misleading comment has already led to #4601, which frees the buffer in fdisk_reset_ask() and thus introduces use-after-free and double free for all fdisk_ask_string() users.