### PR TITLE
libmount: fix X-mount.idmap ID names in code and man page

### DIFF
--- a/libmount/src/hook_idmap.c
+++ b/libmount/src/hook_idmap.c
@@ -40,10 +40,22 @@ typedef enum idmap_type_t {
 	ID_TYPE_UIDGID,	/* uidmap and gidmap entry */
 } idmap_type_t;
 
+/*
+ * struct id_map keeps one ID-mapping entry. The IDs are written to
+ * /proc/<pid>/{u,g}id_map as "<inner> <outer> <range>", which is the
+ * kernel's "ID-inside-ns ID-outside-ns length" format (the same order
+ * as unshare --map-users and mount --map-users).
+ *
+ * Note that for an idmapped mount the kernel resolves the mapping
+ * downwards (see map_id_down() and make_vfsuid() in the kernel), so
+ * 'inner' is the ID stored in the filesystem and 'outer' is the ID
+ * visible in the mount. For example "1000 2000 1" makes a file owned
+ * by 1000 on disk appear as owned by 2000.
+ */
 struct id_map {
 	idmap_type_t map_type;
-	uint32_t nsid;
-	uint32_t hostid;
+	uint32_t inner;
+	uint32_t outer;
 	uint32_t range;
 	struct list_head map_head;
 };
@@ -152,7 +164,7 @@ static int map_ids(struct list_head *idmap, pid_t pid)
 			left = sizeof(mapbuf) - (pos - mapbuf);
 			fill = snprintf(pos, left,
 					"%" PRIu32 " %" PRIu32 " %" PRIu32 "\n",
-					map->nsid, map->hostid, map->range);
+					map->inner, map->outer, map->range);
 			/*
 			 * The kernel only takes <= 4k for writes to
 			 * /proc/<pid>/{g,u}id_map
@@ -436,7 +448,7 @@ static int hook_prepare_options(
 
 	/*
 	 * This is an explicit ID-mapping list of the form:
-	 * [id-type]:id-mount:id-host:id-range [...]
+	 * [id-type]:inner:outer:range [...]
 	 *
 	 * We split the list into separate ID-mapping entries. The individual
 	 * ID-mapping entries are separated by ' '.
@@ -448,23 +460,23 @@ static int hook_prepare_options(
 	     tok = strtok_r(NULL, " ", &saveptr)) {
 		struct id_map *idmap;
 		idmap_type_t map_type;
-		uint32_t nsid = UINT_MAX, hostid = UINT_MAX, range = UINT_MAX;
+		uint32_t inner = UINT_MAX, outer = UINT_MAX, range = UINT_MAX;
 
 		if (ul_startswith(tok, "b:")) {
-			/* b:id-mount:id-host:id-range */
+			/* b:inner:outer:range */
 			map_type = ID_TYPE_UIDGID;
 			tok += 2;
 		} else if (ul_startswith(tok, "g:")) {
-			/* g:id-mount:id-host:id-range */
+			/* g:inner:outer:range */
 			map_type = ID_TYPE_GID;
 			tok += 2;
 		} else if (ul_startswith(tok, "u:")) {
-			/* u:id-mount:id-host:id-range */
+			/* u:inner:outer:range */
 			map_type = ID_TYPE_UID;
 			tok += 2;
 		} else {
 			/*
-			 * id-mount:id-host:id-range
+			 * inner:outer:range
 			 *
 			 * If the user didn't specify it explicitly then they
 			 * want this to be both a gid- and uidmap.
@@ -472,9 +484,9 @@ static int hook_prepare_options(
 			map_type = ID_TYPE_UIDGID;
 		}
 
-		/* id-mount:id-host:id-range */
-		rc = sscanf(tok, "%" PRIu32 ":%" PRIu32 ":%" PRIu32, &nsid,
-			    &hostid, &range);
+		/* inner:outer:range */
+		rc = sscanf(tok, "%" PRIu32 ":%" PRIu32 ":%" PRIu32, &inner,
+			    &outer, &range);
 		if (rc != 3)
 			goto err;
 
@@ -483,8 +495,8 @@ static int hook_prepare_options(
 			goto err;
 
 		idmap->map_type = map_type;
-		idmap->nsid = nsid;
-		idmap->hostid = hostid;
+		idmap->inner = inner;
+		idmap->outer = outer;
 		idmap->range = range;
 		INIT_LIST_HEAD(&idmap->map_head);
 		list_add_tail(&idmap->map_head, &hd->id_map);

--- a/sys-utils/mount.8.adoc
+++ b/sys-utils/mount.8.adoc
@@ -385,7 +385,7 @@ Move a subtree to some other place. See above, the subsection *The move operatio
 Allow to make a target directory (mountpoint) if it does not exist yet. Alias to "-o X-mount.mkdir[=mode]", the default mode is 0755. For more details see *X-mount.mkdir* below.
 
 *--map-groups*, *--map-users* _inner_:_outer_:_count_::
-Add the specified user/group mapping to an *X-mount.idmap* map. These options can be given multiple times to build up complete mappings for users and groups. For more details see *X-mount.idmap* below.
+Add the specified user/group mapping to an *X-mount.idmap* map. The _inner_ ID is the starting ID as stored in the filesystem and the _outer_ ID is the starting ID as it appears in the new mount. These options can be given multiple times to build up complete mappings for users and groups. For more details see *X-mount.idmap* below.
 
 *--map-users* /proc/_PID_/ns/user::
 Use the specified user namespace for user and group mapping in an id-mapped mount. This is an alias for "-o X-mount.idmap=/proc/_PID_/ns/user" and cannot be used twice nor together with the _inner_:_outer_:_count_ option format above. For more details see *X-mount.idmap* below.
@@ -824,7 +824,7 @@ Set _mountpoint_'s ownership after mounting. Names resolved in the target mount 
 *X-mount.mode*=_mode_::
 Set _mountpoint_'s mode after mounting.
 
-*X-mount.idmap*=__id-type__:__id-mount__:__id-host__:__id-range__ [__id-type__:__id-mount__:__id-host__:__id-range__], *X-mount.idmap*=__file__::
+*X-mount.idmap*=__type__:__inner__:__outer__:__range__ [__type__:__inner__:__outer__:__range__], *X-mount.idmap*=__file__::
 Use this option to create an idmapped mount.
 This feature requires the new file-descriptor-based mount API (available since Linux 5.2).
 An idmapped mount allows the ownership of all files located under a mount to be changed according to the ID-mapping associated with a user namespace.
@@ -833,17 +833,17 @@ The relevant ID-mapping can be specified in two ways:
 +
 * A user can specify the ID-mapping directly.
 +
-The ID-mapping must be specified using the syntax __id-type__:__id-mount__:__id-host__:__id-range__.
-Specifying *u* as the __id-type__ prefix creates a UID-mapping, *g* creates a GID-mapping and omitting __id-type__ or specifying *b* creates both a UID- and GID-mapping.
-The __id-mount__ parameter indicates the starting ID in the new mount.
-The __id-host__ parameter indicates the starting ID in the filesystem.
-The __id-range__ parameter indicates how many IDs are to be mapped.
+The ID-mapping must be specified using the syntax __type__:__inner__:__outer__:__range__.
+Specifying *u* as the __type__ prefix creates a UID-mapping, *g* creates a GID-mapping and omitting __type__ or specifying *b* creates both a UID- and GID-mapping.
+The __inner__ and __outer__ IDs are given in the same order as in _/proc/[pid]/uid_map_ (see *user_namespaces*(7)) and for *--map-users* above.
+For an idmapped mount this means that __inner__ is the starting ID as stored in the filesystem, and __outer__ is the starting ID as it appears in the new mount.
+The __range__ parameter indicates how many IDs are to be mapped.
 It is possible to specify multiple ID-mappings.
 +
 The individual ID mappings must be separated by spaces. Please note that in the __/etc/fstab__ file, spaces are interpreted as separators between fields. To avoid this, you must escape them using \040. For example, X-mount.idmap=0:0:1\040500:1000:1.
 +
-For example, the ID-mapping *X-mount.idmap=u:1000:0:1 g:1001:1:2 5000:1000:2* creates an idmapped mount where
-UID 0 is mapped to UID 1000, GID 1 is mapped to GID 1001, GID 2 is mapped to GID 1002, UID and GID 1000 are mapped to 5000, and UID and GID 1001 are mapped to 5001 in the mount.
+For example, the ID-mapping *X-mount.idmap=u:1000:0:1 g:1001:1:2 5000:1000:2* creates an idmapped mount where a file owned by
+UID 1000 in the filesystem appears as owned by UID 0 in the mount, GID 1001 appears as GID 1, GID 1002 appears as GID 2, UID and GID 5000 appear as 1000, and UID and GID 5001 appear as 1001.
 +
 When an ID-mapping is specified directly, a new user namespace will be allocated with the requested ID-mapping.
 The newly created user namespace will be attached to the mount.


### PR DESCRIPTION
The `X-mount.idmap` man page describes the mapping as `id-mount:id-host`, claiming the first field is the ID in the new mount and the second the ID in the filesystem. It is the other way round.

For an idmapped mount the kernel resolves the mapping downwards (`map_id_down()` in `make_vfsuid()`), so the ID stored in the filesystem is looked up in the first column of the map and the second column is what userspace sees through the mount. Verified on a real tmpfs:

```
X-mount.idmap=u:1000:0:1 g:1001:1:2 5000:1000:2

on disk                  through the idmapped mount
uid 1000, gid 0     ->   uid 0,     gid 65534
uid 0,    gid 1001  ->   uid 65534, gid 1
uid 0,    gid 1002  ->   uid 65534, gid 2
uid/gid 5000        ->   uid/gid 1000
uid/gid 5001        ->   uid/gid 1001
```

The order in the code has always been right; the problem is the names. `hook_idmap.c` called the fields `nsid`/`hostid`, which invites reading the first one as "the ID I will see in the mount", while the man page used yet another pair of names (`id-mount`/`id-host`) and attached them to the wrong positions. Two vocabularies for the same two columns, neither of them obvious.

This patch uses the `inner`/`outer` terminology already used by `/proc/[pid]/uid_map`, `unshare(1)` and `mount --map-users` (see `unshare.1.adoc`, which states its argument order was chosen "for consistency with the ordering used in /proc/[pid]/uid_map and the X-mount.idmap mount option"), renames the variables in `hook_idmap.c` to match, and fixes the man page order and example.

No functional change.

## Backport

The stable branches need this as well. Note that `b38324a9a` ("mount: fix grammar and typo in X-mount.idmap documentation") also never left master, so `stable/v2.42` and `stable/v2.41` are missing both changes; both should be cherry-picked, `b38324a9a` first.

Addresses #4608. The same documentation problem was reported earlier in #4400 by @christian-oudard.