### PR TITLE
include: fix hardcoded stdout in fputsln()

### DIFF
--- a/include/c.h
+++ b/include/c.h
@@ -567,7 +567,7 @@ static inline void print_features(const char *const*features, const char *prefix
 static inline int fputsln(const char *s, FILE *stream) {
 	if (fputs(s, stream) == EOF)
 		return EOF;
-	return fputc('\n', stdout);
+	return fputc('\n', stream);
 }
 
 /*


### PR DESCRIPTION
Good evening, 

The change is quite simple. 
I just hope I'm not overlooking some detail regarding this!

Thank you,

```
fputsln() is intended to append a newline to the user-provided stream. However, the fputc() call was mistakenly hardcoded to stdout.

This fixes the function to use the correct stream parameter.
```