### PR TITLE
libsmartcols: reject consecutive regex quantifiers

### DIFF
--- a/libsmartcols/src/filter-param.c
+++ b/libsmartcols/src/filter-param.c
@@ -139,18 +139,22 @@ static int is_unsafe_regex(const char *pattern)
 	size_t i, len = strlen(pattern);
 
 	for (i = 0; i + 1 < len; i++) {
-		if ((pattern[i] == '+' || pattern[i] == '*')
-		    && (pattern[i + 1] == '+' || pattern[i + 1] == '*'))
+		/* Reject consecutive ERE quantifiers.  glibc's regcomp() can recurse
+		 * deeply while normalizing malformed runs such as "a???". */
+		if ((pattern[i] == '+' || pattern[i] == '*' || pattern[i] == '?')
+		    && (pattern[i + 1] == '+' || pattern[i + 1] == '*' ||
+			    pattern[i + 1] == '?'))
 			return 1;
 
 		if (pattern[i] == ')'
-		    && (pattern[i + 1] == '+' || pattern[i + 1] == '*')) {
+		    && (pattern[i + 1] == '+' || pattern[i + 1] == '*' ||
+			    pattern[i + 1] == '?')) {
 			int j;
 
 			for (j = (int) i - 1; j >= 0; j--) {
 				if (pattern[j] == '(')
 					break;
-				if (pattern[j] == '+' || pattern[j] == '*')
+				if (pattern[j] == '+' || pattern[j] == '*' || pattern[j] == '?')
 					return 1;
 			}
 		}


### PR DESCRIPTION
## Summary

The minimized OSS-Fuzz testcase for issue 555446687 reaches `scols_new_filter()` with a regex containing a long run of `?` quantifiers. glibc `regcomp()` recursively normalizes this malformed expression until the process exhausts its stack.

Extend the existing unsafe-regex guard to reject consecutive `?` quantifiers and repeated quantifiers following a group, before invoking the regex compiler. The filter parser already reports these expressions as invalid, so valid filters are unchanged.

Validation: rebuilt libsmartcols with AddressSanitizer and UndefinedBehaviorSanitizer and replayed the minimized `test_smartcols_fuzz` testcase without findings.

This is a Google Patch Rewards OSS-Fuzz Tier 2 patch. AI assistance was used and is disclosed.
