### PR TITLE
mbsalign: skip whole CSI sequences when counting cells

### DIFF
--- a/lib/mbsalign.c
+++ b/lib/mbsalign.c
@@ -45,12 +45,21 @@ size_t mbs_nwidth(const char *buf, size_t bufsz)
 		if (*p == '\033') {
 			p++;
 
-			/* try detect "\e[x;ym" and skip on success */
-			if (*p && *p == '[') {
-				const char *e = p;
-				while (*e && e < last && *e != 'm')
+			/* try detect a CSI sequence "\e[" and skip on success;
+			 * it is parameter bytes (0x30-0x3f), then intermediate
+			 * bytes (0x20-0x2f), terminated by a final byte
+			 * (0x40-0x7e). None of them occupies a cell. */
+			if (*p == '[') {
+				const char *e = p + 1;
+
+				while (e <= last && (unsigned char) *e >= 0x30
+						 && (unsigned char) *e <= 0x3f)
 					e++;
-				if (*e == 'm')
+				while (e <= last && (unsigned char) *e >= 0x20
+						 && (unsigned char) *e <= 0x2f)
+					e++;
+				if (e <= last && (unsigned char) *e >= 0x40
+					       && (unsigned char) *e <= 0x7e)
 					p = e + 1;
 			}
 			/* try detect SCS sequences "\e(X", "\e)X", "\e*X", "\e+X" and skip on success */

--- a/tests/expected/column/ansiescape-csi
+++ b/tests/expected/column/ansiescape-csi
@@ -1,0 +1,4 @@
+[Khome|B
+xx  |D
+[2Jred |E
+[?25lyy  |F

--- a/tests/ts/column/ansiescape
+++ b/tests/ts/column/ansiescape
@@ -34,4 +34,9 @@ printf '%b' "\033[32mgreen\033(B\033[m|colored with SCS reset\n\033[31mred\033[m
 	| $TS_CMD_COLUMN --table --separator '|' --output-separator '|' >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
 ts_finalize_subtest
 
+ts_init_subtest "csi"
+printf '%b' "\033[Khome|B\nxx|D\n\033[2Jred|E\n\033[?25lyy|F\n" \
+	| $TS_CMD_COLUMN --table --separator '|' --output-separator '|' >> "$TS_OUTPUT" 2>> "$TS_ERRLOG"
+ts_finalize_subtest
+
 ts_finalize


### PR DESCRIPTION
`mbs_nwidth()` skips ANSI escape sequences when counting cells, but it terminates a CSI sequence by scanning for the byte `'m'`:

```c
while (*e && e < last && *e != 'm')
        e++;
if (*e == 'm')
        p = e + 1;
```

`'m'` is the final byte of SGR only. For any other CSI sequence the scan runs past the end of the sequence and consumes the ordinary text that follows it, up to the next `'m'` in the data. When the data contains no `'m'` at all, the sequence is not skipped and its bytes are then counted as printable characters.

The result is wrong in both directions:

| input | cells | measured |
| --- | --- | --- |
| `\e[Khome` | 4 | 1 |
| `\e[2Jhome` | 4 | 1 |
| `\e[?25lhome` | 4 | 1 |
| `\e[3Ahome` | 4 | 1 |
| `\e[2Jhoue` | 4 | 7 |

`column(1)` calls `scols_table_enable_noencoding()` unconditionally on the non-JSON path (text-utils/column.c), and that flag is what selects `mbs_nwidth()`/`mbs_width()` for column sizing in libsmartcols. So input carrying a non-SGR sequence is laid out to the wrong width on the default path:

```
$ printf '\033[Khome\tB\nxx\tD\n' | column -t -s $'\t' | cat -v
^[[Khome      |B
xx     |D
```

`column(1)` is the only user of that flag, so nothing else changes.

The fix bounds the scan to an actual CSI sequence as defined by ECMA-48: parameter bytes (0x30-0x3f), then intermediate bytes (0x20-0x2f), terminated by a final byte (0x40-0x7e). An incomplete sequence is left alone, as before.

After the fix the same input aligns:

```
^[[Khome  |B
xx    |D
```

### Testing

- New `csi` subtest in `tests/ts/column/ansiescape`, covering `\e[K`, `\e[2J` and `\e[?25l`. Verified that it fails without the change to `lib/mbsalign.c`.
- The existing `sgr` and `scs` subtests are unaffected.
- Full suite: all 408 tests pass. The three `KNOWN FAILED` entries (`chrt-non-user`, `mbsencode-invalid-utf8`, `script/replay-live`) are unrelated and fail identically before the change.
- Builds without new warnings.
