### PR TITLE
blkdev: check blkdev_find_size return value in blkdev_get_size

### DIFF
--- a/lib/blkdev.c
+++ b/lib/blkdev.c
@@ -177,7 +177,11 @@ blkdev_get_size(int fd, unsigned long long *bytes)
 		}
 	}
 
-	*bytes = blkdev_find_size(fd);
+	off_t size = blkdev_find_size(fd);
+	if (size < 0)
+		return -1;
+
+	*bytes = (unsigned long)size;
 	return 0;
 }
 


### PR DESCRIPTION
blkdev_find_size() returns -1 on error, but the return value was
unconditionally assigned to *bytes, causing silent conversion to a
large unsigned value and a false success return. Check for negative
return and propagate the error properly.