### PR TITLE
tests: verify restricted mounts use pinned targets

### DIFF
--- a/tests/commands.sh
+++ b/tests/commands.sh
@@ -132,6 +132,7 @@ TS_CMD_MKCRAMFS=${TS_CMD_MKCRAMFS:-"${ts_commandsdir}mkfs.cramfs"}
 TS_CMD_MKMINIX=${TS_CMD_MKMINIX:-"${ts_commandsdir}mkfs.minix"}
 TS_CMD_MKSWAP=${TS_CMD_MKSWAP:-"${ts_commandsdir}mkswap"}
 TS_CMD_MOUNT=${TS_CMD_MOUNT:-"${ts_commandsdir}mount"}
+TS_CMD_MOUNTSTATIC=${TS_CMD_MOUNTSTATIC:-"${ts_commandsdir}mount.static"}
 TS_CMD_MOUNTPOINT=${TS_CMD_MOUNTPOINT:-"${ts_commandsdir}mountpoint"}
 TS_CMD_NAMEI=${TS_CMD_NAMEI-"${ts_commandsdir}namei"}
 TS_CMD_NSENTER=${TS_CMD_NSENTER-"${ts_commandsdir}nsenter"}

--- a/tests/expected/mount/restricted-fd
+++ b/tests/expected/mount/restricted-fd
@@ -1,0 +1,1 @@
+Success

--- a/tests/ts/mount/restricted-fd
+++ b/tests/ts/mount/restricted-fd
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+TS_TOPDIR="${0%/*}/../.."
+TS_DESC="restricted target file descriptor"
+
+. "$TS_TOPDIR"/functions.sh
+ts_init "$*"
+
+ts_skip_nonroot
+ts_check_prog "getent"
+ts_check_prog "strace"
+ts_check_test_command "$TS_CMD_MOUNTSTATIC"
+ts_check_test_command "$TS_CMD_UMOUNT"
+
+grep -q 'nodev[[:space:]]*tmpfs' /proc/filesystems || \
+	ts_skip "tmpfs unsupported"
+getent passwd "$TS_TESTUSER" &> /dev/null || \
+	ts_skip "$TS_TESTUSER user is missing"
+[ -w /etc/fstab ] || ts_skip "/etc/fstab is not writable"
+[ -d /proc/self/fd ] || ts_skip "/proc/self/fd is unavailable"
+
+TRACE="$TS_OUTDIR/${TS_TESTNAME}.strace"
+TS_FSTAB=/etc/fstab
+
+cleanup() {
+	$TS_CMD_UMOUNT "$TS_MOUNTPOINT" &> /dev/null
+	ts_fstab_clean
+	rm -f "$TRACE"
+}
+trap cleanup EXIT
+
+mkdir -p "$TS_MOUNTPOINT"
+chmod 0755 "$TS_MOUNTPOINT"
+
+ts_init_suid "$TS_CMD_MOUNTSTATIC"
+[ -u "$TS_CMD_MOUNTSTATIC" ] || ts_skip "cannot setup suid test"
+
+ts_fstab_add "none" "$TS_MOUNTPOINT" "tmpfs" "user,noauto"
+
+if ! strace -f -qq -s 4096 -e trace=openat2,mount,move_mount \
+	-u "$TS_TESTUSER" -o "$TRACE" -- \
+	"$TS_CMD_MOUNTSTATIC" "$TS_MOUNTPOINT" \
+	>> "$TS_OUTPUT" 2>> "$TS_ERRLOG"; then
+	grep -q "must be superuser to use mount" "$TS_ERRLOG" && \
+		ts_skip "cannot execute suid mount under strace"
+	cat "$TRACE" >> "$TS_ERRLOG"
+	ts_die "restricted mount failed"
+fi
+
+if ! grep -Eq \
+	'mount\([^,]+, "/proc/self/fd/[0-9]+"|move_mount\([^,]+, "", [0-9]+, "", [^)]*MOVE_MOUNT_T_EMPTY_PATH' \
+	"$TRACE"; then
+	cat "$TRACE" >> "$TS_ERRLOG"
+	ts_die "restricted mount did not use the pinned target"
+fi
+
+$TS_CMD_UMOUNT "$TS_MOUNTPOINT" >> "$TS_OUTPUT" 2>> "$TS_ERRLOG" || \
+	ts_die "cannot unmount test filesystem"
+ts_fstab_clean
+
+trap - EXIT
+cleanup
+
+ts_log "Success"
+ts_finalize

--- a/tests/ts/mount/xnocanon
+++ b/tests/ts/mount/xnocanon
@@ -27,6 +27,7 @@ ts_check_test_command "$TS_CMD_FINDMNT"
 
 ts_skip_nonroot
 
+$TS_CMD_MOUNT --version | grep -q 'fd-based' || ts_skip "no fd-based API"
 [ "$("$TS_HELPER_SYSINFO" fsopen-ok)" == "1" ] || ts_skip "no fs-API"
 
 [ -d $TS_MOUNTPOINT ] || mkdir -p $TS_MOUNTPOINT

--- a/tools/config-gen.d/static.conf
+++ b/tools/config-gen.d/static.conf
@@ -1,3 +1,5 @@
 include:core.conf
 
 --enable-static-programs
+--without-systemd
+--without-econf


### PR DESCRIPTION
- Add a setuid static-mount regression test to ensure non-root mounts use pinned targets with both the FD-based and legacy mount APIs.